### PR TITLE
feat(deploy): add Helm chart for Kubernetes deployment

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,85 @@
+name: Helm Chart
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/helm/**'
+      - '.github/workflows/helm.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'deploy/helm/**'
+      - '.github/workflows/helm.yml'
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: helm lint + template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+
+      - name: helm lint
+        run: helm lint deploy/helm/spur
+
+      # Render every scenario the chart claims to support so a broken template
+      # fails the build instead of failing in a customer cluster.
+      - name: helm template (defaults — 3-replica Raft HA)
+        run: helm template ci deploy/helm/spur > /tmp/render-default.yaml
+
+      - name: helm template (single-node dev)
+        run: |
+          helm template ci deploy/helm/spur \
+            --set controller.replicaCount=1 \
+            --set controller.persistence.enabled=false \
+            --set controller.pdb.enabled=false \
+            --set agent.gpu.rocm=false \
+            --set agent.nodeSelector=null \
+            --set operator.enabled=false \
+            --set crds.install=false \
+            > /tmp/render-single.yaml
+
+      - name: helm template (external Postgres)
+        run: |
+          helm template ci deploy/helm/spur \
+            --set accounting.externalDatabase.existingSecret=spur-db-creds \
+            --set accounting.embeddedPostgres.enabled=false \
+            > /tmp/render-extdb.yaml
+
+      - name: helm template (REST API ingress)
+        run: |
+          helm template ci deploy/helm/spur \
+            --set restd.ingress.enabled=true \
+            --set restd.ingress.className=nginx \
+            --set 'restd.ingress.hosts[0].host=spur.example.com' \
+            --set 'restd.ingress.hosts[0].paths[0].path=/' \
+            --set 'restd.ingress.hosts[0].paths[0].pathType=Prefix' \
+            > /tmp/render-ingress.yaml
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL -o /tmp/kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf /tmp/kubeconform.tar.gz -C /usr/local/bin kubeconform
+
+      # Validate every rendered scenario against real Kubernetes API schemas.
+      # --strict catches unknown fields; --ignore-missing-schemas lets the
+      # SpurJob CRD instances through without us hosting a custom schema.
+      - name: kubeconform validate (all scenarios)
+        run: |
+          set -e
+          for f in /tmp/render-*.yaml; do
+            echo "==> $f"
+            kubeconform \
+              -strict \
+              -ignore-missing-schemas \
+              -kubernetes-version 1.29.0 \
+              -summary \
+              "$f"
+          done

--- a/deploy/helm/spur/.helmignore
+++ b/deploy/helm/spur/.helmignore
@@ -1,0 +1,20 @@
+# Patterns to ignore when packaging Helm charts.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.idea/
+*.tmproj
+.vscode/
+ci/
+tests/
+README.md.tmpl

--- a/deploy/helm/spur/Chart.yaml
+++ b/deploy/helm/spur/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: spur
+description: |
+  Spur — AI-native job scheduler. Drop-in Slurm-compatible scheduler
+  with always-on Raft, GPU-first scheduling, and a Kubernetes operator
+  that reconciles SpurJob CRs into pods.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.25.0-0"
+home: https://github.com/ROCm/spur
+sources:
+  - https://github.com/ROCm/spur
+maintainers:
+  - name: ROCm/spur maintainers
+    url: https://github.com/ROCm/spur
+keywords:
+  - hpc
+  - slurm
+  - scheduler
+  - gpu
+  - rocm
+  - ai
+icon: https://raw.githubusercontent.com/ROCm/spur/main/docs/_static/logo.png
+annotations:
+  artifacthub.io/category: skip-prediction
+  artifacthub.io/containsSecurityUpdates: "false"

--- a/deploy/helm/spur/README.md
+++ b/deploy/helm/spur/README.md
@@ -1,0 +1,98 @@
+# Spur Helm Chart
+
+Spur — an AI-native, Slurm-compatible job scheduler — packaged as a Helm chart.
+
+## TL;DR
+
+```bash
+helm install spur ./deploy/helm/spur \
+  --namespace spur --create-namespace \
+  --set image.repository=ghcr.io/rocm/spur \
+  --set image.tag=0.1.0
+```
+
+## What gets deployed
+
+| Component | Kind | Default replicas | Purpose |
+|---|---|---|---|
+| `spurctld` | StatefulSet (headless) | 3 | Controller + Raft consensus + scheduler |
+| `spurd` | DaemonSet | per node | Node agent on every compute node |
+| `spurrestd` | Deployment | 2 | Slurm-compatible REST API |
+| `spurdbd` | Deployment | 1 | Accounting (PostgreSQL) |
+| `spur-k8s-operator` | Deployment | 1 | Reconciles `SpurJob` CRs into pods |
+| `SpurJob` CRD | CRD (`crds/`) | — | Kubernetes-native job submission |
+
+All components share the same image (multi-call binary). Pick what you need with `<component>.enabled`.
+
+## Requirements
+
+- Kubernetes ≥ 1.25
+- Helm ≥ 3.8
+- Default StorageClass available (for the controller PVC) — or set `controller.persistence.storageClass`
+- For GPU scheduling: nodes labeled `spur.amd.com/compute=true` with ROCm devices (`/dev/kfd`, `/dev/dri`)
+
+## Common overrides
+
+**Single-node dev cluster** — no Raft HA, no persistence, no GPU:
+
+```yaml
+controller:
+  replicaCount: 1
+  persistence:
+    enabled: false
+  pdb:
+    enabled: false
+agent:
+  nodeSelector: {}      # deploy on every node
+  gpu:
+    rocm: false
+```
+
+**Production with external Postgres**:
+
+```yaml
+accounting:
+  externalDatabase:
+    existingSecret: spur-db-creds   # secret with key "url"
+  embeddedPostgres:
+    enabled: false
+```
+
+**Disable the operator** (you only want the scheduler + CLI, not K8s-native jobs):
+
+```yaml
+operator:
+  enabled: false
+crds:
+  install: false
+```
+
+## Upgrade & rollback
+
+```bash
+helm upgrade spur ./deploy/helm/spur -n spur -f my-values.yaml
+helm rollback spur -n spur
+```
+
+Config changes roll the controller automatically via `checksum/config` annotation.
+
+## CRDs
+
+The `SpurJob` CRD ships under `crds/`. Helm installs it on first `helm install` but never upgrades or deletes it — that's by design (deleting a CRD wipes every CR). To upgrade the CRD:
+
+```bash
+kubectl apply -f deploy/helm/spur/crds/spurjob-crd.yaml
+```
+
+If you manage CRDs externally (e.g. ArgoCD pre-sync hook), set `crds.install=false` and ship `crds/spurjob-crd.yaml` yourself.
+
+## Uninstall
+
+```bash
+helm uninstall spur -n spur
+kubectl delete crd spurjobs.spur.amd.com   # only if you want to drop CRs too
+```
+
+## Values reference
+
+See `values.yaml` — every key is documented inline.

--- a/deploy/helm/spur/crds/spurjob-crd.yaml
+++ b/deploy/helm/spur/crds/spurjob-crd.yaml
@@ -1,0 +1,237 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: spurjobs.spur.amd.com
+spec:
+  group: spur.amd.com
+  names:
+    categories: []
+    kind: SpurJob
+    plural: spurjobs
+    shortNames: []
+    singular: spurjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.state
+      name: State
+      type: string
+    - jsonPath: .status.spurJobId
+      name: Job ID
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for SpurJobSpec via `CustomResource`
+        properties:
+          spec:
+            description: "SpurJob CRD spec \u2014 Kubernetes-native way to submit\
+              \ GPU jobs to Spur.\n\napiVersion: spur.amd.com/v1alpha1\nkind: SpurJob"
+            properties:
+              account:
+                description: Spur account.
+                nullable: true
+                type: string
+              args:
+                default: []
+                description: Arguments to the command.
+                items:
+                  type: string
+                type: array
+              arraySpec:
+                description: Job array spec (e.g., "0-99%10").
+                nullable: true
+                type: string
+              command:
+                default: []
+                description: Command to run in the container.
+                items:
+                  type: string
+                type: array
+              cpusPerTask:
+                default: 1
+                description: CPUs per task.
+                format: uint32
+                minimum: 0.0
+                type: integer
+              dependencies:
+                default: []
+                description: Job dependencies (e.g., ["afterok:123", "afterany:456"]).
+                items:
+                  type: string
+                type: array
+              env:
+                additionalProperties:
+                  type: string
+                default: {}
+                description: Environment variables.
+                type: object
+              extraResources:
+                additionalProperties:
+                  type: string
+                default: {}
+                description: 'Extra device plugin resources (e.g., {"rdma/devices":
+                  "1"}).'
+                type: object
+              gpus:
+                default:
+                  count: 0
+                  gpuType: null
+                description: GPU requirements.
+                properties:
+                  count:
+                    default: 0
+                    description: Number of GPUs needed.
+                    format: uint32
+                    minimum: 0.0
+                    type: integer
+                  gpuType:
+                    description: GPU type filter (e.g., "mi300x", "h100").
+                    nullable: true
+                    type: string
+                type: object
+              hostIpc:
+                default: false
+                description: Enable host IPC namespace sharing (for NCCL shared memory).
+                type: boolean
+              hostNetwork:
+                default: false
+                description: Enable host networking (for RDMA/NCCL).
+                type: boolean
+              image:
+                description: Container image to run.
+                type: string
+              memoryPerNode:
+                description: Memory per node (K8s quantity string, e.g. "256Gi").
+                nullable: true
+                type: string
+              name:
+                description: Job name.
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                default: {}
+                description: K8s node selector labels.
+                type: object
+              numNodes:
+                default: 1
+                description: Number of nodes to allocate.
+                format: uint32
+                minimum: 0.0
+                type: integer
+              partition:
+                description: Spur partition to submit to.
+                nullable: true
+                type: string
+              priorityClass:
+                description: K8s PriorityClass name.
+                nullable: true
+                type: string
+              privileged:
+                default: false
+                description: Run container in privileged mode.
+                type: boolean
+              secretEnv:
+                additionalProperties:
+                  type: string
+                default: {}
+                description: "Environment variables from K8s Secrets.\nMap of env\
+                  \ var name \u2192 \"secret-name/key\" reference.\nThe operator injects\
+                  \ these as secretKeyRef env vars into the pod,\nkeeping secrets\
+                  \ out of the SpurJob spec.\n\nExample: `{\"HF_TOKEN\": \"hf-creds/token\"\
+                  , \"API_KEY\": \"my-secret/api-key\"}`"
+                type: object
+              serviceAccount:
+                description: K8s ServiceAccount name.
+                nullable: true
+                type: string
+              shmSize:
+                description: Shared memory size (e.g., "64Gi"). Mounted as emptyDir
+                  at /dev/shm.
+                nullable: true
+                type: string
+              tasksPerNode:
+                default: 1
+                description: Tasks per node (e.g., one per GPU).
+                format: uint32
+                minimum: 0.0
+                type: integer
+              timeLimit:
+                description: Time limit (e.g., "4h", "30m", "1h30m").
+                nullable: true
+                type: string
+              tolerations:
+                default: []
+                description: K8s tolerations.
+                items:
+                  properties:
+                    effect:
+                      nullable: true
+                      type: string
+                    key:
+                      nullable: true
+                      type: string
+                    operator:
+                      default: Equal
+                      type: string
+                    tolerationSeconds:
+                      format: int64
+                      nullable: true
+                      type: integer
+                    value:
+                      nullable: true
+                      type: string
+                  type: object
+                type: array
+              volumes:
+                default: []
+                description: 'Volume mounts: "/src:/dst:ro" for hostPath or "pvc:claim-name:/dst"
+                  for PVCs.'
+                items:
+                  type: string
+                type: array
+            required:
+            - image
+            - name
+            type: object
+          status:
+            description: Status subresource for SpurJob.
+            nullable: true
+            properties:
+              assignedNodes:
+                default: []
+                description: Nodes assigned by the scheduler.
+                items:
+                  type: string
+                type: array
+              message:
+                description: Human-readable message.
+                nullable: true
+                type: string
+              pods:
+                default: []
+                description: Pod names created for this job.
+                items:
+                  type: string
+                type: array
+              spurJobId:
+                description: Spur-assigned job ID.
+                format: uint32
+                minimum: 0.0
+                nullable: true
+                type: integer
+              state:
+                default: ''
+                description: Current state (Pending, Running, Completed, Failed, Cancelled).
+                type: string
+            type: object
+        required:
+        - spec
+        title: SpurJob
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+

--- a/deploy/helm/spur/templates/NOTES.txt
+++ b/deploy/helm/spur/templates/NOTES.txt
@@ -50,10 +50,40 @@ Reach the REST API from inside the cluster:
 WARNING: spurdbd is running with the dev-mode embedded postgres sidecar.
          Data is {{ if .Values.accounting.embeddedPostgres.storage.enabled }}persisted on a PVC{{ else }}stored in emptyDir and will be LOST on restart{{ end }}.
          For production, set accounting.externalDatabase.url (or .existingSecret).
+
+  To fix, pick one of these and re-run `helm upgrade`:
+
+  1) Keep the sidecar but add a PVC (data survives pod restarts):
+
+       helm upgrade {{ .Release.Name }} <chart> -n {{ .Release.Namespace }} --reuse-values \
+         --set accounting.embeddedPostgres.storage.enabled=true \
+         --set accounting.embeddedPostgres.storage.size=8Gi
+         # optionally: --set accounting.embeddedPostgres.storage.storageClass=<class>
+
+  2) Point at an external Postgres (recommended for production):
+
+       kubectl -n {{ .Release.Namespace }} create secret generic spur-db-creds \
+         --from-literal=url='postgresql://user:pass@db.host:5432/spur'
+
+       helm upgrade {{ .Release.Name }} <chart> -n {{ .Release.Namespace }} --reuse-values \
+         --set accounting.externalDatabase.existingSecret=spur-db-creds \
+         --set accounting.embeddedPostgres.enabled=false
+
+  3) Disable accounting entirely (no job history / usage records):
+
+       helm upgrade {{ .Release.Name }} <chart> -n {{ .Release.Namespace }} --reuse-values \
+         --set accounting.enabled=false
 {{- end }}
 
 {{- if not .Values.controller.persistence.enabled }}
 
 WARNING: controller.persistence.enabled=false — Raft log lives in emptyDir.
          Quorum cluster state will be lost if all pods restart simultaneously.
+
+  To fix, re-run `helm upgrade` with a PVC for the controller:
+
+       helm upgrade {{ .Release.Name }} <chart> -n {{ .Release.Namespace }} --reuse-values \
+         --set controller.persistence.enabled=true \
+         --set controller.persistence.size=1Gi
+         # optionally: --set controller.persistence.storageClass=<class>
 {{- end }}

--- a/deploy/helm/spur/templates/NOTES.txt
+++ b/deploy/helm/spur/templates/NOTES.txt
@@ -1,0 +1,59 @@
+Spur {{ .Chart.AppVersion }} installed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Components:
+{{- if .Values.controller.enabled }}
+  - spurctld          StatefulSet, replicas={{ .Values.controller.replicaCount }}{{ if gt (.Values.controller.replicaCount | int) 1 }} (Raft HA){{ end }}
+{{- end }}
+{{- if .Values.agent.enabled }}
+  - spurd             DaemonSet (selector: {{ .Values.agent.nodeSelector | toJson }})
+{{- end }}
+{{- if .Values.restd.enabled }}
+  - spurrestd         Deployment, replicas={{ .Values.restd.replicaCount }}, service :{{ .Values.restd.service.port }}
+{{- end }}
+{{- if .Values.accounting.enabled }}
+  - spurdbd           Deployment ({{ if or (ne .Values.accounting.externalDatabase.url "") (ne .Values.accounting.externalDatabase.existingSecret "") }}external DB{{ else }}embedded postgres dev sidecar{{ end }})
+{{- end }}
+{{- if .Values.operator.enabled }}
+  - spur-k8s-operator Deployment (reconciles SpurJob CRs)
+{{- end }}
+
+Quick checks:
+
+  kubectl -n {{ .Release.Namespace }} get pods
+  kubectl -n {{ .Release.Namespace }} rollout status statefulset/spurctld
+
+Submit a job via the operator (requires the CRD, installed by this chart):
+
+  cat <<EOF | kubectl apply -f -
+  apiVersion: spur.amd.com/v1alpha1
+  kind: SpurJob
+  metadata:
+    name: hello
+    namespace: {{ .Release.Namespace }}
+  spec:
+    name: hello
+    image: docker.io/library/busybox:latest
+    command: ["sh", "-c"]
+    args: ["echo hello from spur"]
+  EOF
+
+{{- if .Values.restd.enabled }}
+
+Reach the REST API from inside the cluster:
+
+  kubectl -n {{ .Release.Namespace }} port-forward svc/spurrestd {{ .Values.restd.service.port }}:{{ .Values.restd.service.port }}
+  curl http://localhost:{{ .Values.restd.service.port }}/api/v1/ping
+{{- end }}
+
+{{- if and .Values.accounting.enabled .Values.accounting.embeddedPostgres.enabled (eq .Values.accounting.externalDatabase.url "") (eq .Values.accounting.externalDatabase.existingSecret "") }}
+
+WARNING: spurdbd is running with the dev-mode embedded postgres sidecar.
+         Data is {{ if .Values.accounting.embeddedPostgres.storage.enabled }}persisted on a PVC{{ else }}stored in emptyDir and will be LOST on restart{{ end }}.
+         For production, set accounting.externalDatabase.url (or .existingSecret).
+{{- end }}
+
+{{- if not .Values.controller.persistence.enabled }}
+
+WARNING: controller.persistence.enabled=false — Raft log lives in emptyDir.
+         Quorum cluster state will be lost if all pods restart simultaneously.
+{{- end }}

--- a/deploy/helm/spur/templates/_helpers.tpl
+++ b/deploy/helm/spur/templates/_helpers.tpl
@@ -1,0 +1,130 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "spur.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name. Truncated at 63 chars (DNS-1123 label limit).
+*/}}
+{{- define "spur.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart label string (chart name + version, sanitized).
+*/}}
+{{- define "spur.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Standard labels applied to every object.
+*/}}
+{{- define "spur.labels" -}}
+helm.sh/chart: {{ include "spur.chart" . }}
+{{ include "spur.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: spur
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Selector labels — stable across upgrades. Do NOT add helm.sh/chart or version
+here; selectors are immutable for Deployments/StatefulSets.
+*/}}
+{{- define "spur.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "spur.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Per-component selector labels.
+Usage: {{ include "spur.componentSelectorLabels" (dict "ctx" . "component" "controller") }}
+*/}}
+{{- define "spur.componentSelectorLabels" -}}
+{{ include "spur.selectorLabels" .ctx }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{/*
+Per-component labels (selector labels + chart/version/part-of).
+Usage: {{ include "spur.componentLabels" (dict "ctx" . "component" "controller") }}
+*/}}
+{{- define "spur.componentLabels" -}}
+{{ include "spur.labels" .ctx }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{/*
+Resolved image reference for a given component.
+Falls back to the top-level .Values.image when the component override is empty.
+Usage: {{ include "spur.image" (dict "ctx" . "component" .Values.controller) }}
+*/}}
+{{- define "spur.image" -}}
+{{- $top := .ctx.Values.image -}}
+{{- $c := .component.image | default dict -}}
+{{- $repo := $c.repository | default $top.repository -}}
+{{- $tag := $c.tag | default $top.tag | default .ctx.Chart.AppVersion -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+
+{{/*
+Resolved imagePullPolicy for a given component.
+*/}}
+{{- define "spur.imagePullPolicy" -}}
+{{- $top := .ctx.Values.image -}}
+{{- $c := .component.image | default dict -}}
+{{- default $top.pullPolicy $c.pullPolicy -}}
+{{- end -}}
+
+{{/*
+ServiceAccount name (created or referenced).
+*/}}
+{{- define "spur.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (printf "%s-spur" .Release.Name) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Controller headless service DNS — used by Raft peers and other daemons.
+*/}}
+{{- define "spur.controllerHost" -}}
+{{- printf "spurctld.%s.svc.cluster.local" .Release.Namespace -}}
+{{- end -}}
+
+{{/*
+Raft peers list (Helm-rendered TOML array string) based on replicaCount.
+*/}}
+{{- define "spur.raftPeers" -}}
+{{- $ns := .Release.Namespace -}}
+{{- $port := .Values.controller.service.raftPort | int -}}
+{{- $peers := list -}}
+{{- range $i, $_ := until (.Values.controller.replicaCount | int) -}}
+{{- $peers = append $peers (printf "\"spurctld-%d.spurctld.%s.svc.cluster.local:%d\"," $i $ns $port) -}}
+{{- end -}}
+{{- join "\n" $peers -}}
+{{- end -}}
+
+{{/*
+Accounting endpoint (used in spur.conf).
+*/}}
+{{- define "spur.accountingHost" -}}
+{{- printf "spurdbd.%s.svc.cluster.local:%d" .Release.Namespace (.Values.accounting.service.port | int) -}}
+{{- end -}}

--- a/deploy/helm/spur/templates/accounting.yaml
+++ b/deploy/helm/spur/templates/accounting.yaml
@@ -1,0 +1,142 @@
+{{- if .Values.accounting.enabled }}
+{{- $useExternal := or (ne .Values.accounting.externalDatabase.url "") (ne .Values.accounting.externalDatabase.existingSecret "") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: spurdbd
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "accounting") | nindent 4 }}
+spec:
+  selector:
+    {{- include "spur.componentSelectorLabels" (dict "ctx" . "component" "accounting") | nindent 4 }}
+  ports:
+    - name: grpc
+      port: {{ .Values.accounting.service.port }}
+      targetPort: grpc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spurdbd
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "accounting") | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate          # single PVC, no rolling
+  selector:
+    matchLabels:
+      {{- include "spur.componentSelectorLabels" (dict "ctx" . "component" "accounting") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "spur.componentLabels" (dict "ctx" . "component" "accounting") | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "spur.serviceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.accounting.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.accounting.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.accounting.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: spurdbd
+          image: {{ include "spur.image" (dict "ctx" . "component" .Values.accounting) }}
+          imagePullPolicy: {{ include "spur.imagePullPolicy" (dict "ctx" . "component" .Values.accounting) }}
+          command: [spurdbd]
+          args:
+            - --listen=[::]:{{ .Values.accounting.service.port }}
+            {{- if $useExternal }}
+            {{- if .Values.accounting.externalDatabase.url }}
+            - --database-url=$(SPUR_DB_URL)
+            {{- else }}
+            - --database-url=$(SPUR_DB_URL)
+            {{- end }}
+            {{- else }}
+            - --database-url=postgresql://{{ .Values.accounting.embeddedPostgres.user }}:{{ .Values.accounting.embeddedPostgres.password }}@localhost:5432/{{ .Values.accounting.embeddedPostgres.database }}
+            {{- end }}
+          ports:
+            - containerPort: {{ .Values.accounting.service.port }}
+              name: grpc
+          {{- if $useExternal }}
+          env:
+            - name: SPUR_DB_URL
+              {{- if .Values.accounting.externalDatabase.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.accounting.externalDatabase.existingSecret }}
+                  key: url
+              {{- else }}
+              value: {{ .Values.accounting.externalDatabase.url | quote }}
+              {{- end }}
+          {{- end }}
+          readinessProbe:
+            tcpSocket:
+              port: grpc
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          {{- with .Values.accounting.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- if and (not $useExternal) .Values.accounting.embeddedPostgres.enabled }}
+        # Dev-only sidecar. Production: set accounting.externalDatabase.url.
+        - name: postgres
+          image: {{ .Values.accounting.embeddedPostgres.image }}
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.accounting.embeddedPostgres.user | quote }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.accounting.embeddedPostgres.password | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.accounting.embeddedPostgres.database | quote }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+              name: postgres
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
+        {{- end }}
+      volumes:
+        {{- if and (not $useExternal) .Values.accounting.embeddedPostgres.enabled }}
+        - name: pgdata
+          {{- if .Values.accounting.embeddedPostgres.storage.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "spur.fullname" . }}-pgdata
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+{{- if and (not $useExternal) .Values.accounting.embeddedPostgres.enabled .Values.accounting.embeddedPostgres.storage.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "spur.fullname" . }}-pgdata
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "accounting") | nindent 4 }}
+spec:
+  accessModes: [ReadWriteOnce]
+  {{- with .Values.accounting.embeddedPostgres.storage.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.accounting.embeddedPostgres.storage.size | quote }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/spur/templates/agent.yaml
+++ b/deploy/helm/spur/templates/agent.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.agent.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: spurd
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "agent") | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "spur.componentSelectorLabels" (dict "ctx" . "component" "agent") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "spur.componentLabels" (dict "ctx" . "component" "agent") | nindent 8 }}
+        {{- with .Values.agent.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.agent.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "spur.serviceAccountName" . }}
+      hostPID: {{ .Values.agent.hostPID }}
+      hostNetwork: {{ .Values.agent.hostNetwork }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: spurd
+          image: {{ include "spur.image" (dict "ctx" . "component" .Values.agent) }}
+          imagePullPolicy: {{ include "spur.imagePullPolicy" (dict "ctx" . "component" .Values.agent) }}
+          command: [spurd]
+          args:
+            - --controller={{ include "spur.controllerHost" . }}:{{ .Values.controller.service.grpcPort }}
+            - --listen=[::]:{{ .Values.agent.service.grpcPort }}
+          ports:
+            - containerPort: {{ .Values.agent.service.grpcPort }}
+              name: grpc
+          {{- if .Values.agent.privileged }}
+          securityContext:
+            privileged: true
+          {{- end }}
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            {{- with .Values.agent.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: spool
+              mountPath: /var/spool/spur
+            - name: dev
+              mountPath: /dev
+            - name: sys
+              mountPath: /sys
+              readOnly: true
+            {{- if .Values.agent.gpu.rocm }}
+            - name: dev-kfd
+              mountPath: /dev/kfd
+            - name: dev-dri
+              mountPath: /dev/dri
+            {{- end }}
+          readinessProbe:
+            tcpSocket:
+              port: grpc
+            initialDelaySeconds: {{ .Values.agent.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.agent.probes.readiness.periodSeconds }}
+          {{- with .Values.agent.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: spool
+          hostPath:
+            path: {{ .Values.agent.spool.hostPath }}
+            type: DirectoryOrCreate
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: sys
+          hostPath:
+            path: /sys
+        {{- if .Values.agent.gpu.rocm }}
+        - name: dev-kfd
+          hostPath:
+            path: /dev/kfd
+            type: CharDevice
+        - name: dev-dri
+          hostPath:
+            path: /dev/dri
+            type: Directory
+        {{- end }}
+{{- end }}

--- a/deploy/helm/spur/templates/configmap.yaml
+++ b/deploy/helm/spur/templates/configmap.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "spur.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.labels" . | nindent 4 }}
+data:
+  spur.conf: |
+    cluster_name = {{ .Values.clusterName | quote }}
+
+    [controller]
+    # Raft peers — derived from controller.replicaCount.
+    # node_id is auto-detected from the pod hostname ordinal (spurctld-N → N+1).
+    peers = [
+      {{- include "spur.raftPeers" . | nindent 6 }}
+    ]
+
+    [scheduler]
+    interval_secs = {{ .Values.config.scheduler.intervalSecs }}
+    max_jobs_per_cycle = {{ .Values.config.scheduler.maxJobsPerCycle }}
+    plugin = {{ .Values.config.scheduler.plugin | quote }}
+
+    {{- if .Values.accounting.enabled }}
+
+    [accounting]
+    host = {{ include "spur.accountingHost" . | quote }}
+    {{- end }}
+
+    {{- range .Values.config.partitions }}
+
+    [[partitions]]
+    name = {{ .name | quote }}
+    state = {{ .state | quote }}
+    default = {{ .default }}
+    nodes = {{ .nodes | quote }}
+    max_time = {{ .maxTime | quote }}
+    default_time = {{ .defaultTime | quote }}
+    {{- end }}
+
+    {{- with .Values.config.extraToml }}
+
+    {{ . | nindent 4 }}
+    {{- end }}

--- a/deploy/helm/spur/templates/controller.yaml
+++ b/deploy/helm/spur/templates/controller.yaml
@@ -1,0 +1,139 @@
+{{- if .Values.controller.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: spurctld
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "controller") | nindent 4 }}
+spec:
+  selector:
+    {{- include "spur.componentSelectorLabels" (dict "ctx" . "component" "controller") | nindent 4 }}
+  clusterIP: None  # headless so StatefulSet pods get stable per-pod DNS for Raft
+  ports:
+    - name: grpc
+      port: {{ .Values.controller.service.grpcPort }}
+      targetPort: grpc
+    - name: raft
+      port: {{ .Values.controller.service.raftPort }}
+      targetPort: raft
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: spurctld
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "controller") | nindent 4 }}
+spec:
+  serviceName: spurctld
+  replicas: {{ .Values.controller.replicaCount }}
+  podManagementPolicy: {{ .Values.controller.podManagementPolicy }}
+  selector:
+    matchLabels:
+      {{- include "spur.componentSelectorLabels" (dict "ctx" . "component" "controller") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "spur.componentLabels" (dict "ctx" . "component" "controller") | nindent 8 }}
+        {{- with .Values.controller.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        # Roll pods when the config changes.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.controller.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "spur.serviceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: spurctld
+          image: {{ include "spur.image" (dict "ctx" . "component" .Values.controller) }}
+          imagePullPolicy: {{ include "spur.imagePullPolicy" (dict "ctx" . "component" .Values.controller) }}
+          command: [spurctld]
+          args:
+            - --listen=[::]:{{ .Values.controller.service.grpcPort }}
+            - --config=/etc/spur/spur.conf
+          ports:
+            - containerPort: {{ .Values.controller.service.grpcPort }}
+              name: grpc
+            - containerPort: {{ .Values.controller.service.raftPort }}
+              name: raft
+          volumeMounts:
+            - name: config
+              mountPath: /etc/spur
+            - name: spool
+              mountPath: /var/spool/spur
+          readinessProbe:
+            tcpSocket:
+              port: grpc
+            initialDelaySeconds: {{ .Values.controller.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.probes.readiness.periodSeconds }}
+          livenessProbe:
+            tcpSocket:
+              port: grpc
+            initialDelaySeconds: {{ .Values.controller.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.probes.liveness.periodSeconds }}
+          {{- with .Values.controller.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "spur.fullname" . }}-config
+        {{- if not .Values.controller.persistence.enabled }}
+        - name: spool
+          emptyDir: {}
+        {{- end }}
+  {{- if .Values.controller.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: spool
+      spec:
+        accessModes:
+          {{- toYaml .Values.controller.persistence.accessModes | nindent 10 }}
+        {{- if .Values.controller.persistence.storageClass }}
+        {{- if eq "-" .Values.controller.persistence.storageClass }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: {{ .Values.controller.persistence.storageClass | quote }}
+        {{- end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.controller.persistence.size | quote }}
+  {{- end }}
+{{- if .Values.controller.pdb.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: spurctld
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "controller") | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.controller.pdb.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "spur.componentSelectorLabels" (dict "ctx" . "component" "controller") | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/spur/templates/namespace.yaml
+++ b/deploy/helm/spur/templates/namespace.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/spur/templates/operator.yaml
+++ b/deploy/helm/spur/templates/operator.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.operator.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: spur-k8s-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "operator") | nindent 4 }}
+spec:
+  selector:
+    {{- include "spur.componentSelectorLabels" (dict "ctx" . "component" "operator") | nindent 4 }}
+  ports:
+    - name: grpc
+      port: {{ .Values.operator.service.grpcPort }}
+      targetPort: grpc
+    - name: health
+      port: {{ .Values.operator.service.healthPort }}
+      targetPort: health
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spur-k8s-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "operator") | nindent 4 }}
+spec:
+  replicas: {{ .Values.operator.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "spur.componentSelectorLabels" (dict "ctx" . "component" "operator") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "spur.componentLabels" (dict "ctx" . "component" "operator") | nindent 8 }}
+        {{- with .Values.operator.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.operator.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "spur.serviceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: operator
+          image: {{ include "spur.image" (dict "ctx" . "component" .Values.operator) }}
+          imagePullPolicy: {{ include "spur.imagePullPolicy" (dict "ctx" . "component" .Values.operator) }}
+          command: [spur-k8s-operator]
+          args:
+            - --controller-addr={{ include "spur.controllerHost" . }}:{{ .Values.controller.service.grpcPort }}
+            - --listen=[::]:{{ .Values.operator.service.grpcPort }}
+            - --health-addr=[::]:{{ .Values.operator.service.healthPort }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SPUR_OPERATOR_ADDRESS
+              value: "spur-k8s-operator.$(POD_NAMESPACE).svc.cluster.local"
+          ports:
+            - containerPort: {{ .Values.operator.service.grpcPort }}
+              name: grpc
+            - containerPort: {{ .Values.operator.service.healthPort }}
+              name: health
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: {{ .Values.operator.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.operator.probes.readiness.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: {{ .Values.operator.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.operator.probes.liveness.periodSeconds }}
+          {{- with .Values.operator.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/spur/templates/rbac.yaml
+++ b/deploy/helm/spur/templates/rbac.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "spur.fullname" . }}-operator
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "operator") | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: [pods, pods/status, pods/log]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [""]
+    resources: [services]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [configmaps]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [create, patch]
+  - apiGroups: [spur.amd.com]
+    resources: [spurjobs, spurjobs/status, spurjobs/finalizers]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [policy]
+    resources: [poddisruptionbudgets]
+    verbs: [get, list, watch, create, update, patch, delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "spur.fullname" . }}-operator
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "operator") | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "spur.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "spur.fullname" . }}-operator
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deploy/helm/spur/templates/restd.yaml
+++ b/deploy/helm/spur/templates/restd.yaml
@@ -1,0 +1,123 @@
+{{- if .Values.restd.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: spurrestd
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "restd") | nindent 4 }}
+spec:
+  type: {{ .Values.restd.service.type }}
+  selector:
+    {{- include "spur.componentSelectorLabels" (dict "ctx" . "component" "restd") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.restd.service.port }}
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spurrestd
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "restd") | nindent 4 }}
+spec:
+  replicas: {{ .Values.restd.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "spur.componentSelectorLabels" (dict "ctx" . "component" "restd") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "spur.componentLabels" (dict "ctx" . "component" "restd") | nindent 8 }}
+        {{- with .Values.restd.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.restd.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "spur.serviceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.restd.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.restd.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.restd.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: spurrestd
+          image: {{ include "spur.image" (dict "ctx" . "component" .Values.restd) }}
+          imagePullPolicy: {{ include "spur.imagePullPolicy" (dict "ctx" . "component" .Values.restd) }}
+          command: [spurrestd]
+          args:
+            - --listen=[::]:{{ .Values.restd.service.port }}
+            - --controller=http://{{ include "spur.controllerHost" . }}:{{ .Values.controller.service.grpcPort }}
+          ports:
+            - containerPort: {{ .Values.restd.service.port }}
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /api/v1/ping
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/v1/ping
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          {{- with .Values.restd.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- if and .Values.restd.ingress.enabled .Values.restd.ingress.hosts }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: spurrestd
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.componentLabels" (dict "ctx" . "component" "restd") | nindent 4 }}
+  {{- with .Values.restd.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.restd.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.restd.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.restd.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: spurrestd
+                port:
+                  number: {{ $.Values.restd.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/spur/templates/serviceaccount.yaml
+++ b/deploy/helm/spur/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spur.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spur.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/spur/values.yaml
+++ b/deploy/helm/spur/values.yaml
@@ -1,0 +1,223 @@
+# Default values for Spur.
+#
+# This file is the contract between the chart and its users. Override any value
+# with `--set` or `-f values-overrides.yaml`. Re-running `helm upgrade` after
+# changing values is safe; Helm will diff and reconcile.
+
+# -- Cluster name written into spur.conf
+clusterName: spur-k8s
+
+# Container image shared by all daemons (spurctld / spurd / spurrestd / spurdbd /
+# operator are produced by the same multi-call binary build).
+image:
+  repository: ghcr.io/rocm/spur
+  tag: ""                 # defaults to .Chart.AppVersion when empty
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+# Common labels applied to every object the chart creates.
+commonLabels: {}
+commonAnnotations: {}
+
+# Namespace handling. By default the chart assumes the release namespace
+# already exists (Helm 3 won't create it without --create-namespace). Setting
+# this to true makes the chart render an explicit Namespace object.
+createNamespace: false
+
+# ServiceAccount used by all workloads (operator needs cluster RBAC).
+serviceAccount:
+  create: true
+  name: ""                # default: "<release>-spur"
+  annotations: {}
+
+# RBAC for the operator (ClusterRole / ClusterRoleBinding). Disable in
+# environments where cluster-scoped RBAC is provisioned out-of-band.
+rbac:
+  create: true
+
+# SpurJob CRD lifecycle. The CRD itself lives under crds/ so Helm installs it
+# on first install. Set install=false if you manage CRDs externally (e.g. ArgoCD
+# pre-sync hook). Helm never removes CRDs on uninstall — that's intentional to
+# avoid wiping user CRs.
+crds:
+  install: true
+
+# -----------------------------------------------------------------------------
+# Controller (spurctld) — Raft consensus, scheduler, job dispatch.
+# -----------------------------------------------------------------------------
+controller:
+  enabled: true
+  replicaCount: 3         # set to 1 for single-node dev clusters
+  image:
+    repository: ""        # falls back to .Values.image.repository
+    tag: ""
+    pullPolicy: ""
+  podManagementPolicy: Parallel
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  podLabels: {}
+  podAnnotations: {}
+  persistence:
+    enabled: true
+    storageClass: ""      # "" → cluster default; "-" → disable dynamic provisioning
+    size: 1Gi
+    accessModes: [ReadWriteOnce]
+  service:
+    grpcPort: 6817
+    raftPort: 6821
+  pdb:
+    enabled: true
+    maxUnavailable: 1
+  probes:
+    readiness:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    liveness:
+      initialDelaySeconds: 15
+      periodSeconds: 20
+
+# -----------------------------------------------------------------------------
+# Node agent (spurd) — DaemonSet on every compute node.
+# -----------------------------------------------------------------------------
+agent:
+  enabled: true
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: ""
+  # The DaemonSet only schedules on nodes carrying this label; flip to an empty
+  # map to deploy fleet-wide.
+  nodeSelector:
+    spur.amd.com/compute: "true"
+  tolerations:
+    - key: spur.amd.com/gpu-node
+      operator: Exists
+      effect: NoSchedule
+  affinity: {}
+  hostNetwork: false
+  hostPID: true
+  privileged: true
+  resources: {}
+  podLabels: {}
+  podAnnotations: {}
+  service:
+    grpcPort: 6816
+  # ROCm GPU device exposure. Disable for CPU-only test clusters.
+  gpu:
+    rocm: true            # mounts /dev/kfd and /dev/dri
+  spool:
+    hostPath: /var/spool/spur
+  extraEnv:
+    - name: GPU_ENABLE_PAL
+      value: "0"
+    - name: HSA_ENABLE_SDMA
+      value: "1"
+  probes:
+    readiness:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+
+# -----------------------------------------------------------------------------
+# REST API daemon (spurrestd) — Slurm-compatible HTTP API.
+# -----------------------------------------------------------------------------
+restd:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: ""
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  podLabels: {}
+  podAnnotations: {}
+  service:
+    type: ClusterIP
+    port: 6820
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []             # example: [{ host: spur.example.com, paths: [{ path: /, pathType: Prefix }] }]
+    tls: []
+
+# -----------------------------------------------------------------------------
+# Accounting daemon (spurdbd) — gRPC in front of PostgreSQL.
+# -----------------------------------------------------------------------------
+accounting:
+  enabled: true
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: ""
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  service:
+    port: 6819
+  # External Postgres takes priority over the embedded dev sidecar.
+  # When externalDatabase.url is set, the sidecar is NOT deployed.
+  externalDatabase:
+    url: ""               # e.g. postgresql://user:pass@db.svc:5432/spur
+    existingSecret: ""    # secret containing key "url" with the connection string
+  embeddedPostgres:
+    enabled: true         # dev-mode sidecar; NOT for production
+    image: postgres:16
+    user: spur
+    password: spur
+    database: spur
+    storage:
+      enabled: false      # true → PVC; false → emptyDir (data lost on restart)
+      storageClass: ""
+      size: 8Gi
+
+# -----------------------------------------------------------------------------
+# Kubernetes operator — reconciles SpurJob CRs into pods.
+# -----------------------------------------------------------------------------
+operator:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: ""
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  podLabels: {}
+  podAnnotations: {}
+  service:
+    grpcPort: 6818
+    healthPort: 8080
+  probes:
+    readiness:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+    liveness:
+      initialDelaySeconds: 15
+      periodSeconds: 20
+
+# -----------------------------------------------------------------------------
+# spur.conf contents. Keep these in sync with the controller deployment.
+# -----------------------------------------------------------------------------
+config:
+  scheduler:
+    intervalSecs: 2
+    maxJobsPerCycle: 100
+    plugin: backfill
+  partitions:
+    - name: default
+      state: UP
+      default: true
+      nodes: ALL
+      maxTime: "7d"
+      defaultTime: "1h"
+  # Free-form extra TOML appended verbatim to spur.conf. Use this for any field
+  # not modeled above without forking the chart.
+  extraToml: ""


### PR DESCRIPTION
Closes #255

## Summary

- New Helm chart at `deploy/helm/spur/` packaging spurctld (HA StatefulSet), spurd (DaemonSet), spurrestd, spurdbd, and the operator into a single `helm install`.
- `SpurJob` CRD lives under `crds/` so Helm installs it on first install and leaves it alone on upgrade/uninstall (avoids wiping user CRs).
- CI workflow (`.github/workflows/helm.yml`) runs `helm lint` + `helm template` across four scenarios (defaults / single-node dev / external DB / ingress) and validates the rendered output with `kubeconform --strict` against k8s 1.29.

## What the chart covers

| Component | Kind | Notes |
|---|---|---|
| `spurctld` | StatefulSet + headless Service + PDB | Raft peer list in `spur.conf` is generated from `controller.replicaCount` |
| `spurd` | DaemonSet | ROCm `/dev/kfd` + `/dev/dri` mounts toggleable via `agent.gpu.rocm` |
| `spurrestd` | Deployment + Service + optional Ingress | |
| `spurdbd` | Deployment | External Postgres via secret or dev-mode embedded sidecar |
| `spur-k8s-operator` | Deployment + ClusterRole/Binding | Reconciles `SpurJob` CRs |
| `SpurJob` CRD | `crds/spurjob-crd.yaml` | Helm never removes (by design) |

Templates mirror `examples/k8s/` 1:1 so the raw manifests remain a useful customization reference. `config.extraToml` escape hatch lets users append arbitrary `spur.conf` fields without forking the chart. Config changes roll the controller via `checksum/config` annotation. Post-install `NOTES.txt` prints the connect commands plus actionable `helm upgrade --reuse-values` remediation snippets when dev-mode defaults are in use (embedded postgres without PVC, controller `emptyDir`).

## Test plan

- [x] `helm lint deploy/helm/spur` passes
- [x] `helm template` renders cleanly for: defaults (3-replica Raft HA), single-node dev (1 replica, no PVC, no GPU, no operator), external Postgres via secret, REST API ingress
- [x] CI job runs all four scenarios + kubeconform-validates against k8s 1.29
- [x] Verified Raft peer list generation: `replicaCount=1` → 1 peer, `replicaCount=3` → 3 peers in `spur.conf`
- [ ] End-to-end install against a real cluster — blocked on `ghcr.io/rocm/spur` image not being published yet (today the default `image.repository` is a placeholder; users override with `--set image.repository=...`)

## Out of scope (follow-ups)

- Publishing the chart to a public registry (separate workflow change once the image is published)
- Updating `docs/deployment/kubernetes.rst` to add a Helm section alongside the existing raw-manifest walkthrough
- `helm package` + push to OCI as part of `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)