### PR TITLE
feat(spurd): survive agent restart without interrupting running jobs

### DIFF
--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -66,6 +66,11 @@ impl NodeAllocation {
         }
     }
 
+    /// Whether any job is mid-launch (reserved, not yet committed to `running`).
+    pub fn has_launching(&self) -> bool {
+        !self.launching.is_empty()
+    }
+
     /// Available (unallocated) CPU count.
     pub fn free_cpus(&self) -> u32 {
         self.allocated_cpus.iter().filter(|&&a| !a).count() as u32
@@ -184,7 +189,7 @@ impl NodeAllocation {
             }
         }
 
-        self.allocated_memory_mb += memory_mb;
+        self.allocated_memory_mb = self.allocated_memory_mb.saturating_add(memory_mb);
         for &idx in &gpu_indices {
             self.gpu_allocated[idx] = true;
         }
@@ -206,6 +211,49 @@ impl NodeAllocation {
     pub fn commit_job(&mut self, job_id: u32) -> bool {
         self.launching.remove(&job_id);
         self.owners.contains_key(&job_id)
+    }
+
+    /// Re-adopt an already-committed allocation (e.g. after an agent restart),
+    /// pinning the exact ids rather than re-picking via first-fit. Idempotent:
+    /// a second call for the same job_id is a no-op, so a duplicate manifest
+    /// can't double-count memory (the cpu/gpu bitmaps are naturally
+    /// idempotent, but the memory counter isn't).
+    ///
+    /// GPUs are validated all-or-nothing before any mutation: a manifest naming
+    /// a device already held by another job is rejected with `GpusUnavailable`
+    /// so the caller can refuse the adoption rather than double-book the device
+    /// (releasing one owner would then free a GPU the other still holds).
+    pub fn restore_committed(
+        &mut self,
+        job_id: u32,
+        alloc: AllocationResult,
+    ) -> Result<(), AllocError> {
+        if self.owners.contains_key(&job_id) {
+            return Ok(());
+        }
+        let mut gpu_indices = Vec::with_capacity(alloc.gpu_ids.len());
+        for &device_id in &alloc.gpu_ids {
+            let idx = self
+                .gpus
+                .iter()
+                .position(|g| g.device_id == device_id)
+                .ok_or(AllocError::GpusUnavailable)?;
+            if self.gpu_allocated[idx] || gpu_indices.contains(&idx) {
+                return Err(AllocError::GpusUnavailable);
+            }
+            gpu_indices.push(idx);
+        }
+        for &cpu in &alloc.cpu_ids {
+            if let Some(a) = self.allocated_cpus.get_mut(cpu as usize) {
+                *a = true;
+            }
+        }
+        self.allocated_memory_mb = self.allocated_memory_mb.saturating_add(alloc.memory_mb);
+        for idx in gpu_indices {
+            self.gpu_allocated[idx] = true;
+        }
+        self.owners.insert(job_id, alloc);
+        Ok(())
     }
 
     /// Release a job's allocation by id. Idempotent: releasing an unknown or
@@ -554,6 +602,130 @@ mod tests {
             1,
             "reclaimed GPU stays free after the no-op commit"
         );
+    }
+
+    #[test]
+    fn test_restore_committed_pins_exact_ids_not_first_fit() {
+        let mut node = make_node_with_ids(4, 8_000, vec![0, 1], "mi300x");
+        // Simulate a spurd restart: nothing allocated yet in this fresh
+        // NodeAllocation, but a manifested job actually holds cpu 3 and gpu 1
+        // (not the first-fit picks allocate_for_job would make).
+        let alloc = AllocationResult {
+            cpu_ids: vec![3],
+            gpu_ids: vec![1],
+            memory_mb: 2_000,
+        };
+        node.restore_committed(42, alloc.clone()).unwrap();
+
+        assert_eq!(node.free_cpus(), 3);
+        assert_eq!(node.free_gpus(None), 1);
+        assert_eq!(node.free_memory_mb(), 6_000);
+        assert_eq!(node.allocated_gpu_ids(), vec![1]);
+
+        // A subsequent allocation must not double-book cpu 3 / gpu 1.
+        let next = node.allocate_for_job(43, 1, 0, &[0]).unwrap();
+        assert_eq!(next.cpu_ids, vec![0]);
+        assert!(!next.cpu_ids.contains(&3));
+
+        // Committed (not launching), so reconcile treats it like any other
+        // live job rather than sparing it as mid-launch.
+        let live: HashSet<u32> = [42, 43].into_iter().collect();
+        assert!(node
+            .reconcile(&live, Instant::now(), Duration::from_secs(120))
+            .is_empty());
+        assert!(node.release_job(42));
+        assert_eq!(node.free_memory_mb(), 8_000);
+    }
+
+    #[test]
+    fn test_has_launching_tracks_in_flight_launch() {
+        let mut node = make_node_with_ids(4, 8_000, vec![0], "mi300x");
+        assert!(!node.has_launching());
+        node.allocate_for_job(1, 1, 0, &[0]).unwrap();
+        assert!(
+            node.has_launching(),
+            "reserved-but-not-committed job is launching"
+        );
+        node.commit_job(1);
+        assert!(
+            !node.has_launching(),
+            "committed job is no longer launching"
+        );
+    }
+
+    #[test]
+    fn test_restore_committed_memory_saturates_on_overflow() {
+        // A corrupt/tampered manifest with a huge memory_mb must not wrap the
+        // accounting counter (which would silently corrupt free-memory math).
+        let mut node = make_node_with_ids(4, 8_000, vec![0], "mi300x");
+        node.restore_committed(
+            1,
+            AllocationResult {
+                cpu_ids: vec![],
+                gpu_ids: vec![],
+                memory_mb: u64::MAX,
+            },
+        )
+        .unwrap();
+        node.restore_committed(
+            2,
+            AllocationResult {
+                cpu_ids: vec![],
+                gpu_ids: vec![],
+                memory_mb: u64::MAX,
+            },
+        )
+        .unwrap();
+        // Saturated rather than wrapped; free memory floors at 0.
+        assert_eq!(node.free_memory_mb(), 0);
+    }
+
+    #[test]
+    fn test_restore_committed_rejects_gpu_double_book() {
+        // Two manifests naming the same device: the second adoption must be
+        // rejected, not silently double-book the GPU — otherwise releasing the
+        // first frees a device the second still holds.
+        let mut node = make_node_with_ids(4, 8_000, vec![0, 1], "mi300x");
+        node.restore_committed(
+            1,
+            AllocationResult {
+                cpu_ids: vec![0],
+                gpu_ids: vec![0],
+                memory_mb: 1_000,
+            },
+        )
+        .unwrap();
+        let conflict = node.restore_committed(
+            2,
+            AllocationResult {
+                cpu_ids: vec![1],
+                gpu_ids: vec![0],
+                memory_mb: 1_000,
+            },
+        );
+        assert_eq!(conflict, Err(AllocError::GpusUnavailable));
+        // The rejected adoption left nothing behind: gpu 0 still belongs only to
+        // job 1, and its cpu/memory were not partially applied.
+        assert_eq!(node.allocated_gpu_ids(), vec![0]);
+        assert_eq!(node.free_memory_mb(), 7_000);
+        assert!(!node.release_job(2));
+    }
+
+    #[test]
+    fn test_restore_committed_rejects_unknown_gpu() {
+        // A manifest naming a device this node doesn't have is rejected rather
+        // than silently dropped, so the caller can refuse the adoption.
+        let mut node = make_node_with_ids(4, 8_000, vec![0], "mi300x");
+        let bad = node.restore_committed(
+            1,
+            AllocationResult {
+                cpu_ids: vec![0],
+                gpu_ids: vec![99],
+                memory_mb: 1_000,
+            },
+        );
+        assert_eq!(bad, Err(AllocError::GpusUnavailable));
+        assert_eq!(node.free_memory_mb(), 8_000);
     }
 
     #[test]

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -22,6 +22,11 @@ pub enum AllocError {
     /// still mid-launch, not yet committed or released). A second concurrent
     /// launch would double-count resources, so it is rejected.
     DuplicateJob,
+    /// A CPU named by a restored allocation is unknown to this node, already
+    /// held by another job, or repeated within the same allocation.
+    CpusUnavailable,
+    /// A restored allocation's memory would exceed the node's total.
+    MemoryUnavailable,
 }
 
 /// Per-node resource allocation state.
@@ -223,6 +228,11 @@ impl NodeAllocation {
     /// a device already held by another job is rejected with `GpusUnavailable`
     /// so the caller can refuse the adoption rather than double-book the device
     /// (releasing one owner would then free a GPU the other still holds).
+    /// Re-charge an allocation recovered from a durable record. Validates CPUs,
+    /// memory and GPUs before mutating anything, so a record that conflicts with
+    /// what this node already holds is refused outright rather than partially
+    /// applied — a partial restore is precisely the double-book this exists to
+    /// prevent.
     pub fn restore_committed(
         &mut self,
         job_id: u32,
@@ -243,12 +253,24 @@ impl NodeAllocation {
             }
             gpu_indices.push(idx);
         }
+        let mut cpu_indices = Vec::with_capacity(alloc.cpu_ids.len());
         for &cpu in &alloc.cpu_ids {
-            if let Some(a) = self.allocated_cpus.get_mut(cpu as usize) {
-                *a = true;
+            let idx = cpu as usize;
+            match self.allocated_cpus.get(idx) {
+                Some(false) if !cpu_indices.contains(&idx) => cpu_indices.push(idx),
+                _ => return Err(AllocError::CpusUnavailable),
             }
         }
-        self.allocated_memory_mb = self.allocated_memory_mb.saturating_add(alloc.memory_mb);
+        if self.allocated_memory_mb.saturating_add(alloc.memory_mb) > self.total_memory_mb {
+            return Err(AllocError::MemoryUnavailable);
+        }
+
+        // Every check has passed, so the mutations below cannot leave the
+        // bitmaps disagreeing with `owners`.
+        for idx in cpu_indices {
+            self.allocated_cpus[idx] = true;
+        }
+        self.allocated_memory_mb += alloc.memory_mb;
         for idx in gpu_indices {
             self.gpu_allocated[idx] = true;
         }
@@ -654,30 +676,74 @@ mod tests {
     }
 
     #[test]
-    fn test_restore_committed_memory_saturates_on_overflow() {
-        // A corrupt/tampered manifest with a huge memory_mb must not wrap the
-        // accounting counter (which would silently corrupt free-memory math).
+    fn test_restore_committed_rejects_memory_beyond_node_total() {
+        // A corrupt or tampered record claiming more memory than the node has
+        // must be refused, not absorbed. Accepting it would leave the node
+        // advertising zero free memory forever with no owner to release it.
         let mut node = make_node_with_ids(4, 8_000, vec![0], "mi300x");
-        node.restore_committed(
+        let bad = node.restore_committed(
             1,
             AllocationResult {
                 cpu_ids: vec![],
                 gpu_ids: vec![],
                 memory_mb: u64::MAX,
             },
-        )
-        .unwrap();
+        );
+        assert_eq!(bad, Err(AllocError::MemoryUnavailable));
+        assert_eq!(node.free_memory_mb(), 8_000);
+        assert!(!node.owners.contains_key(&1));
+    }
+
+    #[test]
+    fn test_restore_committed_rejects_cpu_double_book() {
+        // Two records claiming the same cores is the CPU-side equivalent of the
+        // GPU double-book below, and was previously accepted silently.
+        let mut node = make_node_with_ids(4, 8_000, vec![0], "mi300x");
         node.restore_committed(
-            2,
+            1,
             AllocationResult {
-                cpu_ids: vec![],
+                cpu_ids: vec![0, 1],
                 gpu_ids: vec![],
-                memory_mb: u64::MAX,
+                memory_mb: 1_000,
             },
         )
         .unwrap();
-        // Saturated rather than wrapped; free memory floors at 0.
-        assert_eq!(node.free_memory_mb(), 0);
+        let conflict = node.restore_committed(
+            2,
+            AllocationResult {
+                cpu_ids: vec![1, 2],
+                gpu_ids: vec![],
+                memory_mb: 1_000,
+            },
+        );
+        assert_eq!(conflict, Err(AllocError::CpusUnavailable));
+        // Rejected cleanly: core 2 was not charged on the way out.
+        assert!(!node.allocated_cpus[2]);
+        assert!(!node.owners.contains_key(&2));
+    }
+
+    #[test]
+    fn test_restore_committed_rejects_unknown_and_repeated_cpu() {
+        let mut node = make_node_with_ids(4, 8_000, vec![0], "mi300x");
+        let out_of_range = node.restore_committed(
+            1,
+            AllocationResult {
+                cpu_ids: vec![99],
+                gpu_ids: vec![],
+                memory_mb: 0,
+            },
+        );
+        assert_eq!(out_of_range, Err(AllocError::CpusUnavailable));
+        let repeated = node.restore_committed(
+            2,
+            AllocationResult {
+                cpu_ids: vec![1, 1],
+                gpu_ids: vec![],
+                memory_mb: 0,
+            },
+        );
+        assert_eq!(repeated, Err(AllocError::CpusUnavailable));
+        assert!(!node.allocated_cpus[1]);
     }
 
     #[test]

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -22,7 +22,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::Parser;
-use tracing::info;
+use tracing::{info, warn};
 
 use cluster::ClusterManager;
 use rpc_stats::RpcStatsCollector;
@@ -250,6 +250,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Start node health checker (only on leader).
     let hb_timeout = config.controller.heartbeat_timeout_secs.unwrap_or(90);
+    if hb_timeout < 30 {
+        warn!(
+            hb_timeout,
+            "heartbeat_timeout_secs is below 30s; a graceful spurd restart slower than this \
+             will fail its running jobs — this is now the only safety net for a restart, \
+             not just crash detection"
+        );
+    }
     let health_cluster = cluster.clone();
     let health_raft = raft_handle.clone();
     tokio::spawn(async move {

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -26,7 +26,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::Parser;
-use tracing::info;
+use tracing::{info, warn};
 
 use cluster::ClusterManager;
 use rpc_stats::RpcStatsCollector;
@@ -279,6 +279,14 @@ async fn main() -> anyhow::Result<()> {
     // Start node health checker (only on leader).
     const HEALTH_TICK_SECS: u64 = 30;
     let hb_timeout = config.controller.heartbeat_timeout_secs.unwrap_or(90);
+    if hb_timeout < 30 {
+        warn!(
+            hb_timeout,
+            "heartbeat_timeout_secs is below 30s; a graceful spurd restart slower than this \
+             will fail its running jobs — this is now the only safety net for a restart, \
+             not just crash detection"
+        );
+    }
     let health_cluster = cluster.clone();
     let health_raft = raft_handle.clone();
     tokio::spawn(async move {

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -262,13 +262,12 @@ impl RunningJobsHandle {
     /// Deregistering lets the controller reclaim them, matching the pre-manifest
     /// behavior of an unconditional deregister.
     pub async fn has_no_active_jobs(&self) -> bool {
-        if self
-            .running
-            .lock()
-            .await
-            .values()
-            .any(|t| !t.job.is_allocation_only())
-        {
+        // Hold `running` across both checks. Releasing it between them would
+        // reopen the very window this closes: a launch could insert into
+        // `running` after the first check and drop its `launching` reservation
+        // before the second. Lock order is running -> allocation, as elsewhere.
+        let running = self.running.lock().await;
+        if running.values().any(|t| !t.job.is_allocation_only()) {
             return false;
         }
         !self.allocation.lock().await.has_launching()
@@ -500,8 +499,7 @@ impl AgentService {
 
         if manifest.pending.all_discharged() {
             executor::cleanup_job_spool(job_id, manifest.run_attempt);
-            cleanup_completed_job_mpi(job_id, &manifest.mpi, &self.pmi_servers, &self.mpi_host)
-                .await;
+            cleanup_completed_job_mpi(job_id, &manifest.mpi, &self.mpi_host).await;
         }
     }
 
@@ -533,9 +531,8 @@ impl AgentService {
                         error!(job_id, error = ?e, "refusing to adopt job with conflicting resources");
                         continue;
                     }
-                    // Forked jobs ran under container namespaces; a PTY master fd can't survive restart.
-                    let is_root = nix::unistd::geteuid().is_root();
-                    let is_container = manifest.forked;
+                    // A PTY master fd can't survive a restart, so an adopted job
+                    // never has one.
                     self.running.lock().await.insert(
                         job_id,
                         TrackedJob {
@@ -543,9 +540,9 @@ impl AgentService {
                             rootfs_mode: manifest.rootfs_mode,
                             stdout_path: manifest.stdout_path,
                             stderr_path: manifest.stderr_path,
-                            has_pid_namespace: is_root || is_container,
-                            has_user_namespace: is_container && !is_root,
-                            has_mount_namespace: is_root || is_container,
+                            has_pid_namespace: manifest.has_pid_namespace,
+                            has_user_namespace: manifest.has_user_namespace,
+                            has_mount_namespace: manifest.has_mount_namespace,
                             _pty_master: None,
                             work_dir: manifest.work_dir,
                             uid: manifest.uid,
@@ -1783,40 +1780,60 @@ impl SlurmAgent for AgentService {
                 // restart can re-adopt it (see reconcile_running_jobs) instead
                 // of losing track of a job whose process survives the restart.
                 if let Some(pid) = result.job.pid() {
+                    // Captured here, at launch, so the manifest records the
+                    // namespace layout this job actually got rather than what a
+                    // future agent would infer from its own privilege.
+                    let launch_is_root = nix::unistd::geteuid().is_root();
+                    let launch_is_container = launch_cfg.container.is_some();
                     let sentinel = container_exit_status_path.clone().unwrap_or_else(|| {
                         executor::exit_status_path(&result.spool_dir)
                             .to_string_lossy()
                             .into_owned()
                     });
-                    executor::write_job_manifest(
-                        &result.spool_dir,
-                        &executor::JobManifest {
-                            schema_version: 1,
+                    // No start time means no defence against PID reuse, and a
+                    // placeholder would be worse than nothing: `proc_alive`
+                    // compares for equality, so a live process can never match
+                    // it and the next startup would report a still-running job
+                    // as finished. Skip the manifest instead.
+                    match executor::proc_start_time(pid as i32) {
+                        None => warn!(
                             job_id,
-                            run_attempt,
-                            pid: pid as i32,
-                            start_time: executor::proc_start_time(pid as i32).unwrap_or(0),
-                            cgroup_path: result.job.cgroup_path().map(|p| p.to_path_buf()),
-                            forked: matches!(result.job, executor::RunningJob::Forked { .. }),
-                            cpu_ids: launch_cfg.cpu_ids.clone(),
-                            gpu_devices: launch_cfg.gpu_devices.clone(),
-                            cpus: launch_cfg.cpus,
-                            memory_mb: launch_cfg.memory_mb,
-                            uid: launch_cfg.uid,
-                            gid: launch_cfg.gid,
-                            user: launch_cfg.user.clone(),
-                            stdout_path: result.stdout_path.clone(),
-                            stderr_path: result.stderr_path.clone(),
-                            work_dir: launch_cfg.work_dir.clone(),
-                            partition: launch_cfg.partition.clone(),
-                            nodelist: launch_cfg.nodelist.clone(),
-                            mpi: spec.mpi.clone(),
-                            rootfs_mode: rootfs_mode.clone(),
-                            exit_status_path: Some(sentinel),
-                            pending: executor::PendingObligations::default(),
-                            exit: None,
-                        },
-                    );
+                            pid,
+                            "could not read process start time; job will not survive a restart"
+                        ),
+                        Some(start_time) => executor::write_job_manifest(
+                            &result.spool_dir,
+                            &executor::JobManifest {
+                                schema_version: executor::MANIFEST_SCHEMA_VERSION,
+                                job_id,
+                                run_attempt,
+                                pid: pid as i32,
+                                start_time,
+                                cgroup_path: result.job.cgroup_path().map(|p| p.to_path_buf()),
+                                forked: matches!(result.job, executor::RunningJob::Forked { .. }),
+                                has_pid_namespace: launch_is_root || launch_is_container,
+                                has_user_namespace: launch_is_container && !launch_is_root,
+                                has_mount_namespace: launch_is_root || launch_is_container,
+                                cpu_ids: launch_cfg.cpu_ids.clone(),
+                                gpu_devices: launch_cfg.gpu_devices.clone(),
+                                cpus: launch_cfg.cpus,
+                                memory_mb: launch_cfg.memory_mb,
+                                uid: launch_cfg.uid,
+                                gid: launch_cfg.gid,
+                                user: launch_cfg.user.clone(),
+                                stdout_path: result.stdout_path.clone(),
+                                stderr_path: result.stderr_path.clone(),
+                                work_dir: launch_cfg.work_dir.clone(),
+                                partition: launch_cfg.partition.clone(),
+                                nodelist: launch_cfg.nodelist.clone(),
+                                mpi: spec.mpi.clone(),
+                                rootfs_mode: rootfs_mode.clone(),
+                                exit_status_path: Some(sentinel),
+                                pending: executor::PendingObligations::default(),
+                                exit: None,
+                            },
+                        ),
+                    }
                 }
 
                 let mut jobs = self.running.lock().await;
@@ -2177,6 +2194,15 @@ impl SlurmAgent for AgentService {
                         "job {} already registered on this node",
                         req.job_id
                     )),
+                    // Only reachable from restore_committed, which this path
+                    // never calls; map rather than panic so a future caller
+                    // can't turn a resource conflict into an abort.
+                    AllocError::CpusUnavailable => Status::resource_exhausted(
+                        "controller-allocated CPUs unavailable on this node",
+                    ),
+                    AllocError::MemoryUnavailable => Status::resource_exhausted(
+                        "controller-allocated memory unavailable on this node",
+                    ),
                 })?;
             let _ = alloc.commit_job(req.job_id);
         }
@@ -3061,6 +3087,15 @@ impl AgentService {
                 return Err(Status::already_exists(format!(
                     "job {job_id} already has a launch in flight on this node"
                 )));
+            }
+            // Produced only by restore_committed on the restart-adoption path,
+            // which allocate_for_job never reaches. Reject rather than panic so
+            // a future caller can't turn a resource conflict into an abort.
+            Err(e @ (AllocError::CpusUnavailable | AllocError::MemoryUnavailable)) => {
+                warn!(job_id, error = ?e, "rejecting dispatch: node resources unavailable");
+                return Err(Status::resource_exhausted(
+                    "controller-allocated resources unavailable on this node",
+                ));
             }
         };
 
@@ -5489,6 +5524,9 @@ mod tests {
                 start_time,
                 cgroup_path: None,
                 forked: false,
+                has_pid_namespace: false,
+                has_user_namespace: false,
+                has_mount_namespace: false,
                 cpu_ids: vec![0],
                 gpu_devices: vec![],
                 cpus: 1,
@@ -5563,6 +5601,9 @@ mod tests {
                 start_time: 0,
                 cgroup_path: None,
                 forked: false,
+                has_pid_namespace: false,
+                has_user_namespace: false,
+                has_mount_namespace: false,
                 cpu_ids: vec![],
                 gpu_devices: vec![],
                 cpus: 1,
@@ -5651,6 +5692,9 @@ mod tests {
                 start_time: 0,
                 cgroup_path: None,
                 forked: false,
+                has_pid_namespace: false,
+                has_user_namespace: false,
+                has_mount_namespace: false,
                 cpu_ids: vec![],
                 gpu_devices: vec![],
                 cpus: 1,
@@ -5707,6 +5751,7 @@ mod tests {
             std::collections::HashMap::new(),
             String::new(),
             String::new(),
+            new_running_jobs(),
         ))
     }
 
@@ -5746,6 +5791,9 @@ mod tests {
             start_time: 0,
             cgroup_path: None,
             forked: false,
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
             cpu_ids: vec![],
             gpu_devices: vec![],
             cpus: 1,
@@ -5845,6 +5893,9 @@ mod tests {
             start_time,
             cgroup_path: None,
             forked: false,
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
             cpu_ids,
             gpu_devices: vec![],
             cpus: 1,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -93,6 +93,57 @@ async fn cleanup_completed_job_mpi(
     }
 }
 
+/// The inputs one job's epilog + SPANK teardown hooks need. Built from either a
+/// live `CompletedJob` (monitor path) or an adopted `JobManifest` (restart path)
+/// so both run identical teardown.
+struct CompletionContext {
+    job_id: u32,
+    work_dir: String,
+    uid: u32,
+    gid: u32,
+    partition: String,
+    nodelist: String,
+    gpu_devices: Vec<u32>,
+    cpus: u32,
+    memory_mb: u64,
+}
+
+/// Cloneable handle exposing only whether any jobs are active, for use after
+/// `AgentService` itself has moved into the gRPC server (see main's SIGTERM
+/// handler).
+#[derive(Clone)]
+pub struct RunningJobsHandle {
+    running: Arc<Mutex<HashMap<u32, TrackedJob>>>,
+    allocation: Arc<Mutex<NodeAllocation>>,
+}
+
+impl RunningJobsHandle {
+    /// True when no job with a live process is tracked AND none is mid-launch. A
+    /// job spawned but not yet inserted into `running` still holds a `launching`
+    /// reservation, so checking both closes the window where a SIGTERM would
+    /// deregister (and force-evict) an in-flight launch.
+    ///
+    /// `AllocationOnly` reservations (srun/salloc) are excluded: they have no
+    /// process and are never written to a manifest, so a restarted spurd can't
+    /// re-adopt them. Keeping the node registered on their behalf would strand
+    /// the reservation (the controller still holds the resources while the agent
+    /// forgets them, then first-fits the same ids to the next dispatch).
+    /// Deregistering lets the controller reclaim them, matching the pre-manifest
+    /// behavior of an unconditional deregister.
+    pub async fn has_no_active_jobs(&self) -> bool {
+        if self
+            .running
+            .lock()
+            .await
+            .values()
+            .any(|t| !t.job.is_allocation_only())
+        {
+            return false;
+        }
+        !self.allocation.lock().await.has_launching()
+    }
+}
+
 pub struct AgentService {
     pub reporter: Arc<NodeReporter>,
     /// In-memory only: starts empty on every spurd start/restart, regardless
@@ -210,6 +261,176 @@ impl AgentService {
         self.k0s.clone()
     }
 
+    pub fn running_jobs_handle(&self) -> RunningJobsHandle {
+        RunningJobsHandle {
+            running: self.running.clone(),
+            allocation: self.allocation.clone(),
+        }
+    }
+
+    /// Re-adopt jobs whose process survived a spurd restart, restoring their
+    /// resource allocation before this agent starts accepting new launches.
+    /// Must run before the gRPC server starts serving.
+    pub async fn reconcile_running_jobs(&self) {
+        // Discharge teardown inline so a completion isn't lost, but bounded so an
+        // unreachable controller can't block serving (heartbeat is the backstop).
+        let dead = self.adopt_manifests().await;
+        let discharge_all = async {
+            for (spool_dir, manifest) in dead {
+                self.discharge_obligations(&spool_dir, manifest).await;
+            }
+        };
+        if tokio::time::timeout(RECONCILE_REPORT_BUDGET, discharge_all)
+            .await
+            .is_err()
+        {
+            warn!("obligation discharge during reconcile timed out; continuing to serve");
+        }
+    }
+
+    /// Discharge the still-owed teardown obligations for a job that finished
+    /// while spurd was down, driving the manifest's ledger to empty. Each step
+    /// is skipped if already done (recorded in `manifest.pending`) and the
+    /// manifest is rewritten after each so an interrupted discharge resumes
+    /// rather than repeating a non-idempotent step (notably the epilog). The
+    /// spool/manifest is removed only once everything is discharged; otherwise
+    /// it is left for the next startup to retry — the node is heartbeating, so
+    /// the controller never times the job out on its own.
+    async fn discharge_obligations(
+        &self,
+        spool_dir: &std::path::Path,
+        mut manifest: executor::JobManifest,
+    ) {
+        let job_id = manifest.job_id;
+        let (exit_code, signal) = manifest.exit.unwrap_or((-1, 0));
+
+        if manifest.pending.epilog {
+            let ctx = CompletionContext {
+                job_id,
+                work_dir: manifest.work_dir.clone(),
+                uid: manifest.uid,
+                gid: manifest.gid,
+                partition: manifest.partition.clone(),
+                nodelist: manifest.nodelist.clone(),
+                gpu_devices: manifest.gpu_devices.clone(),
+                cpus: manifest.cpus,
+                memory_mb: manifest.memory_mb,
+            };
+            manifest.pending.drain = run_teardown_hooks(&self.hooks, &self.spank, &ctx).await;
+            manifest.pending.epilog = false;
+            executor::write_job_manifest(spool_dir, &manifest);
+        }
+
+        if manifest.pending.report_completion {
+            let drain = manifest.pending.drain.then(|| DrainRequest {
+                reason: "epilog script failed".into(),
+            });
+            let reported = report_completion(
+                &self.reporter.controller_addr,
+                job_id,
+                exit_code,
+                signal,
+                manifest.run_attempt,
+                &self.reporter.hostname,
+                drain.as_ref(),
+            )
+            .await;
+            if !reported {
+                // Report lost; leave the manifest (epilog already marked done, so
+                // the retry won't re-run it) for the next startup to resend.
+                return;
+            }
+            manifest.pending.report_completion = false;
+        }
+
+        if manifest.pending.all_discharged() {
+            executor::cleanup_job_spool(job_id, manifest.run_attempt);
+            cleanup_completed_job_mpi(job_id, &manifest.mpi, &self.pmi_servers, &self.mpi_host)
+                .await;
+        }
+    }
+
+    /// Scan manifests, re-adopt still-alive jobs into local state, and return
+    /// the dead jobs (spool dir + manifest) whose teardown obligations still
+    /// need discharging. Split from the discharge so it is testable without a
+    /// live controller.
+    async fn adopt_manifests(&self) -> Vec<(std::path::PathBuf, executor::JobManifest)> {
+        let mut dead = Vec::new();
+        for (spool_dir, manifest) in executor::scan_job_manifests() {
+            let job_id = manifest.job_id;
+            match executor::reconcile_manifest(&spool_dir, manifest) {
+                executor::ReconcileOutcome::Alive { job, manifest } => {
+                    let alloc = AllocationResult {
+                        cpu_ids: manifest.cpu_ids.clone(),
+                        gpu_ids: manifest.gpu_devices.clone(),
+                        memory_mb: manifest.memory_mb,
+                    };
+                    if let Err(e) = self
+                        .allocation
+                        .lock()
+                        .await
+                        .restore_committed(job_id, alloc)
+                    {
+                        // A device this manifest claims is already held by an
+                        // adopted job: adopting anyway would double-book it. Leave
+                        // the process running and its manifest in place, and skip
+                        // re-adoption so this node's accounting stays consistent.
+                        error!(job_id, error = ?e, "refusing to adopt job with conflicting resources");
+                        continue;
+                    }
+                    // Forked jobs ran under container namespaces; a PTY master fd can't survive restart.
+                    let is_root = nix::unistd::geteuid().is_root();
+                    let is_container = manifest.forked;
+                    self.running.lock().await.insert(
+                        job_id,
+                        TrackedJob {
+                            job,
+                            rootfs_mode: manifest.rootfs_mode,
+                            stdout_path: manifest.stdout_path,
+                            stderr_path: manifest.stderr_path,
+                            has_pid_namespace: is_root || is_container,
+                            has_user_namespace: is_container && !is_root,
+                            has_mount_namespace: is_root || is_container,
+                            _pty_master: None,
+                            work_dir: manifest.work_dir,
+                            uid: manifest.uid,
+                            gid: manifest.gid,
+                            user: manifest.user,
+                            partition: manifest.partition,
+                            gpu_devices: manifest.gpu_devices,
+                            cpus: manifest.cpus,
+                            memory_mb: manifest.memory_mb,
+                            nodelist: manifest.nodelist,
+                            mpi: manifest.mpi,
+                            run_attempt: manifest.run_attempt,
+                        },
+                    );
+                    info!(job_id, "re-adopted job that survived a spurd restart");
+                }
+                executor::ReconcileOutcome::Dead { manifest } => {
+                    let (exit_code, signal) = manifest.exit.unwrap_or((-1, 0));
+                    warn!(
+                        job_id,
+                        exit_code, signal, "job finished while spurd was down"
+                    );
+                    // The process is gone, so its rootfs and cgroup can be torn
+                    // down now. Persist the manifest with the resolved exit
+                    // recorded, so a report that only lands on a later restart
+                    // stays accurate after the sentinel/rootfs are gone. The
+                    // spool (and manifest) is kept until every obligation is
+                    // discharged (see reconcile_running_jobs).
+                    crate::container::cleanup_rootfs(job_id, &manifest.rootfs_mode);
+                    if let Some(ref cgroup) = manifest.cgroup_path {
+                        executor::cleanup_cgroup(cgroup);
+                    }
+                    executor::write_job_manifest(&spool_dir, &manifest);
+                    dead.push((spool_dir, manifest));
+                }
+            }
+        }
+        dead
+    }
+
     /// Spawn a background task to monitor running jobs and report completions.
     pub fn start_monitor(&self, controller_addr: String) {
         let running = self.running.clone();
@@ -267,7 +488,6 @@ impl AgentService {
                 for c in &completed {
                     jobs.remove(&c.job_id);
                     crate::container::cleanup_rootfs(c.job_id, &c.rootfs_mode);
-                    crate::executor::cleanup_job_spool(c.job_id);
                     if let Some(ref cgroup) = c.cgroup {
                         crate::executor::cleanup_cgroup(cgroup);
                     }
@@ -290,72 +510,48 @@ impl AgentService {
                     .map(|h| h.to_string_lossy().to_string())
                     .unwrap_or_else(|_| "localhost".into());
 
-                let mut drain_jobs: std::collections::HashSet<u32> =
-                    std::collections::HashSet::new();
-
-                // Run epilog hook for completed jobs
-                if let Some(ref epilog_script) = hooks.epilog {
-                    for c in &completed {
-                        let ctx = spur_core::hooks::HookContext {
-                            job_id: c.job_id,
-                            work_dir: c.work_dir.clone(),
-                            uid: c.uid,
-                            gid: c.gid,
-                            partition: c.partition.clone(),
-                            nodelist: c.nodelist.clone(),
-                            script_context: "epilog_slurmd".into(),
-                            gpu_devices: c.gpu_devices.clone(),
-                            cpus: c.cpus,
-                            memory_mb: c.memory_mb,
-                        };
-                        if let Err(e) = spur_core::hooks::run_hook(epilog_script, &ctx).await {
-                            error!(
-                                job_id = c.job_id,
-                                error = %e,
-                                "epilog hook failed — requesting node drain"
-                            );
-                            drain_jobs.insert(c.job_id);
-                        }
-                    }
-                }
-
-                // Invoke SPANK TaskExit and JobEpilog hooks for completed jobs
-                if let Some(ref spank_host) = *spank {
-                    for c in &completed {
-                        let context = SpankContext {
-                            job_id: c.job_id,
-                            uid: c.uid,
-                            gid: c.gid,
-                            ..Default::default()
-                        };
-                        let mut handle = SpankHandle::new(context, HashMap::new());
-                        if let Err(e) = spank_host.invoke_hook(SpankHook::TaskExit, &mut handle) {
-                            warn!(c.job_id, error = %e, "SPANK TaskExit hook failed");
-                        }
-                        if let Err(e) = spank_host.invoke_hook(SpankHook::JobEpilog, &mut handle) {
-                            warn!(c.job_id, error = %e, "SPANK JobEpilog hook failed");
-                        }
-                    }
-                }
-
                 for c in &completed {
-                    let drain = if drain_jobs.contains(&c.job_id) {
-                        Some(DrainRequest {
-                            reason: "epilog script failed".into(),
-                        })
-                    } else {
-                        None
+                    let ctx = CompletionContext {
+                        job_id: c.job_id,
+                        work_dir: c.work_dir.clone(),
+                        uid: c.uid,
+                        gid: c.gid,
+                        partition: c.partition.clone(),
+                        nodelist: c.nodelist.clone(),
+                        gpu_devices: c.gpu_devices.clone(),
+                        cpus: c.cpus,
+                        memory_mb: c.memory_mb,
                     };
-                    report_completion(
+                    let drain = run_teardown_hooks(&hooks, &spank, &ctx).await;
+                    let drain_req = drain.then(|| DrainRequest {
+                        reason: "epilog script failed".into(),
+                    });
+                    let reported = report_completion(
                         &controller_addr,
                         c.job_id,
                         c.exit_code,
                         c.signal,
                         c.run_attempt,
                         &local_hostname,
-                        drain.as_ref(),
+                        drain_req.as_ref(),
                     )
                     .await;
+                    // Keep the spool (and its manifest) until the controller has
+                    // the completion: if the report was lost, a restarted spurd
+                    // re-adopts the manifest and retries rather than stranding the
+                    // job in Running forever. Record that the epilog is already
+                    // done so the restart retries only the report, not the
+                    // (possibly non-idempotent) epilog.
+                    if reported {
+                        crate::executor::cleanup_job_spool(c.job_id, c.run_attempt);
+                    } else {
+                        crate::executor::mark_manifest_epilog_discharged(
+                            c.job_id,
+                            c.run_attempt,
+                            (c.exit_code, c.signal),
+                            drain,
+                        );
+                    }
                 }
             }
         });
@@ -370,6 +566,13 @@ struct DrainRequest {
 /// above a typical image pull + fork so a normal launch is spared; one stalled
 /// past this bound is reclaimed.
 const LAUNCHING_TTL: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// In-container path where a job records its exit code; host-visible in the rootfs.
+const CONTAINER_EXIT_STATUS_PATH: &str = "/tmp/spur_exit_status";
+
+/// Cap on completion reporting during startup reconcile, so an unreachable
+/// controller can't keep spurd from serving.
+const RECONCILE_REPORT_BUDGET: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Reclaim allocations whose job is no longer tracked and is not mid-launch,
 /// using the running set as ground truth. Callers hold the `running` lock
@@ -713,6 +916,62 @@ fn inject_script_args(script: &str, args: &[String]) -> Result<String, Status> {
     Ok(format!("{set_line}\n{script}"))
 }
 
+/// Run the epilog + SPANK TaskExit/JobEpilog teardown hooks for a completed job.
+/// Returns true if the epilog failed and the node should be drained. Shared by
+/// the live monitor and the restart-adoption path so an adopted job gets the
+/// same epilog (GPU reset, scratch purge), SPANK hooks, and epilog-failure drain
+/// as a live one — none of which the adoption path used to run.
+async fn run_teardown_hooks(
+    hooks: &HooksConfig,
+    spank: &Option<SpankHost>,
+    ctx: &CompletionContext,
+) -> bool {
+    let mut drain = false;
+    if let Some(ref epilog_script) = hooks.epilog {
+        let hook_ctx = spur_core::hooks::HookContext {
+            job_id: ctx.job_id,
+            work_dir: ctx.work_dir.clone(),
+            uid: ctx.uid,
+            gid: ctx.gid,
+            partition: ctx.partition.clone(),
+            nodelist: ctx.nodelist.clone(),
+            script_context: "epilog_slurmd".into(),
+            gpu_devices: ctx.gpu_devices.clone(),
+            cpus: ctx.cpus,
+            memory_mb: ctx.memory_mb,
+        };
+        if let Err(e) = spur_core::hooks::run_hook(epilog_script, &hook_ctx).await {
+            error!(
+                job_id = ctx.job_id,
+                error = %e,
+                "epilog hook failed — requesting node drain"
+            );
+            drain = true;
+        }
+    }
+
+    if let Some(spank_host) = spank {
+        let context = SpankContext {
+            job_id: ctx.job_id,
+            uid: ctx.uid,
+            gid: ctx.gid,
+            ..Default::default()
+        };
+        let mut handle = SpankHandle::new(context, HashMap::new());
+        if let Err(e) = spank_host.invoke_hook(SpankHook::TaskExit, &mut handle) {
+            warn!(ctx.job_id, error = %e, "SPANK TaskExit hook failed");
+        }
+        if let Err(e) = spank_host.invoke_hook(SpankHook::JobEpilog, &mut handle) {
+            warn!(ctx.job_id, error = %e, "SPANK JobEpilog hook failed");
+        }
+    }
+    drain
+}
+
+/// Report a job completion to the controller. Returns true only if the
+/// controller acknowledged it, so the caller can keep the job's manifest for a
+/// restart-time retry when the report was lost (transient failure exhausted its
+/// retries, or a non-retryable rejection).
 async fn report_completion(
     controller_addr: &str,
     job_id: u32,
@@ -721,7 +980,7 @@ async fn report_completion(
     run_attempt: u32,
     reporting_node: &str,
     drain: Option<&DrainRequest>,
-) {
+) -> bool {
     // Wire `state` is derived from `exit_code` alone (advisory): a signaled job
     // reports Completed/0 because the controller's validator requires
     // state<->exit_code agreement. The controller rederives the true Failed /
@@ -766,26 +1025,39 @@ async fn report_completion(
     })
     .await;
 
+    // Return whether the controller acknowledged the completion, so the caller
+    // can keep the job's manifest for a restart-time retry when the report was
+    // lost (transient failure exhausted its retries, or a non-retryable
+    // rejection) rather than deleting it and stranding the job in Running.
     match result {
-        Ok(_) => info!(
-            job_id,
-            exit_code,
-            controller = %controller_addr,
-            "reported completion to controller"
-        ),
-        Err(e) if e.retryable() => error!(
-            job_id,
-            exit_code,
-            attempts = CONTROLLER_RPC_ATTEMPTS,
-            error = %e,
-            "gave up reporting completion to controller"
-        ),
-        Err(e) => error!(
-            job_id,
-            exit_code,
-            error = %e,
-            "ReportJobStatus failed with non-retryable error"
-        ),
+        Ok(_) => {
+            info!(
+                job_id,
+                exit_code,
+                controller = %controller_addr,
+                "reported completion to controller"
+            );
+            true
+        }
+        Err(e) if e.retryable() => {
+            error!(
+                job_id,
+                exit_code,
+                attempts = CONTROLLER_RPC_ATTEMPTS,
+                error = %e,
+                "gave up reporting completion to controller"
+            );
+            false
+        }
+        Err(e) => {
+            error!(
+                job_id,
+                exit_code,
+                error = %e,
+                "ReportJobStatus failed with non-retryable error"
+            );
+            false
+        }
     }
 }
 
@@ -1008,6 +1280,7 @@ impl SlurmAgent for AgentService {
         // the Rust container runtime (fork + container_init + pivot_root).
         let mut container_config: Option<crate::container::ContainerConfig> = None;
         let mut rootfs_path: Option<std::path::PathBuf> = None;
+        let mut container_exit_status_path: Option<String> = None;
 
         let (launch_script, rootfs_mode) = if !spec.container_image.is_empty() {
             info!(job_id, image = %spec.container_image, "launching containerized job");
@@ -1069,9 +1342,20 @@ impl SlurmAgent for AgentService {
                 crate::container::setup_rootfs(&image_path, job_id, cfg.name.as_deref())
                     .map_err(|e| Status::internal(format!("container setup failed: {}", e)))?;
 
-            // Copy user script into rootfs/tmp/ so it's accessible after pivot_root
+            // Copy user script into rootfs/tmp/ so it's accessible after pivot_root.
+            // Wrap it to record the exit code at an in-container path, so a
+            // restarted spurd can read the real code back (host-visible in rootfs).
             let container_script = format!("{}/tmp/spur_job_{}.sh", rootfs.display(), job_id);
-            std::fs::write(&container_script, &script).map_err(|e| {
+            let wrapped = executor::wrap_with_exit_sentinel(
+                &script,
+                std::path::Path::new(CONTAINER_EXIT_STATUS_PATH),
+            );
+            container_exit_status_path = Some(format!(
+                "{}{}",
+                rootfs.display(),
+                CONTAINER_EXIT_STATUS_PATH
+            ));
+            std::fs::write(&container_script, &wrapped).map_err(|e| {
                 Status::internal(format!("failed to write container script: {}", e))
             })?;
             #[cfg(unix)]
@@ -1257,6 +1541,7 @@ impl SlurmAgent for AgentService {
 
         let launch_cfg = executor::JobLaunchConfig {
             job_id,
+            run_attempt,
             script: launch_script,
             work_dir: work_dir.clone(),
             name: spec.name.clone(),
@@ -1295,6 +1580,46 @@ impl SlurmAgent for AgentService {
         match executor::launch_job(&launch_cfg, (*self.spank).as_ref()).await {
             Ok(mut result) => {
                 pmix_guard.as_mut().map(PmixLaunchGuard::disarm);
+                // Written before this job is tracked anywhere else, so a spurd
+                // restart can re-adopt it (see reconcile_running_jobs) instead
+                // of losing track of a job whose process survives the restart.
+                if let Some(pid) = result.job.pid() {
+                    let sentinel = container_exit_status_path.clone().unwrap_or_else(|| {
+                        executor::exit_status_path(&result.spool_dir)
+                            .to_string_lossy()
+                            .into_owned()
+                    });
+                    executor::write_job_manifest(
+                        &result.spool_dir,
+                        &executor::JobManifest {
+                            schema_version: 1,
+                            job_id,
+                            run_attempt,
+                            pid: pid as i32,
+                            start_time: executor::proc_start_time(pid as i32).unwrap_or(0),
+                            cgroup_path: result.job.cgroup_path().map(|p| p.to_path_buf()),
+                            forked: matches!(result.job, executor::RunningJob::Forked { .. }),
+                            cpu_ids: launch_cfg.cpu_ids.clone(),
+                            gpu_devices: launch_cfg.gpu_devices.clone(),
+                            cpus: launch_cfg.cpus,
+                            memory_mb: launch_cfg.memory_mb,
+                            uid: launch_cfg.uid,
+                            gid: launch_cfg.gid,
+                            user: launch_cfg.user.clone(),
+                            stdout_path: result.stdout_path.clone(),
+                            stderr_path: result.stderr_path.clone(),
+                            work_dir: launch_cfg.work_dir.clone(),
+                            partition: launch_cfg.partition.clone(),
+                            nodelist: launch_cfg.nodelist.clone(),
+                            mpi: spec.mpi.clone(),
+                            rootfs_mode: rootfs_mode.clone(),
+                            exit_status_path: Some(sentinel),
+                            pending: executor::PendingObligations::default(),
+                            exit: None,
+                        },
+                    );
+                }
+
                 let mut jobs = self.running.lock().await;
                 // Commit the reservation: the job now has a tracked process, so
                 // it is no longer exempt from reconcile. Take the running lock
@@ -1323,15 +1648,11 @@ impl SlurmAgent for AgentService {
                     let running = self.running.clone();
                     tokio::spawn(async move {
                         reap_killed_job(result.job).await;
-                        // rootfs/spool paths are derived from job_id, so the
-                        // controller re-dispatching the same id to this node
-                        // would reuse them. Skip that cleanup if a live run for
-                        // job_id reappeared, or this reap would delete its files.
-                        // The cgroup handle is this launch's own, so it is always
-                        // safe to release.
+                        // Spool/cgroup are attempt-scoped; rootfs is job_id-keyed,
+                        // so skip it if a live run for job_id reappeared.
+                        crate::executor::cleanup_job_spool(job_id, run_attempt);
                         if !running.lock().await.contains_key(&job_id) {
                             crate::container::cleanup_rootfs(job_id, &rootfs_mode);
-                            crate::executor::cleanup_job_spool(job_id);
                         }
                         if let Some(ref cg) = cgroup {
                             crate::executor::cleanup_cgroup(cg);
@@ -2842,6 +3163,32 @@ impl TrackedJob {
             run_attempt: 0,
         }
     }
+
+    /// A tracked srun/salloc reservation with no process, matching what
+    /// `register_job_allocation` inserts.
+    fn dummy_allocation_only() -> Self {
+        Self {
+            job: executor::RunningJob::AllocationOnly,
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
+            _pty_master: None,
+            work_dir: "/tmp".into(),
+            uid: 0,
+            gid: 0,
+            user: String::new(),
+            partition: String::new(),
+            gpu_devices: Vec::new(),
+            cpus: 1,
+            memory_mb: 0,
+            nodelist: String::new(),
+            mpi: String::new(),
+            run_attempt: 0,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -3082,6 +3429,36 @@ mod tests {
             resp.error.contains("No such file or directory"),
             "the cause chain must survive into the reported error, got {:?}",
             resp.error
+        );
+    }
+
+    #[tokio::test]
+    async fn has_no_active_jobs_ignores_allocation_only_reservations() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let handle = svc.running_jobs_handle();
+        assert!(handle.has_no_active_jobs().await, "idle node has no jobs");
+
+        // A reservation with no process must not keep the node registered on
+        // SIGTERM: it isn't persisted to a manifest, so it can't be re-adopted,
+        // and holding the node would strand it (double-book on next dispatch).
+        svc.insert_test_job(1, TrackedJob::dummy_allocation_only())
+            .await;
+        assert!(
+            handle.has_no_active_jobs().await,
+            "reservation-only node deregisters so the controller reclaims it"
+        );
+
+        // A real running process, by contrast, must keep the node registered so
+        // a restart can re-adopt it.
+        svc.insert_test_job(2, TrackedJob::dummy(0)).await;
+        assert!(
+            !handle.has_no_active_jobs().await,
+            "a live job keeps the node registered"
         );
     }
 
@@ -4300,6 +4677,456 @@ mod tests {
             0,
             "a disarmed guard must leave the committed reservation intact"
         );
+    }
+
+    // Simulates a spurd restart: a job manifest on disk for a still-running
+    // process must be re-adopted into `running` with its allocation restored,
+    // before this agent would start accepting new LaunchJob calls.
+    #[tokio::test]
+    async fn reconcile_running_jobs_resumes_live_job_and_restores_allocation() {
+        // Serialize against other tests that scan the shared spool-root
+        // manifest tree — see MANIFEST_SCAN_TEST_LOCK.
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.lock().await;
+        let job_id = 987_654_326;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = std::env::temp_dir()
+            .join("spur")
+            .join(format!("job{job_id}_1"));
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        let mut child = std::process::Command::new("sleep")
+            .arg("2")
+            .spawn()
+            .unwrap();
+        let pid = child.id() as i32;
+        let start_time = executor::proc_start_time(pid).unwrap();
+
+        executor::write_job_manifest(
+            &spool_dir,
+            &executor::JobManifest {
+                schema_version: 1,
+                job_id,
+                run_attempt: 3,
+                pid,
+                start_time,
+                cgroup_path: None,
+                forked: false,
+                cpu_ids: vec![0],
+                gpu_devices: vec![],
+                cpus: 1,
+                memory_mb: 512,
+                uid,
+                gid,
+                user: String::new(),
+                stdout_path: "/dev/null".into(),
+                stderr_path: "/dev/null".into(),
+                work_dir: "/tmp".into(),
+                partition: "default".into(),
+                nodelist: "test-node".into(),
+                mpi: String::new(),
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                exit_status_path: None,
+                pending: executor::PendingObligations::default(),
+                exit: None,
+            },
+        );
+
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let free_cpus_before = svc.allocation.lock().await.free_cpus();
+
+        svc.reconcile_running_jobs().await;
+
+        assert!(
+            svc.running.lock().await.contains_key(&job_id),
+            "resumed job must be tracked in `running`"
+        );
+        assert_eq!(
+            svc.allocation.lock().await.free_cpus(),
+            free_cpus_before - 1,
+            "resumed job's cpu must be reflected in NodeAllocation before new launches are admitted"
+        );
+
+        child.kill().unwrap();
+        let _ = child.wait();
+        executor::cleanup_job_spool(job_id, 1);
+    }
+
+    // A job that finished entirely while spurd was restarting must still be
+    // reported to the controller — it must not be left "Running" forever.
+    #[tokio::test]
+    async fn reconcile_running_jobs_reports_completion_for_job_finished_while_down() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.lock().await;
+        let job_id = 987_654_327;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = std::env::temp_dir()
+            .join("spur")
+            .join(format!("job{job_id}_1"));
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id() as i32;
+        child.wait().unwrap();
+        std::fs::write(spool_dir.join("exit_status"), "5\n").unwrap();
+
+        executor::write_job_manifest(
+            &spool_dir,
+            &executor::JobManifest {
+                schema_version: 1,
+                job_id,
+                run_attempt: 1,
+                pid,
+                start_time: 0,
+                cgroup_path: None,
+                forked: false,
+                cpu_ids: vec![],
+                gpu_devices: vec![],
+                cpus: 1,
+                memory_mb: 0,
+                uid,
+                gid,
+                user: String::new(),
+                stdout_path: String::new(),
+                stderr_path: String::new(),
+                work_dir: "/tmp".into(),
+                partition: "default".into(),
+                nodelist: "test-node".into(),
+                mpi: String::new(),
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                exit_status_path: None,
+                pending: executor::PendingObligations::default(),
+                exit: None,
+            },
+        );
+
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        // adopt_manifests returns the dead jobs' (spool, manifest); the
+        // obligation discharge (report) is separate and needs no controller here.
+        let dead = svc.adopt_manifests().await;
+
+        // Filter to this test's id: scan reads the shared spool root, so a
+        // manifest a concurrent launch test left behind must not fail this.
+        let mine: Vec<&(std::path::PathBuf, executor::JobManifest)> =
+            dead.iter().filter(|(_, m)| m.job_id == job_id).collect();
+        assert_eq!(mine.len(), 1, "the finished job yields one completion");
+        let manifest = &mine[0].1;
+        assert_eq!(manifest.job_id, job_id);
+        assert_eq!(
+            (manifest.exit, manifest.run_attempt),
+            (Some((5, 0)), 1),
+            "a job finished while down must record its real exit code to report"
+        );
+        assert!(
+            manifest.pending.epilog && manifest.pending.report_completion,
+            "adopt_manifests records obligations but discharges none itself"
+        );
+        assert!(
+            !svc.running.lock().await.contains_key(&job_id),
+            "a job that already finished must not be tracked as running"
+        );
+        // The spool (and manifest) is kept until obligations are discharged, so
+        // a lost report can be retried on the next restart. adopt_manifests does
+        // not report, so the spool must still be present here.
+        assert!(spool_dir.exists());
+        executor::cleanup_job_spool(job_id, 1);
+    }
+
+    // If the completion report can't reach the controller, the spool (and its
+    // manifest) must survive so the next spurd startup re-adopts it and retries —
+    // otherwise the job is stranded in Running (the node heartbeats, so the
+    // controller never times it out).
+    #[tokio::test]
+    async fn reconcile_keeps_spool_when_completion_report_fails() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.lock().await;
+        let job_id = 987_654_328;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = std::env::temp_dir()
+            .join("spur")
+            .join(format!("job{job_id}_1"));
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id() as i32;
+        child.wait().unwrap();
+        std::fs::write(spool_dir.join("exit_status"), "0\n").unwrap();
+
+        executor::write_job_manifest(
+            &spool_dir,
+            &executor::JobManifest {
+                schema_version: 1,
+                job_id,
+                run_attempt: 1,
+                pid,
+                start_time: 0,
+                cgroup_path: None,
+                forked: false,
+                cpu_ids: vec![],
+                gpu_devices: vec![],
+                cpus: 1,
+                memory_mb: 0,
+                uid,
+                gid,
+                user: String::new(),
+                stdout_path: String::new(),
+                stderr_path: String::new(),
+                work_dir: "/tmp".into(),
+                partition: "default".into(),
+                nodelist: "test-node".into(),
+                mpi: String::new(),
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                exit_status_path: None,
+                pending: executor::PendingObligations::default(),
+                exit: None,
+            },
+        );
+
+        // Controller address that refuses connections, so every report attempt
+        // fails and the completion report returns false.
+        let svc = AgentService::new(
+            dead_controller_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        svc.reconcile_running_jobs().await;
+
+        assert!(
+            spool_dir.exists() && spool_dir.join("manifest.json").exists(),
+            "an unreported completion keeps its spool + manifest for a restart retry"
+        );
+        executor::cleanup_job_spool(job_id, 1);
+    }
+
+    fn dead_controller_reporter() -> Arc<NodeReporter> {
+        Arc::new(NodeReporter::new(
+            "test-node".into(),
+            "http://127.0.0.1:1".into(),
+            ResourceSet {
+                cpus: 4,
+                memory_mb: 8192,
+                ..Default::default()
+            },
+            spur_net::NodeAddress {
+                ip: "127.0.0.1".into(),
+                hostname: "test-node".into(),
+                port: 6818,
+                source: spur_net::AddressSource::Static,
+            },
+            std::collections::HashMap::new(),
+            String::new(),
+            String::new(),
+        ))
+    }
+
+    // The obligation ledger's core guarantee: when the completion report keeps
+    // failing, the epilog must run exactly ONCE across repeated restart-retries,
+    // not once per retry — the manifest records epilog-discharged before the
+    // report is attempted, so a retry resumes at the still-owed report only.
+    #[tokio::test]
+    async fn discharge_runs_epilog_once_across_report_retries() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.lock().await;
+        let job_id = 987_654_329;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = std::env::temp_dir()
+            .join("spur")
+            .join(format!("job{job_id}_1"));
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        // Epilog appends a line each time it runs; counting lines counts runs.
+        let epilog_marker = std::env::temp_dir().join(format!("spur_epilog_ran_{job_id}"));
+        let _ = std::fs::remove_file(&epilog_marker);
+        let epilog_script = std::env::temp_dir().join(format!("spur_epilog_{job_id}.sh"));
+        std::fs::write(
+            &epilog_script,
+            format!("#!/bin/bash\necho ran >> {}\n", epilog_marker.display()),
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&epilog_script).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&epilog_script, perms).unwrap();
+
+        let dead = executor::JobManifest {
+            schema_version: 1,
+            job_id,
+            run_attempt: 1,
+            pid: 999_999_999, // a pid that isn't alive, so reconcile sees it dead
+            start_time: 0,
+            cgroup_path: None,
+            forked: false,
+            cpu_ids: vec![],
+            gpu_devices: vec![],
+            cpus: 1,
+            memory_mb: 0,
+            uid,
+            gid,
+            user: String::new(),
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            work_dir: "/tmp".into(),
+            partition: "default".into(),
+            nodelist: "test-node".into(),
+            mpi: String::new(),
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            exit_status_path: None,
+            pending: executor::PendingObligations::default(),
+            exit: Some((3, 0)),
+        };
+        executor::write_job_manifest(&spool_dir, &dead);
+
+        let hooks = HooksConfig {
+            epilog: Some(epilog_script.to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        let svc = AgentService::new(
+            dead_controller_reporter(),
+            hooks,
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        // Two restart-retries, both with the controller unreachable. Discharge
+        // this job's manifest directly (rather than the global scan, which would
+        // also pick up other concurrent tests' manifests in the shared spool
+        // root) so the assertion is about this job alone.
+        let read_manifest = || {
+            let bytes = std::fs::read(spool_dir.join("manifest.json")).unwrap();
+            serde_json::from_slice::<executor::JobManifest>(&bytes).unwrap()
+        };
+        svc.discharge_obligations(&spool_dir, read_manifest()).await;
+        assert!(
+            !read_manifest().pending.epilog,
+            "epilog marked discharged after the first pass"
+        );
+        svc.discharge_obligations(&spool_dir, read_manifest()).await;
+
+        let runs = std::fs::read_to_string(&epilog_marker)
+            .map(|s| s.lines().count())
+            .unwrap_or(0);
+        assert_eq!(
+            runs, 1,
+            "epilog runs once across retries, not once per retry"
+        );
+        assert!(
+            spool_dir.join("manifest.json").exists(),
+            "manifest kept while the report is still owed"
+        );
+
+        executor::cleanup_job_spool(job_id, 1);
+        let _ = std::fs::remove_file(&epilog_marker);
+        let _ = std::fs::remove_file(&epilog_script);
+    }
+
+    // One reconcile pass with both a surviving job and a finished job: the live
+    // one is re-adopted into `running`, only the dead one yields a completion.
+    #[tokio::test]
+    async fn adopt_manifests_adopts_live_and_reports_only_dead() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.lock().await;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let base = std::env::temp_dir().join("spur");
+
+        let live_id = 987_654_340;
+        let live_dir = base.join(format!("job{live_id}_1"));
+        std::fs::create_dir_all(&live_dir).unwrap();
+        // Long-lived so it is unambiguously alive when reconcile scans it.
+        let mut live_child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let live_pid = live_child.id() as i32;
+        let live_start = executor::proc_start_time(live_pid).unwrap();
+
+        let dead_id = 987_654_341;
+        let dead_dir = base.join(format!("job{dead_id}_1"));
+        std::fs::create_dir_all(&dead_dir).unwrap();
+        let mut dead_child = std::process::Command::new("true").spawn().unwrap();
+        let dead_pid = dead_child.id() as i32;
+        dead_child.wait().unwrap();
+        std::fs::write(dead_dir.join("exit_status"), "9\n").unwrap();
+
+        let manifest = |job_id, pid, start_time, cpu_ids: Vec<u32>| executor::JobManifest {
+            schema_version: 1,
+            job_id,
+            run_attempt: 1,
+            pid,
+            start_time,
+            cgroup_path: None,
+            forked: false,
+            cpu_ids,
+            gpu_devices: vec![],
+            cpus: 1,
+            memory_mb: 0,
+            uid,
+            gid,
+            user: String::new(),
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            work_dir: "/tmp".into(),
+            partition: "default".into(),
+            nodelist: "test-node".into(),
+            mpi: String::new(),
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            exit_status_path: None,
+            pending: executor::PendingObligations::default(),
+            exit: None,
+        };
+        executor::write_job_manifest(&live_dir, &manifest(live_id, live_pid, live_start, vec![0]));
+        executor::write_job_manifest(&dead_dir, &manifest(dead_id, dead_pid, 0, vec![]));
+
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let dead = svc.adopt_manifests().await;
+
+        // Filter to this test's ids: scan reads the shared spool root, so an
+        // unrelated leftover manifest must not fail the assertion.
+        let mine: Vec<&(std::path::PathBuf, executor::JobManifest)> = dead
+            .iter()
+            .filter(|(_, m)| m.job_id == live_id || m.job_id == dead_id)
+            .collect();
+        assert_eq!(mine.len(), 1, "only the finished job yields a completion");
+        let manifest = &mine[0].1;
+        assert_eq!(manifest.job_id, dead_id);
+        assert_eq!(
+            (manifest.exit, manifest.run_attempt),
+            (Some((9, 0)), 1),
+            "only the finished job yields a completion to report"
+        );
+        let running = svc.running.lock().await;
+        assert!(
+            running.contains_key(&live_id),
+            "the surviving job is adopted"
+        );
+        assert!(
+            !running.contains_key(&dead_id),
+            "the finished job is not adopted"
+        );
+        drop(running);
+
+        live_child.kill().unwrap();
+        let _ = live_child.wait();
+        executor::cleanup_job_spool(live_id, 1);
+        executor::cleanup_job_spool(dead_id, 1);
     }
 
     #[tokio::test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -224,6 +224,57 @@ async fn step_cancel_requested(
         .is_some_and(|step| step.cancel_requested)
 }
 
+/// The inputs one job's epilog + SPANK teardown hooks need. Built from either a
+/// live `CompletedJob` (monitor path) or an adopted `JobManifest` (restart path)
+/// so both run identical teardown.
+struct CompletionContext {
+    job_id: u32,
+    work_dir: String,
+    uid: u32,
+    gid: u32,
+    partition: String,
+    nodelist: String,
+    gpu_devices: Vec<u32>,
+    cpus: u32,
+    memory_mb: u64,
+}
+
+/// Cloneable handle exposing only whether any jobs are active, for use after
+/// `AgentService` itself has moved into the gRPC server (see main's SIGTERM
+/// handler).
+#[derive(Clone)]
+pub struct RunningJobsHandle {
+    running: Arc<Mutex<HashMap<u32, TrackedJob>>>,
+    allocation: Arc<Mutex<NodeAllocation>>,
+}
+
+impl RunningJobsHandle {
+    /// True when no job with a live process is tracked AND none is mid-launch. A
+    /// job spawned but not yet inserted into `running` still holds a `launching`
+    /// reservation, so checking both closes the window where a SIGTERM would
+    /// deregister (and force-evict) an in-flight launch.
+    ///
+    /// `AllocationOnly` reservations (srun/salloc) are excluded: they have no
+    /// process and are never written to a manifest, so a restarted spurd can't
+    /// re-adopt them. Keeping the node registered on their behalf would strand
+    /// the reservation (the controller still holds the resources while the agent
+    /// forgets them, then first-fits the same ids to the next dispatch).
+    /// Deregistering lets the controller reclaim them, matching the pre-manifest
+    /// behavior of an unconditional deregister.
+    pub async fn has_no_active_jobs(&self) -> bool {
+        if self
+            .running
+            .lock()
+            .await
+            .values()
+            .any(|t| !t.job.is_allocation_only())
+        {
+            return false;
+        }
+        !self.allocation.lock().await.has_launching()
+    }
+}
+
 pub struct AgentService {
     pub reporter: Arc<NodeReporter>,
     /// In-memory only: starts empty on every spurd start/restart, regardless
@@ -365,6 +416,176 @@ impl AgentService {
         self.k0s.clone()
     }
 
+    pub fn running_jobs_handle(&self) -> RunningJobsHandle {
+        RunningJobsHandle {
+            running: self.running.clone(),
+            allocation: self.allocation.clone(),
+        }
+    }
+
+    /// Re-adopt jobs whose process survived a spurd restart, restoring their
+    /// resource allocation before this agent starts accepting new launches.
+    /// Must run before the gRPC server starts serving.
+    pub async fn reconcile_running_jobs(&self) {
+        // Discharge teardown inline so a completion isn't lost, but bounded so an
+        // unreachable controller can't block serving (heartbeat is the backstop).
+        let dead = self.adopt_manifests().await;
+        let discharge_all = async {
+            for (spool_dir, manifest) in dead {
+                self.discharge_obligations(&spool_dir, manifest).await;
+            }
+        };
+        if tokio::time::timeout(RECONCILE_REPORT_BUDGET, discharge_all)
+            .await
+            .is_err()
+        {
+            warn!("obligation discharge during reconcile timed out; continuing to serve");
+        }
+    }
+
+    /// Discharge the still-owed teardown obligations for a job that finished
+    /// while spurd was down, driving the manifest's ledger to empty. Each step
+    /// is skipped if already done (recorded in `manifest.pending`) and the
+    /// manifest is rewritten after each so an interrupted discharge resumes
+    /// rather than repeating a non-idempotent step (notably the epilog). The
+    /// spool/manifest is removed only once everything is discharged; otherwise
+    /// it is left for the next startup to retry — the node is heartbeating, so
+    /// the controller never times the job out on its own.
+    async fn discharge_obligations(
+        &self,
+        spool_dir: &std::path::Path,
+        mut manifest: executor::JobManifest,
+    ) {
+        let job_id = manifest.job_id;
+        let (exit_code, signal) = manifest.exit.unwrap_or((-1, 0));
+
+        if manifest.pending.epilog {
+            let ctx = CompletionContext {
+                job_id,
+                work_dir: manifest.work_dir.clone(),
+                uid: manifest.uid,
+                gid: manifest.gid,
+                partition: manifest.partition.clone(),
+                nodelist: manifest.nodelist.clone(),
+                gpu_devices: manifest.gpu_devices.clone(),
+                cpus: manifest.cpus,
+                memory_mb: manifest.memory_mb,
+            };
+            manifest.pending.drain = run_teardown_hooks(&self.hooks, &self.spank, &ctx).await;
+            manifest.pending.epilog = false;
+            executor::write_job_manifest(spool_dir, &manifest);
+        }
+
+        if manifest.pending.report_completion {
+            let drain = manifest.pending.drain.then(|| DrainRequest {
+                reason: "epilog script failed".into(),
+            });
+            let reported = report_completion(
+                &self.reporter.controller_addr,
+                job_id,
+                exit_code,
+                signal,
+                manifest.run_attempt,
+                &self.reporter.hostname,
+                drain.as_ref(),
+            )
+            .await;
+            if !reported {
+                // Report lost; leave the manifest (epilog already marked done, so
+                // the retry won't re-run it) for the next startup to resend.
+                return;
+            }
+            manifest.pending.report_completion = false;
+        }
+
+        if manifest.pending.all_discharged() {
+            executor::cleanup_job_spool(job_id, manifest.run_attempt);
+            cleanup_completed_job_mpi(job_id, &manifest.mpi, &self.pmi_servers, &self.mpi_host)
+                .await;
+        }
+    }
+
+    /// Scan manifests, re-adopt still-alive jobs into local state, and return
+    /// the dead jobs (spool dir + manifest) whose teardown obligations still
+    /// need discharging. Split from the discharge so it is testable without a
+    /// live controller.
+    async fn adopt_manifests(&self) -> Vec<(std::path::PathBuf, executor::JobManifest)> {
+        let mut dead = Vec::new();
+        for (spool_dir, manifest) in executor::scan_job_manifests() {
+            let job_id = manifest.job_id;
+            match executor::reconcile_manifest(&spool_dir, manifest) {
+                executor::ReconcileOutcome::Alive { job, manifest } => {
+                    let alloc = AllocationResult {
+                        cpu_ids: manifest.cpu_ids.clone(),
+                        gpu_ids: manifest.gpu_devices.clone(),
+                        memory_mb: manifest.memory_mb,
+                    };
+                    if let Err(e) = self
+                        .allocation
+                        .lock()
+                        .await
+                        .restore_committed(job_id, alloc)
+                    {
+                        // A device this manifest claims is already held by an
+                        // adopted job: adopting anyway would double-book it. Leave
+                        // the process running and its manifest in place, and skip
+                        // re-adoption so this node's accounting stays consistent.
+                        error!(job_id, error = ?e, "refusing to adopt job with conflicting resources");
+                        continue;
+                    }
+                    // Forked jobs ran under container namespaces; a PTY master fd can't survive restart.
+                    let is_root = nix::unistd::geteuid().is_root();
+                    let is_container = manifest.forked;
+                    self.running.lock().await.insert(
+                        job_id,
+                        TrackedJob {
+                            job,
+                            rootfs_mode: manifest.rootfs_mode,
+                            stdout_path: manifest.stdout_path,
+                            stderr_path: manifest.stderr_path,
+                            has_pid_namespace: is_root || is_container,
+                            has_user_namespace: is_container && !is_root,
+                            has_mount_namespace: is_root || is_container,
+                            _pty_master: None,
+                            work_dir: manifest.work_dir,
+                            uid: manifest.uid,
+                            gid: manifest.gid,
+                            user: manifest.user,
+                            partition: manifest.partition,
+                            gpu_devices: manifest.gpu_devices,
+                            cpus: manifest.cpus,
+                            memory_mb: manifest.memory_mb,
+                            nodelist: manifest.nodelist,
+                            mpi: manifest.mpi,
+                            run_attempt: manifest.run_attempt,
+                        },
+                    );
+                    info!(job_id, "re-adopted job that survived a spurd restart");
+                }
+                executor::ReconcileOutcome::Dead { manifest } => {
+                    let (exit_code, signal) = manifest.exit.unwrap_or((-1, 0));
+                    warn!(
+                        job_id,
+                        exit_code, signal, "job finished while spurd was down"
+                    );
+                    // The process is gone, so its rootfs and cgroup can be torn
+                    // down now. Persist the manifest with the resolved exit
+                    // recorded, so a report that only lands on a later restart
+                    // stays accurate after the sentinel/rootfs are gone. The
+                    // spool (and manifest) is kept until every obligation is
+                    // discharged (see reconcile_running_jobs).
+                    crate::container::cleanup_rootfs(job_id, &manifest.rootfs_mode);
+                    if let Some(ref cgroup) = manifest.cgroup_path {
+                        executor::cleanup_cgroup(cgroup);
+                    }
+                    executor::write_job_manifest(&spool_dir, &manifest);
+                    dead.push((spool_dir, manifest));
+                }
+            }
+        }
+        dead
+    }
+
     /// Spawn a background task to monitor running jobs and report completions.
     pub fn start_monitor(&self, controller_addr: String) {
         let running = self.running.clone();
@@ -421,7 +642,6 @@ impl AgentService {
                 for c in &completed {
                     jobs.remove(&c.job_id);
                     crate::container::cleanup_rootfs(c.job_id, &c.rootfs_mode);
-                    crate::executor::cleanup_job_spool(c.job_id);
                     if let Some(ref cgroup) = c.cgroup {
                         crate::executor::cleanup_cgroup(cgroup);
                     }
@@ -444,72 +664,48 @@ impl AgentService {
                     .map(|h| h.to_string_lossy().to_string())
                     .unwrap_or_else(|_| "localhost".into());
 
-                let mut drain_jobs: std::collections::HashSet<u32> =
-                    std::collections::HashSet::new();
-
-                // Run epilog hook for completed jobs
-                if let Some(ref epilog_script) = hooks.epilog {
-                    for c in &completed {
-                        let ctx = spur_core::hooks::HookContext {
-                            job_id: c.job_id,
-                            work_dir: c.work_dir.clone(),
-                            uid: c.uid,
-                            gid: c.gid,
-                            partition: c.partition.clone(),
-                            nodelist: c.nodelist.clone(),
-                            script_context: "epilog_slurmd".into(),
-                            gpu_devices: c.gpu_devices.clone(),
-                            cpus: c.cpus,
-                            memory_mb: c.memory_mb,
-                        };
-                        if let Err(e) = spur_core::hooks::run_hook(epilog_script, &ctx).await {
-                            error!(
-                                job_id = c.job_id,
-                                error = %e,
-                                "epilog hook failed — requesting node drain"
-                            );
-                            drain_jobs.insert(c.job_id);
-                        }
-                    }
-                }
-
-                // Invoke SPANK TaskExit and JobEpilog hooks for completed jobs
-                if let Some(ref spank_host) = *spank {
-                    for c in &completed {
-                        let context = SpankContext {
-                            job_id: c.job_id,
-                            uid: c.uid,
-                            gid: c.gid,
-                            ..Default::default()
-                        };
-                        let mut handle = SpankHandle::new(context, HashMap::new());
-                        if let Err(e) = spank_host.invoke_hook(SpankHook::TaskExit, &mut handle) {
-                            warn!(c.job_id, error = %e, "SPANK TaskExit hook failed");
-                        }
-                        if let Err(e) = spank_host.invoke_hook(SpankHook::JobEpilog, &mut handle) {
-                            warn!(c.job_id, error = %e, "SPANK JobEpilog hook failed");
-                        }
-                    }
-                }
-
                 for c in &completed {
-                    let drain = if drain_jobs.contains(&c.job_id) {
-                        Some(DrainRequest {
-                            reason: "epilog script failed".into(),
-                        })
-                    } else {
-                        None
+                    let ctx = CompletionContext {
+                        job_id: c.job_id,
+                        work_dir: c.work_dir.clone(),
+                        uid: c.uid,
+                        gid: c.gid,
+                        partition: c.partition.clone(),
+                        nodelist: c.nodelist.clone(),
+                        gpu_devices: c.gpu_devices.clone(),
+                        cpus: c.cpus,
+                        memory_mb: c.memory_mb,
                     };
-                    report_completion(
+                    let drain = run_teardown_hooks(&hooks, &spank, &ctx).await;
+                    let drain_req = drain.then(|| DrainRequest {
+                        reason: "epilog script failed".into(),
+                    });
+                    let reported = report_completion(
                         &controller_addr,
                         c.job_id,
                         c.exit_code,
                         c.signal,
                         c.run_attempt,
                         &local_hostname,
-                        drain.as_ref(),
+                        drain_req.as_ref(),
                     )
                     .await;
+                    // Keep the spool (and its manifest) until the controller has
+                    // the completion: if the report was lost, a restarted spurd
+                    // re-adopts the manifest and retries rather than stranding the
+                    // job in Running forever. Record that the epilog is already
+                    // done so the restart retries only the report, not the
+                    // (possibly non-idempotent) epilog.
+                    if reported {
+                        crate::executor::cleanup_job_spool(c.job_id, c.run_attempt);
+                    } else {
+                        crate::executor::mark_manifest_epilog_discharged(
+                            c.job_id,
+                            c.run_attempt,
+                            (c.exit_code, c.signal),
+                            drain,
+                        );
+                    }
                 }
             }
         });
@@ -524,6 +720,13 @@ struct DrainRequest {
 /// above a typical image pull + fork so a normal launch is spared; one stalled
 /// past this bound is reclaimed.
 const LAUNCHING_TTL: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// In-container path where a job records its exit code; host-visible in the rootfs.
+const CONTAINER_EXIT_STATUS_PATH: &str = "/tmp/spur_exit_status";
+
+/// Cap on completion reporting during startup reconcile, so an unreachable
+/// controller can't keep spurd from serving.
+const RECONCILE_REPORT_BUDGET: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Reclaim allocations whose job is no longer tracked and is not mid-launch,
 /// using the running set as ground truth. Callers hold the `running` lock
@@ -894,6 +1097,62 @@ fn inject_script_args(script: &str, args: &[String]) -> Result<String, Status> {
     Ok(format!("{set_line}\n{script}"))
 }
 
+/// Run the epilog + SPANK TaskExit/JobEpilog teardown hooks for a completed job.
+/// Returns true if the epilog failed and the node should be drained. Shared by
+/// the live monitor and the restart-adoption path so an adopted job gets the
+/// same epilog (GPU reset, scratch purge), SPANK hooks, and epilog-failure drain
+/// as a live one — none of which the adoption path used to run.
+async fn run_teardown_hooks(
+    hooks: &HooksConfig,
+    spank: &Option<SpankHost>,
+    ctx: &CompletionContext,
+) -> bool {
+    let mut drain = false;
+    if let Some(ref epilog_script) = hooks.epilog {
+        let hook_ctx = spur_core::hooks::HookContext {
+            job_id: ctx.job_id,
+            work_dir: ctx.work_dir.clone(),
+            uid: ctx.uid,
+            gid: ctx.gid,
+            partition: ctx.partition.clone(),
+            nodelist: ctx.nodelist.clone(),
+            script_context: "epilog_slurmd".into(),
+            gpu_devices: ctx.gpu_devices.clone(),
+            cpus: ctx.cpus,
+            memory_mb: ctx.memory_mb,
+        };
+        if let Err(e) = spur_core::hooks::run_hook(epilog_script, &hook_ctx).await {
+            error!(
+                job_id = ctx.job_id,
+                error = %e,
+                "epilog hook failed — requesting node drain"
+            );
+            drain = true;
+        }
+    }
+
+    if let Some(spank_host) = spank {
+        let context = SpankContext {
+            job_id: ctx.job_id,
+            uid: ctx.uid,
+            gid: ctx.gid,
+            ..Default::default()
+        };
+        let mut handle = SpankHandle::new(context, HashMap::new());
+        if let Err(e) = spank_host.invoke_hook(SpankHook::TaskExit, &mut handle) {
+            warn!(ctx.job_id, error = %e, "SPANK TaskExit hook failed");
+        }
+        if let Err(e) = spank_host.invoke_hook(SpankHook::JobEpilog, &mut handle) {
+            warn!(ctx.job_id, error = %e, "SPANK JobEpilog hook failed");
+        }
+    }
+    drain
+}
+
+/// Report a job completion to the controller. Returns true only if the
+/// controller acknowledged it, so the caller can keep the job's manifest for a
+/// restart-time retry when the report was lost (transient failure exhausted its
+/// retries, or a non-retryable rejection).
 async fn report_completion(
     controller_addr: &str,
     job_id: u32,
@@ -902,7 +1161,7 @@ async fn report_completion(
     run_attempt: u32,
     reporting_node: &str,
     drain: Option<&DrainRequest>,
-) {
+) -> bool {
     // Wire `state` is derived from `exit_code` alone (advisory): a signaled job
     // reports Completed/0 because the controller's validator requires
     // state<->exit_code agreement. The controller rederives the true Failed /
@@ -947,26 +1206,39 @@ async fn report_completion(
     })
     .await;
 
+    // Return whether the controller acknowledged the completion, so the caller
+    // can keep the job's manifest for a restart-time retry when the report was
+    // lost (transient failure exhausted its retries, or a non-retryable
+    // rejection) rather than deleting it and stranding the job in Running.
     match result {
-        Ok(_) => info!(
-            job_id,
-            exit_code,
-            controller = %controller_addr,
-            "reported completion to controller"
-        ),
-        Err(e) if e.retryable() => error!(
-            job_id,
-            exit_code,
-            attempts = CONTROLLER_RPC_ATTEMPTS,
-            error = %e,
-            "gave up reporting completion to controller"
-        ),
-        Err(e) => error!(
-            job_id,
-            exit_code,
-            error = %e,
-            "ReportJobStatus failed with non-retryable error"
-        ),
+        Ok(_) => {
+            info!(
+                job_id,
+                exit_code,
+                controller = %controller_addr,
+                "reported completion to controller"
+            );
+            true
+        }
+        Err(e) if e.retryable() => {
+            error!(
+                job_id,
+                exit_code,
+                attempts = CONTROLLER_RPC_ATTEMPTS,
+                error = %e,
+                "gave up reporting completion to controller"
+            );
+            false
+        }
+        Err(e) => {
+            error!(
+                job_id,
+                exit_code,
+                error = %e,
+                "ReportJobStatus failed with non-retryable error"
+            );
+            false
+        }
     }
 }
 
@@ -1218,6 +1490,7 @@ impl SlurmAgent for AgentService {
         // the Rust container runtime (fork + container_init + pivot_root).
         let mut container_config: Option<crate::container::ContainerConfig> = None;
         let mut rootfs_path: Option<std::path::PathBuf> = None;
+        let mut container_exit_status_path: Option<String> = None;
 
         let (launch_script, rootfs_mode) = if !spec.container_image.is_empty() {
             info!(job_id, image = %spec.container_image, "launching containerized job");
@@ -1279,9 +1552,20 @@ impl SlurmAgent for AgentService {
                 crate::container::setup_rootfs(&image_path, job_id, cfg.name.as_deref())
                     .map_err(|e| Status::internal(format!("container setup failed: {}", e)))?;
 
-            // Copy user script into rootfs/tmp/ so it's accessible after pivot_root
+            // Copy user script into rootfs/tmp/ so it's accessible after pivot_root.
+            // Wrap it to record the exit code at an in-container path, so a
+            // restarted spurd can read the real code back (host-visible in rootfs).
             let container_script = format!("{}/tmp/spur_job_{}.sh", rootfs.display(), job_id);
-            std::fs::write(&container_script, &script).map_err(|e| {
+            let wrapped = executor::wrap_with_exit_sentinel(
+                &script,
+                std::path::Path::new(CONTAINER_EXIT_STATUS_PATH),
+            );
+            container_exit_status_path = Some(format!(
+                "{}{}",
+                rootfs.display(),
+                CONTAINER_EXIT_STATUS_PATH
+            ));
+            std::fs::write(&container_script, &wrapped).map_err(|e| {
                 Status::internal(format!("failed to write container script: {}", e))
             })?;
             #[cfg(unix)]
@@ -1455,6 +1739,7 @@ impl SlurmAgent for AgentService {
 
         let launch_cfg = executor::JobLaunchConfig {
             job_id,
+            run_attempt,
             script: launch_script,
             work_dir: work_dir.clone(),
             name: spec.name.clone(),
@@ -1494,6 +1779,46 @@ impl SlurmAgent for AgentService {
         match executor::launch_job(&launch_cfg, (*self.spank).as_ref()).await {
             Ok(mut result) => {
                 pmix_guard.as_mut().map(PmixLaunchGuard::disarm);
+                // Written before this job is tracked anywhere else, so a spurd
+                // restart can re-adopt it (see reconcile_running_jobs) instead
+                // of losing track of a job whose process survives the restart.
+                if let Some(pid) = result.job.pid() {
+                    let sentinel = container_exit_status_path.clone().unwrap_or_else(|| {
+                        executor::exit_status_path(&result.spool_dir)
+                            .to_string_lossy()
+                            .into_owned()
+                    });
+                    executor::write_job_manifest(
+                        &result.spool_dir,
+                        &executor::JobManifest {
+                            schema_version: 1,
+                            job_id,
+                            run_attempt,
+                            pid: pid as i32,
+                            start_time: executor::proc_start_time(pid as i32).unwrap_or(0),
+                            cgroup_path: result.job.cgroup_path().map(|p| p.to_path_buf()),
+                            forked: matches!(result.job, executor::RunningJob::Forked { .. }),
+                            cpu_ids: launch_cfg.cpu_ids.clone(),
+                            gpu_devices: launch_cfg.gpu_devices.clone(),
+                            cpus: launch_cfg.cpus,
+                            memory_mb: launch_cfg.memory_mb,
+                            uid: launch_cfg.uid,
+                            gid: launch_cfg.gid,
+                            user: launch_cfg.user.clone(),
+                            stdout_path: result.stdout_path.clone(),
+                            stderr_path: result.stderr_path.clone(),
+                            work_dir: launch_cfg.work_dir.clone(),
+                            partition: launch_cfg.partition.clone(),
+                            nodelist: launch_cfg.nodelist.clone(),
+                            mpi: spec.mpi.clone(),
+                            rootfs_mode: rootfs_mode.clone(),
+                            exit_status_path: Some(sentinel),
+                            pending: executor::PendingObligations::default(),
+                            exit: None,
+                        },
+                    );
+                }
+
                 let mut jobs = self.running.lock().await;
                 // Commit the reservation: the job now has a tracked process, so
                 // it is no longer exempt from reconcile. Take the running lock
@@ -1521,15 +1846,11 @@ impl SlurmAgent for AgentService {
                     let running = self.running.clone();
                     tokio::spawn(async move {
                         reap_killed_job(result.job).await;
-                        // rootfs/spool paths are derived from job_id, so the
-                        // controller re-dispatching the same id to this node
-                        // would reuse them. Skip that cleanup if a live run for
-                        // job_id reappeared, or this reap would delete its files.
-                        // The cgroup handle is this launch's own, so it is always
-                        // safe to release.
+                        // Spool/cgroup are attempt-scoped; rootfs is job_id-keyed,
+                        // so skip it if a live run for job_id reappeared.
+                        crate::executor::cleanup_job_spool(job_id, run_attempt);
                         if !running.lock().await.contains_key(&job_id) {
                             crate::container::cleanup_rootfs(job_id, &rootfs_mode);
-                            crate::executor::cleanup_job_spool(job_id);
                         }
                         if let Some(ref cg) = cgroup {
                             crate::executor::cleanup_cgroup(cg);
@@ -3217,6 +3538,32 @@ impl TrackedJob {
             run_attempt: 0,
         }
     }
+
+    /// A tracked srun/salloc reservation with no process, matching what
+    /// `register_job_allocation` inserts.
+    fn dummy_allocation_only() -> Self {
+        Self {
+            job: executor::RunningJob::AllocationOnly,
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
+            _pty_master: None,
+            work_dir: "/tmp".into(),
+            uid: 0,
+            gid: 0,
+            user: String::new(),
+            partition: String::new(),
+            gpu_devices: Vec::new(),
+            cpus: 1,
+            memory_mb: 0,
+            nodelist: String::new(),
+            mpi: String::new(),
+            run_attempt: 0,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -3740,6 +4087,36 @@ mod tests {
             resp.error.contains("No such file or directory"),
             "the cause chain must survive into the reported error, got {:?}",
             resp.error
+        );
+    }
+
+    #[tokio::test]
+    async fn has_no_active_jobs_ignores_allocation_only_reservations() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let handle = svc.running_jobs_handle();
+        assert!(handle.has_no_active_jobs().await, "idle node has no jobs");
+
+        // A reservation with no process must not keep the node registered on
+        // SIGTERM: it isn't persisted to a manifest, so it can't be re-adopted,
+        // and holding the node would strand it (double-book on next dispatch).
+        svc.insert_test_job(1, TrackedJob::dummy_allocation_only())
+            .await;
+        assert!(
+            handle.has_no_active_jobs().await,
+            "reservation-only node deregisters so the controller reclaims it"
+        );
+
+        // A real running process, by contrast, must keep the node registered so
+        // a restart can re-adopt it.
+        svc.insert_test_job(2, TrackedJob::dummy(0)).await;
+        assert!(
+            !handle.has_no_active_jobs().await,
+            "a live job keeps the node registered"
         );
     }
 
@@ -5077,6 +5454,456 @@ mod tests {
             0,
             "a disarmed guard must leave the committed reservation intact"
         );
+    }
+
+    // Simulates a spurd restart: a job manifest on disk for a still-running
+    // process must be re-adopted into `running` with its allocation restored,
+    // before this agent would start accepting new LaunchJob calls.
+    #[tokio::test]
+    async fn reconcile_running_jobs_resumes_live_job_and_restores_allocation() {
+        // Serialize against other tests that scan the shared spool-root
+        // manifest tree — see MANIFEST_SCAN_TEST_LOCK.
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.lock().await;
+        let job_id = 987_654_326;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = std::env::temp_dir()
+            .join("spur")
+            .join(format!("job{job_id}_1"));
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        let mut child = std::process::Command::new("sleep")
+            .arg("2")
+            .spawn()
+            .unwrap();
+        let pid = child.id() as i32;
+        let start_time = executor::proc_start_time(pid).unwrap();
+
+        executor::write_job_manifest(
+            &spool_dir,
+            &executor::JobManifest {
+                schema_version: 1,
+                job_id,
+                run_attempt: 3,
+                pid,
+                start_time,
+                cgroup_path: None,
+                forked: false,
+                cpu_ids: vec![0],
+                gpu_devices: vec![],
+                cpus: 1,
+                memory_mb: 512,
+                uid,
+                gid,
+                user: String::new(),
+                stdout_path: "/dev/null".into(),
+                stderr_path: "/dev/null".into(),
+                work_dir: "/tmp".into(),
+                partition: "default".into(),
+                nodelist: "test-node".into(),
+                mpi: String::new(),
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                exit_status_path: None,
+                pending: executor::PendingObligations::default(),
+                exit: None,
+            },
+        );
+
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let free_cpus_before = svc.allocation.lock().await.free_cpus();
+
+        svc.reconcile_running_jobs().await;
+
+        assert!(
+            svc.running.lock().await.contains_key(&job_id),
+            "resumed job must be tracked in `running`"
+        );
+        assert_eq!(
+            svc.allocation.lock().await.free_cpus(),
+            free_cpus_before - 1,
+            "resumed job's cpu must be reflected in NodeAllocation before new launches are admitted"
+        );
+
+        child.kill().unwrap();
+        let _ = child.wait();
+        executor::cleanup_job_spool(job_id, 1);
+    }
+
+    // A job that finished entirely while spurd was restarting must still be
+    // reported to the controller — it must not be left "Running" forever.
+    #[tokio::test]
+    async fn reconcile_running_jobs_reports_completion_for_job_finished_while_down() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.lock().await;
+        let job_id = 987_654_327;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = std::env::temp_dir()
+            .join("spur")
+            .join(format!("job{job_id}_1"));
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id() as i32;
+        child.wait().unwrap();
+        std::fs::write(spool_dir.join("exit_status"), "5\n").unwrap();
+
+        executor::write_job_manifest(
+            &spool_dir,
+            &executor::JobManifest {
+                schema_version: 1,
+                job_id,
+                run_attempt: 1,
+                pid,
+                start_time: 0,
+                cgroup_path: None,
+                forked: false,
+                cpu_ids: vec![],
+                gpu_devices: vec![],
+                cpus: 1,
+                memory_mb: 0,
+                uid,
+                gid,
+                user: String::new(),
+                stdout_path: String::new(),
+                stderr_path: String::new(),
+                work_dir: "/tmp".into(),
+                partition: "default".into(),
+                nodelist: "test-node".into(),
+                mpi: String::new(),
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                exit_status_path: None,
+                pending: executor::PendingObligations::default(),
+                exit: None,
+            },
+        );
+
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        // adopt_manifests returns the dead jobs' (spool, manifest); the
+        // obligation discharge (report) is separate and needs no controller here.
+        let dead = svc.adopt_manifests().await;
+
+        // Filter to this test's id: scan reads the shared spool root, so a
+        // manifest a concurrent launch test left behind must not fail this.
+        let mine: Vec<&(std::path::PathBuf, executor::JobManifest)> =
+            dead.iter().filter(|(_, m)| m.job_id == job_id).collect();
+        assert_eq!(mine.len(), 1, "the finished job yields one completion");
+        let manifest = &mine[0].1;
+        assert_eq!(manifest.job_id, job_id);
+        assert_eq!(
+            (manifest.exit, manifest.run_attempt),
+            (Some((5, 0)), 1),
+            "a job finished while down must record its real exit code to report"
+        );
+        assert!(
+            manifest.pending.epilog && manifest.pending.report_completion,
+            "adopt_manifests records obligations but discharges none itself"
+        );
+        assert!(
+            !svc.running.lock().await.contains_key(&job_id),
+            "a job that already finished must not be tracked as running"
+        );
+        // The spool (and manifest) is kept until obligations are discharged, so
+        // a lost report can be retried on the next restart. adopt_manifests does
+        // not report, so the spool must still be present here.
+        assert!(spool_dir.exists());
+        executor::cleanup_job_spool(job_id, 1);
+    }
+
+    // If the completion report can't reach the controller, the spool (and its
+    // manifest) must survive so the next spurd startup re-adopts it and retries —
+    // otherwise the job is stranded in Running (the node heartbeats, so the
+    // controller never times it out).
+    #[tokio::test]
+    async fn reconcile_keeps_spool_when_completion_report_fails() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.lock().await;
+        let job_id = 987_654_328;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = std::env::temp_dir()
+            .join("spur")
+            .join(format!("job{job_id}_1"));
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id() as i32;
+        child.wait().unwrap();
+        std::fs::write(spool_dir.join("exit_status"), "0\n").unwrap();
+
+        executor::write_job_manifest(
+            &spool_dir,
+            &executor::JobManifest {
+                schema_version: 1,
+                job_id,
+                run_attempt: 1,
+                pid,
+                start_time: 0,
+                cgroup_path: None,
+                forked: false,
+                cpu_ids: vec![],
+                gpu_devices: vec![],
+                cpus: 1,
+                memory_mb: 0,
+                uid,
+                gid,
+                user: String::new(),
+                stdout_path: String::new(),
+                stderr_path: String::new(),
+                work_dir: "/tmp".into(),
+                partition: "default".into(),
+                nodelist: "test-node".into(),
+                mpi: String::new(),
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                exit_status_path: None,
+                pending: executor::PendingObligations::default(),
+                exit: None,
+            },
+        );
+
+        // Controller address that refuses connections, so every report attempt
+        // fails and the completion report returns false.
+        let svc = AgentService::new(
+            dead_controller_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        svc.reconcile_running_jobs().await;
+
+        assert!(
+            spool_dir.exists() && spool_dir.join("manifest.json").exists(),
+            "an unreported completion keeps its spool + manifest for a restart retry"
+        );
+        executor::cleanup_job_spool(job_id, 1);
+    }
+
+    fn dead_controller_reporter() -> Arc<NodeReporter> {
+        Arc::new(NodeReporter::new(
+            "test-node".into(),
+            "http://127.0.0.1:1".into(),
+            ResourceSet {
+                cpus: 4,
+                memory_mb: 8192,
+                ..Default::default()
+            },
+            spur_net::NodeAddress {
+                ip: "127.0.0.1".into(),
+                hostname: "test-node".into(),
+                port: 6818,
+                source: spur_net::AddressSource::Static,
+            },
+            std::collections::HashMap::new(),
+            String::new(),
+            String::new(),
+        ))
+    }
+
+    // The obligation ledger's core guarantee: when the completion report keeps
+    // failing, the epilog must run exactly ONCE across repeated restart-retries,
+    // not once per retry — the manifest records epilog-discharged before the
+    // report is attempted, so a retry resumes at the still-owed report only.
+    #[tokio::test]
+    async fn discharge_runs_epilog_once_across_report_retries() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.lock().await;
+        let job_id = 987_654_329;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = std::env::temp_dir()
+            .join("spur")
+            .join(format!("job{job_id}_1"));
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        // Epilog appends a line each time it runs; counting lines counts runs.
+        let epilog_marker = std::env::temp_dir().join(format!("spur_epilog_ran_{job_id}"));
+        let _ = std::fs::remove_file(&epilog_marker);
+        let epilog_script = std::env::temp_dir().join(format!("spur_epilog_{job_id}.sh"));
+        std::fs::write(
+            &epilog_script,
+            format!("#!/bin/bash\necho ran >> {}\n", epilog_marker.display()),
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&epilog_script).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&epilog_script, perms).unwrap();
+
+        let dead = executor::JobManifest {
+            schema_version: 1,
+            job_id,
+            run_attempt: 1,
+            pid: 999_999_999, // a pid that isn't alive, so reconcile sees it dead
+            start_time: 0,
+            cgroup_path: None,
+            forked: false,
+            cpu_ids: vec![],
+            gpu_devices: vec![],
+            cpus: 1,
+            memory_mb: 0,
+            uid,
+            gid,
+            user: String::new(),
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            work_dir: "/tmp".into(),
+            partition: "default".into(),
+            nodelist: "test-node".into(),
+            mpi: String::new(),
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            exit_status_path: None,
+            pending: executor::PendingObligations::default(),
+            exit: Some((3, 0)),
+        };
+        executor::write_job_manifest(&spool_dir, &dead);
+
+        let hooks = HooksConfig {
+            epilog: Some(epilog_script.to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        let svc = AgentService::new(
+            dead_controller_reporter(),
+            hooks,
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        // Two restart-retries, both with the controller unreachable. Discharge
+        // this job's manifest directly (rather than the global scan, which would
+        // also pick up other concurrent tests' manifests in the shared spool
+        // root) so the assertion is about this job alone.
+        let read_manifest = || {
+            let bytes = std::fs::read(spool_dir.join("manifest.json")).unwrap();
+            serde_json::from_slice::<executor::JobManifest>(&bytes).unwrap()
+        };
+        svc.discharge_obligations(&spool_dir, read_manifest()).await;
+        assert!(
+            !read_manifest().pending.epilog,
+            "epilog marked discharged after the first pass"
+        );
+        svc.discharge_obligations(&spool_dir, read_manifest()).await;
+
+        let runs = std::fs::read_to_string(&epilog_marker)
+            .map(|s| s.lines().count())
+            .unwrap_or(0);
+        assert_eq!(
+            runs, 1,
+            "epilog runs once across retries, not once per retry"
+        );
+        assert!(
+            spool_dir.join("manifest.json").exists(),
+            "manifest kept while the report is still owed"
+        );
+
+        executor::cleanup_job_spool(job_id, 1);
+        let _ = std::fs::remove_file(&epilog_marker);
+        let _ = std::fs::remove_file(&epilog_script);
+    }
+
+    // One reconcile pass with both a surviving job and a finished job: the live
+    // one is re-adopted into `running`, only the dead one yields a completion.
+    #[tokio::test]
+    async fn adopt_manifests_adopts_live_and_reports_only_dead() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.lock().await;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let base = std::env::temp_dir().join("spur");
+
+        let live_id = 987_654_340;
+        let live_dir = base.join(format!("job{live_id}_1"));
+        std::fs::create_dir_all(&live_dir).unwrap();
+        // Long-lived so it is unambiguously alive when reconcile scans it.
+        let mut live_child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let live_pid = live_child.id() as i32;
+        let live_start = executor::proc_start_time(live_pid).unwrap();
+
+        let dead_id = 987_654_341;
+        let dead_dir = base.join(format!("job{dead_id}_1"));
+        std::fs::create_dir_all(&dead_dir).unwrap();
+        let mut dead_child = std::process::Command::new("true").spawn().unwrap();
+        let dead_pid = dead_child.id() as i32;
+        dead_child.wait().unwrap();
+        std::fs::write(dead_dir.join("exit_status"), "9\n").unwrap();
+
+        let manifest = |job_id, pid, start_time, cpu_ids: Vec<u32>| executor::JobManifest {
+            schema_version: 1,
+            job_id,
+            run_attempt: 1,
+            pid,
+            start_time,
+            cgroup_path: None,
+            forked: false,
+            cpu_ids,
+            gpu_devices: vec![],
+            cpus: 1,
+            memory_mb: 0,
+            uid,
+            gid,
+            user: String::new(),
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            work_dir: "/tmp".into(),
+            partition: "default".into(),
+            nodelist: "test-node".into(),
+            mpi: String::new(),
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            exit_status_path: None,
+            pending: executor::PendingObligations::default(),
+            exit: None,
+        };
+        executor::write_job_manifest(&live_dir, &manifest(live_id, live_pid, live_start, vec![0]));
+        executor::write_job_manifest(&dead_dir, &manifest(dead_id, dead_pid, 0, vec![]));
+
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let dead = svc.adopt_manifests().await;
+
+        // Filter to this test's ids: scan reads the shared spool root, so an
+        // unrelated leftover manifest must not fail the assertion.
+        let mine: Vec<&(std::path::PathBuf, executor::JobManifest)> = dead
+            .iter()
+            .filter(|(_, m)| m.job_id == live_id || m.job_id == dead_id)
+            .collect();
+        assert_eq!(mine.len(), 1, "only the finished job yields a completion");
+        let manifest = &mine[0].1;
+        assert_eq!(manifest.job_id, dead_id);
+        assert_eq!(
+            (manifest.exit, manifest.run_attempt),
+            (Some((9, 0)), 1),
+            "only the finished job yields a completion to report"
+        );
+        let running = svc.running.lock().await;
+        assert!(
+            running.contains_key(&live_id),
+            "the surviving job is adopted"
+        );
+        assert!(
+            !running.contains_key(&dead_id),
+            "the finished job is not adopted"
+        );
+        drop(running);
+
+        live_child.kill().unwrap();
+        let _ = live_child.wait();
+        executor::cleanup_job_spool(live_id, 1);
+        executor::cleanup_job_spool(dead_id, 1);
     }
 
     #[tokio::test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -67,7 +67,7 @@ mod gpu_deny_tests {
 
 pub(crate) struct TrackedJob {
     job: executor::RunningJob,
-    rootfs_mode: crate::container::RootfsMode,
+    rootfs: Option<crate::container::JobRootfs>,
     stdout_path: String,
     stderr_path: String,
     has_pid_namespace: bool,
@@ -95,7 +95,7 @@ struct CompletedJob {
     exit_code: i32,
     signal: i32,
     run_attempt: u32,
-    rootfs_mode: crate::container::RootfsMode,
+    rootfs: Option<crate::container::JobRootfs>,
     cgroup: Option<std::path::PathBuf>,
     work_dir: String,
     uid: u32,
@@ -537,7 +537,7 @@ impl AgentService {
                         job_id,
                         TrackedJob {
                             job,
-                            rootfs_mode: manifest.rootfs_mode,
+                            rootfs: manifest.rootfs.clone(),
                             stdout_path: manifest.stdout_path,
                             stderr_path: manifest.stderr_path,
                             has_pid_namespace: manifest.has_pid_namespace,
@@ -571,7 +571,9 @@ impl AgentService {
                     // stays accurate after the sentinel/rootfs are gone. The
                     // spool (and manifest) is kept until every obligation is
                     // discharged (see reconcile_running_jobs).
-                    crate::container::cleanup_rootfs(job_id, &manifest.rootfs_mode);
+                    if let Some(ref rootfs) = manifest.rootfs {
+                        crate::container::cleanup_rootfs(rootfs);
+                    }
                     if let Some(ref cgroup) = manifest.cgroup_path {
                         executor::cleanup_cgroup(cgroup);
                     }
@@ -616,7 +618,7 @@ impl AgentService {
                                 exit_code,
                                 signal,
                                 run_attempt: tracked.run_attempt,
-                                rootfs_mode: tracked.rootfs_mode.clone(),
+                                rootfs: tracked.rootfs.clone(),
                                 cgroup,
                                 work_dir: tracked.work_dir.clone(),
                                 uid: tracked.uid,
@@ -638,7 +640,9 @@ impl AgentService {
 
                 for c in &completed {
                     jobs.remove(&c.job_id);
-                    crate::container::cleanup_rootfs(c.job_id, &c.rootfs_mode);
+                    if let Some(ref rootfs) = c.rootfs {
+                        crate::container::cleanup_rootfs(rootfs);
+                    }
                     if let Some(ref cgroup) = c.cgroup {
                         crate::executor::cleanup_cgroup(cgroup);
                     }
@@ -779,6 +783,32 @@ impl Drop for LaunchReservationGuard {
             handle.spawn(async move {
                 allocation.lock().await.release_job(job_id);
             });
+        }
+    }
+}
+
+/// Tears down a rootfs created by a launch that exits before commit, including
+/// on cancellation. Attempt-keyed dirs are never reused, so a leak is permanent.
+struct LaunchRootfsGuard {
+    rootfs: Option<crate::container::JobRootfs>,
+}
+
+impl LaunchRootfsGuard {
+    fn new(rootfs: Option<crate::container::JobRootfs>) -> Self {
+        Self { rootfs }
+    }
+
+    /// Hand ownership back once the job is committed and teardown belongs to
+    /// the normal completion path.
+    fn disarm(&mut self) -> Option<crate::container::JobRootfs> {
+        self.rootfs.take()
+    }
+}
+
+impl Drop for LaunchRootfsGuard {
+    fn drop(&mut self) {
+        if let Some(rootfs) = self.rootfs.take() {
+            crate::container::cleanup_rootfs(&rootfs);
         }
     }
 }
@@ -1489,7 +1519,7 @@ impl SlurmAgent for AgentService {
         let mut rootfs_path: Option<std::path::PathBuf> = None;
         let mut container_exit_status_path: Option<String> = None;
 
-        let (launch_script, rootfs_mode) = if !spec.container_image.is_empty() {
+        let (launch_script, owned_rootfs) = if !spec.container_image.is_empty() {
             info!(job_id, image = %spec.container_image, "launching containerized job");
 
             let mounts: Vec<crate::container::BindMount> = spec
@@ -1545,9 +1575,13 @@ impl SlurmAgent for AgentService {
             )
             .map_err(|e| Status::failed_precondition(e.to_string()))?;
 
-            let (rootfs, rootfs_mode) =
-                crate::container::setup_rootfs(&image_path, job_id, cfg.name.as_deref())
-                    .map_err(|e| Status::internal(format!("container setup failed: {}", e)))?;
+            let (rootfs, owned_rootfs) = crate::container::setup_rootfs(
+                &image_path,
+                job_id,
+                run_attempt,
+                cfg.name.as_deref(),
+            )
+            .map_err(|e| Status::internal(format!("container setup failed: {}", e)))?;
 
             // Copy user script into rootfs/tmp/ so it's accessible after pivot_root.
             // Wrap it to record the exit code at an in-container path, so a
@@ -1580,9 +1614,9 @@ impl SlurmAgent for AgentService {
             // The launch_script passed to executor is the user's script
             // (used as fallback for non-container path; for container path,
             // the executor reads from rootfs/tmp/ directly).
-            (script, rootfs_mode)
+            (script, owned_rootfs)
         } else {
-            (script, crate::container::RootfsMode::Extracted)
+            (script, None)
         };
 
         let mut pmix_guard = None;
@@ -1647,6 +1681,9 @@ impl SlurmAgent for AgentService {
 
         // Release the reservation on any exit before commit, including a
         // cancelled launch future; disarmed once committed to `running`.
+        // Armed before any fallible step so every early return, and future
+        // cancellation, tears the rootfs down.
+        let mut rootfs_guard = LaunchRootfsGuard::new(owned_rootfs);
         let mut reservation_guard = LaunchReservationGuard::new(self.allocation.clone(), job_id);
 
         let injection = {
@@ -1827,7 +1864,7 @@ impl SlurmAgent for AgentService {
                                 partition: launch_cfg.partition.clone(),
                                 nodelist: launch_cfg.nodelist.clone(),
                                 mpi: spec.mpi.clone(),
-                                rootfs_mode: rootfs_mode.clone(),
+                                rootfs: rootfs_guard.rootfs.clone(),
                                 exit_status_path: Some(sentinel),
                                 pending: executor::PendingObligations::default(),
                                 exit: None,
@@ -1860,14 +1897,12 @@ impl SlurmAgent for AgentService {
                     }
                     let _ = result.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
                     let cgroup = result.job.take_cgroup();
-                    let running = self.running.clone();
+                    let aborted_rootfs = rootfs_guard.disarm();
                     tokio::spawn(async move {
                         reap_killed_job(result.job).await;
-                        // Spool/cgroup are attempt-scoped; rootfs is job_id-keyed,
-                        // so skip it if a live run for job_id reappeared.
                         crate::executor::cleanup_job_spool(job_id, run_attempt);
-                        if !running.lock().await.contains_key(&job_id) {
-                            crate::container::cleanup_rootfs(job_id, &rootfs_mode);
+                        if let Some(ref rootfs) = aborted_rootfs {
+                            crate::container::cleanup_rootfs(rootfs);
                         }
                         if let Some(ref cg) = cgroup {
                             crate::executor::cleanup_cgroup(cg);
@@ -1893,7 +1928,7 @@ impl SlurmAgent for AgentService {
                     job_id,
                     TrackedJob {
                         job: result.job,
-                        rootfs_mode: rootfs_mode.clone(),
+                        rootfs: rootfs_guard.disarm(),
                         stdout_path: result.stdout_path,
                         stderr_path: result.stderr_path,
                         has_pid_namespace: is_root || is_container,
@@ -1921,7 +1956,17 @@ impl SlurmAgent for AgentService {
                 if let Some(old) = displaced {
                     if old.run_attempt < run_attempt {
                         let _ = old.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
-                        tokio::spawn(reap_killed_job(old.job));
+                        let old_rootfs = old.rootfs;
+                        let old_attempt = old.run_attempt;
+                        tokio::spawn(async move {
+                            reap_killed_job(old.job).await;
+                            // Attempt-keyed, so this is the displaced run's own
+                            // rootfs and spool, not the one just launched.
+                            crate::executor::cleanup_job_spool(job_id, old_attempt);
+                            if let Some(ref rootfs) = old_rootfs {
+                                crate::container::cleanup_rootfs(rootfs);
+                            }
+                        });
                     }
                 }
                 Ok(Response::new(LaunchJobResponse {
@@ -2219,7 +2264,7 @@ impl SlurmAgent for AgentService {
             req.job_id,
             TrackedJob {
                 job: executor::RunningJob::AllocationOnly,
-                rootfs_mode: crate::container::RootfsMode::Extracted,
+                rootfs: None,
                 stdout_path: String::new(),
                 stderr_path: String::new(),
                 has_pid_namespace: false,
@@ -3553,7 +3598,7 @@ impl TrackedJob {
                 child,
                 cgroup_path: None,
             },
-            rootfs_mode: crate::container::RootfsMode::Extracted,
+            rootfs: None,
             stdout_path: "/dev/null".into(),
             stderr_path: "/dev/null".into(),
             has_pid_namespace: false,
@@ -3579,7 +3624,7 @@ impl TrackedJob {
     fn dummy_allocation_only() -> Self {
         Self {
             job: executor::RunningJob::AllocationOnly,
-            rootfs_mode: crate::container::RootfsMode::Extracted,
+            rootfs: None,
             stdout_path: String::new(),
             stderr_path: String::new(),
             has_pid_namespace: false,
@@ -5540,7 +5585,7 @@ mod tests {
                 partition: "default".into(),
                 nodelist: "test-node".into(),
                 mpi: String::new(),
-                rootfs_mode: crate::container::RootfsMode::Extracted,
+                rootfs: None,
                 exit_status_path: None,
                 pending: executor::PendingObligations::default(),
                 exit: None,
@@ -5617,7 +5662,7 @@ mod tests {
                 partition: "default".into(),
                 nodelist: "test-node".into(),
                 mpi: String::new(),
-                rootfs_mode: crate::container::RootfsMode::Extracted,
+                rootfs: None,
                 exit_status_path: None,
                 pending: executor::PendingObligations::default(),
                 exit: None,
@@ -5708,7 +5753,7 @@ mod tests {
                 partition: "default".into(),
                 nodelist: "test-node".into(),
                 mpi: String::new(),
-                rootfs_mode: crate::container::RootfsMode::Extracted,
+                rootfs: None,
                 exit_status_path: None,
                 pending: executor::PendingObligations::default(),
                 exit: None,
@@ -5807,7 +5852,7 @@ mod tests {
             partition: "default".into(),
             nodelist: "test-node".into(),
             mpi: String::new(),
-            rootfs_mode: crate::container::RootfsMode::Extracted,
+            rootfs: None,
             exit_status_path: None,
             pending: executor::PendingObligations::default(),
             exit: Some((3, 0)),
@@ -5909,7 +5954,7 @@ mod tests {
             partition: "default".into(),
             nodelist: "test-node".into(),
             mpi: String::new(),
-            rootfs_mode: crate::container::RootfsMode::Extracted,
+            rootfs: None,
             exit_status_path: None,
             pending: executor::PendingObligations::default(),
             exit: None,
@@ -6060,7 +6105,7 @@ mod tests {
                 child,
                 cgroup_path: None,
             },
-            rootfs_mode: crate::container::RootfsMode::Extracted,
+            rootfs: None,
             stdout_path: "/dev/null".into(),
             stderr_path: "/dev/null".into(),
             has_pid_namespace: false,
@@ -6120,7 +6165,7 @@ mod tests {
                     child,
                     cgroup_path: None,
                 },
-                rootfs_mode: crate::container::RootfsMode::Extracted,
+                rootfs: None,
                 stdout_path: "/dev/null".into(),
                 stderr_path: "/dev/null".into(),
                 has_pid_namespace: false,
@@ -6388,5 +6433,43 @@ mod tests {
             }
         }
         panic!("did not receive exit status from bridge");
+    }
+
+    fn owned_rootfs_at(base: &std::path::Path) -> crate::container::JobRootfs {
+        std::fs::create_dir_all(base.join("tmp")).unwrap();
+        crate::container::JobRootfs {
+            base_dir: base.to_path_buf(),
+            mode: crate::container::RootfsMode::Extracted,
+        }
+    }
+
+    /// A launch that fails after creating the rootfs must not leak it — the dir
+    /// is attempt-keyed, so no later attempt reuses or reclaims it.
+    #[test]
+    fn launch_rootfs_guard_tears_down_an_uncommitted_rootfs() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("job_1_0");
+
+        drop(LaunchRootfsGuard::new(Some(owned_rootfs_at(&base))));
+
+        assert!(!base.exists(), "uncommitted rootfs should be removed");
+    }
+
+    #[test]
+    fn launch_rootfs_guard_leaves_a_committed_rootfs_to_the_job() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("job_1_0");
+        let mut guard = LaunchRootfsGuard::new(Some(owned_rootfs_at(&base)));
+
+        let handed_over = guard.disarm();
+        drop(guard);
+
+        assert_eq!(handed_over.map(|r| r.base_dir), Some(base.clone()));
+        assert!(base.exists(), "committed rootfs is the job's to keep");
+    }
+
+    #[test]
+    fn launch_rootfs_guard_is_inert_for_non_container_jobs() {
+        drop(LaunchRootfsGuard::new(None));
     }
 }

--- a/crates/spurd/src/container.rs
+++ b/crates/spurd/src/container.rs
@@ -216,7 +216,7 @@ pub fn resolve_image(
 }
 
 /// How the rootfs was set up — determines cleanup strategy.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum RootfsMode {
     /// Extracted via unsquashfs — cleanup by removing the directory.
     Extracted,

--- a/crates/spurd/src/container.rs
+++ b/crates/spurd/src/container.rs
@@ -224,41 +224,91 @@ pub enum RootfsMode {
     Overlay,
 }
 
+/// A rootfs this job owns and must tear down. Carries the directory because
+/// [`container_dir`] reads live environment a restarted agent may not share.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct JobRootfs {
+    pub base_dir: PathBuf,
+    pub mode: RootfsMode,
+}
+
+/// Where a job's rootfs goes and whether the job owns it.
+#[derive(Debug, PartialEq)]
+struct RootfsPlan {
+    base_dir: PathBuf,
+    /// Named containers persist across jobs, so a job never owns one.
+    owned: bool,
+}
+
+/// Decide the rootfs location without touching the filesystem. Unnamed dirs are
+/// keyed by run attempt so a same-node redispatch can't land on a live run.
+fn plan_rootfs(cdir: &Path, job_id: u32, run_attempt: u32, name: Option<&str>) -> RootfsPlan {
+    match name {
+        Some(name) => RootfsPlan {
+            base_dir: cdir.join(sanitize_name(name)),
+            owned: false,
+        },
+        None => RootfsPlan {
+            base_dir: cdir.join(format!("job_{}_{}", job_id, run_attempt)),
+            owned: true,
+        },
+    }
+}
+
 /// Create a container rootfs from a squashfs image.
 ///
-/// Tries overlayfs mount first (fast, no disk copy) and falls back to
-/// unsquashfs extraction if not root or mount fails.
+/// An unnamed rootfs tries overlayfs first and falls back to unsquashfs
+/// extraction if not root or the mount fails; named containers are extracted.
 ///
-/// Named containers always use extraction (they persist across jobs).
+/// Returns the path to run in, and the teardown record — `None` for named
+/// containers, which persist across jobs and are never the job's to remove.
 pub fn setup_rootfs(
     image_path: &Path,
     job_id: u32,
+    run_attempt: u32,
     name: Option<&str>,
-) -> anyhow::Result<(PathBuf, RootfsMode)> {
-    let cdir = container_dir();
-    let base_dir = if let Some(name) = name {
-        cdir.join(sanitize_name(name))
-    } else {
-        cdir.join(format!("job_{}", job_id))
-    };
+) -> anyhow::Result<(PathBuf, Option<JobRootfs>)> {
+    setup_rootfs_in(&container_dir(), image_path, job_id, run_attempt, name)
+}
 
-    // If named container already exists, reuse it
-    if base_dir.exists() && name.is_some() {
-        debug!(path = %base_dir.display(), "reusing named container");
-        return Ok((base_dir, RootfsMode::Extracted));
+fn setup_rootfs_in(
+    cdir: &Path,
+    image_path: &Path,
+    job_id: u32,
+    run_attempt: u32,
+    name: Option<&str>,
+) -> anyhow::Result<(PathBuf, Option<JobRootfs>)> {
+    let plan = plan_rootfs(cdir, job_id, run_attempt, name);
+    if !plan.owned {
+        if plan.base_dir.exists() {
+            debug!(path = %plan.base_dir.display(), "reusing named container");
+            return Ok((plan.base_dir, None));
+        }
+        setup_rootfs_extract(image_path, &plan.base_dir)?;
+        return Ok((plan.base_dir, None));
     }
 
-    // Try overlayfs mount first (unnamed containers only, requires root)
-    if name.is_none() && nix::unistd::geteuid().is_root() {
-        if let Ok(merged) = setup_rootfs_overlay(image_path, &base_dir) {
-            return Ok((merged, RootfsMode::Overlay));
+    if nix::unistd::geteuid().is_root() {
+        if let Ok(merged) = setup_rootfs_overlay(image_path, &plan.base_dir) {
+            return Ok((merged, Some(plan.into_owned(RootfsMode::Overlay))));
         }
         debug!("overlayfs mount failed, falling back to extraction");
     }
 
-    // Fallback: extract with unsquashfs
-    setup_rootfs_extract(image_path, &base_dir)?;
-    Ok((base_dir, RootfsMode::Extracted))
+    setup_rootfs_extract(image_path, &plan.base_dir)?;
+    Ok((
+        plan.base_dir.clone(),
+        Some(plan.into_owned(RootfsMode::Extracted)),
+    ))
+}
+
+impl RootfsPlan {
+    fn into_owned(self, mode: RootfsMode) -> JobRootfs {
+        JobRootfs {
+            base_dir: self.base_dir,
+            mode,
+        }
+    }
 }
 
 /// Mount squashfs image read-only, then layer a tmpfs overlay on top.
@@ -397,16 +447,16 @@ pub fn parse_mount(spec: &str) -> anyhow::Result<BindMount> {
     }
 }
 
-/// Clean up an unnamed container rootfs.
+/// Clean up a rootfs the job owns.
 ///
 /// Handles both overlay (unmount) and extracted (rm -rf) modes.
-pub fn cleanup_rootfs(job_id: u32, mode: &RootfsMode) {
-    let base_dir = container_dir().join(format!("job_{}", job_id));
+pub fn cleanup_rootfs(rootfs: &JobRootfs) {
+    let base_dir = &rootfs.base_dir;
     if !base_dir.exists() {
         return;
     }
 
-    if *mode == RootfsMode::Overlay {
+    if rootfs.mode == RootfsMode::Overlay {
         // Unmount in reverse order: overlay, upper tmpfs, lower squashfs
         let merged = base_dir.join("merged");
         let upper = base_dir.join("upper");
@@ -418,7 +468,7 @@ pub fn cleanup_rootfs(job_id: u32, mode: &RootfsMode) {
         }
     }
 
-    if let Err(e) = std::fs::remove_dir_all(&base_dir) {
+    if let Err(e) = std::fs::remove_dir_all(base_dir) {
         warn!(
             path = %base_dir.display(),
             error = %e,
@@ -1748,8 +1798,79 @@ mod tests {
     #[test]
     fn test_cleanup_rootfs_nonexistent() {
         // Should not panic when cleaning up a rootfs that doesn't exist
-        cleanup_rootfs(999999, &RootfsMode::Extracted);
-        cleanup_rootfs(999998, &RootfsMode::Overlay);
+        for mode in [RootfsMode::Extracted, RootfsMode::Overlay] {
+            cleanup_rootfs(&JobRootfs {
+                base_dir: PathBuf::from("/nonexistent/spur-test/job_999999_0"),
+                mode,
+            });
+        }
+    }
+
+    #[test]
+    fn unnamed_rootfs_is_owned_and_scoped_to_one_run_attempt() {
+        let cdir = Path::new("/containers");
+
+        let first = plan_rootfs(cdir, 7, 0, None);
+        let second = plan_rootfs(cdir, 7, 1, None);
+
+        assert_eq!(first.base_dir, cdir.join("job_7_0"));
+        assert_ne!(first.base_dir, second.base_dir);
+        assert!(first.owned && second.owned);
+    }
+
+    /// A named container outlives the job whether or not it already exists, so
+    /// neither branch may hand the job a record that would delete it.
+    #[test]
+    fn named_container_is_never_owned_by_the_job() {
+        let cdir = Path::new("/containers");
+
+        let plan = plan_rootfs(cdir, 7, 3, Some("shared-env"));
+
+        assert_eq!(plan.base_dir, cdir.join("shared-env"));
+        assert!(!plan.owned);
+        assert_eq!(plan, plan_rootfs(cdir, 99, 0, Some("shared-env")));
+    }
+
+    /// Tearing down one attempt must not remove a redispatched attempt's rootfs.
+    #[test]
+    fn cleanup_removes_only_the_recorded_attempt() {
+        let root = tempfile::tempdir().unwrap();
+        let first = plan_rootfs(root.path(), 42, 0, None).base_dir;
+        let second = plan_rootfs(root.path(), 42, 1, None).base_dir;
+        std::fs::create_dir_all(first.join("tmp")).unwrap();
+        std::fs::create_dir_all(second.join("tmp")).unwrap();
+
+        cleanup_rootfs(&JobRootfs {
+            base_dir: first.clone(),
+            mode: RootfsMode::Extracted,
+        });
+
+        assert!(!first.exists(), "recorded attempt should be removed");
+        assert!(second.exists(), "redispatched attempt must survive");
+    }
+
+    /// A named container outlives the job, so the job must not be handed a
+    /// teardown record that would delete it.
+    #[test]
+    fn named_container_yields_no_teardown_record() {
+        let cdir = tempfile::tempdir().unwrap();
+        let existing = cdir.path().join("shared-env");
+        std::fs::create_dir_all(&existing).unwrap();
+
+        let (path, owned) = setup_rootfs_in(
+            cdir.path(),
+            Path::new("/nonexistent.sqsh"),
+            5,
+            0,
+            Some("shared-env"),
+        )
+        .unwrap();
+
+        assert_eq!(path, existing);
+        assert!(
+            owned.is_none(),
+            "named container is not the job's to remove"
+        );
     }
 
     // --- run_hooks ---

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -112,6 +112,18 @@ const CGROUP_ROOT: &str = "/sys/fs/cgroup/spur";
 /// never hit an NFS root_squash mount. Mirrors Slurm's SlurmdSpoolDir.
 const SPOOL_ROOT: &str = "/var/spool/spur";
 
+/// Candidate spool bases, highest priority first. The user-controlled temp
+/// fallback is only used when spurd is NOT root — root must never scan or write
+/// a world-reachable base (a user could plant a manifest there and have root
+/// trust it verbatim on restart).
+fn spool_bases() -> Vec<PathBuf> {
+    let mut bases = vec![PathBuf::from(SPOOL_ROOT)];
+    if !nix::unistd::geteuid().is_root() {
+        bases.push(std::env::temp_dir().join("spur"));
+    }
+    bases
+}
+
 pub struct ContainerLaunchConfig {
     pub config: ContainerConfig,
     pub rootfs: PathBuf,
@@ -134,6 +146,9 @@ pub enum LaunchIo {
 
 pub struct JobLaunchConfig {
     pub job_id: JobId,
+    /// Disambiguates the cgroup path across a same-node redispatch of the
+    /// same job_id, so displacing an old run can never SIGKILL the new one.
+    pub run_attempt: u32,
     pub script: String,
     pub work_dir: String,
     /// Needed to expand `%x`/`%u`/`%N`/`%a`/`%A` in output paths as the controller does.
@@ -173,6 +188,7 @@ pub struct LaunchResult {
     pub stderr_path: String,
     /// Master fd of the PTY (only set when `io_mode == LaunchIo::Pty`).
     pub pty_master: Option<OwnedFd>,
+    pub spool_dir: PathBuf,
 }
 
 /// Owns the resolved fds for a job's stdio, built once and consumed by both
@@ -310,6 +326,15 @@ pub enum RunningJob {
     },
     /// Allocation registered without a batch process (standalone srun).
     AllocationOnly,
+    /// A job re-adopted from a manifest after spurd restarted; the new process
+    /// isn't spurd's child, so completion is detected via cgroup population
+    /// rather than waitpid. See `reconcile_running_jobs`.
+    Resumed {
+        pid: i32,
+        start_time: u64,
+        cgroup_path: Option<PathBuf>,
+        exit_status_path: PathBuf,
+    },
 }
 
 /// Split a finished process's wait status into (exit_code, signal).
@@ -364,6 +389,18 @@ impl RunningJob {
         match self {
             RunningJob::Managed { child, .. } => child.id(),
             RunningJob::Forked { pid, .. } => Some(*pid as u32),
+            RunningJob::Resumed { pid, .. } => Some(*pid as u32),
+            RunningJob::AllocationOnly => None,
+        }
+    }
+
+    /// Non-consuming peek at the cgroup path, for recording it in a job
+    /// manifest without disturbing `take_cgroup`'s completion-time handoff.
+    pub fn cgroup_path(&self) -> Option<&Path> {
+        match self {
+            RunningJob::Managed { cgroup_path, .. } => cgroup_path.as_deref(),
+            RunningJob::Forked { cgroup_path, .. } => cgroup_path.as_deref(),
+            RunningJob::Resumed { cgroup_path, .. } => cgroup_path.as_deref(),
             RunningJob::AllocationOnly => None,
         }
     }
@@ -404,6 +441,36 @@ impl RunningJob {
                     Err(e) => Err(e.into()),
                 }
             }
+            RunningJob::Resumed {
+                pid,
+                start_time,
+                cgroup_path,
+                exit_status_path,
+            } => {
+                // A populated cgroup is authoritative proof the job is alive; an
+                // empty one, proof it exited. But an unreadable cgroup.events
+                // (non-v2 host, or the process was never moved in) is NOT proof
+                // of exit — falling straight to "done" there would report every
+                // adopted job complete on the first post-restart tick and release
+                // its GPUs while the real workload keeps running. Fall back to a
+                // direct pid liveness check in that case.
+                let done = match cgroup_path {
+                    Some(cg) => match cgroup_liveness(cg) {
+                        CgroupLiveness::Populated => false,
+                        CgroupLiveness::Empty => true,
+                        CgroupLiveness::Unknown => !proc_alive(*pid, *start_time),
+                    },
+                    None => !proc_alive(*pid, *start_time),
+                };
+                if !done {
+                    return Ok(None);
+                }
+                Ok(Some(
+                    read_exit_status(exit_status_path)
+                        .map(decode_shell_exit)
+                        .unwrap_or((-1, 0)),
+                ))
+            }
             RunningJob::AllocationOnly => Ok(None),
         }
     }
@@ -432,6 +499,15 @@ impl RunningJob {
                 kill_process_tree(*pid, sig);
                 Ok(())
             }
+            RunningJob::Resumed {
+                pid, cgroup_path, ..
+            } => {
+                match cgroup_path {
+                    Some(cg) => cgroup_signal_all(cg, sig),
+                    None => kill_process_tree(*pid, sig),
+                }
+                Ok(())
+            }
             RunningJob::AllocationOnly => Ok(()),
         }
     }
@@ -440,9 +516,370 @@ impl RunningJob {
         match self {
             RunningJob::Managed { cgroup_path, .. } => cgroup_path.take(),
             RunningJob::Forked { cgroup_path, .. } => cgroup_path.take(),
+            RunningJob::Resumed { cgroup_path, .. } => cgroup_path.take(),
             RunningJob::AllocationOnly => None,
         }
     }
+}
+
+const MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// What the agent still owes a job whose process has ended. Persisted in the
+/// manifest and cleared step by step as each obligation is discharged, so a
+/// restart that interrupts teardown (e.g. a completion report that never
+/// reached the controller) resumes from where it left off instead of re-running
+/// an already-done, possibly non-idempotent step like the epilog. Absent the
+/// ledger, a retried teardown would run the epilog (GPU reset, scratch purge,
+/// SPANK JobEpilog) twice.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct PendingObligations {
+    /// Run the epilog + SPANK TaskExit/JobEpilog hooks (and drain on failure).
+    #[serde(default = "default_true")]
+    pub epilog: bool,
+    /// Report the completion to the controller.
+    #[serde(default = "default_true")]
+    pub report_completion: bool,
+    /// Set when the epilog failed, so the still-owed completion report carries a
+    /// drain request even if it lands on a later restart (the epilog itself is
+    /// no longer owed by then, so the drain intent must be remembered here).
+    #[serde(default)]
+    pub drain: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for PendingObligations {
+    fn default() -> Self {
+        Self {
+            epilog: true,
+            report_completion: true,
+            drain: false,
+        }
+    }
+}
+
+impl PendingObligations {
+    /// True once nothing is owed, so the job's spool/manifest can be removed.
+    pub fn all_discharged(&self) -> bool {
+        !self.epilog && !self.report_completion
+    }
+}
+
+/// The record spurd re-adopts a job from after a restart. Split into two
+/// concerns: **identity** — how to find the process and confirm it's still the
+/// same one — and **obligations** — what the agent still owes the job once its
+/// process ends (resource release, epilog, completion report). Structuring the
+/// record around "what must still happen" rather than only "what the process
+/// looks like" keeps the restart teardown honest: every obligation has an
+/// explicit home in the schema instead of being re-derived by the reconcile
+/// code, which is where obligations were silently dropped before.
+///
+/// Written right after a successful spawn so a graceful restart doesn't lose
+/// track of (or double-book resources for) a job that's still running, then
+/// rewritten as obligations are discharged during teardown.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct JobManifest {
+    pub schema_version: u32,
+    pub job_id: JobId,
+    pub run_attempt: u32,
+
+    // --- Identity: locate and verify the process on restart. ---
+    pub pid: i32,
+    pub start_time: u64,
+    pub cgroup_path: Option<PathBuf>,
+    pub forked: bool,
+    /// Host path to the job's exit-status sentinel (inside rootfs for containers).
+    #[serde(default)]
+    pub exit_status_path: Option<String>,
+    pub rootfs_mode: crate::container::RootfsMode,
+
+    // --- Obligations: what the agent still owes this job. ---
+    /// Remaining teardown steps; each cleared as it is discharged.
+    #[serde(default)]
+    pub pending: PendingObligations,
+    /// The resolved (exit_code, signal), recorded once the process is first seen
+    /// dead. A container's exit sentinel lives in the job rootfs, which is torn
+    /// down as soon as the job is adopted dead, so the outcome must be captured
+    /// here for a report that only lands on a later restart to still be accurate.
+    #[serde(default)]
+    pub exit: Option<(i32, i32)>,
+    /// Resources held by the job, released back to the node on teardown.
+    pub cpu_ids: Vec<u32>,
+    pub gpu_devices: Vec<u32>,
+    pub cpus: u32,
+    pub memory_mb: u64,
+    /// Context the epilog + completion report need.
+    pub uid: u32,
+    pub gid: u32,
+    /// Owning username, restored on re-adopt so exec/attach access gating still
+    /// recognizes the owner of a job that survived a restart.
+    #[serde(default)]
+    pub user: String,
+    pub stdout_path: String,
+    pub stderr_path: String,
+    pub work_dir: String,
+    pub partition: String,
+    pub nodelist: String,
+    pub mpi: String,
+}
+
+fn manifest_path(spool_dir: &Path) -> PathBuf {
+    spool_dir.join("manifest.json")
+}
+
+pub(crate) fn exit_status_path(spool_dir: &Path) -> PathBuf {
+    spool_dir.join("exit_status")
+}
+
+/// Write a job's manifest. Best-effort: a failure here just means the job
+/// won't survive a spurd restart, same as not having this feature. Written via
+/// a temp file + rename so a crash mid-write can't leave a torn manifest.
+///
+/// Mode 0600: the manifest carries the job's uid/gid/cgroup/resource ids, and a
+/// co-located user could open it by its predictable path in the traversable spool dir.
+pub fn write_job_manifest(spool_dir: &Path, manifest: &JobManifest) {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let path = manifest_path(spool_dir);
+    let tmp = path.with_extension("json.tmp");
+    let bytes = match serde_json::to_vec(manifest) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(job_id = manifest.job_id, error = %e, "failed to serialize job manifest");
+            return;
+        }
+    };
+    let write = || -> std::io::Result<()> {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&tmp)?;
+        f.write_all(&bytes)?;
+        f.sync_all()?;
+        std::fs::rename(&tmp, &path)
+    };
+    if let Err(e) = write() {
+        warn!(job_id = manifest.job_id, error = %e, "failed to write job manifest");
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
+/// `/proc/<pid>/stat` field 22 (starttime) — disambiguates a live process
+/// from a different one that has since reused the same pid.
+pub fn proc_start_time(pid: i32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    // comm (field 2) is parenthesized and may itself contain ')'; split on
+    // the last one so the fixed-width fields after it parse safely.
+    stat.rsplit_once(')')?
+        .1
+        .split_whitespace()
+        .nth(19)?
+        .parse()
+        .ok()
+}
+
+fn proc_alive(pid: i32, start_time: u64) -> bool {
+    proc_start_time(pid) == Some(start_time)
+}
+
+/// Liveness verdict from a cgroup's `cgroup.events`.
+#[derive(Debug, PartialEq, Eq)]
+enum CgroupLiveness {
+    /// `populated 1`: at least one process is still in the cgroup.
+    Populated,
+    /// `populated 0`: the cgroup exists but is empty — everything has exited.
+    Empty,
+    /// `cgroup.events` is missing or unreadable. On cgroup-v2 this means the dir
+    /// was already removed (empty); but a non-v2/hybrid host, or a job never
+    /// moved into the cgroup, also lands here — so it is NOT proof of exit and
+    /// the caller must fall back to a direct pid liveness check.
+    Unknown,
+}
+
+/// Read a cgroup-v2 `cgroup.events` to decide whether it still holds processes.
+fn cgroup_liveness(cgroup_path: &Path) -> CgroupLiveness {
+    let Ok(events) = std::fs::read_to_string(cgroup_path.join("cgroup.events")) else {
+        return CgroupLiveness::Unknown;
+    };
+    if events.lines().any(|line| line.trim() == "populated 1") {
+        CgroupLiveness::Populated
+    } else {
+        CgroupLiveness::Empty
+    }
+}
+
+/// Signal every process in a cgroup, regardless of whether spurd is their
+/// parent. SIGKILL uses the atomic `cgroup.kill` (5.14+) when available;
+/// other signals, and older kernels, signal each `cgroup.procs` pid directly.
+fn cgroup_signal_all(cgroup_path: &Path, sig: Signal) {
+    if sig == Signal::SIGKILL && std::fs::write(cgroup_path.join("cgroup.kill"), "1").is_ok() {
+        return;
+    }
+    if let Ok(pids) = std::fs::read_to_string(cgroup_path.join("cgroup.procs")) {
+        for pid_str in pids.lines() {
+            if let Ok(pid) = pid_str.trim().parse::<i32>() {
+                let _ = signal::kill(Pid::from_raw(pid), sig);
+            }
+        }
+    }
+}
+
+/// Decode a shell `$?` value the way `decode_wait_status` decodes a real wait
+/// status: 128+N means death by signal N.
+fn decode_shell_exit(raw: i32) -> (i32, i32) {
+    if (129..=192).contains(&raw) {
+        (0, raw - 128)
+    } else {
+        (raw, 0)
+    }
+}
+
+fn read_exit_status(path: &Path) -> Option<i32> {
+    // The container sentinel lives in a job-writable rootfs, so it is fully
+    // untrusted input on the restart path. O_NONBLOCK means opening a planted
+    // FIFO can't block spurd startup forever (a blocking open of a writer-less
+    // FIFO never returns); O_NOFOLLOW refuses a symlink; the regular-file +
+    // single-link fstat check refuses a FIFO/device/hardlink; and the capped
+    // read refuses an arbitrarily large file.
+    use std::io::Read;
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    let f = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .ok()?;
+    let meta = f.metadata().ok()?;
+    if !meta.file_type().is_file() || meta.nlink() != 1 {
+        return None;
+    }
+    let mut buf = String::new();
+    f.take(64).read_to_string(&mut buf).ok()?;
+    buf.trim().parse().ok()
+}
+
+/// Wrap a job script so its exit code survives even if spurd isn't around to
+/// `wait()` it. A top-level `trap ... EXIT` fires on any exit — normal end,
+/// internal `exit N`, or an uncaught error under `set -e` — and re-exits with
+/// the same code so the wrapper's own exit status (what the normal,
+/// non-restarted path reports via `Child::try_wait`) is unchanged. Read back by
+/// `decode_shell_exit` on resume.
+///
+/// The trap is prepended rather than wrapping the body in a subshell: bash
+/// parses (and runs) a plain script incrementally, so a syntax error deep in the
+/// script still runs the lines above it, exactly as an unwrapped job would. A
+/// subshell (or brace group) is one compound command that must parse in full
+/// before any of it runs, which would change failure semantics for every job on
+/// the universal launch path to buy an exit code only on the rare restart path.
+pub(crate) fn wrap_with_exit_sentinel(script: &str, exit_status_path: &Path) -> String {
+    format!(
+        "trap '_spur_rc=$?; echo $_spur_rc > {}; exit $_spur_rc' EXIT\n{}\n",
+        exit_status_path.display(),
+        script,
+    )
+}
+
+/// Outcome of checking one manifest found on startup.
+pub enum ReconcileOutcome {
+    Alive {
+        job: RunningJob,
+        manifest: JobManifest,
+    },
+    /// The process is gone; the controller must not be left waiting forever
+    /// for a completion report that will never come. The manifest carries the
+    /// resolved exit (in `manifest.exit`) and the still-owed obligations.
+    Dead { manifest: JobManifest },
+}
+
+/// Find every job manifest left behind by a previous spurd process.
+pub fn scan_job_manifests() -> Vec<(PathBuf, JobManifest)> {
+    let mut found = Vec::new();
+    for base in spool_bases() {
+        let Ok(entries) = std::fs::read_dir(&base) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let spool_dir = entry.path();
+            let Ok(bytes) = std::fs::read(manifest_path(&spool_dir)) else {
+                continue;
+            };
+            match serde_json::from_slice::<JobManifest>(&bytes) {
+                Ok(manifest) if manifest.schema_version == MANIFEST_SCHEMA_VERSION => {
+                    found.push((spool_dir, manifest));
+                }
+                Ok(manifest) => warn!(
+                    job_id = manifest.job_id,
+                    version = manifest.schema_version,
+                    "skipping job manifest with unknown schema version"
+                ),
+                Err(e) => warn!(dir = %spool_dir.display(), error = %e, "unreadable job manifest"),
+            }
+        }
+    }
+    dedup_manifests_by_job_id(found)
+}
+
+/// A job_id should only ever have one manifest (whichever `SPOOL_ROOT`/tmp
+/// base `create_job_spool_dir` used), but a stale leftover in the other base
+/// (e.g. from a run under a different privilege level) would otherwise make
+/// `reconcile_running_jobs` double-restore its allocation. Keep only the
+/// highest run_attempt per job_id.
+fn dedup_manifests_by_job_id(found: Vec<(PathBuf, JobManifest)>) -> Vec<(PathBuf, JobManifest)> {
+    let mut by_job: HashMap<JobId, (PathBuf, JobManifest)> = HashMap::new();
+    for (dir, manifest) in found {
+        match by_job.get(&manifest.job_id) {
+            Some((_, existing)) if existing.run_attempt >= manifest.run_attempt => {
+                warn!(
+                    job_id = manifest.job_id,
+                    dir = %dir.display(),
+                    "ignoring duplicate/stale job manifest"
+                );
+            }
+            _ => {
+                by_job.insert(manifest.job_id, (dir, manifest));
+            }
+        }
+    }
+    by_job.into_values().collect()
+}
+
+/// Decide whether a manifested job's process survived the restart.
+pub fn reconcile_manifest(spool_dir: &Path, mut manifest: JobManifest) -> ReconcileOutcome {
+    let sentinel = manifest
+        .exit_status_path
+        .clone()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| exit_status_path(spool_dir));
+    if proc_alive(manifest.pid, manifest.start_time) {
+        let job = RunningJob::Resumed {
+            pid: manifest.pid,
+            start_time: manifest.start_time,
+            cgroup_path: manifest.cgroup_path.clone(),
+            exit_status_path: sentinel,
+        };
+        return ReconcileOutcome::Alive { job, manifest };
+    }
+    // Resolve the exit only the first time the job is seen dead. On a retry
+    // after a partial teardown the sentinel/cgroup may already be gone, so trust
+    // the exit recorded in the manifest instead of re-reading and getting -1.
+    if manifest.exit.is_none() {
+        let (exit_code, mut signal) = read_exit_status(&sentinel)
+            .map(decode_shell_exit)
+            .unwrap_or((-1, 0));
+        // An OOM kill while spurd was down writes no sentinel; recover it from
+        // the cgroup so the outcome isn't a bare -1, matching the live monitor.
+        if let Some(ref cgroup) = manifest.cgroup_path {
+            if cgroup_oom_killed(cgroup) {
+                signal |= spur_core::job::OOM_SIGNAL_FLAG;
+            }
+        }
+        manifest.exit = Some((exit_code, signal));
+    }
+    ReconcileOutcome::Dead { manifest }
 }
 
 /// Launch a job script on this node.
@@ -483,6 +920,7 @@ async fn spawn_job_process(
 ) -> Result<LaunchResult, LaunchError> {
     let JobLaunchConfig {
         job_id,
+        run_attempt,
         ref script,
         ref work_dir,
         ref environment,
@@ -502,7 +940,7 @@ async fn spawn_job_process(
     info!(job_id, work_dir, "launching job");
 
     // Set up cgroup for isolation
-    let cgroup_path = setup_cgroup(job_id, cpus, memory_mb, cpu_ids)?;
+    let cgroup_path = setup_cgroup(job_id, run_attempt, cpus, memory_mb, cpu_ids)?;
 
     // Ensure work_dir exists on this node (the submitted path may only exist on the submitting
     // node). If creation fails (e.g. path is under another user's home), fall back to /tmp so
@@ -532,10 +970,16 @@ async fn spawn_job_process(
 
     // Script + wrapper live in the node-local spool dir, not work_dir (see
     // SPOOL_ROOT), so root-side writes survive NFS root_squash work_dirs.
-    let spool_dir = create_job_spool_dir(job_id, uid, gid)?;
+    let spool_dir = create_job_spool_dir(job_id, run_attempt, uid, gid)?;
     let script_path = spool_dir.join("spur_job.sh");
-    write_job_scratch(&script_path, script, uid, gid)
+    let wrapped_script = wrap_with_exit_sentinel(script, &exit_status_path(&spool_dir));
+    write_job_scratch(&script_path, &wrapped_script, uid, gid)
         .context("failed to write job script")
+        .map_err(|e| classify_spool_error(&spool_dir, e))?;
+    // Pre-create the exit-status sentinel owned by the job, so the wrapped
+    // script can truncate-write it without the spool dir being world-writable.
+    write_job_scratch(&exit_status_path(&spool_dir), "", uid, gid)
+        .context("failed to create exit-status sentinel")
         .map_err(|e| classify_spool_error(&spool_dir, e))?;
 
     // Build resolved output paths (empty for PTY mode since output goes to the terminal).
@@ -670,6 +1114,7 @@ async fn spawn_job_process(
             stdout_path: stdout_resolved,
             stderr_path: stderr_resolved,
             pty_master,
+            spool_dir,
         });
     }
 
@@ -849,12 +1294,15 @@ async fn spawn_job_process(
     // Drop the slave fd immediately so the master gets EOF when the child exits.
     let pty_master = job_io.into_master();
 
-    // Move process into cgroup
-    if let Some(ref cgroup) = cgroup_path {
-        if let Some(pid) = child.id() {
-            move_to_cgroup(cgroup, pid);
-        }
-    }
+    // Move process into cgroup. If the move fails the process runs outside the
+    // cgroup, so the cgroup can't report its liveness on restart — drop the path
+    // so reconcile falls back to a direct pid check instead of misreading an
+    // empty cgroup as an exited job.
+    let cgroup_path = match (cgroup_path, child.id()) {
+        (Some(cgroup), Some(pid)) if move_to_cgroup(&cgroup, pid) => Some(cgroup),
+        (Some(_), _) => None,
+        (None, _) => None,
+    };
 
     debug!(
         job_id,
@@ -868,18 +1316,46 @@ async fn spawn_job_process(
         stdout_path: stdout_resolved,
         stderr_path: stderr_resolved,
         pty_master,
+        spool_dir,
     })
+}
+
+/// The cgroup path for one job run. Keyed by job_id *and* run_attempt so a
+/// same-node redispatch never shares a cgroup with (and can't accidentally
+/// cgroup-wide-kill) a still-finishing prior run.
+fn cgroup_path_for(job_id: JobId, run_attempt: u32) -> PathBuf {
+    PathBuf::from(CGROUP_ROOT).join(format!("job_{}_{}", job_id, run_attempt))
+}
+
+/// Whether `/sys/fs/cgroup` is a unified cgroup-v2 mount. A v1/hybrid host has a
+/// tmpfs there instead, so a job dir created under it is an ordinary directory
+/// with no `cgroup.events` — which the reconcile path can't tell apart from an
+/// exited job. Detecting this up front lets `setup_cgroup` decline to create a
+/// fake hierarchy and run without cgroup isolation instead.
+fn cgroup_v2_available() -> bool {
+    matches!(
+        nix::sys::statfs::statfs(Path::new("/sys/fs/cgroup")),
+        Ok(s) if s.filesystem_type() == nix::sys::statfs::CGROUP2_SUPER_MAGIC
+    )
 }
 
 /// Set up a cgroups v2 hierarchy for a job.
 fn setup_cgroup(
     job_id: JobId,
+    run_attempt: u32,
     cpus: u32,
     memory_mb: u64,
     cpu_ids: &[u32],
 ) -> anyhow::Result<Option<PathBuf>> {
+    // Without a real cgroup-v2 mount, create_dir_all would make a plain
+    // directory that never gets a cgroup.events file — indistinguishable on
+    // restart from an exited job. Run without isolation rather than lie.
+    if !cgroup_v2_available() {
+        warn!(job_id, "cgroup v2 not available, running without isolation");
+        return Ok(None);
+    }
     let cgroup_root = PathBuf::from(CGROUP_ROOT);
-    let cgroup_path = cgroup_root.join(format!("job_{}", job_id));
+    let cgroup_path = cgroup_path_for(job_id, run_attempt);
 
     // Delegate controllers to children: in cgroup-v2 a child only gets
     // memory.*/cpu.*/pids.* files if the parent lists them in subtree_control;
@@ -1279,23 +1755,24 @@ fn create_dir_as_user(dir: &Path, uid: u32, gid: u32) -> bool {
 
 /// Create a node-local spool directory for a job's scratch files. Prefers
 /// `SPOOL_ROOT`; falls back to a temp dir when it isn't writable (e.g. non-root
-/// dev runs). When spurd is root and the job targets a user, the dir is handed
-/// to that user so the job — which runs as the user — can traverse it.
-fn create_job_spool_dir(job_id: JobId, uid: u32, gid: u32) -> Result<PathBuf, LaunchError> {
+/// dev runs). Kept root-owned and 0o711 so a co-located user can't plant a
+/// symlink over the root-authored manifest, which is trusted on restart. Keyed
+/// by `(job_id, run_attempt)` so a same-node redispatch never reuses a prior
+/// run's dir.
+fn create_job_spool_dir(
+    job_id: JobId,
+    run_attempt: u32,
+    uid: u32,
+    _gid: u32,
+) -> Result<PathBuf, LaunchError> {
     let mut failures = Vec::new();
-    for base in [PathBuf::from(SPOOL_ROOT), std::env::temp_dir().join("spur")] {
-        let dir = base.join(format!("job{}", job_id));
+    for base in spool_bases() {
+        let dir = base.join(format!("job{}_{}", job_id, run_attempt));
         match std::fs::create_dir_all(&dir) {
             Ok(()) => {
                 if should_run_as_user(uid) {
-                    use nix::unistd::{Gid, Uid};
-                    // Path-based chown is safe here: the spool tree is
-                    // root-owned, not user-controlled, so no symlink TOCTOU.
-                    let _ = nix::unistd::chown(
-                        &dir,
-                        Some(Uid::from_raw(uid)),
-                        Some(Gid::from_raw(gid)),
-                    );
+                    use std::os::unix::fs::PermissionsExt;
+                    let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o711));
                 }
                 return Ok(dir);
             }
@@ -1369,12 +1846,40 @@ pub(crate) fn write_job_scratch(
     Ok(())
 }
 
-/// Remove a job's spool directory (best-effort), mirroring Slurm purging its
-/// batchdir after completion. Tries both candidate roots since the fallback
-/// location isn't recorded.
-pub fn cleanup_job_spool(job_id: JobId) {
-    for base in [PathBuf::from(SPOOL_ROOT), std::env::temp_dir().join("spur")] {
-        let _ = std::fs::remove_dir_all(base.join(format!("job{}", job_id)));
+/// Remove one run attempt's spool dir. Scoped to `run_attempt` so cleaning a
+/// completed run never deletes a concurrent same-node redispatch's live spool.
+pub fn cleanup_job_spool(job_id: JobId, run_attempt: u32) {
+    let dir = format!("job{}_{}", job_id, run_attempt);
+    for base in spool_bases() {
+        let _ = std::fs::remove_dir_all(base.join(&dir));
+    }
+}
+
+/// Mark a job's epilog obligation discharged in its on-disk manifest, recording
+/// the resolved exit and any drain intent. Called on the live monitor path only
+/// when a completion report fails: the job is already gone from `running`, so a
+/// restart re-adopts it from this manifest — without this, the retry would
+/// re-run the (possibly non-idempotent) epilog. No-op if the manifest is already
+/// gone. Kept off the common success path so a normal completion pays nothing.
+pub fn mark_manifest_epilog_discharged(
+    job_id: JobId,
+    run_attempt: u32,
+    exit: (i32, i32),
+    drain: bool,
+) {
+    let dir = format!("job{}_{}", job_id, run_attempt);
+    for base in spool_bases() {
+        let spool_dir = base.join(&dir);
+        let Ok(bytes) = std::fs::read(manifest_path(&spool_dir)) else {
+            continue;
+        };
+        if let Ok(mut manifest) = serde_json::from_slice::<JobManifest>(&bytes) {
+            manifest.pending.epilog = false;
+            manifest.pending.drain = drain;
+            manifest.exit = Some(exit);
+            write_job_manifest(&spool_dir, &manifest);
+            return;
+        }
     }
 }
 
@@ -1411,7 +1916,13 @@ async fn launch_container_job(
     job_io: JobIo,
 ) -> anyhow::Result<(RunningJob, Option<OwnedFd>)> {
     let job_id = cfg.job_id;
-    let cgroup_path = setup_cgroup(job_id, cfg.cpus, cfg.memory_mb, &cfg.cpu_ids)?;
+    let cgroup_path = setup_cgroup(
+        job_id,
+        cfg.run_attempt,
+        cfg.cpus,
+        cfg.memory_mb,
+        &cfg.cpu_ids,
+    )?;
 
     // Sync pipe: child writes status, parent reads.
     // Convert OwnedFd to raw fds for manual lifecycle management across fork.
@@ -1537,9 +2048,13 @@ async fn launch_container_job(
 
             let child_pid = child.as_raw();
 
-            if let Some(ref cgroup) = cgroup_path {
-                let _ = std::fs::write(cgroup.join("cgroup.procs"), child_pid.to_string());
-            }
+            // If the move fails the process runs outside the cgroup, so the
+            // cgroup can't report its liveness on restart — drop the path so
+            // reconcile falls back to a direct pid check (see the Managed path).
+            let cgroup_path = match cgroup_path {
+                Some(cgroup) if move_to_cgroup(&cgroup, child_pid as u32) => Some(cgroup),
+                _ => None,
+            };
 
             // pidfd prevents PID recycling; falls back gracefully on kernels < 5.3
             let pidfd = pidfd_open(child_pid).ok();
@@ -1694,6 +2209,575 @@ fn wrap_with_burst_buffer(script: &str, bb: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_manifest(job_id: JobId, run_attempt: u32) -> JobManifest {
+        JobManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            job_id,
+            run_attempt,
+            pid: 1,
+            start_time: 0,
+            cgroup_path: None,
+            forked: false,
+            cpu_ids: vec![0, 1],
+            gpu_devices: vec![],
+            cpus: 2,
+            memory_mb: 1024,
+            uid: nix::unistd::getuid().as_raw(),
+            gid: nix::unistd::getgid().as_raw(),
+            user: String::new(),
+            stdout_path: "/tmp/out".into(),
+            stderr_path: "/tmp/err".into(),
+            work_dir: "/tmp".into(),
+            partition: "default".into(),
+            nodelist: "n1".into(),
+            mpi: String::new(),
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            exit_status_path: None,
+            pending: PendingObligations::default(),
+            exit: None,
+        }
+    }
+
+    #[test]
+    fn decode_shell_exit_splits_normal_and_signal() {
+        assert_eq!(decode_shell_exit(0), (0, 0));
+        assert_eq!(decode_shell_exit(5), (5, 0));
+        assert_eq!(decode_shell_exit(137), (0, 9)); // 128 + SIGKILL
+        assert_eq!(decode_shell_exit(143), (0, 15)); // 128 + SIGTERM
+    }
+
+    #[test]
+    fn proc_start_time_matches_a_live_process_and_disappears_once_reaped() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("2")
+            .spawn()
+            .unwrap();
+        let pid = child.id() as i32;
+        let start_time = proc_start_time(pid).expect("live process must have a start time");
+        assert!(proc_alive(pid, start_time));
+        assert!(!proc_alive(pid, start_time.wrapping_add(1)));
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+        assert_eq!(proc_start_time(pid), None);
+        assert!(!proc_alive(pid, start_time));
+    }
+
+    #[test]
+    fn wrap_with_exit_sentinel_captures_normal_exit_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let exit_path = dir.path().join("exit_status");
+        let script = wrap_with_exit_sentinel("exit 5", &exit_path);
+        let script_path = dir.path().join("script.sh");
+        std::fs::write(&script_path, script).unwrap();
+
+        let status = std::process::Command::new("bash")
+            .arg(&script_path)
+            .status()
+            .unwrap();
+        // The wrapper's own exit status must match the original script's, so
+        // the normal (non-restarted) Managed path's Child::try_wait is
+        // unaffected by wrapping.
+        assert_eq!(status.code(), Some(5));
+        assert_eq!(std::fs::read_to_string(&exit_path).unwrap().trim(), "5");
+    }
+
+    #[test]
+    fn wrap_with_exit_sentinel_captures_child_signal_death() {
+        // A child command dying by signal makes bash exit 128+N; the EXIT trap
+        // sees that in $? and records it, matching how bash already reports an
+        // unwrapped script whose last command dies by signal.
+        let dir = tempfile::tempdir().unwrap();
+        let exit_path = dir.path().join("exit_status");
+        let script = wrap_with_exit_sentinel("(kill -TERM $BASHPID; sleep 5)", &exit_path);
+        let script_path = dir.path().join("script.sh");
+        std::fs::write(&script_path, script).unwrap();
+
+        let status = std::process::Command::new("bash")
+            .arg(&script_path)
+            .status()
+            .unwrap();
+        assert_eq!(status.code(), Some(143));
+        assert_eq!(std::fs::read_to_string(&exit_path).unwrap().trim(), "143");
+    }
+
+    #[test]
+    fn wrap_with_exit_sentinel_runs_lines_before_a_later_syntax_error() {
+        // The universal-path guarantee: a syntax error deep in the script must
+        // not prevent the lines above it from running (a subshell/brace-group
+        // wrapper parses the whole body first and would run nothing).
+        let dir = tempfile::tempdir().unwrap();
+        let exit_path = dir.path().join("exit_status");
+        let marker = dir.path().join("marker");
+        let body = format!("echo ran > {}\nif [\n", marker.display());
+        let script = wrap_with_exit_sentinel(&body, &exit_path);
+        let script_path = dir.path().join("script.sh");
+        std::fs::write(&script_path, script).unwrap();
+
+        let status = std::process::Command::new("bash")
+            .arg(&script_path)
+            .status()
+            .unwrap();
+        assert!(!status.success(), "the syntax error still fails the job");
+        assert_eq!(
+            std::fs::read_to_string(&marker).unwrap().trim(),
+            "ran",
+            "the line before the syntax error still ran"
+        );
+    }
+
+    #[test]
+    fn cgroup_path_for_disambiguates_run_attempts_of_same_job() {
+        // A same-node redispatch must never land the new run in the old
+        // run's cgroup, or displacing the old run (cgroup-wide SIGKILL for a
+        // Resumed job) would kill the new run too.
+        let a = cgroup_path_for(42, 1);
+        let b = cgroup_path_for(42, 2);
+        assert_ne!(a, b);
+        assert_eq!(cgroup_path_for(42, 1), a, "must be deterministic");
+    }
+
+    #[test]
+    fn cgroup_liveness_reflects_events_file() {
+        let dir = tempfile::tempdir().unwrap();
+        // Missing file is Unknown (not proof of exit): a non-v2 host or a
+        // process never moved in also lands here, so the caller must fall back
+        // to a direct pid check rather than assume the job finished.
+        assert_eq!(cgroup_liveness(dir.path()), CgroupLiveness::Unknown);
+        std::fs::write(dir.path().join("cgroup.events"), "populated 1\nfrozen 0\n").unwrap();
+        assert_eq!(cgroup_liveness(dir.path()), CgroupLiveness::Populated);
+        std::fs::write(dir.path().join("cgroup.events"), "populated 0\nfrozen 0\n").unwrap();
+        assert_eq!(cgroup_liveness(dir.path()), CgroupLiveness::Empty);
+    }
+
+    #[test]
+    fn resumed_without_cgroup_events_falls_back_to_pid_liveness() {
+        // The Issue-1 regression guard: a Resumed job whose cgroup dir has no
+        // cgroup.events (non-v2 host, or process never moved in) must NOT be
+        // reported complete while its pid is still alive.
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let pid = child.id() as i32;
+        let start_time = proc_start_time(pid).unwrap();
+        let mut job = RunningJob::Resumed {
+            pid,
+            start_time,
+            cgroup_path: Some(dir.path().to_path_buf()),
+            exit_status_path: dir.path().join("exit_status"),
+        };
+        // Alive pid + unreadable cgroup.events => not done (falls back to pid).
+        assert_eq!(job.try_wait().unwrap(), None);
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn cgroup_signal_all_uses_procs_list_for_non_kill_signals() {
+        // Non-SIGKILL signals (graceful_cancel's initial SIGTERM,
+        // suspend/resume) always go through the per-pid cgroup.procs path —
+        // only SIGKILL ever attempts the atomic cgroup.kill fast path.
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .spawn()
+            .unwrap();
+        std::fs::write(dir.path().join("cgroup.procs"), child.id().to_string()).unwrap();
+
+        cgroup_signal_all(dir.path(), Signal::SIGTERM);
+
+        use std::os::unix::process::ExitStatusExt;
+        let status = child.wait().unwrap();
+        assert_eq!(status.signal(), Some(15));
+    }
+
+    #[test]
+    fn cgroup_signal_all_falls_back_when_cgroup_kill_unwritable() {
+        // A plain tempdir would let `cgroup.kill` be created as an ordinary
+        // (inert) file, masking the fallback. Making the dir read-only
+        // forces the write to fail, like a kernel without cgroup.kill (<5.14)
+        // would, so this only exercises the intended fallback as non-root.
+        if nix::unistd::geteuid().is_root() {
+            return;
+        }
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .spawn()
+            .unwrap();
+        std::fs::write(dir.path().join("cgroup.procs"), child.id().to_string()).unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        cgroup_signal_all(dir.path(), Signal::SIGKILL);
+
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        use std::os::unix::process::ExitStatusExt;
+        let status = child.wait().unwrap();
+        assert_eq!(status.signal(), Some(9));
+    }
+
+    #[test]
+    fn resumed_try_wait_uses_cgroup_population_when_available() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("cgroup.events"), "populated 1\nfrozen 0\n").unwrap();
+        let exit_path = dir.path().join("exit_status");
+        let mut job = RunningJob::Resumed {
+            pid: 1,
+            start_time: 0,
+            cgroup_path: Some(dir.path().to_path_buf()),
+            exit_status_path: exit_path.clone(),
+        };
+        assert_eq!(job.try_wait().unwrap(), None);
+
+        std::fs::write(dir.path().join("cgroup.events"), "populated 0\nfrozen 0\n").unwrap();
+        std::fs::write(&exit_path, "3\n").unwrap();
+        assert_eq!(job.try_wait().unwrap(), Some((3, 0)));
+    }
+
+    #[test]
+    fn resumed_try_wait_falls_back_to_proc_liveness_without_cgroup() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("2")
+            .spawn()
+            .unwrap();
+        let pid = child.id() as i32;
+        let start_time = proc_start_time(pid).unwrap();
+        let mut job = RunningJob::Resumed {
+            pid,
+            start_time,
+            cgroup_path: None,
+            exit_status_path: PathBuf::from("/nonexistent/exit_status"),
+        };
+        assert_eq!(job.try_wait().unwrap(), None);
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+        // No sentinel file for this fallback path -> best-effort -1.
+        assert_eq!(job.try_wait().unwrap(), Some((-1, 0)));
+    }
+
+    // A resumed container (forked) job reports its real exit code from the
+    // in-rootfs sentinel, not an approximate -1.
+    #[test]
+    fn resumed_try_wait_reads_real_exit_code_from_sentinel() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("cgroup.events"), "populated 0\nfrozen 0\n").unwrap();
+        let exit_path = dir.path().join("spur_exit_status");
+        std::fs::write(&exit_path, "7\n").unwrap();
+        let mut job = RunningJob::Resumed {
+            pid: 1,
+            start_time: 0,
+            cgroup_path: Some(dir.path().to_path_buf()),
+            exit_status_path: exit_path,
+        };
+        assert_eq!(job.try_wait().unwrap(), Some((7, 0)));
+    }
+
+    // A job-planted symlink at the sentinel path must not be followed by root.
+    #[test]
+    fn read_exit_status_refuses_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real");
+        std::fs::write(&target, "7\n").unwrap();
+        let link = dir.path().join("spur_exit_status");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert_eq!(read_exit_status(&link), None, "symlinked sentinel refused");
+        assert_eq!(
+            read_exit_status(&target),
+            Some(7),
+            "a real file still reads"
+        );
+    }
+
+    // A job-planted FIFO at the sentinel path must not block spurd startup: a
+    // blocking read-only open of a writer-less FIFO never returns, and this runs
+    // before the gRPC server starts, so it would brick the agent.
+    #[test]
+    fn read_exit_status_refuses_fifo() {
+        use std::os::unix::ffi::OsStrExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spur_exit_status");
+        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) }, 0);
+        // No writer is ever opened; if the guard regressed this call would hang.
+        assert_eq!(read_exit_status(&path), None, "FIFO sentinel refused");
+    }
+
+    // A job under a writable rootfs can bloat the sentinel; the read is capped.
+    #[test]
+    fn read_exit_status_reads_only_the_capped_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spur_exit_status");
+        // Interior space past the 64-byte cap: unbounded read fails to parse, the
+        // capped read sees only the leading "7".
+        let body = format!("7{}8", " ".repeat(100));
+        std::fs::write(&path, body).unwrap();
+        assert_eq!(read_exit_status(&path), Some(7));
+    }
+
+    #[test]
+    fn write_job_manifest_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        write_job_manifest(dir.path(), &sample_manifest(1, 1));
+        let mode = std::fs::metadata(manifest_path(dir.path()))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "manifest must not be world/group readable"
+        );
+    }
+
+    #[test]
+    fn manifest_round_trip_scan_and_reconcile_alive() {
+        // Serialize against other tests that scan the shared spool-root
+        // manifest tree — see MANIFEST_SCAN_TEST_LOCK.
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.blocking_lock();
+        let job_id: JobId = 987_654_324;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = create_job_spool_dir(job_id, 1, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+
+        let mut child = std::process::Command::new("sleep")
+            .arg("2")
+            .spawn()
+            .unwrap();
+        let pid = child.id() as i32;
+        let start_time = proc_start_time(pid).unwrap();
+
+        write_job_manifest(
+            &spool_dir,
+            &JobManifest {
+                schema_version: MANIFEST_SCHEMA_VERSION,
+                job_id,
+                run_attempt: 1,
+                pid,
+                start_time,
+                cgroup_path: None,
+                forked: false,
+                cpu_ids: vec![0, 1],
+                gpu_devices: vec![],
+                cpus: 2,
+                memory_mb: 1024,
+                uid,
+                gid,
+                user: String::new(),
+                stdout_path: "/tmp/out".into(),
+                stderr_path: "/tmp/err".into(),
+                work_dir: "/tmp".into(),
+                partition: "default".into(),
+                nodelist: "n1".into(),
+                mpi: String::new(),
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                exit_status_path: None,
+                pending: PendingObligations::default(),
+                exit: None,
+            },
+        );
+
+        let (found_dir, found_manifest) = scan_job_manifests()
+            .into_iter()
+            .find(|(_, m)| m.job_id == job_id)
+            .expect("manifest not found by scan");
+        assert_eq!(found_dir, spool_dir);
+        assert_eq!(found_manifest.cpu_ids, vec![0, 1]);
+
+        match reconcile_manifest(&found_dir, found_manifest) {
+            ReconcileOutcome::Alive { job, manifest } => {
+                assert_eq!(manifest.job_id, job_id);
+                assert!(matches!(job, RunningJob::Resumed { pid: p, .. } if p == pid));
+            }
+            ReconcileOutcome::Dead { .. } => panic!("expected Alive outcome for a live process"),
+        }
+
+        child.kill().unwrap();
+        let _ = child.wait();
+        cleanup_job_spool(job_id, 1);
+    }
+
+    #[test]
+    fn reconcile_manifest_dead_reports_exit_status_from_sentinel() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.blocking_lock();
+        let job_id: JobId = 987_654_325;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = create_job_spool_dir(job_id, 1, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+
+        // Spawn and fully reap so the pid is verifiably gone before we
+        // reconcile, mirroring a job that finished while spurd was down.
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id() as i32;
+        child.wait().unwrap();
+        std::fs::write(exit_status_path(&spool_dir), "7\n").unwrap();
+
+        let manifest = JobManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            job_id,
+            run_attempt: 1,
+            pid,
+            start_time: 0,
+            cgroup_path: None,
+            forked: false,
+            cpu_ids: vec![],
+            gpu_devices: vec![],
+            cpus: 1,
+            memory_mb: 0,
+            uid,
+            gid,
+            user: String::new(),
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            work_dir: "/tmp".into(),
+            partition: "default".into(),
+            nodelist: "n1".into(),
+            mpi: String::new(),
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            exit_status_path: None,
+            pending: PendingObligations::default(),
+            exit: None,
+        };
+
+        match reconcile_manifest(&spool_dir, manifest) {
+            ReconcileOutcome::Dead { manifest } => {
+                assert_eq!(manifest.exit, Some((7, 0)))
+            }
+            ReconcileOutcome::Alive { .. } => panic!("gone process must not be Alive"),
+        }
+        cleanup_job_spool(job_id, 1);
+    }
+
+    // A job OOM-killed while spurd was down writes no sentinel; the OOM flag is
+    // recovered from the cgroup so the outcome isn't a bare -1.
+    #[test]
+    fn reconcile_manifest_dead_recovers_oom_from_cgroup() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.blocking_lock();
+        let job_id: JobId = 987_654_332;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = create_job_spool_dir(job_id, 1, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+        let cgroup = tempfile::tempdir().unwrap();
+        std::fs::write(cgroup.path().join("memory.events"), "oom_kill 1\n").unwrap();
+
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id() as i32;
+        child.wait().unwrap();
+
+        let manifest = JobManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            job_id,
+            run_attempt: 1,
+            pid,
+            start_time: 0,
+            cgroup_path: Some(cgroup.path().to_path_buf()),
+            forked: false,
+            cpu_ids: vec![],
+            gpu_devices: vec![],
+            cpus: 1,
+            memory_mb: 0,
+            uid,
+            gid,
+            user: String::new(),
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            work_dir: "/tmp".into(),
+            partition: "default".into(),
+            nodelist: "n1".into(),
+            mpi: String::new(),
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            exit_status_path: None,
+            pending: PendingObligations::default(),
+            exit: None,
+        };
+
+        match reconcile_manifest(&spool_dir, manifest) {
+            ReconcileOutcome::Dead { manifest } => {
+                let (_, signal) = manifest.exit.expect("dead outcome records the exit");
+                assert_ne!(signal & spur_core::job::OOM_SIGNAL_FLAG, 0, "OOM flag set");
+            }
+            ReconcileOutcome::Alive { .. } => panic!("gone process must not be Alive"),
+        }
+        cleanup_job_spool(job_id, 1);
+    }
+
+    // Distinct run_attempts get distinct spool dirs, and cleaning one attempt
+    // must leave a concurrent redispatch's attempt untouched.
+    #[test]
+    fn spool_dir_cleanup_is_scoped_to_one_run_attempt() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.blocking_lock();
+        let job_id: JobId = 987_654_330;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+
+        let d1 = create_job_spool_dir(job_id, 1, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+        let d2 = create_job_spool_dir(job_id, 2, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+        assert_ne!(d1, d2, "distinct run_attempts must get distinct dirs");
+        assert!(d1.is_dir() && d2.is_dir());
+
+        cleanup_job_spool(job_id, 1);
+        assert!(!d1.exists(), "the cleaned attempt is removed");
+        assert!(d2.exists(), "a different attempt's spool must survive");
+
+        cleanup_job_spool(job_id, 2);
+        assert!(!d2.exists());
+    }
+
+    // write_job_manifest replaces atomically: a leftover temp file is never
+    // picked up as a live manifest by the scanner.
+    #[test]
+    fn manifest_write_leaves_no_temp_file() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.blocking_lock();
+        let job_id: JobId = 987_654_331;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = create_job_spool_dir(job_id, 1, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+
+        write_job_manifest(
+            &spool_dir,
+            &JobManifest {
+                schema_version: MANIFEST_SCHEMA_VERSION,
+                job_id,
+                run_attempt: 1,
+                pid: 1,
+                start_time: 0,
+                cgroup_path: None,
+                forked: false,
+                cpu_ids: vec![],
+                gpu_devices: vec![],
+                cpus: 1,
+                memory_mb: 0,
+                uid,
+                gid,
+                user: String::new(),
+                stdout_path: String::new(),
+                stderr_path: String::new(),
+                work_dir: "/tmp".into(),
+                partition: "default".into(),
+                nodelist: "n1".into(),
+                mpi: String::new(),
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                exit_status_path: None,
+                pending: PendingObligations::default(),
+                exit: None,
+            },
+        );
+
+        assert!(manifest_path(&spool_dir).is_file());
+        assert!(!spool_dir.join("manifest.json.tmp").exists());
+        cleanup_job_spool(job_id, 1);
+    }
 
     #[test]
     fn decode_wait_status_splits_exit_and_signal() {
@@ -2064,11 +3148,12 @@ mod tests {
         let job_id: JobId = 987_654_321;
         // LaunchError has no Debug impl on purpose (it must not be convertible
         // back into an anyhow::Error), so report it through Display.
-        let dir = create_job_spool_dir(job_id, uid, gid)
+        let dir = create_job_spool_dir(job_id, 1, uid, gid)
             .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+
         assert!(dir.is_dir());
         write_job_scratch(&dir.join("spur_job.sh"), "x", uid, gid).unwrap();
-        cleanup_job_spool(job_id);
+        cleanup_job_spool(job_id, 1);
         assert!(!dir.exists());
     }
 
@@ -2139,6 +3224,7 @@ mod tests {
     fn launch_cfg_for_paths(job_id: JobId, name: &str, user: &str, node: &str) -> JobLaunchConfig {
         JobLaunchConfig {
             job_id,
+            run_attempt: 0,
             script: String::new(),
             work_dir: String::new(),
             name: name.to_string(),

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -112,6 +112,18 @@ const CGROUP_ROOT: &str = "/sys/fs/cgroup/spur";
 /// never hit an NFS root_squash mount. Mirrors Slurm's SlurmdSpoolDir.
 const SPOOL_ROOT: &str = "/var/spool/spur";
 
+/// Candidate spool bases, highest priority first. The user-controlled temp
+/// fallback is only used when spurd is NOT root — root must never scan or write
+/// a world-reachable base (a user could plant a manifest there and have root
+/// trust it verbatim on restart).
+fn spool_bases() -> Vec<PathBuf> {
+    let mut bases = vec![PathBuf::from(SPOOL_ROOT)];
+    if !nix::unistd::geteuid().is_root() {
+        bases.push(std::env::temp_dir().join("spur"));
+    }
+    bases
+}
+
 pub struct ContainerLaunchConfig {
     pub config: ContainerConfig,
     pub rootfs: PathBuf,
@@ -134,6 +146,9 @@ pub enum LaunchIo {
 
 pub struct JobLaunchConfig {
     pub job_id: JobId,
+    /// Disambiguates the cgroup path across a same-node redispatch of the
+    /// same job_id, so displacing an old run can never SIGKILL the new one.
+    pub run_attempt: u32,
     pub script: String,
     pub work_dir: String,
     /// Needed to expand `%x`/`%u`/`%N`/`%a`/`%A` in output paths as the controller does.
@@ -171,6 +186,7 @@ pub struct LaunchResult {
     pub stderr_path: String,
     /// Master fd of the PTY (only set when `io_mode == LaunchIo::Pty`).
     pub pty_master: Option<OwnedFd>,
+    pub spool_dir: PathBuf,
 }
 
 /// Owns the resolved fds for a job's stdio, built once and consumed by both
@@ -285,6 +301,15 @@ pub enum RunningJob {
     },
     /// Allocation registered without a batch process (standalone srun).
     AllocationOnly,
+    /// A job re-adopted from a manifest after spurd restarted; the new process
+    /// isn't spurd's child, so completion is detected via cgroup population
+    /// rather than waitpid. See `reconcile_running_jobs`.
+    Resumed {
+        pid: i32,
+        start_time: u64,
+        cgroup_path: Option<PathBuf>,
+        exit_status_path: PathBuf,
+    },
 }
 
 /// Split a finished process's wait status into (exit_code, signal).
@@ -339,6 +364,18 @@ impl RunningJob {
         match self {
             RunningJob::Managed { child, .. } => child.id(),
             RunningJob::Forked { pid, .. } => Some(*pid as u32),
+            RunningJob::Resumed { pid, .. } => Some(*pid as u32),
+            RunningJob::AllocationOnly => None,
+        }
+    }
+
+    /// Non-consuming peek at the cgroup path, for recording it in a job
+    /// manifest without disturbing `take_cgroup`'s completion-time handoff.
+    pub fn cgroup_path(&self) -> Option<&Path> {
+        match self {
+            RunningJob::Managed { cgroup_path, .. } => cgroup_path.as_deref(),
+            RunningJob::Forked { cgroup_path, .. } => cgroup_path.as_deref(),
+            RunningJob::Resumed { cgroup_path, .. } => cgroup_path.as_deref(),
             RunningJob::AllocationOnly => None,
         }
     }
@@ -379,6 +416,36 @@ impl RunningJob {
                     Err(e) => Err(e.into()),
                 }
             }
+            RunningJob::Resumed {
+                pid,
+                start_time,
+                cgroup_path,
+                exit_status_path,
+            } => {
+                // A populated cgroup is authoritative proof the job is alive; an
+                // empty one, proof it exited. But an unreadable cgroup.events
+                // (non-v2 host, or the process was never moved in) is NOT proof
+                // of exit — falling straight to "done" there would report every
+                // adopted job complete on the first post-restart tick and release
+                // its GPUs while the real workload keeps running. Fall back to a
+                // direct pid liveness check in that case.
+                let done = match cgroup_path {
+                    Some(cg) => match cgroup_liveness(cg) {
+                        CgroupLiveness::Populated => false,
+                        CgroupLiveness::Empty => true,
+                        CgroupLiveness::Unknown => !proc_alive(*pid, *start_time),
+                    },
+                    None => !proc_alive(*pid, *start_time),
+                };
+                if !done {
+                    return Ok(None);
+                }
+                Ok(Some(
+                    read_exit_status(exit_status_path)
+                        .map(decode_shell_exit)
+                        .unwrap_or((-1, 0)),
+                ))
+            }
             RunningJob::AllocationOnly => Ok(None),
         }
     }
@@ -407,6 +474,15 @@ impl RunningJob {
                 kill_process_tree(*pid, sig);
                 Ok(())
             }
+            RunningJob::Resumed {
+                pid, cgroup_path, ..
+            } => {
+                match cgroup_path {
+                    Some(cg) => cgroup_signal_all(cg, sig),
+                    None => kill_process_tree(*pid, sig),
+                }
+                Ok(())
+            }
             RunningJob::AllocationOnly => Ok(()),
         }
     }
@@ -415,9 +491,370 @@ impl RunningJob {
         match self {
             RunningJob::Managed { cgroup_path, .. } => cgroup_path.take(),
             RunningJob::Forked { cgroup_path, .. } => cgroup_path.take(),
+            RunningJob::Resumed { cgroup_path, .. } => cgroup_path.take(),
             RunningJob::AllocationOnly => None,
         }
     }
+}
+
+const MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// What the agent still owes a job whose process has ended. Persisted in the
+/// manifest and cleared step by step as each obligation is discharged, so a
+/// restart that interrupts teardown (e.g. a completion report that never
+/// reached the controller) resumes from where it left off instead of re-running
+/// an already-done, possibly non-idempotent step like the epilog. Absent the
+/// ledger, a retried teardown would run the epilog (GPU reset, scratch purge,
+/// SPANK JobEpilog) twice.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct PendingObligations {
+    /// Run the epilog + SPANK TaskExit/JobEpilog hooks (and drain on failure).
+    #[serde(default = "default_true")]
+    pub epilog: bool,
+    /// Report the completion to the controller.
+    #[serde(default = "default_true")]
+    pub report_completion: bool,
+    /// Set when the epilog failed, so the still-owed completion report carries a
+    /// drain request even if it lands on a later restart (the epilog itself is
+    /// no longer owed by then, so the drain intent must be remembered here).
+    #[serde(default)]
+    pub drain: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for PendingObligations {
+    fn default() -> Self {
+        Self {
+            epilog: true,
+            report_completion: true,
+            drain: false,
+        }
+    }
+}
+
+impl PendingObligations {
+    /// True once nothing is owed, so the job's spool/manifest can be removed.
+    pub fn all_discharged(&self) -> bool {
+        !self.epilog && !self.report_completion
+    }
+}
+
+/// The record spurd re-adopts a job from after a restart. Split into two
+/// concerns: **identity** — how to find the process and confirm it's still the
+/// same one — and **obligations** — what the agent still owes the job once its
+/// process ends (resource release, epilog, completion report). Structuring the
+/// record around "what must still happen" rather than only "what the process
+/// looks like" keeps the restart teardown honest: every obligation has an
+/// explicit home in the schema instead of being re-derived by the reconcile
+/// code, which is where obligations were silently dropped before.
+///
+/// Written right after a successful spawn so a graceful restart doesn't lose
+/// track of (or double-book resources for) a job that's still running, then
+/// rewritten as obligations are discharged during teardown.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct JobManifest {
+    pub schema_version: u32,
+    pub job_id: JobId,
+    pub run_attempt: u32,
+
+    // --- Identity: locate and verify the process on restart. ---
+    pub pid: i32,
+    pub start_time: u64,
+    pub cgroup_path: Option<PathBuf>,
+    pub forked: bool,
+    /// Host path to the job's exit-status sentinel (inside rootfs for containers).
+    #[serde(default)]
+    pub exit_status_path: Option<String>,
+    pub rootfs_mode: crate::container::RootfsMode,
+
+    // --- Obligations: what the agent still owes this job. ---
+    /// Remaining teardown steps; each cleared as it is discharged.
+    #[serde(default)]
+    pub pending: PendingObligations,
+    /// The resolved (exit_code, signal), recorded once the process is first seen
+    /// dead. A container's exit sentinel lives in the job rootfs, which is torn
+    /// down as soon as the job is adopted dead, so the outcome must be captured
+    /// here for a report that only lands on a later restart to still be accurate.
+    #[serde(default)]
+    pub exit: Option<(i32, i32)>,
+    /// Resources held by the job, released back to the node on teardown.
+    pub cpu_ids: Vec<u32>,
+    pub gpu_devices: Vec<u32>,
+    pub cpus: u32,
+    pub memory_mb: u64,
+    /// Context the epilog + completion report need.
+    pub uid: u32,
+    pub gid: u32,
+    /// Owning username, restored on re-adopt so exec/attach access gating still
+    /// recognizes the owner of a job that survived a restart.
+    #[serde(default)]
+    pub user: String,
+    pub stdout_path: String,
+    pub stderr_path: String,
+    pub work_dir: String,
+    pub partition: String,
+    pub nodelist: String,
+    pub mpi: String,
+}
+
+fn manifest_path(spool_dir: &Path) -> PathBuf {
+    spool_dir.join("manifest.json")
+}
+
+pub(crate) fn exit_status_path(spool_dir: &Path) -> PathBuf {
+    spool_dir.join("exit_status")
+}
+
+/// Write a job's manifest. Best-effort: a failure here just means the job
+/// won't survive a spurd restart, same as not having this feature. Written via
+/// a temp file + rename so a crash mid-write can't leave a torn manifest.
+///
+/// Mode 0600: the manifest carries the job's uid/gid/cgroup/resource ids, and a
+/// co-located user could open it by its predictable path in the traversable spool dir.
+pub fn write_job_manifest(spool_dir: &Path, manifest: &JobManifest) {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let path = manifest_path(spool_dir);
+    let tmp = path.with_extension("json.tmp");
+    let bytes = match serde_json::to_vec(manifest) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(job_id = manifest.job_id, error = %e, "failed to serialize job manifest");
+            return;
+        }
+    };
+    let write = || -> std::io::Result<()> {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&tmp)?;
+        f.write_all(&bytes)?;
+        f.sync_all()?;
+        std::fs::rename(&tmp, &path)
+    };
+    if let Err(e) = write() {
+        warn!(job_id = manifest.job_id, error = %e, "failed to write job manifest");
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
+/// `/proc/<pid>/stat` field 22 (starttime) — disambiguates a live process
+/// from a different one that has since reused the same pid.
+pub fn proc_start_time(pid: i32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    // comm (field 2) is parenthesized and may itself contain ')'; split on
+    // the last one so the fixed-width fields after it parse safely.
+    stat.rsplit_once(')')?
+        .1
+        .split_whitespace()
+        .nth(19)?
+        .parse()
+        .ok()
+}
+
+fn proc_alive(pid: i32, start_time: u64) -> bool {
+    proc_start_time(pid) == Some(start_time)
+}
+
+/// Liveness verdict from a cgroup's `cgroup.events`.
+#[derive(Debug, PartialEq, Eq)]
+enum CgroupLiveness {
+    /// `populated 1`: at least one process is still in the cgroup.
+    Populated,
+    /// `populated 0`: the cgroup exists but is empty — everything has exited.
+    Empty,
+    /// `cgroup.events` is missing or unreadable. On cgroup-v2 this means the dir
+    /// was already removed (empty); but a non-v2/hybrid host, or a job never
+    /// moved into the cgroup, also lands here — so it is NOT proof of exit and
+    /// the caller must fall back to a direct pid liveness check.
+    Unknown,
+}
+
+/// Read a cgroup-v2 `cgroup.events` to decide whether it still holds processes.
+fn cgroup_liveness(cgroup_path: &Path) -> CgroupLiveness {
+    let Ok(events) = std::fs::read_to_string(cgroup_path.join("cgroup.events")) else {
+        return CgroupLiveness::Unknown;
+    };
+    if events.lines().any(|line| line.trim() == "populated 1") {
+        CgroupLiveness::Populated
+    } else {
+        CgroupLiveness::Empty
+    }
+}
+
+/// Signal every process in a cgroup, regardless of whether spurd is their
+/// parent. SIGKILL uses the atomic `cgroup.kill` (5.14+) when available;
+/// other signals, and older kernels, signal each `cgroup.procs` pid directly.
+fn cgroup_signal_all(cgroup_path: &Path, sig: Signal) {
+    if sig == Signal::SIGKILL && std::fs::write(cgroup_path.join("cgroup.kill"), "1").is_ok() {
+        return;
+    }
+    if let Ok(pids) = std::fs::read_to_string(cgroup_path.join("cgroup.procs")) {
+        for pid_str in pids.lines() {
+            if let Ok(pid) = pid_str.trim().parse::<i32>() {
+                let _ = signal::kill(Pid::from_raw(pid), sig);
+            }
+        }
+    }
+}
+
+/// Decode a shell `$?` value the way `decode_wait_status` decodes a real wait
+/// status: 128+N means death by signal N.
+fn decode_shell_exit(raw: i32) -> (i32, i32) {
+    if (129..=192).contains(&raw) {
+        (0, raw - 128)
+    } else {
+        (raw, 0)
+    }
+}
+
+fn read_exit_status(path: &Path) -> Option<i32> {
+    // The container sentinel lives in a job-writable rootfs, so it is fully
+    // untrusted input on the restart path. O_NONBLOCK means opening a planted
+    // FIFO can't block spurd startup forever (a blocking open of a writer-less
+    // FIFO never returns); O_NOFOLLOW refuses a symlink; the regular-file +
+    // single-link fstat check refuses a FIFO/device/hardlink; and the capped
+    // read refuses an arbitrarily large file.
+    use std::io::Read;
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    let f = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .ok()?;
+    let meta = f.metadata().ok()?;
+    if !meta.file_type().is_file() || meta.nlink() != 1 {
+        return None;
+    }
+    let mut buf = String::new();
+    f.take(64).read_to_string(&mut buf).ok()?;
+    buf.trim().parse().ok()
+}
+
+/// Wrap a job script so its exit code survives even if spurd isn't around to
+/// `wait()` it. A top-level `trap ... EXIT` fires on any exit — normal end,
+/// internal `exit N`, or an uncaught error under `set -e` — and re-exits with
+/// the same code so the wrapper's own exit status (what the normal,
+/// non-restarted path reports via `Child::try_wait`) is unchanged. Read back by
+/// `decode_shell_exit` on resume.
+///
+/// The trap is prepended rather than wrapping the body in a subshell: bash
+/// parses (and runs) a plain script incrementally, so a syntax error deep in the
+/// script still runs the lines above it, exactly as an unwrapped job would. A
+/// subshell (or brace group) is one compound command that must parse in full
+/// before any of it runs, which would change failure semantics for every job on
+/// the universal launch path to buy an exit code only on the rare restart path.
+pub(crate) fn wrap_with_exit_sentinel(script: &str, exit_status_path: &Path) -> String {
+    format!(
+        "trap '_spur_rc=$?; echo $_spur_rc > {}; exit $_spur_rc' EXIT\n{}\n",
+        exit_status_path.display(),
+        script,
+    )
+}
+
+/// Outcome of checking one manifest found on startup.
+pub enum ReconcileOutcome {
+    Alive {
+        job: RunningJob,
+        manifest: JobManifest,
+    },
+    /// The process is gone; the controller must not be left waiting forever
+    /// for a completion report that will never come. The manifest carries the
+    /// resolved exit (in `manifest.exit`) and the still-owed obligations.
+    Dead { manifest: JobManifest },
+}
+
+/// Find every job manifest left behind by a previous spurd process.
+pub fn scan_job_manifests() -> Vec<(PathBuf, JobManifest)> {
+    let mut found = Vec::new();
+    for base in spool_bases() {
+        let Ok(entries) = std::fs::read_dir(&base) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let spool_dir = entry.path();
+            let Ok(bytes) = std::fs::read(manifest_path(&spool_dir)) else {
+                continue;
+            };
+            match serde_json::from_slice::<JobManifest>(&bytes) {
+                Ok(manifest) if manifest.schema_version == MANIFEST_SCHEMA_VERSION => {
+                    found.push((spool_dir, manifest));
+                }
+                Ok(manifest) => warn!(
+                    job_id = manifest.job_id,
+                    version = manifest.schema_version,
+                    "skipping job manifest with unknown schema version"
+                ),
+                Err(e) => warn!(dir = %spool_dir.display(), error = %e, "unreadable job manifest"),
+            }
+        }
+    }
+    dedup_manifests_by_job_id(found)
+}
+
+/// A job_id should only ever have one manifest (whichever `SPOOL_ROOT`/tmp
+/// base `create_job_spool_dir` used), but a stale leftover in the other base
+/// (e.g. from a run under a different privilege level) would otherwise make
+/// `reconcile_running_jobs` double-restore its allocation. Keep only the
+/// highest run_attempt per job_id.
+fn dedup_manifests_by_job_id(found: Vec<(PathBuf, JobManifest)>) -> Vec<(PathBuf, JobManifest)> {
+    let mut by_job: HashMap<JobId, (PathBuf, JobManifest)> = HashMap::new();
+    for (dir, manifest) in found {
+        match by_job.get(&manifest.job_id) {
+            Some((_, existing)) if existing.run_attempt >= manifest.run_attempt => {
+                warn!(
+                    job_id = manifest.job_id,
+                    dir = %dir.display(),
+                    "ignoring duplicate/stale job manifest"
+                );
+            }
+            _ => {
+                by_job.insert(manifest.job_id, (dir, manifest));
+            }
+        }
+    }
+    by_job.into_values().collect()
+}
+
+/// Decide whether a manifested job's process survived the restart.
+pub fn reconcile_manifest(spool_dir: &Path, mut manifest: JobManifest) -> ReconcileOutcome {
+    let sentinel = manifest
+        .exit_status_path
+        .clone()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| exit_status_path(spool_dir));
+    if proc_alive(manifest.pid, manifest.start_time) {
+        let job = RunningJob::Resumed {
+            pid: manifest.pid,
+            start_time: manifest.start_time,
+            cgroup_path: manifest.cgroup_path.clone(),
+            exit_status_path: sentinel,
+        };
+        return ReconcileOutcome::Alive { job, manifest };
+    }
+    // Resolve the exit only the first time the job is seen dead. On a retry
+    // after a partial teardown the sentinel/cgroup may already be gone, so trust
+    // the exit recorded in the manifest instead of re-reading and getting -1.
+    if manifest.exit.is_none() {
+        let (exit_code, mut signal) = read_exit_status(&sentinel)
+            .map(decode_shell_exit)
+            .unwrap_or((-1, 0));
+        // An OOM kill while spurd was down writes no sentinel; recover it from
+        // the cgroup so the outcome isn't a bare -1, matching the live monitor.
+        if let Some(ref cgroup) = manifest.cgroup_path {
+            if cgroup_oom_killed(cgroup) {
+                signal |= spur_core::job::OOM_SIGNAL_FLAG;
+            }
+        }
+        manifest.exit = Some((exit_code, signal));
+    }
+    ReconcileOutcome::Dead { manifest }
 }
 
 /// Launch a job script on this node.
@@ -458,6 +895,7 @@ async fn spawn_job_process(
 ) -> Result<LaunchResult, LaunchError> {
     let JobLaunchConfig {
         job_id,
+        run_attempt,
         ref script,
         ref work_dir,
         ref environment,
@@ -477,7 +915,7 @@ async fn spawn_job_process(
     info!(job_id, work_dir, "launching job");
 
     // Set up cgroup for isolation
-    let cgroup_path = setup_cgroup(job_id, cpus, memory_mb, cpu_ids)?;
+    let cgroup_path = setup_cgroup(job_id, run_attempt, cpus, memory_mb, cpu_ids)?;
 
     // Ensure work_dir exists on this node (the submitted path may only exist on the submitting
     // node). If creation fails (e.g. path is under another user's home), fall back to /tmp so
@@ -507,10 +945,16 @@ async fn spawn_job_process(
 
     // Script + wrapper live in the node-local spool dir, not work_dir (see
     // SPOOL_ROOT), so root-side writes survive NFS root_squash work_dirs.
-    let spool_dir = create_job_spool_dir(job_id, uid, gid)?;
+    let spool_dir = create_job_spool_dir(job_id, run_attempt, uid, gid)?;
     let script_path = spool_dir.join("spur_job.sh");
-    write_job_scratch(&script_path, script, uid, gid)
+    let wrapped_script = wrap_with_exit_sentinel(script, &exit_status_path(&spool_dir));
+    write_job_scratch(&script_path, &wrapped_script, uid, gid)
         .context("failed to write job script")
+        .map_err(|e| classify_spool_error(&spool_dir, e))?;
+    // Pre-create the exit-status sentinel owned by the job, so the wrapped
+    // script can truncate-write it without the spool dir being world-writable.
+    write_job_scratch(&exit_status_path(&spool_dir), "", uid, gid)
+        .context("failed to create exit-status sentinel")
         .map_err(|e| classify_spool_error(&spool_dir, e))?;
 
     // Build resolved output paths (empty for PTY mode since output goes to the terminal).
@@ -637,6 +1081,7 @@ async fn spawn_job_process(
             stdout_path: stdout_resolved,
             stderr_path: stderr_resolved,
             pty_master,
+            spool_dir,
         });
     }
 
@@ -779,12 +1224,15 @@ async fn spawn_job_process(
     // Drop the slave fd immediately so the master gets EOF when the child exits.
     let pty_master = job_io.into_master();
 
-    // Move process into cgroup
-    if let Some(ref cgroup) = cgroup_path {
-        if let Some(pid) = child.id() {
-            move_to_cgroup(cgroup, pid);
-        }
-    }
+    // Move process into cgroup. If the move fails the process runs outside the
+    // cgroup, so the cgroup can't report its liveness on restart — drop the path
+    // so reconcile falls back to a direct pid check instead of misreading an
+    // empty cgroup as an exited job.
+    let cgroup_path = match (cgroup_path, child.id()) {
+        (Some(cgroup), Some(pid)) if move_to_cgroup(&cgroup, pid) => Some(cgroup),
+        (Some(_), _) => None,
+        (None, _) => None,
+    };
 
     debug!(
         job_id,
@@ -798,18 +1246,46 @@ async fn spawn_job_process(
         stdout_path: stdout_resolved,
         stderr_path: stderr_resolved,
         pty_master,
+        spool_dir,
     })
+}
+
+/// The cgroup path for one job run. Keyed by job_id *and* run_attempt so a
+/// same-node redispatch never shares a cgroup with (and can't accidentally
+/// cgroup-wide-kill) a still-finishing prior run.
+fn cgroup_path_for(job_id: JobId, run_attempt: u32) -> PathBuf {
+    PathBuf::from(CGROUP_ROOT).join(format!("job_{}_{}", job_id, run_attempt))
+}
+
+/// Whether `/sys/fs/cgroup` is a unified cgroup-v2 mount. A v1/hybrid host has a
+/// tmpfs there instead, so a job dir created under it is an ordinary directory
+/// with no `cgroup.events` — which the reconcile path can't tell apart from an
+/// exited job. Detecting this up front lets `setup_cgroup` decline to create a
+/// fake hierarchy and run without cgroup isolation instead.
+fn cgroup_v2_available() -> bool {
+    matches!(
+        nix::sys::statfs::statfs(Path::new("/sys/fs/cgroup")),
+        Ok(s) if s.filesystem_type() == nix::sys::statfs::CGROUP2_SUPER_MAGIC
+    )
 }
 
 /// Set up a cgroups v2 hierarchy for a job.
 fn setup_cgroup(
     job_id: JobId,
+    run_attempt: u32,
     cpus: u32,
     memory_mb: u64,
     cpu_ids: &[u32],
 ) -> anyhow::Result<Option<PathBuf>> {
+    // Without a real cgroup-v2 mount, create_dir_all would make a plain
+    // directory that never gets a cgroup.events file — indistinguishable on
+    // restart from an exited job. Run without isolation rather than lie.
+    if !cgroup_v2_available() {
+        warn!(job_id, "cgroup v2 not available, running without isolation");
+        return Ok(None);
+    }
     let cgroup_root = PathBuf::from(CGROUP_ROOT);
-    let cgroup_path = cgroup_root.join(format!("job_{}", job_id));
+    let cgroup_path = cgroup_path_for(job_id, run_attempt);
 
     // Delegate controllers to children: in cgroup-v2 a child only gets
     // memory.*/cpu.*/pids.* files if the parent lists them in subtree_control;
@@ -1142,23 +1618,24 @@ fn create_dir_as_user(dir: &Path, uid: u32, gid: u32) -> bool {
 
 /// Create a node-local spool directory for a job's scratch files. Prefers
 /// `SPOOL_ROOT`; falls back to a temp dir when it isn't writable (e.g. non-root
-/// dev runs). When spurd is root and the job targets a user, the dir is handed
-/// to that user so the job — which runs as the user — can traverse it.
-fn create_job_spool_dir(job_id: JobId, uid: u32, gid: u32) -> Result<PathBuf, LaunchError> {
+/// dev runs). Kept root-owned and 0o711 so a co-located user can't plant a
+/// symlink over the root-authored manifest, which is trusted on restart. Keyed
+/// by `(job_id, run_attempt)` so a same-node redispatch never reuses a prior
+/// run's dir.
+fn create_job_spool_dir(
+    job_id: JobId,
+    run_attempt: u32,
+    uid: u32,
+    _gid: u32,
+) -> Result<PathBuf, LaunchError> {
     let mut failures = Vec::new();
-    for base in [PathBuf::from(SPOOL_ROOT), std::env::temp_dir().join("spur")] {
-        let dir = base.join(format!("job{}", job_id));
+    for base in spool_bases() {
+        let dir = base.join(format!("job{}_{}", job_id, run_attempt));
         match std::fs::create_dir_all(&dir) {
             Ok(()) => {
                 if should_run_as_user(uid) {
-                    use nix::unistd::{Gid, Uid};
-                    // Path-based chown is safe here: the spool tree is
-                    // root-owned, not user-controlled, so no symlink TOCTOU.
-                    let _ = nix::unistd::chown(
-                        &dir,
-                        Some(Uid::from_raw(uid)),
-                        Some(Gid::from_raw(gid)),
-                    );
+                    use std::os::unix::fs::PermissionsExt;
+                    let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o711));
                 }
                 return Ok(dir);
             }
@@ -1232,12 +1709,40 @@ pub(crate) fn write_job_scratch(
     Ok(())
 }
 
-/// Remove a job's spool directory (best-effort), mirroring Slurm purging its
-/// batchdir after completion. Tries both candidate roots since the fallback
-/// location isn't recorded.
-pub fn cleanup_job_spool(job_id: JobId) {
-    for base in [PathBuf::from(SPOOL_ROOT), std::env::temp_dir().join("spur")] {
-        let _ = std::fs::remove_dir_all(base.join(format!("job{}", job_id)));
+/// Remove one run attempt's spool dir. Scoped to `run_attempt` so cleaning a
+/// completed run never deletes a concurrent same-node redispatch's live spool.
+pub fn cleanup_job_spool(job_id: JobId, run_attempt: u32) {
+    let dir = format!("job{}_{}", job_id, run_attempt);
+    for base in spool_bases() {
+        let _ = std::fs::remove_dir_all(base.join(&dir));
+    }
+}
+
+/// Mark a job's epilog obligation discharged in its on-disk manifest, recording
+/// the resolved exit and any drain intent. Called on the live monitor path only
+/// when a completion report fails: the job is already gone from `running`, so a
+/// restart re-adopts it from this manifest — without this, the retry would
+/// re-run the (possibly non-idempotent) epilog. No-op if the manifest is already
+/// gone. Kept off the common success path so a normal completion pays nothing.
+pub fn mark_manifest_epilog_discharged(
+    job_id: JobId,
+    run_attempt: u32,
+    exit: (i32, i32),
+    drain: bool,
+) {
+    let dir = format!("job{}_{}", job_id, run_attempt);
+    for base in spool_bases() {
+        let spool_dir = base.join(&dir);
+        let Ok(bytes) = std::fs::read(manifest_path(&spool_dir)) else {
+            continue;
+        };
+        if let Ok(mut manifest) = serde_json::from_slice::<JobManifest>(&bytes) {
+            manifest.pending.epilog = false;
+            manifest.pending.drain = drain;
+            manifest.exit = Some(exit);
+            write_job_manifest(&spool_dir, &manifest);
+            return;
+        }
     }
 }
 
@@ -1274,7 +1779,13 @@ async fn launch_container_job(
     job_io: JobIo,
 ) -> anyhow::Result<(RunningJob, Option<OwnedFd>)> {
     let job_id = cfg.job_id;
-    let cgroup_path = setup_cgroup(job_id, cfg.cpus, cfg.memory_mb, &cfg.cpu_ids)?;
+    let cgroup_path = setup_cgroup(
+        job_id,
+        cfg.run_attempt,
+        cfg.cpus,
+        cfg.memory_mb,
+        &cfg.cpu_ids,
+    )?;
 
     // Sync pipe: child writes status, parent reads.
     // Convert OwnedFd to raw fds for manual lifecycle management across fork.
@@ -1400,9 +1911,13 @@ async fn launch_container_job(
 
             let child_pid = child.as_raw();
 
-            if let Some(ref cgroup) = cgroup_path {
-                let _ = std::fs::write(cgroup.join("cgroup.procs"), child_pid.to_string());
-            }
+            // If the move fails the process runs outside the cgroup, so the
+            // cgroup can't report its liveness on restart — drop the path so
+            // reconcile falls back to a direct pid check (see the Managed path).
+            let cgroup_path = match cgroup_path {
+                Some(cgroup) if move_to_cgroup(&cgroup, child_pid as u32) => Some(cgroup),
+                _ => None,
+            };
 
             // pidfd prevents PID recycling; falls back gracefully on kernels < 5.3
             let pidfd = pidfd_open(child_pid).ok();
@@ -1557,6 +2072,575 @@ fn wrap_with_burst_buffer(script: &str, bb: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_manifest(job_id: JobId, run_attempt: u32) -> JobManifest {
+        JobManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            job_id,
+            run_attempt,
+            pid: 1,
+            start_time: 0,
+            cgroup_path: None,
+            forked: false,
+            cpu_ids: vec![0, 1],
+            gpu_devices: vec![],
+            cpus: 2,
+            memory_mb: 1024,
+            uid: nix::unistd::getuid().as_raw(),
+            gid: nix::unistd::getgid().as_raw(),
+            user: String::new(),
+            stdout_path: "/tmp/out".into(),
+            stderr_path: "/tmp/err".into(),
+            work_dir: "/tmp".into(),
+            partition: "default".into(),
+            nodelist: "n1".into(),
+            mpi: String::new(),
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            exit_status_path: None,
+            pending: PendingObligations::default(),
+            exit: None,
+        }
+    }
+
+    #[test]
+    fn decode_shell_exit_splits_normal_and_signal() {
+        assert_eq!(decode_shell_exit(0), (0, 0));
+        assert_eq!(decode_shell_exit(5), (5, 0));
+        assert_eq!(decode_shell_exit(137), (0, 9)); // 128 + SIGKILL
+        assert_eq!(decode_shell_exit(143), (0, 15)); // 128 + SIGTERM
+    }
+
+    #[test]
+    fn proc_start_time_matches_a_live_process_and_disappears_once_reaped() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("2")
+            .spawn()
+            .unwrap();
+        let pid = child.id() as i32;
+        let start_time = proc_start_time(pid).expect("live process must have a start time");
+        assert!(proc_alive(pid, start_time));
+        assert!(!proc_alive(pid, start_time.wrapping_add(1)));
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+        assert_eq!(proc_start_time(pid), None);
+        assert!(!proc_alive(pid, start_time));
+    }
+
+    #[test]
+    fn wrap_with_exit_sentinel_captures_normal_exit_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let exit_path = dir.path().join("exit_status");
+        let script = wrap_with_exit_sentinel("exit 5", &exit_path);
+        let script_path = dir.path().join("script.sh");
+        std::fs::write(&script_path, script).unwrap();
+
+        let status = std::process::Command::new("bash")
+            .arg(&script_path)
+            .status()
+            .unwrap();
+        // The wrapper's own exit status must match the original script's, so
+        // the normal (non-restarted) Managed path's Child::try_wait is
+        // unaffected by wrapping.
+        assert_eq!(status.code(), Some(5));
+        assert_eq!(std::fs::read_to_string(&exit_path).unwrap().trim(), "5");
+    }
+
+    #[test]
+    fn wrap_with_exit_sentinel_captures_child_signal_death() {
+        // A child command dying by signal makes bash exit 128+N; the EXIT trap
+        // sees that in $? and records it, matching how bash already reports an
+        // unwrapped script whose last command dies by signal.
+        let dir = tempfile::tempdir().unwrap();
+        let exit_path = dir.path().join("exit_status");
+        let script = wrap_with_exit_sentinel("(kill -TERM $BASHPID; sleep 5)", &exit_path);
+        let script_path = dir.path().join("script.sh");
+        std::fs::write(&script_path, script).unwrap();
+
+        let status = std::process::Command::new("bash")
+            .arg(&script_path)
+            .status()
+            .unwrap();
+        assert_eq!(status.code(), Some(143));
+        assert_eq!(std::fs::read_to_string(&exit_path).unwrap().trim(), "143");
+    }
+
+    #[test]
+    fn wrap_with_exit_sentinel_runs_lines_before_a_later_syntax_error() {
+        // The universal-path guarantee: a syntax error deep in the script must
+        // not prevent the lines above it from running (a subshell/brace-group
+        // wrapper parses the whole body first and would run nothing).
+        let dir = tempfile::tempdir().unwrap();
+        let exit_path = dir.path().join("exit_status");
+        let marker = dir.path().join("marker");
+        let body = format!("echo ran > {}\nif [\n", marker.display());
+        let script = wrap_with_exit_sentinel(&body, &exit_path);
+        let script_path = dir.path().join("script.sh");
+        std::fs::write(&script_path, script).unwrap();
+
+        let status = std::process::Command::new("bash")
+            .arg(&script_path)
+            .status()
+            .unwrap();
+        assert!(!status.success(), "the syntax error still fails the job");
+        assert_eq!(
+            std::fs::read_to_string(&marker).unwrap().trim(),
+            "ran",
+            "the line before the syntax error still ran"
+        );
+    }
+
+    #[test]
+    fn cgroup_path_for_disambiguates_run_attempts_of_same_job() {
+        // A same-node redispatch must never land the new run in the old
+        // run's cgroup, or displacing the old run (cgroup-wide SIGKILL for a
+        // Resumed job) would kill the new run too.
+        let a = cgroup_path_for(42, 1);
+        let b = cgroup_path_for(42, 2);
+        assert_ne!(a, b);
+        assert_eq!(cgroup_path_for(42, 1), a, "must be deterministic");
+    }
+
+    #[test]
+    fn cgroup_liveness_reflects_events_file() {
+        let dir = tempfile::tempdir().unwrap();
+        // Missing file is Unknown (not proof of exit): a non-v2 host or a
+        // process never moved in also lands here, so the caller must fall back
+        // to a direct pid check rather than assume the job finished.
+        assert_eq!(cgroup_liveness(dir.path()), CgroupLiveness::Unknown);
+        std::fs::write(dir.path().join("cgroup.events"), "populated 1\nfrozen 0\n").unwrap();
+        assert_eq!(cgroup_liveness(dir.path()), CgroupLiveness::Populated);
+        std::fs::write(dir.path().join("cgroup.events"), "populated 0\nfrozen 0\n").unwrap();
+        assert_eq!(cgroup_liveness(dir.path()), CgroupLiveness::Empty);
+    }
+
+    #[test]
+    fn resumed_without_cgroup_events_falls_back_to_pid_liveness() {
+        // The Issue-1 regression guard: a Resumed job whose cgroup dir has no
+        // cgroup.events (non-v2 host, or process never moved in) must NOT be
+        // reported complete while its pid is still alive.
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let pid = child.id() as i32;
+        let start_time = proc_start_time(pid).unwrap();
+        let mut job = RunningJob::Resumed {
+            pid,
+            start_time,
+            cgroup_path: Some(dir.path().to_path_buf()),
+            exit_status_path: dir.path().join("exit_status"),
+        };
+        // Alive pid + unreadable cgroup.events => not done (falls back to pid).
+        assert_eq!(job.try_wait().unwrap(), None);
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn cgroup_signal_all_uses_procs_list_for_non_kill_signals() {
+        // Non-SIGKILL signals (graceful_cancel's initial SIGTERM,
+        // suspend/resume) always go through the per-pid cgroup.procs path —
+        // only SIGKILL ever attempts the atomic cgroup.kill fast path.
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .spawn()
+            .unwrap();
+        std::fs::write(dir.path().join("cgroup.procs"), child.id().to_string()).unwrap();
+
+        cgroup_signal_all(dir.path(), Signal::SIGTERM);
+
+        use std::os::unix::process::ExitStatusExt;
+        let status = child.wait().unwrap();
+        assert_eq!(status.signal(), Some(15));
+    }
+
+    #[test]
+    fn cgroup_signal_all_falls_back_when_cgroup_kill_unwritable() {
+        // A plain tempdir would let `cgroup.kill` be created as an ordinary
+        // (inert) file, masking the fallback. Making the dir read-only
+        // forces the write to fail, like a kernel without cgroup.kill (<5.14)
+        // would, so this only exercises the intended fallback as non-root.
+        if nix::unistd::geteuid().is_root() {
+            return;
+        }
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .spawn()
+            .unwrap();
+        std::fs::write(dir.path().join("cgroup.procs"), child.id().to_string()).unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        cgroup_signal_all(dir.path(), Signal::SIGKILL);
+
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        use std::os::unix::process::ExitStatusExt;
+        let status = child.wait().unwrap();
+        assert_eq!(status.signal(), Some(9));
+    }
+
+    #[test]
+    fn resumed_try_wait_uses_cgroup_population_when_available() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("cgroup.events"), "populated 1\nfrozen 0\n").unwrap();
+        let exit_path = dir.path().join("exit_status");
+        let mut job = RunningJob::Resumed {
+            pid: 1,
+            start_time: 0,
+            cgroup_path: Some(dir.path().to_path_buf()),
+            exit_status_path: exit_path.clone(),
+        };
+        assert_eq!(job.try_wait().unwrap(), None);
+
+        std::fs::write(dir.path().join("cgroup.events"), "populated 0\nfrozen 0\n").unwrap();
+        std::fs::write(&exit_path, "3\n").unwrap();
+        assert_eq!(job.try_wait().unwrap(), Some((3, 0)));
+    }
+
+    #[test]
+    fn resumed_try_wait_falls_back_to_proc_liveness_without_cgroup() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("2")
+            .spawn()
+            .unwrap();
+        let pid = child.id() as i32;
+        let start_time = proc_start_time(pid).unwrap();
+        let mut job = RunningJob::Resumed {
+            pid,
+            start_time,
+            cgroup_path: None,
+            exit_status_path: PathBuf::from("/nonexistent/exit_status"),
+        };
+        assert_eq!(job.try_wait().unwrap(), None);
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+        // No sentinel file for this fallback path -> best-effort -1.
+        assert_eq!(job.try_wait().unwrap(), Some((-1, 0)));
+    }
+
+    // A resumed container (forked) job reports its real exit code from the
+    // in-rootfs sentinel, not an approximate -1.
+    #[test]
+    fn resumed_try_wait_reads_real_exit_code_from_sentinel() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("cgroup.events"), "populated 0\nfrozen 0\n").unwrap();
+        let exit_path = dir.path().join("spur_exit_status");
+        std::fs::write(&exit_path, "7\n").unwrap();
+        let mut job = RunningJob::Resumed {
+            pid: 1,
+            start_time: 0,
+            cgroup_path: Some(dir.path().to_path_buf()),
+            exit_status_path: exit_path,
+        };
+        assert_eq!(job.try_wait().unwrap(), Some((7, 0)));
+    }
+
+    // A job-planted symlink at the sentinel path must not be followed by root.
+    #[test]
+    fn read_exit_status_refuses_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real");
+        std::fs::write(&target, "7\n").unwrap();
+        let link = dir.path().join("spur_exit_status");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert_eq!(read_exit_status(&link), None, "symlinked sentinel refused");
+        assert_eq!(
+            read_exit_status(&target),
+            Some(7),
+            "a real file still reads"
+        );
+    }
+
+    // A job-planted FIFO at the sentinel path must not block spurd startup: a
+    // blocking read-only open of a writer-less FIFO never returns, and this runs
+    // before the gRPC server starts, so it would brick the agent.
+    #[test]
+    fn read_exit_status_refuses_fifo() {
+        use std::os::unix::ffi::OsStrExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spur_exit_status");
+        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) }, 0);
+        // No writer is ever opened; if the guard regressed this call would hang.
+        assert_eq!(read_exit_status(&path), None, "FIFO sentinel refused");
+    }
+
+    // A job under a writable rootfs can bloat the sentinel; the read is capped.
+    #[test]
+    fn read_exit_status_reads_only_the_capped_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spur_exit_status");
+        // Interior space past the 64-byte cap: unbounded read fails to parse, the
+        // capped read sees only the leading "7".
+        let body = format!("7{}8", " ".repeat(100));
+        std::fs::write(&path, body).unwrap();
+        assert_eq!(read_exit_status(&path), Some(7));
+    }
+
+    #[test]
+    fn write_job_manifest_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        write_job_manifest(dir.path(), &sample_manifest(1, 1));
+        let mode = std::fs::metadata(manifest_path(dir.path()))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "manifest must not be world/group readable"
+        );
+    }
+
+    #[test]
+    fn manifest_round_trip_scan_and_reconcile_alive() {
+        // Serialize against other tests that scan the shared spool-root
+        // manifest tree — see MANIFEST_SCAN_TEST_LOCK.
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.blocking_lock();
+        let job_id: JobId = 987_654_324;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = create_job_spool_dir(job_id, 1, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+
+        let mut child = std::process::Command::new("sleep")
+            .arg("2")
+            .spawn()
+            .unwrap();
+        let pid = child.id() as i32;
+        let start_time = proc_start_time(pid).unwrap();
+
+        write_job_manifest(
+            &spool_dir,
+            &JobManifest {
+                schema_version: MANIFEST_SCHEMA_VERSION,
+                job_id,
+                run_attempt: 1,
+                pid,
+                start_time,
+                cgroup_path: None,
+                forked: false,
+                cpu_ids: vec![0, 1],
+                gpu_devices: vec![],
+                cpus: 2,
+                memory_mb: 1024,
+                uid,
+                gid,
+                user: String::new(),
+                stdout_path: "/tmp/out".into(),
+                stderr_path: "/tmp/err".into(),
+                work_dir: "/tmp".into(),
+                partition: "default".into(),
+                nodelist: "n1".into(),
+                mpi: String::new(),
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                exit_status_path: None,
+                pending: PendingObligations::default(),
+                exit: None,
+            },
+        );
+
+        let (found_dir, found_manifest) = scan_job_manifests()
+            .into_iter()
+            .find(|(_, m)| m.job_id == job_id)
+            .expect("manifest not found by scan");
+        assert_eq!(found_dir, spool_dir);
+        assert_eq!(found_manifest.cpu_ids, vec![0, 1]);
+
+        match reconcile_manifest(&found_dir, found_manifest) {
+            ReconcileOutcome::Alive { job, manifest } => {
+                assert_eq!(manifest.job_id, job_id);
+                assert!(matches!(job, RunningJob::Resumed { pid: p, .. } if p == pid));
+            }
+            ReconcileOutcome::Dead { .. } => panic!("expected Alive outcome for a live process"),
+        }
+
+        child.kill().unwrap();
+        let _ = child.wait();
+        cleanup_job_spool(job_id, 1);
+    }
+
+    #[test]
+    fn reconcile_manifest_dead_reports_exit_status_from_sentinel() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.blocking_lock();
+        let job_id: JobId = 987_654_325;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = create_job_spool_dir(job_id, 1, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+
+        // Spawn and fully reap so the pid is verifiably gone before we
+        // reconcile, mirroring a job that finished while spurd was down.
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id() as i32;
+        child.wait().unwrap();
+        std::fs::write(exit_status_path(&spool_dir), "7\n").unwrap();
+
+        let manifest = JobManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            job_id,
+            run_attempt: 1,
+            pid,
+            start_time: 0,
+            cgroup_path: None,
+            forked: false,
+            cpu_ids: vec![],
+            gpu_devices: vec![],
+            cpus: 1,
+            memory_mb: 0,
+            uid,
+            gid,
+            user: String::new(),
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            work_dir: "/tmp".into(),
+            partition: "default".into(),
+            nodelist: "n1".into(),
+            mpi: String::new(),
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            exit_status_path: None,
+            pending: PendingObligations::default(),
+            exit: None,
+        };
+
+        match reconcile_manifest(&spool_dir, manifest) {
+            ReconcileOutcome::Dead { manifest } => {
+                assert_eq!(manifest.exit, Some((7, 0)))
+            }
+            ReconcileOutcome::Alive { .. } => panic!("gone process must not be Alive"),
+        }
+        cleanup_job_spool(job_id, 1);
+    }
+
+    // A job OOM-killed while spurd was down writes no sentinel; the OOM flag is
+    // recovered from the cgroup so the outcome isn't a bare -1.
+    #[test]
+    fn reconcile_manifest_dead_recovers_oom_from_cgroup() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.blocking_lock();
+        let job_id: JobId = 987_654_332;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = create_job_spool_dir(job_id, 1, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+        let cgroup = tempfile::tempdir().unwrap();
+        std::fs::write(cgroup.path().join("memory.events"), "oom_kill 1\n").unwrap();
+
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id() as i32;
+        child.wait().unwrap();
+
+        let manifest = JobManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            job_id,
+            run_attempt: 1,
+            pid,
+            start_time: 0,
+            cgroup_path: Some(cgroup.path().to_path_buf()),
+            forked: false,
+            cpu_ids: vec![],
+            gpu_devices: vec![],
+            cpus: 1,
+            memory_mb: 0,
+            uid,
+            gid,
+            user: String::new(),
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            work_dir: "/tmp".into(),
+            partition: "default".into(),
+            nodelist: "n1".into(),
+            mpi: String::new(),
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            exit_status_path: None,
+            pending: PendingObligations::default(),
+            exit: None,
+        };
+
+        match reconcile_manifest(&spool_dir, manifest) {
+            ReconcileOutcome::Dead { manifest } => {
+                let (_, signal) = manifest.exit.expect("dead outcome records the exit");
+                assert_ne!(signal & spur_core::job::OOM_SIGNAL_FLAG, 0, "OOM flag set");
+            }
+            ReconcileOutcome::Alive { .. } => panic!("gone process must not be Alive"),
+        }
+        cleanup_job_spool(job_id, 1);
+    }
+
+    // Distinct run_attempts get distinct spool dirs, and cleaning one attempt
+    // must leave a concurrent redispatch's attempt untouched.
+    #[test]
+    fn spool_dir_cleanup_is_scoped_to_one_run_attempt() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.blocking_lock();
+        let job_id: JobId = 987_654_330;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+
+        let d1 = create_job_spool_dir(job_id, 1, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+        let d2 = create_job_spool_dir(job_id, 2, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+        assert_ne!(d1, d2, "distinct run_attempts must get distinct dirs");
+        assert!(d1.is_dir() && d2.is_dir());
+
+        cleanup_job_spool(job_id, 1);
+        assert!(!d1.exists(), "the cleaned attempt is removed");
+        assert!(d2.exists(), "a different attempt's spool must survive");
+
+        cleanup_job_spool(job_id, 2);
+        assert!(!d2.exists());
+    }
+
+    // write_job_manifest replaces atomically: a leftover temp file is never
+    // picked up as a live manifest by the scanner.
+    #[test]
+    fn manifest_write_leaves_no_temp_file() {
+        let _guard = crate::MANIFEST_SCAN_TEST_LOCK.blocking_lock();
+        let job_id: JobId = 987_654_331;
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        let spool_dir = create_job_spool_dir(job_id, 1, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+
+        write_job_manifest(
+            &spool_dir,
+            &JobManifest {
+                schema_version: MANIFEST_SCHEMA_VERSION,
+                job_id,
+                run_attempt: 1,
+                pid: 1,
+                start_time: 0,
+                cgroup_path: None,
+                forked: false,
+                cpu_ids: vec![],
+                gpu_devices: vec![],
+                cpus: 1,
+                memory_mb: 0,
+                uid,
+                gid,
+                user: String::new(),
+                stdout_path: String::new(),
+                stderr_path: String::new(),
+                work_dir: "/tmp".into(),
+                partition: "default".into(),
+                nodelist: "n1".into(),
+                mpi: String::new(),
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                exit_status_path: None,
+                pending: PendingObligations::default(),
+                exit: None,
+            },
+        );
+
+        assert!(manifest_path(&spool_dir).is_file());
+        assert!(!spool_dir.join("manifest.json.tmp").exists());
+        cleanup_job_spool(job_id, 1);
+    }
 
     #[test]
     fn decode_wait_status_splits_exit_and_signal() {
@@ -1927,11 +3011,12 @@ mod tests {
         let job_id: JobId = 987_654_321;
         // LaunchError has no Debug impl on purpose (it must not be convertible
         // back into an anyhow::Error), so report it through Display.
-        let dir = create_job_spool_dir(job_id, uid, gid)
+        let dir = create_job_spool_dir(job_id, 1, uid, gid)
             .unwrap_or_else(|e| panic!("create spool dir: {e}"));
+
         assert!(dir.is_dir());
         write_job_scratch(&dir.join("spur_job.sh"), "x", uid, gid).unwrap();
-        cleanup_job_spool(job_id);
+        cleanup_job_spool(job_id, 1);
         assert!(!dir.exists());
     }
 
@@ -2002,6 +3087,7 @@ mod tests {
     fn launch_cfg_for_paths(job_id: JobId, name: &str, user: &str, node: &str) -> JobLaunchConfig {
         JobLaunchConfig {
             job_id,
+            run_attempt: 0,
             script: String::new(),
             work_dir: String::new(),
             name: name.to_string(),

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -603,7 +603,10 @@ pub struct JobManifest {
     /// Host path to the job's exit-status sentinel (inside rootfs for containers).
     #[serde(default)]
     pub exit_status_path: Option<String>,
-    pub rootfs_mode: crate::container::RootfsMode,
+    /// Rootfs this job owns and must remove. None for non-container jobs, and
+    /// for named containers, which outlive the job.
+    #[serde(default)]
+    pub rootfs: Option<crate::container::JobRootfs>,
 
     // --- Obligations: what the agent still owes this job. ---
     /// Remaining teardown steps; each cleared as it is discharged.
@@ -2305,11 +2308,53 @@ mod tests {
             partition: "default".into(),
             nodelist: "n1".into(),
             mpi: String::new(),
-            rootfs_mode: crate::container::RootfsMode::Extracted,
+            rootfs: None,
             exit_status_path: None,
             pending: PendingObligations::default(),
             exit: None,
         }
+    }
+
+    /// Frozen at the pre-`rootfs` shape on purpose — never regenerate it. A
+    /// manifest written by an older agent must still load, not strand the job.
+    #[test]
+    fn manifest_without_rootfs_field_still_loads() {
+        let frozen = r#"{
+            "schema_version": 1, "job_id": 7, "run_attempt": 2,
+            "pid": 4242, "start_time": 99, "cgroup_path": null, "forked": true,
+            "has_pid_namespace": true, "has_user_namespace": false,
+            "has_mount_namespace": true, "exit_status_path": "/var/spool/spur/job7_2/rc",
+            "rootfs_mode": "Extracted",
+            "cpu_ids": [0, 1], "gpu_devices": [3], "cpus": 2, "memory_mb": 1024,
+            "uid": 1000, "gid": 1000, "user": "alice",
+            "stdout_path": "/tmp/o", "stderr_path": "/tmp/e", "work_dir": "/tmp",
+            "partition": "default", "nodelist": "n1", "mpi": ""
+        }"#;
+
+        let m: JobManifest = serde_json::from_str(frozen).expect("old manifest must deserialize");
+
+        assert_eq!(m.job_id, 7);
+        assert_eq!(m.run_attempt, 2);
+        assert!(m.rootfs.is_none(), "unknown rootfs must not be invented");
+        assert!(m.has_mount_namespace);
+    }
+
+    /// The teardown path reads the rootfs back off disk, so it has to survive
+    /// the real write, not just an in-memory round trip.
+    #[test]
+    fn recorded_rootfs_survives_the_manifest_write() {
+        let spool = tempfile::tempdir().unwrap();
+        let mut m = sample_manifest(11, 4);
+        m.rootfs = Some(crate::container::JobRootfs {
+            base_dir: PathBuf::from("/var/spool/spur/containers/job_11_4"),
+            mode: crate::container::RootfsMode::Overlay,
+        });
+
+        write_job_manifest(spool.path(), &m);
+        let raw = std::fs::read_to_string(spool.path().join("manifest.json")).unwrap();
+        let decoded: JobManifest = serde_json::from_str(&raw).unwrap();
+
+        assert_eq!(decoded.rootfs, m.rootfs);
     }
 
     #[test]
@@ -2661,7 +2706,7 @@ mod tests {
             has_user_namespace: false,
             has_mount_namespace: false,
             exit_status_path: None,
-            rootfs_mode: crate::container::RootfsMode::Extracted,
+            rootfs: None,
             pending: PendingObligations::default(),
             exit: Some((3, 0)),
             cpu_ids: vec![],
@@ -2708,7 +2753,7 @@ mod tests {
             has_user_namespace: false,
             has_mount_namespace: true,
             exit_status_path: None,
-            rootfs_mode: crate::container::RootfsMode::Extracted,
+            rootfs: None,
             pending: PendingObligations::default(),
             exit: None,
             cpu_ids: vec![],
@@ -2787,7 +2832,7 @@ mod tests {
                 partition: "default".into(),
                 nodelist: "n1".into(),
                 mpi: String::new(),
-                rootfs_mode: crate::container::RootfsMode::Extracted,
+                rootfs: None,
                 exit_status_path: None,
                 pending: PendingObligations::default(),
                 exit: None,
@@ -2854,7 +2899,7 @@ mod tests {
             partition: "default".into(),
             nodelist: "n1".into(),
             mpi: String::new(),
-            rootfs_mode: crate::container::RootfsMode::Extracted,
+            rootfs: None,
             exit_status_path: None,
             pending: PendingObligations::default(),
             exit: None,
@@ -2910,7 +2955,7 @@ mod tests {
             partition: "default".into(),
             nodelist: "n1".into(),
             mpi: String::new(),
-            rootfs_mode: crate::container::RootfsMode::Extracted,
+            rootfs: None,
             exit_status_path: None,
             pending: PendingObligations::default(),
             exit: None,
@@ -2987,7 +3032,7 @@ mod tests {
                 partition: "default".into(),
                 nodelist: "n1".into(),
                 mpi: String::new(),
-                rootfs_mode: crate::container::RootfsMode::Extracted,
+                rootfs: None,
                 exit_status_path: None,
                 pending: PendingObligations::default(),
                 exit: None,

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -522,7 +522,7 @@ impl RunningJob {
     }
 }
 
-const MANIFEST_SCHEMA_VERSION: u32 = 1;
+pub(crate) const MANIFEST_SCHEMA_VERSION: u32 = 1;
 
 /// What the agent still owes a job whose process has ended. Persisted in the
 /// manifest and cleared step by step as each obligation is discharged, so a
@@ -590,6 +590,16 @@ pub struct JobManifest {
     pub start_time: u64,
     pub cgroup_path: Option<PathBuf>,
     pub forked: bool,
+    /// Namespace layout as it was at launch. Recorded rather than re-derived,
+    /// because the formula depends on whether the agent was privileged, and a
+    /// restarted agent may not match the one that launched the job — getting
+    /// these wrong sends exec/attach into the wrong namespaces.
+    #[serde(default)]
+    pub has_pid_namespace: bool,
+    #[serde(default)]
+    pub has_user_namespace: bool,
+    #[serde(default)]
+    pub has_mount_namespace: bool,
     /// Host path to the job's exit-status sentinel (inside rootfs for containers).
     #[serde(default)]
     pub exit_status_path: Option<String>,
@@ -776,10 +786,28 @@ fn read_exit_status(path: &Path) -> Option<i32> {
 /// before any of it runs, which would change failure semantics for every job on
 /// the universal launch path to buy an exit code only on the rare restart path.
 pub(crate) fn wrap_with_exit_sentinel(script: &str, exit_status_path: &Path) -> String {
+    // Signals need their own traps. bash does run the EXIT trap when the shell
+    // is terminated, but `$?` there holds the last *completed* command's status
+    // rather than 128+N — so an EXIT trap alone records a job we stopped as
+    // having finished successfully. Each handler clears the traps first so the
+    // status is written exactly once even though `exit` re-enters EXIT.
+    //
+    // SIGKILL cannot be trapped; it leaves no sentinel, and the reader treats a
+    // missing sentinel as a failure, which is the correct answer there.
+    //
+    // These stay top-level simple commands so bash's incremental execution
+    // still runs them when a later line of the user script fails to parse.
     format!(
-        "trap '_spur_rc=$?; echo $_spur_rc > {}; exit $_spur_rc' EXIT\n{}\n",
-        exit_status_path.display(),
-        script,
+        "_spur_rc_file='{path}'\n\
+         _spur_exit() {{ trap - EXIT HUP INT QUIT TERM; echo \"$1\" > \"$_spur_rc_file\"; exit \"$1\"; }}\n\
+         trap '_spur_exit $?' EXIT\n\
+         trap '_spur_exit 129' HUP\n\
+         trap '_spur_exit 130' INT\n\
+         trap '_spur_exit 131' QUIT\n\
+         trap '_spur_exit 143' TERM\n\
+         {script}\n",
+        path = exit_status_path.display(),
+        script = script,
     )
 }
 
@@ -796,7 +824,42 @@ pub enum ReconcileOutcome {
 }
 
 /// Find every job manifest left behind by a previous spurd process.
+/// Warn when records left by a previous *unprivileged* agent exist but cannot
+/// be trusted by this privileged one.
+///
+/// A root agent deliberately refuses to read the user-writable temp base — a
+/// user could plant a manifest there and have root act on it verbatim. But
+/// silently skipping it means that correcting a deployment from unprivileged to
+/// privileged strands every job that was running under the old agent, with no
+/// completion report, no epilog and no resources released. Say so loudly.
+fn warn_on_unreadable_foreign_spool() {
+    if !nix::unistd::geteuid().is_root() {
+        return;
+    }
+    let foreign = std::env::temp_dir().join("spur");
+    let Ok(entries) = std::fs::read_dir(&foreign) else {
+        return;
+    };
+    let stranded: Vec<String> = entries
+        .flatten()
+        .filter(|e| manifest_path(&e.path()).exists())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    if !stranded.is_empty() {
+        warn!(
+            base = %foreign.display(),
+            count = stranded.len(),
+            dirs = ?stranded,
+            "ignoring job records written by an unprivileged agent: this agent is privileged and \
+             will not trust a user-writable location. Those jobs cannot be adopted, will never \
+             report completion, and their resources stay charged until the controller reclaims \
+             them. Clean the directory once the processes are gone."
+        );
+    }
+}
+
 pub fn scan_job_manifests() -> Vec<(PathBuf, JobManifest)> {
+    warn_on_unreadable_foreign_spool();
     let mut found = Vec::new();
     for base in spool_bases() {
         let Ok(entries) = std::fs::read_dir(&base) else {
@@ -854,6 +917,13 @@ pub fn reconcile_manifest(spool_dir: &Path, mut manifest: JobManifest) -> Reconc
         .clone()
         .map(PathBuf::from)
         .unwrap_or_else(|| exit_status_path(spool_dir));
+    // A recorded exit is final. Checking liveness first would let a recycled
+    // PID resurrect an already-finished job and re-run its teardown, and no
+    // liveness answer can be more authoritative than an outcome we already
+    // observed and persisted.
+    if manifest.exit.is_some() {
+        return ReconcileOutcome::Dead { manifest };
+    }
     if proc_alive(manifest.pid, manifest.start_time) {
         let job = RunningJob::Resumed {
             pid: manifest.pid,
@@ -2219,6 +2289,9 @@ mod tests {
             start_time: 0,
             cgroup_path: None,
             forked: false,
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
             cpu_ids: vec![0, 1],
             gpu_devices: vec![],
             cpus: 2,
@@ -2281,6 +2354,41 @@ mod tests {
         // unaffected by wrapping.
         assert_eq!(status.code(), Some(5));
         assert_eq!(std::fs::read_to_string(&exit_path).unwrap().trim(), "5");
+    }
+
+    #[test]
+    fn wrap_with_exit_sentinel_records_terminate_signal_not_a_stale_status() {
+        // The shell itself being terminated is the `scancel` path. `true` leaves
+        // $? == 0, so an EXIT-only trap would observe that 0 and record a
+        // stopped job as a clean success — the defect this guards.
+        let dir = tempfile::tempdir().unwrap();
+        let exit_path = dir.path().join("exit_status");
+        let script = wrap_with_exit_sentinel("true\nkill -TERM $$", &exit_path);
+        let script_path = dir.path().join("script.sh");
+        std::fs::write(&script_path, script).unwrap();
+
+        let status = std::process::Command::new("bash")
+            .arg(&script_path)
+            .status()
+            .unwrap();
+        assert_eq!(status.code(), Some(143));
+        assert_eq!(std::fs::read_to_string(&exit_path).unwrap().trim(), "143");
+    }
+
+    #[test]
+    fn wrap_with_exit_sentinel_records_interrupt_signal() {
+        let dir = tempfile::tempdir().unwrap();
+        let exit_path = dir.path().join("exit_status");
+        let script = wrap_with_exit_sentinel("true\nkill -INT $$", &exit_path);
+        let script_path = dir.path().join("script.sh");
+        std::fs::write(&script_path, script).unwrap();
+
+        let status = std::process::Command::new("bash")
+            .arg(&script_path)
+            .status()
+            .unwrap();
+        assert_eq!(status.code(), Some(130));
+        assert_eq!(std::fs::read_to_string(&exit_path).unwrap().trim(), "130");
     }
 
     #[test]
@@ -2536,6 +2644,106 @@ mod tests {
     }
 
     #[test]
+    fn reconcile_trusts_a_recorded_exit_over_a_live_pid() {
+        // A record whose outcome was already resolved must stay dead even if its
+        // PID now belongs to something else, or teardown runs twice.
+        let dir = tempfile::tempdir().unwrap();
+        let mut m = JobManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            job_id: 7,
+            run_attempt: 1,
+            // Our own PID, so the liveness check would say "alive" if consulted.
+            pid: std::process::id() as i32,
+            start_time: proc_start_time(std::process::id() as i32).unwrap(),
+            cgroup_path: None,
+            forked: false,
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
+            exit_status_path: None,
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            pending: PendingObligations::default(),
+            exit: Some((3, 0)),
+            cpu_ids: vec![],
+            gpu_devices: vec![],
+            cpus: 1,
+            memory_mb: 0,
+            uid: 0,
+            gid: 0,
+            user: String::new(),
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            work_dir: String::new(),
+            partition: String::new(),
+            nodelist: String::new(),
+            mpi: String::new(),
+        };
+        match reconcile_manifest(dir.path(), m.clone()) {
+            ReconcileOutcome::Dead { manifest } => assert_eq!(manifest.exit, Some((3, 0))),
+            ReconcileOutcome::Alive { .. } => panic!("a recorded exit must not be re-litigated"),
+        }
+        // Without a recorded exit the same record is correctly seen as alive.
+        m.exit = None;
+        assert!(matches!(
+            reconcile_manifest(dir.path(), m),
+            ReconcileOutcome::Alive { .. }
+        ));
+    }
+
+    #[test]
+    fn manifest_namespace_layout_survives_a_round_trip_and_defaults_safely() {
+        // The layout must come from the record, not from the reading agent's own
+        // privilege — a privileged agent adopting a job launched by an
+        // unprivileged one (or vice versa) would otherwise send exec/attach into
+        // the wrong namespaces.
+        let m = JobManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            job_id: 7,
+            run_attempt: 1,
+            pid: 1234,
+            start_time: 99,
+            cgroup_path: None,
+            forked: false,
+            has_pid_namespace: true,
+            has_user_namespace: false,
+            has_mount_namespace: true,
+            exit_status_path: None,
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            pending: PendingObligations::default(),
+            exit: None,
+            cpu_ids: vec![],
+            gpu_devices: vec![],
+            cpus: 1,
+            memory_mb: 0,
+            uid: 1000,
+            gid: 1000,
+            user: "vm".into(),
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            work_dir: String::new(),
+            partition: String::new(),
+            nodelist: String::new(),
+            mpi: String::new(),
+        };
+        let back: JobManifest = serde_json::from_slice(&serde_json::to_vec(&m).unwrap()).unwrap();
+        assert!(back.has_pid_namespace);
+        assert!(!back.has_user_namespace);
+        assert!(back.has_mount_namespace);
+
+        // A record written before these fields existed must still load, and must
+        // default to the conservative "no namespaces" answer rather than failing.
+        let mut value: serde_json::Value = serde_json::to_value(&m).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("has_pid_namespace");
+        obj.remove("has_user_namespace");
+        obj.remove("has_mount_namespace");
+        let older: JobManifest = serde_json::from_value(value).unwrap();
+        assert!(!older.has_pid_namespace);
+        assert!(!older.has_user_namespace);
+        assert!(!older.has_mount_namespace);
+    }
+
+    #[test]
     fn manifest_round_trip_scan_and_reconcile_alive() {
         // Serialize against other tests that scan the shared spool-root
         // manifest tree — see MANIFEST_SCAN_TEST_LOCK.
@@ -2563,6 +2771,9 @@ mod tests {
                 start_time,
                 cgroup_path: None,
                 forked: false,
+                has_pid_namespace: false,
+                has_user_namespace: false,
+                has_mount_namespace: false,
                 cpu_ids: vec![0, 1],
                 gpu_devices: vec![],
                 cpus: 2,
@@ -2627,6 +2838,9 @@ mod tests {
             start_time: 0,
             cgroup_path: None,
             forked: false,
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
             cpu_ids: vec![],
             gpu_devices: vec![],
             cpus: 1,
@@ -2680,6 +2894,9 @@ mod tests {
             start_time: 0,
             cgroup_path: Some(cgroup.path().to_path_buf()),
             forked: false,
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
             cpu_ids: vec![],
             gpu_devices: vec![],
             cpus: 1,
@@ -2754,6 +2971,9 @@ mod tests {
                 start_time: 0,
                 cgroup_path: None,
                 forked: false,
+                has_pid_namespace: false,
+                has_user_namespace: false,
+                has_mount_namespace: false,
                 cpu_ids: vec![],
                 gpu_devices: vec![],
                 cpus: 1,

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -27,6 +27,14 @@ use spur_devices::DeviceRegistry;
 
 use reporter::NodeReporter;
 
+/// Tests that scan the shared spool-root manifest tree (`executor::
+/// scan_job_manifests`/`reconcile_running_jobs`) must serialize against each
+/// other, or one test can pick up a manifest a concurrently-running test left
+/// behind in the same shared directory.
+#[cfg(test)]
+pub(crate) static MANIFEST_SCAN_TEST_LOCK: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
+
 fn log_memlock_status(memlock: spur_core::config::MemlockLimit) {
     use spur_core::config::MemlockLimit;
     let configured_desc = match memlock {
@@ -321,7 +329,16 @@ async fn main() -> anyhow::Result<()> {
     k0s.adopt_running_unit().await;
     tokio::spawn(k0s.supervise());
 
+    // Re-adopt batch jobs whose process survived a prior spurd's restart,
+    // before this agent starts accepting new launches (must not double-book
+    // resources still held by a job it doesn't yet know about).
+    agent_service.reconcile_running_jobs().await;
+
     agent_service.start_monitor(args.controller.clone());
+
+    // Read before agent_service moves into the server, so a SIGTERM with
+    // running jobs can be told apart from a plain idle-node shutdown.
+    let running_jobs = agent_service.running_jobs_handle();
 
     let addr = args.listen.parse()?;
     info!(%addr, "agent gRPC server listening");
@@ -335,17 +352,25 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         result = server_future => { result?; }
         _ = sigterm.recv() => {
-            info!("received SIGTERM, deregistering from controller");
-            let dereg_reporter = reporter.clone();
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                dereg_reporter.deregister("agent shutdown"),
-            )
-            .await
-            {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => warn!(error = %e, "deregistration failed"),
-                Err(_) => warn!("deregistration timed out"),
+            if running_jobs.has_no_active_jobs().await {
+                info!("received SIGTERM, deregistering from controller");
+                let dereg_reporter = reporter.clone();
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    dereg_reporter.deregister("agent shutdown"),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => warn!(error = %e, "deregistration failed"),
+                    Err(_) => warn!("deregistration timed out"),
+                }
+            } else {
+                // Do not deregister: that would force-evict running jobs
+                // immediately. Their manifests let a restarted spurd re-adopt
+                // them; the controller's heartbeat timeout is the backstop if
+                // this agent doesn't come back in time.
+                info!("received SIGTERM with running jobs, shutting down without deregistering");
             }
         }
     }

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -27,6 +27,14 @@ use spur_devices::DeviceRegistry;
 
 use reporter::NodeReporter;
 
+/// Tests that scan the shared spool-root manifest tree (`executor::
+/// scan_job_manifests`/`reconcile_running_jobs`) must serialize against each
+/// other, or one test can pick up a manifest a concurrently-running test left
+/// behind in the same shared directory.
+#[cfg(test)]
+pub(crate) static MANIFEST_SCAN_TEST_LOCK: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
+
 fn log_memlock_status(memlock: spur_core::config::MemlockLimit) {
     use spur_core::config::MemlockLimit;
     let configured_desc = match memlock {
@@ -354,7 +362,16 @@ async fn main() -> anyhow::Result<()> {
     k0s.adopt_running_unit().await;
     tokio::spawn(k0s.supervise());
 
+    // Re-adopt batch jobs whose process survived a prior spurd's restart,
+    // before this agent starts accepting new launches (must not double-book
+    // resources still held by a job it doesn't yet know about).
+    agent_service.reconcile_running_jobs().await;
+
     agent_service.start_monitor(args.controller.clone());
+
+    // Read before agent_service moves into the server, so a SIGTERM with
+    // running jobs can be told apart from a plain idle-node shutdown.
+    let running_jobs = agent_service.running_jobs_handle();
 
     let addr = args.listen.parse()?;
     info!(%addr, "agent gRPC server listening");
@@ -399,17 +416,25 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         result = server_future => { result?; }
         _ = sigterm.recv() => {
-            info!("received SIGTERM, deregistering from controller");
-            let dereg_reporter = reporter.clone();
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                dereg_reporter.deregister("agent shutdown"),
-            )
-            .await
-            {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => warn!(error = %e, "deregistration failed"),
-                Err(_) => warn!("deregistration timed out"),
+            if running_jobs.has_no_active_jobs().await {
+                info!("received SIGTERM, deregistering from controller");
+                let dereg_reporter = reporter.clone();
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    dereg_reporter.deregister("agent shutdown"),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => warn!(error = %e, "deregistration failed"),
+                    Err(_) => warn!("deregistration timed out"),
+                }
+            } else {
+                // Do not deregister: that would force-evict running jobs
+                // immediately. Their manifests let a restarted spurd re-adopt
+                // them; the controller's heartbeat timeout is the backstop if
+                // this agent doesn't come back in time.
+                info!("received SIGTERM with running jobs, shutting down without deregistering");
             }
         }
     }

--- a/tests/native_host/e2e/test_deregistration.py
+++ b/tests/native_host/e2e/test_deregistration.py
@@ -8,6 +8,7 @@ Covers: graceful drain+remove, forced eviction, dead-node auto-cleanup,
 agent self-deregistration, and the bug fix for failing jobs on downed nodes.
 """
 
+import re
 import time
 
 import pytest
@@ -80,6 +81,13 @@ def _sigterm_agent(cluster, node_index):
     node.exec_allow_fail(
         f"{prefix}pkill -TERM -f '{cluster.bin_dir}/spurd' 2>/dev/null || true"
     )
+
+
+def _job_exit_code(cluster, job_id):
+    """Return the code half of `scontrol show job`'s ExitCode=code:signal."""
+    out = cluster.scontrol("show", "job", str(job_id))
+    m = re.search(r"ExitCode=(\d+):", out)
+    return int(m.group(1)) if m else None
 
 
 class TestDrainAndRemove:
@@ -176,6 +184,162 @@ class TestAgentSelfDeregistration:
 
         _sigterm_agent(cluster, 1)
         _wait_node_gone(cluster, node1, timeout=30)
+
+
+class TestAgentRestartPreservesRunningJob:
+    """Restarting spurd in place (e.g. a binary upgrade via `systemctl
+    restart spurd`) must not interrupt a running job, as long as the
+    restart completes within heartbeat_timeout_secs.
+
+    This is the acceptance test for the seamless-upgrade fix: a graceful
+    SIGTERM must not force-evict the node (unlike TestForcedEviction, which
+    covers the deliberate `--force` admin path), and spurd must reconcile
+    the still-running job — and its resource allocation — on restart
+    instead of losing track of it and stranding or double-booking the
+    node's CPUs.
+
+    NOTE: this currently fails on an unfixed spurd, which force-deregisters
+    (and thus evicts) the node on every SIGTERM regardless of running jobs.
+    """
+
+    HB_TIMEOUT = 15
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {"controller": {"heartbeat_timeout_secs": self.HB_TIMEOUT}}
+
+    def test_restart_agent_mid_job_survives(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        node0 = cluster.node_names[0]
+
+        script = cluster.write_file(
+            "restart_survive.sh", "#!/bin/bash\nsleep 20\necho done\n"
+        )
+        sbatch_out = cluster.sbatch(
+            ["-N", "1", "-c", "2", f"--nodelist={node0}", script]
+        )
+        job_id = parse_job_id(sbatch_out)
+        assert job_id is not None
+
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            if job_state(cluster.squeue_all(), job_id) == "R":
+                break
+            time.sleep(1)
+        assert job_state(cluster.squeue_all(), job_id) == "R"
+
+        node_before = cluster.scontrol_show_node(node0)
+        assert "CPUAlloc=2" in node_before, node_before
+
+        # Simulate an in-place binary upgrade: graceful SIGTERM + relaunch,
+        # well within heartbeat_timeout_secs.
+        cluster.restart_agent(0)
+
+        state = job_state(cluster.squeue_all(), job_id)
+        assert state not in (None, "NF", "F"), (
+            f"job was interrupted by agent restart, state={state}"
+        )
+
+        state = _wait_job_terminal(cluster, job_id, timeout=60)
+        assert state == "CD", f"expected COMPLETED after restart, got {state}"
+
+        # Allocation must not have been stranded (leaked as still-allocated
+        # after the job finished) or double-booked (reserved twice across
+        # the restart) — once the job's done, CPUAlloc must fall back to 0.
+        node_after = cluster.scontrol_show_node(node0)
+        assert "CPUAlloc=0" in node_after, node_after
+
+
+class TestExitCodePreservedAcrossRestart:
+    """A job that spans a spurd restart must still report its real exit code,
+    for both plain and containerized jobs. Container jobs run their script
+    inside the pivoted rootfs, so the exit-status sentinel has to be recorded
+    at a host-visible path or a re-adopted container job would report -1.
+    """
+
+    HB_TIMEOUT = 30
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {"controller": {"heartbeat_timeout_secs": self.HB_TIMEOUT}}
+
+    def _run_across_restart(self, cluster, extra_args, exit_code):
+        # Sleep long enough to still be running when the restarted agent
+        # re-adopts it, then exit with a distinct code so a success default
+        # (-1/0) can't masquerade as the real one.
+        script = cluster.write_file(
+            f"exit_across_restart_{exit_code}.sh",
+            f"#!/bin/bash\nsleep 25\nexit {exit_code}\n",
+        )
+        job_id = parse_job_id(
+            cluster.sbatch(["-N", "1"] + extra_args + [script])
+        )
+        assert job_id is not None
+
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            if job_state(cluster.squeue_all(), job_id) == "R":
+                break
+            time.sleep(1)
+        assert job_state(cluster.squeue_all(), job_id) == "R"
+
+        cluster.restart_agent(0)
+
+        state = _wait_job_terminal(cluster, job_id, timeout=60)
+        expected_state = "CD" if exit_code == 0 else "F"
+        assert state == expected_state, (
+            f"expected {expected_state} (exit {exit_code}) after restart, got {state}"
+        )
+        code = _job_exit_code(cluster, job_id)
+        assert code == exit_code, (
+            f"expected ExitCode {exit_code} after restart, got {code}"
+        )
+
+    def test_plain_job_success_exit_code_survives_restart(self, cluster):
+        self._run_across_restart(cluster, [], exit_code=0)
+
+    def test_plain_job_failure_exit_code_survives_restart(self, cluster):
+        self._run_across_restart(cluster, [], exit_code=7)
+
+    def test_container_job_success_exit_code_survives_restart(self, cluster, tmp_path):
+        cluster.container_preflight()
+        image = cluster.build_container_image(tmp_path)
+        self._run_across_restart(cluster, [f"--container-image={image}"], exit_code=0)
+
+    def test_container_job_failure_exit_code_survives_restart(self, cluster, tmp_path):
+        cluster.container_preflight()
+        image = cluster.build_container_image(tmp_path)
+        self._run_across_restart(cluster, [f"--container-image={image}"], exit_code=7)
+
+    def test_exit_code_reported_when_job_finishes_while_agent_down(self, cluster):
+        # The job finishes entirely while spurd is dead, so on restart it is
+        # reconciled via the manifest's exit-status sentinel (the Dead path),
+        # not re-adopted. Its real code must still reach the controller.
+        script = cluster.write_file(
+            "finish_while_down.sh", "#!/bin/bash\nsleep 8\nexit 7\n"
+        )
+        job_id = parse_job_id(cluster.sbatch(["-N", "1", script]))
+        assert job_id is not None
+
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            if job_state(cluster.squeue_all(), job_id) == "R":
+                break
+            time.sleep(1)
+        assert job_state(cluster.squeue_all(), job_id) == "R"
+
+        # Kill spurd (no deregister), let the job finish while it is down,
+        # then bring spurd back — all within heartbeat_timeout so the
+        # controller doesn't evict the node first.
+        _kill_agent(cluster, 0)
+        time.sleep(12)
+        cluster.nodes[0].exec(cluster._spurd_start_cmd(0))
+        time.sleep(5)
+
+        state = _wait_job_terminal(cluster, job_id, timeout=self.HB_TIMEOUT)
+        assert state == "F", f"expected FAILED (exit 7) via Dead path, got {state}"
+        code = _job_exit_code(cluster, job_id)
+        assert code == 7, f"expected ExitCode 7 via Dead path, got {code}"
 
 
 class TestDownNodeFailsJobs:

--- a/tests/native_host/e2e/test_deregistration.py
+++ b/tests/native_host/e2e/test_deregistration.py
@@ -8,6 +8,7 @@ Covers: graceful drain+remove, forced eviction, dead-node auto-cleanup,
 agent self-deregistration, and the bug fix for failing jobs on downed nodes.
 """
 
+import re
 import time
 
 import pytest
@@ -82,6 +83,13 @@ def _sigterm_agent(cluster, node_index):
     node.exec_allow_fail(
         f"{prefix}pkill -TERM -f '{cluster.bin_dir}/spurd' 2>/dev/null || true"
     )
+
+
+def _job_exit_code(cluster, job_id):
+    """Return the code half of `scontrol show job`'s ExitCode=code:signal."""
+    out = cluster.scontrol("show", "job", str(job_id))
+    m = re.search(r"ExitCode=(\d+):", out)
+    return int(m.group(1)) if m else None
 
 
 class TestDrainAndRemove:
@@ -178,6 +186,162 @@ class TestAgentSelfDeregistration:
 
         _sigterm_agent(cluster, 1)
         _wait_node_gone(cluster, node1, timeout=30)
+
+
+class TestAgentRestartPreservesRunningJob:
+    """Restarting spurd in place (e.g. a binary upgrade via `systemctl
+    restart spurd`) must not interrupt a running job, as long as the
+    restart completes within heartbeat_timeout_secs.
+
+    This is the acceptance test for the seamless-upgrade fix: a graceful
+    SIGTERM must not force-evict the node (unlike TestForcedEviction, which
+    covers the deliberate `--force` admin path), and spurd must reconcile
+    the still-running job — and its resource allocation — on restart
+    instead of losing track of it and stranding or double-booking the
+    node's CPUs.
+
+    NOTE: this currently fails on an unfixed spurd, which force-deregisters
+    (and thus evicts) the node on every SIGTERM regardless of running jobs.
+    """
+
+    HB_TIMEOUT = 15
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {"controller": {"heartbeat_timeout_secs": self.HB_TIMEOUT}}
+
+    def test_restart_agent_mid_job_survives(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        node0 = cluster.node_names[0]
+
+        script = cluster.write_file(
+            "restart_survive.sh", "#!/bin/bash\nsleep 20\necho done\n"
+        )
+        sbatch_out = cluster.sbatch(
+            ["-N", "1", "-c", "2", f"--nodelist={node0}", script]
+        )
+        job_id = parse_job_id(sbatch_out)
+        assert job_id is not None
+
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            if job_state(cluster.squeue_all(), job_id) == "R":
+                break
+            time.sleep(1)
+        assert job_state(cluster.squeue_all(), job_id) == "R"
+
+        node_before = cluster.scontrol_show_node(node0)
+        assert "CPUAlloc=2" in node_before, node_before
+
+        # Simulate an in-place binary upgrade: graceful SIGTERM + relaunch,
+        # well within heartbeat_timeout_secs.
+        cluster.restart_agent(0)
+
+        state = job_state(cluster.squeue_all(), job_id)
+        assert state not in (None, "NF", "F"), (
+            f"job was interrupted by agent restart, state={state}"
+        )
+
+        state = _wait_job_terminal(cluster, job_id, timeout=60)
+        assert state == "CD", f"expected COMPLETED after restart, got {state}"
+
+        # Allocation must not have been stranded (leaked as still-allocated
+        # after the job finished) or double-booked (reserved twice across
+        # the restart) — once the job's done, CPUAlloc must fall back to 0.
+        node_after = cluster.scontrol_show_node(node0)
+        assert "CPUAlloc=0" in node_after, node_after
+
+
+class TestExitCodePreservedAcrossRestart:
+    """A job that spans a spurd restart must still report its real exit code,
+    for both plain and containerized jobs. Container jobs run their script
+    inside the pivoted rootfs, so the exit-status sentinel has to be recorded
+    at a host-visible path or a re-adopted container job would report -1.
+    """
+
+    HB_TIMEOUT = 30
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {"controller": {"heartbeat_timeout_secs": self.HB_TIMEOUT}}
+
+    def _run_across_restart(self, cluster, extra_args, exit_code):
+        # Sleep long enough to still be running when the restarted agent
+        # re-adopts it, then exit with a distinct code so a success default
+        # (-1/0) can't masquerade as the real one.
+        script = cluster.write_file(
+            f"exit_across_restart_{exit_code}.sh",
+            f"#!/bin/bash\nsleep 25\nexit {exit_code}\n",
+        )
+        job_id = parse_job_id(
+            cluster.sbatch(["-N", "1"] + extra_args + [script])
+        )
+        assert job_id is not None
+
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            if job_state(cluster.squeue_all(), job_id) == "R":
+                break
+            time.sleep(1)
+        assert job_state(cluster.squeue_all(), job_id) == "R"
+
+        cluster.restart_agent(0)
+
+        state = _wait_job_terminal(cluster, job_id, timeout=60)
+        expected_state = "CD" if exit_code == 0 else "F"
+        assert state == expected_state, (
+            f"expected {expected_state} (exit {exit_code}) after restart, got {state}"
+        )
+        code = _job_exit_code(cluster, job_id)
+        assert code == exit_code, (
+            f"expected ExitCode {exit_code} after restart, got {code}"
+        )
+
+    def test_plain_job_success_exit_code_survives_restart(self, cluster):
+        self._run_across_restart(cluster, [], exit_code=0)
+
+    def test_plain_job_failure_exit_code_survives_restart(self, cluster):
+        self._run_across_restart(cluster, [], exit_code=7)
+
+    def test_container_job_success_exit_code_survives_restart(self, cluster, tmp_path):
+        cluster.container_preflight()
+        image = cluster.build_container_image(tmp_path)
+        self._run_across_restart(cluster, [f"--container-image={image}"], exit_code=0)
+
+    def test_container_job_failure_exit_code_survives_restart(self, cluster, tmp_path):
+        cluster.container_preflight()
+        image = cluster.build_container_image(tmp_path)
+        self._run_across_restart(cluster, [f"--container-image={image}"], exit_code=7)
+
+    def test_exit_code_reported_when_job_finishes_while_agent_down(self, cluster):
+        # The job finishes entirely while spurd is dead, so on restart it is
+        # reconciled via the manifest's exit-status sentinel (the Dead path),
+        # not re-adopted. Its real code must still reach the controller.
+        script = cluster.write_file(
+            "finish_while_down.sh", "#!/bin/bash\nsleep 8\nexit 7\n"
+        )
+        job_id = parse_job_id(cluster.sbatch(["-N", "1", script]))
+        assert job_id is not None
+
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            if job_state(cluster.squeue_all(), job_id) == "R":
+                break
+            time.sleep(1)
+        assert job_state(cluster.squeue_all(), job_id) == "R"
+
+        # Kill spurd (no deregister), let the job finish while it is down,
+        # then bring spurd back — all within heartbeat_timeout so the
+        # controller doesn't evict the node first.
+        _kill_agent(cluster, 0)
+        time.sleep(12)
+        cluster.nodes[0].exec(cluster._spurd_start_cmd(0))
+        time.sleep(5)
+
+        state = _wait_job_terminal(cluster, job_id, timeout=self.HB_TIMEOUT)
+        assert state == "F", f"expected FAILED (exit 7) via Dead path, got {state}"
+        code = _job_exit_code(cluster, job_id)
+        assert code == 7, f"expected ExitCode 7 via Dead path, got {code}"
 
 
 class TestDownNodeFailsJobs:


### PR DESCRIPTION
## Summary

`spurd`'s SIGTERM handler unconditionally deregistered the node, which force-evicts every running job on it — so any graceful restart (a binary upgrade via `systemctl restart spurd`) failed in-flight jobs, even though the job process itself could survive it: it already runs in its own process group and cgroup, outside spurd's systemd cgroup.

This makes a graceful restart transparent to running jobs, as long as it completes within `heartbeat_timeout_secs`. The heartbeat timeout stays the backstop for a restart that takes too long — the same bound Slurm documents for a `slurmd` upgrade.

## Approach

- **SIGTERM** deregisters only when the agent has no active jobs (none running, none mid-launch). An idle or reservation-only node still deregisters immediately so the controller reclaims it.

- **Per-job manifest**, written atomically (temp + rename) right after launch, split into two concerns:
  - *identity* — pid, `/proc/<pid>` start time (detects PID reuse), cgroup path, exit-sentinel path, container rootfs, and the namespace layout **as recorded at launch**; re-deriving any of it would depend on the restarted agent's environment and privilege, which need not match the agent that launched the job.
  - *obligations* — what the agent still owes the job (release resources, epilog + SPANK, report completion), each a pending flag, plus the resolved exit once observed. Structuring the record around what must still happen keeps teardown honest: every obligation has a home in the schema instead of being re-derived by reconcile code, which is where they were being silently dropped.

- **Completion detection without `waitpid`.** A restarted agent no longer parents the job, so it cannot `wait()` it. Liveness is a tri-state cgroup read (`cgroup.events`): populated → alive, empty → done, unreadable → fall back to a `/proc/<pid>` check rather than assume completion. The exit code comes from a sentinel the job's wrapper writes. The wrapper installs an EXIT trap **plus explicit HUP/INT/QUIT/TERM traps**, because bash's `$?` inside an EXIT trap holds the last completed command's status rather than `128+N` — without them a job stopped by `scancel` or a time limit recorded as *successful*.

- **Reconcile = discharging obligations.** Before serving new launches, the agent scans manifests and either re-adopts a live job — restoring its allocation all-or-nothing across CPUs, memory and GPUs, so it can't double-book what a survivor still holds — or drives a finished job's ledger to empty: epilog + SPANK, then the report, persisting after each step. The spool is removed only once every obligation is discharged. A lost report is retried on the next startup and does **not** re-run the non-idempotent epilog (GPU reset, scratch purge). Live-monitored and adopted completions share one teardown path.

- **Container jobs** get the same exit wrapper applied to the in-container script, writing to a host-visible path inside the rootfs, so a re-adopted container job reports its true exit code instead of an approximate `-1`.

- **Everything a job owns is keyed by `(job_id, run_attempt)`** — cgroup, spool dir, and container rootfs — so a same-node redispatch can never collide with a run that is still finishing. Ownership of a rootfs is now explicit rather than incidental: setup returns a teardown record for a rootfs the job owns and nothing for a named container, which outlives the job. Previously a named container was spared only because the recomputed path happened not to match it.

  Per-attempt keying removes a property that has to be replaced deliberately. When every attempt shared one directory, a rootfs orphaned by a failed launch was reused and eventually reclaimed by the next attempt; distinct directories make that leak permanent. Two paths therefore clean up explicitly — a drop guard tears down a rootfs whose launch exits before commit (including on cancellation, which no error path can catch), and a redispatch that displaces an older run tears down that run's rootfs and spool.

- The spool dir stays root-owned `0o711` with the sentinel pre-created and chowned to the job, so a co-located user can't plant a symlink over the root-authored manifest.

- `spurctld` warns at startup if `heartbeat_timeout_secs` is under 30s, since it is more load-bearing now.

## Known limitations

- **A job using `--mpi=pmix` does not survive a restart, and does not fail cleanly either.** The PMIx server runs inside the agent process, so a restart takes it down underneath the job's ranks. Ranks hold a persistent connection to it for their whole lifetime and still depend on it after startup — the finalize barrier, and endpoint lookup for any peer a rank has not yet contacted — and PMIx has no supported path for a restarted server to re-accept existing clients. Worse, a long-standing Open MPI defect blocks the abort that a lost-connection event is supposed to trigger, so the ranks hang rather than exit, holding their accelerators until the wall clock reclaims them. No on-disk record can close this; it requires moving the PMIx server out of the agent process. This is the most severe limitation listed here.

- **Job steps are not covered.** The manifest is per-job, not per-step. The agent's step table lives only in memory and comes back empty after a restart, so a running step is orphaned and never reaped, its output — buffered in the agent rather than written to disk — is lost, and a cancel for that step is **silently dropped**: the caller is told it succeeded while the step keeps running. A batch script made of `srun` steps is the ordinary case, not a corner.

- **A restart slower than `heartbeat_timeout_secs`** falls back to today's eviction path; a job redispatched elsewhere during one isn't proactively cleaned up on the original node.

- **Exit truth for an adopted job is inferred rather than observed.** Death by signal is now recorded by the explicit traps, SIGKILL leaves no sentinel and is correctly read as a failure, and an OOM is recovered from the cgroup. What stays unrecoverable is a job killed by something outside Spur, other than the OOM killer, while the agent was down. Note the exit *code* is job-authored on the normal path too — a script can end `exit 0` after a failing command — so a container writing its own sentinel is not a new class of untruth.

- **A crash and a graceful stop are equivalent for adoption**, because the manifest is written at launch rather than at shutdown, so both leave identical on-disk state and re-adopt identically. What a crash additionally loses is on the controller side: no deregistration, so the job stays listed as running until the heartbeat timeout.

- **Records written by an unprivileged agent are deliberately not read by a privileged one.** The scan skips a world-writable base when running as root, so root never trusts a manifest a user could have planted. The consequence is that correcting a deployment from unprivileged to root strands every job that was running under the old agent — no completion, no epilog, no resources released. The agent warns when it finds such records rather than skipping them silently.

- Interactive `srun` allocations aren't manifested and don't survive a restart — the client connection drops in any case.

- Smaller follow-ups: manifests have no age bound, so a permanently-rejected completion report is retried on every startup; and no manifest is written at all in the narrow window where the process start time can't be read, so such a job is not adoptable.

## Testing

- Unit tests in `executor.rs`, `agent_server.rs`, `container.rs` and `cons_tres.rs`, several driving real spawned processes: signal traps recording `128+N` (measured against the old wrapper, which wrote `0` on a self-TERM after a successful command); the ledger running the epilog exactly once across repeated report retries; tri-state cgroup liveness falling back to `/proc`; all-or-nothing restore rejecting a CPU, memory or GPU double-book; the sentinel reader refusing a planted FIFO or symlink and capping the read; attempt-scoped spool and rootfs isolation; a rootfs plan that is owned for an unnamed container and never owned for a named one; the launch guard tearing down an uncommitted rootfs and releasing a committed one; atomic manifest write; and a frozen manifest fixture pinned at the pre-`rootfs` shape.
- E2E (`test_deregistration.py`): restart mid-job and assert the job survives, completes, and its allocation is neither stranded nor double-booked; exit code preserved for plain and container jobs × success and failure; and a job that finishes entirely while the agent is down still reports its true exit code.
- `cargo clippy --workspace --exclude spur-ffi --all-targets` and `cargo fmt` clean; `cargo test` passes.
- Verified end-to-end on an isolated, throwaway deployment on non-production ports, exercising real container jobs: a container job's rootfs created under its attempt-scoped directory and removed on completion; a container job re-adopted across an agent restart, running to completion afterwards, with teardown removing the directory recorded in its manifest rather than the one the restarted agent would have resolved from its own environment; and a container launch failing after rootfs creation leaving nothing behind.
