### PR TITLE
fix(spurctld): report BeginTime while --begin defers a job

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2215,10 +2215,9 @@ impl ClusterManager {
             });
         }
 
-        // A begin-deferred job reaches none of the blocker checks above, which
-        // all pass ineligible candidates straight through, so this is the only
-        // place its wait can be named. Structural blockers already claimed the
-        // jobs they explain, keeping their precedence over the hold.
+        // The only tagger for begin-deferred jobs: the blocker checks above pass
+        // ineligible candidates through without claiming them. Running after them
+        // preserves their precedence, so a structural blocker still outranks the hold.
         candidates.retain(|candidate| {
             if candidate.scheduling_eligible {
                 return true;

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2215,7 +2215,19 @@ impl ClusterManager {
             });
         }
 
-        candidates.retain(|candidate| candidate.scheduling_eligible);
+        // A begin-deferred job reaches none of the blocker checks above, which
+        // all pass ineligible candidates straight through, so this is the only
+        // place its wait can be named. Structural blockers already claimed the
+        // jobs they explain, keeping their precedence over the hold.
+        candidates.retain(|candidate| {
+            if candidate.scheduling_eligible {
+                return true;
+            }
+            if candidate.job.is_begin_held(now) {
+                record_blocked(&mut blocked, candidate, PendingReason::BeginTime);
+            }
+            false
+        });
 
         PendingJobClassification {
             jobs: candidates
@@ -7806,6 +7818,95 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tag_blocked_sets_begin_time_reason_for_a_deferred_job() {
+        // A --begin deferral used to report None, the same string shown for a job
+        // the scheduler simply had not reached yet, leaving no way to tell them
+        // apart from squeue or scontrol.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        let mut spec = basic_spec("deferred");
+        spec.begin_time = Some(Utc::now() + chrono::Duration::hours(1));
+        let job_id = submit_and_wait(&cm, spec);
+
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::BeginTime
+        );
+        assert!(
+            !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "a deferred job must stay out of scheduling"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn begin_time_reason_gives_way_once_the_hold_lapses() {
+        // A sticky BeginTime would keep claiming the job waits on a start time
+        // that has already passed.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        let mut spec = basic_spec("begin-lapse");
+        spec.begin_time = Some(Utc::now() + chrono::Duration::hours(1));
+        let job_id = submit_and_wait(&cm, spec);
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::BeginTime
+        );
+
+        {
+            let mut jobs = cm.jobs.write();
+            jobs.get_mut(&job_id).unwrap().spec.begin_time =
+                Some(Utc::now() - chrono::Duration::seconds(1));
+        }
+
+        assert!(
+            cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "an elapsed hold must return the job to scheduling"
+        );
+
+        // An empty cluster forces a real wait reason, which must win.
+        let empty_state = spur_sched::traits::ClusterState {
+            nodes: &[],
+            partitions: &[],
+            reservations: &[],
+            topology: None,
+        };
+        let snapshot = cm.get_job(job_id).unwrap();
+        cm.update_pending_reasons(&[&snapshot], &empty_state);
+        assert_ne!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::BeginTime,
+            "the real wait reason must replace a lapsed hold"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_structural_blocker_outranks_a_begin_time_hold() {
+        // Both apply. The partition explains why the job cannot run at all,
+        // which is more useful than naming a start time it will never reach.
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.partitions[0].state = "DOWN".into();
+        let cm = test_cluster_with_config(&dir, config).await;
+
+        let mut spec = basic_spec("down-and-deferred");
+        spec.partition = Some("default".into());
+        spec.begin_time = Some(Utc::now() + chrono::Duration::hours(1));
+        let job_id = submit_and_wait(&cm, spec);
+
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::PartitionInactive
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn multi_partition_job_reaches_scheduling_when_one_partition_is_eligible() {
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
@@ -10031,6 +10132,9 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn future_begin_jobs_do_not_receive_consumable_block_reasons() {
+        // A consumable shortage is transient and may well be gone by the time a
+        // deferred job's start time arrives, so the hold is the honest reason to
+        // report and the shortage must not be recorded in its place.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "n1", 8, 16000);
@@ -10047,6 +10151,8 @@ mod tests {
         bb_spec.burst_buffer = Some("capacity=500".into());
         let bb_id = submit_and_wait(&cm, bb_spec);
 
+        // Seed an unrelated reason so the pass has something to overwrite: the
+        // hold has to be recorded even when the job already carries a reason.
         {
             let mut jobs = cm.jobs.write();
             jobs.get_mut(&license_id).unwrap().pending_reason = PendingReason::Priority;
@@ -10063,11 +10169,13 @@ mod tests {
         assert!(!pending.contains(&bb_id));
         assert_eq!(
             cm.get_job(license_id).unwrap().pending_reason,
-            PendingReason::Priority
+            PendingReason::BeginTime,
+            "a missing license must not displace the deferral as the reason"
         );
         assert_eq!(
             cm.get_job(bb_id).unwrap().pending_reason,
-            PendingReason::Priority
+            PendingReason::BeginTime,
+            "a burst-buffer shortfall must not displace the deferral as the reason"
         );
     }
 

--- a/tests/native_host/e2e/test_begin_time.py
+++ b/tests/native_host/e2e/test_begin_time.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E test for the reason reported while --begin defers a job.
+
+A job held back by ``--begin`` sits in PENDING until its start time arrives.
+Reporting ``None`` for that wait is indistinguishable from a job the scheduler
+has simply not reached yet, so there is no way to tell a deliberate deferral
+apart from an idle scheduler pass. Slurm reports ``BeginTime`` here.
+
+The reason is recomputed each scheduling cycle, so both assertions below poll
+rather than sampling once.
+"""
+
+import time
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+DEFER_SECONDS = 40
+
+
+def _wait_for_reason(cluster, job_id: int, reason: str, timeout: int = 60) -> str:
+    """Poll ``scontrol show job`` until it reports *reason*. Returns the output."""
+    deadline = time.time() + timeout
+    last = ""
+    while time.time() < deadline:
+        last = cluster.scontrol("show", "job", str(job_id))
+        if f"Reason={reason}" in last:
+            return last
+        time.sleep(2)
+    raise AssertionError(
+        f"job {job_id} never reported Reason={reason} within {timeout}s; "
+        f"last scontrol output:\n{last}"
+    )
+
+
+class TestBeginTimeReason:
+    def test_deferred_job_reports_begin_time_then_runs(self, cluster):
+        script = cluster.write_file("begin-ok.sh", "#!/bin/bash\necho ran\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "begin-defer", f"--begin=now+{DEFER_SECONDS}seconds", script])
+        )
+        assert job_id is not None
+
+        wait_job_state(cluster, job_id, "PD")
+        show = _wait_for_reason(cluster, job_id, "BeginTime")
+        assert "JobState=PENDING" in show, show
+
+        # squeue's REASON column is the surface most users actually read.
+        squeue = cluster.squeue([])
+        assert "(BeginTime)" in squeue, squeue
+
+        # The deferral itself must still work: the reason is cosmetic, and a job
+        # stuck reporting BeginTime forever would be a worse bug than None.
+        state = wait_job(cluster, job_id, timeout=DEFER_SECONDS + 120)
+        assert state == "CD", f"deferred job must still run to completion, got {state}"
+        assert "Reason=BeginTime" not in cluster.scontrol("show", "job", str(job_id))
+
+    def test_job_without_a_begin_time_never_reports_begin_time(self, cluster):
+        # Guards against tagging every job the scheduler passes over.
+        script = cluster.write_file("begin-plain.sh", "#!/bin/bash\necho ran\n")
+        job_id = parse_job_id(cluster.sbatch(["-J", "begin-plain", script]))
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=120)
+        assert state == "CD", f"expected COMPLETED, got {state}"
+        assert "Reason=BeginTime" not in cluster.scontrol("show", "job", str(job_id))


### PR DESCRIPTION
## Motivation

A job held back by `--begin` sat in `PENDING` with `Reason=None` — the same string shown for a job the scheduler has simply not reached yet. Nothing distinguished a deliberate deferral from an idle scheduling pass, on `squeue`, `scontrol show job`, or the REST `state_reason` field. Slurm reports `BeginTime` for this case.

Fixes #547.

## Technical Details

`classify_pending_jobs` marked a begin-deferred job `scheduling_eligible = false` and then dropped it at the closing `candidates.retain(...)` without ever pushing it onto the `blocked` list that feeds `apply_blocked_pending_reasons`. It reached none of the blocker checks either, since those all pass ineligible candidates straight through, so no code path could name its wait. `PendingReason::BeginTime` was therefore only ever set by the preemption-requeue path.

Notably, the filter at the top of the same function already short-circuits jobs that are begin-held *and* already tagged `BeginTime`, so a tagger was anticipated — it was just never written.

The hold is now recorded at that final `retain`, keyed on the existing `Job::is_begin_held` predicate rather than on `!scheduling_eligible`, so only a genuine begin-time deferral is tagged.

Two consequences of where it sits:

[1] Placing it after the blocker checks preserves their existing precedence. A deferred job that also sits in a down partition still reports `PartitionInactive`, which explains why it cannot run at all, rather than naming a start time it will never reach. There is a test for this.

[2] Consumable shortages (licenses, burst buffer) continue to be skipped for deferred jobs. Those are transient and may well be resolved by the time the start time arrives, so the hold is the honest reason to show.

The scheduler loop already calls `pending_jobs_and_tag_reasons()` before its `pending.is_empty()` early return, specifically so reasons stay fresh when nothing is schedulable — which is exactly the issue's single-deferred-job-on-an-idle-cluster scenario, so no change was needed there.

## Note on a changed test expectation

`future_begin_jobs_do_not_receive_consumable_block_reasons` asserted that a deferred job's reason was left *untouched*, using that as a proxy for "no consumable shortage was recorded". That invariant still holds — the license and burst-buffer checks continue to skip ineligible candidates — but the proxy no longer works, since the reason is now the deferral instead of whatever the job carried before. The assertions were updated to name the real invariant.

## Test Plan

- Unit tests in `spurctld` for the deferral being tagged, the reason giving way once the hold lapses, and a structural blocker outranking the hold. The first two were confirmed to fail without the fix.
- New `tests/native_host/e2e/test_begin_time.py` covering the reported flow plus a control job with no `--begin`.
- Clippy, fmt, and the full workspace suite.
- Live single-node LXD cluster (Ubuntu 24.04) reproducing the issue's commands.

## Test Result

Clippy and fmt clean; full workspace suite passes. Both new unit tests fail on `main` with `left: None, right: BeginTime`, matching the reported symptom exactly.

On the LXD cluster, `sbatch --begin=now+40seconds ok.sh`:

```
$ squeue
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
                 1   default /root/ok     root PD       0:00      1 (BeginTime)

$ scontrol show job 1
   JobState=PENDING Reason=BeginTime
```

The REST surface named in the issue agrees — `GET /slurm/v0.0.42/job/2` returned `job_state = PENDING` with `state_reason = BeginTime`.

The deferral itself still works: the job started 41 seconds after submit for a 40-second `--begin`, ran to completion, and its reason did not remain stuck at `BeginTime`.

## Submission Checklist

- Look over the contributing guidelines at <https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests>.

Made with [Cursor](https://cursor.com)