### PR TITLE
fix(spur-cli): support ALL in node subcommands

### DIFF
--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -8,8 +8,9 @@
 //! ephemeral localhost port, serve a hand-written service on it, and hand the
 //! caller back the address plus a shared record of what the server observed.
 //! Only a handful of RPCs are implemented (`CreateJobStep`, `RunStep`,
-//! `GetNodes`, `UpdateNode`); every other RPC reports `unimplemented` so an
-//! unexpected call fails loudly instead of silently returning a default.
+//! `GetNodes`, `UpdateNode`, `DrainNode`, `DeregisterNode`); every other RPC
+//! reports `unimplemented` so an unexpected call fails loudly instead of
+//! silently returning a default.
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -35,6 +36,8 @@ pub(crate) struct StepCapture {
     run_step_calls: Arc<AtomicU32>,
     get_node_names: Arc<Mutex<Vec<String>>>,
     update_node_names: Arc<Mutex<Vec<String>>>,
+    drain_node_names: Arc<Mutex<Vec<String>>>,
+    deregister_node_calls: Arc<Mutex<Vec<(String, bool)>>>,
     /// Node names that `update_node` should reject with `NotFound`.
     update_node_fail_names: Arc<Mutex<HashSet<String>>>,
 }
@@ -61,6 +64,14 @@ impl StepCapture {
 
     pub(crate) fn update_node_names(&self) -> Vec<String> {
         self.update_node_names.lock().unwrap().clone()
+    }
+
+    pub(crate) fn drain_node_names(&self) -> Vec<String> {
+        self.drain_node_names.lock().unwrap().clone()
+    }
+
+    pub(crate) fn deregister_node_calls(&self) -> Vec<(String, bool)> {
+        self.deregister_node_calls.lock().unwrap().clone()
     }
 
     pub(crate) fn set_update_node_fail_names(&self, names: HashSet<String>) {
@@ -156,6 +167,31 @@ mock_controller_impl! {
                 .collect();
             Ok(tonic::Response::new(proto::GetNodesResponse { nodes }))
         }
+
+        async fn drain_node(
+            &self,
+            request: tonic::Request<proto::DrainNodeRequest>,
+        ) -> Result<tonic::Response<proto::DrainNodeResponse>, tonic::Status> {
+            self.capture
+                .drain_node_names
+                .lock()
+                .unwrap()
+                .push(request.into_inner().name);
+            Ok(tonic::Response::new(proto::DrainNodeResponse::default()))
+        }
+
+        async fn deregister_node(
+            &self,
+            request: tonic::Request<proto::DeregisterNodeRequest>,
+        ) -> Result<tonic::Response<proto::DeregisterNodeResponse>, tonic::Status> {
+            let request = request.into_inner();
+            self.capture
+                .deregister_node_calls
+                .lock()
+                .unwrap()
+                .push((request.name, request.force));
+            Ok(tonic::Response::new(proto::DeregisterNodeResponse::default()))
+        }
     }
     unimplemented {
         submit_job(proto::SubmitJobRequest) -> proto::SubmitJobResponse;
@@ -169,8 +205,6 @@ mock_controller_impl! {
         update_job(proto::UpdateJobRequest) -> ();
         requeue_job(proto::RequeueJobRequest) -> proto::RequeueJobResponse;
         get_node(proto::GetNodeRequest) -> proto::NodeInfo;
-        drain_node(proto::DrainNodeRequest) -> proto::DrainNodeResponse;
-        deregister_node(proto::DeregisterNodeRequest) -> proto::DeregisterNodeResponse;
         deregister_agent(proto::DeregisterAgentRequest) -> ();
         get_partitions(proto::GetPartitionsRequest) -> proto::GetPartitionsResponse;
         create_partition(proto::CreatePartitionRequest) -> ();

--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -8,8 +8,8 @@
 //! ephemeral localhost port, serve a hand-written service on it, and hand the
 //! caller back the address plus a shared record of what the server observed.
 //! Only a handful of RPCs are implemented (`CreateJobStep`, `RunStep`,
-//! `UpdateNode`); every other RPC reports `unimplemented` so an unexpected call
-//! fails loudly instead of silently returning a default.
+//! `GetNodes`, `UpdateNode`); every other RPC reports `unimplemented` so an
+//! unexpected call fails loudly instead of silently returning a default.
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -33,6 +33,7 @@ pub(crate) struct StepCapture {
     create_step_num_tasks: Arc<AtomicU32>,
     run_step_step_id: Arc<AtomicU32>,
     run_step_calls: Arc<AtomicU32>,
+    get_node_names: Arc<Mutex<Vec<String>>>,
     update_node_names: Arc<Mutex<Vec<String>>>,
     /// Node names that `update_node` should reject with `NotFound`.
     update_node_fail_names: Arc<Mutex<HashSet<String>>>,
@@ -52,6 +53,10 @@ impl StepCapture {
     /// Number of `RunStep` calls, so tests can assert dispatch stopped early.
     pub(crate) fn run_step_calls(&self) -> u32 {
         self.run_step_calls.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn set_get_node_names(&self, names: Vec<String>) {
+        *self.get_node_names.lock().unwrap() = names;
     }
 
     pub(crate) fn update_node_names(&self) -> Vec<String> {
@@ -133,6 +138,24 @@ mock_controller_impl! {
             }
             Ok(tonic::Response::new(()))
         }
+
+        async fn get_nodes(
+            &self,
+            _request: tonic::Request<proto::GetNodesRequest>,
+        ) -> Result<tonic::Response<proto::GetNodesResponse>, tonic::Status> {
+            let nodes = self
+                .capture
+                .get_node_names
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|name| proto::NodeInfo {
+                    name: name.clone(),
+                    ..Default::default()
+                })
+                .collect();
+            Ok(tonic::Response::new(proto::GetNodesResponse { nodes }))
+        }
     }
     unimplemented {
         submit_job(proto::SubmitJobRequest) -> proto::SubmitJobResponse;
@@ -145,7 +168,6 @@ mock_controller_impl! {
         resume_job(proto::ResumeJobRequest) -> ();
         update_job(proto::UpdateJobRequest) -> ();
         requeue_job(proto::RequeueJobRequest) -> proto::RequeueJobResponse;
-        get_nodes(proto::GetNodesRequest) -> proto::GetNodesResponse;
         get_node(proto::GetNodeRequest) -> proto::NodeInfo;
         drain_node(proto::DrainNodeRequest) -> proto::DrainNodeResponse;
         deregister_node(proto::DeregisterNodeRequest) -> proto::DeregisterNodeResponse;

--- a/crates/spur-cli/src/node.rs
+++ b/crates/spur-cli/src/node.rs
@@ -3,6 +3,7 @@
 
 //! `spur node` subcommands for node lifecycle management.
 
+use crate::scontrol::{is_all_node_pattern, resolve_node_names};
 use std::collections::HashMap;
 
 use anyhow::{bail, Context, Result};
@@ -34,7 +35,7 @@ pub enum NodeCommand {
     /// Labels are key=value pairs used for partition routing.
     /// Append a trailing dash to remove a label (e.g., "pool-").
     Label {
-        /// Node names: comma-separated list and/or hostlist range (e.g. "n1,n2", "n[1-4]")
+        /// Node names: ALL, a comma-separated list, and/or a hostlist range (e.g. "n1,n2", "n[1-4]")
         node: String,
         /// Labels to set (key=value) or remove (key-)
         #[arg(required = true)]
@@ -42,15 +43,18 @@ pub enum NodeCommand {
     },
     /// Drain one or more nodes: stop scheduling new jobs while existing jobs finish.
     Drain {
-        /// Node names: comma-separated list and/or hostlist range (e.g. "n1,n2", "n[1-4]")
+        /// Node names: ALL, a comma-separated list, and/or a hostlist range (e.g. "n1,n2", "n[1-4]")
         node: String,
         /// Reason for draining
         #[arg(long)]
         reason: Option<String>,
     },
     /// Remove one or more nodes from the cluster entirely.
+    ///
+    /// ALL removes every registered node, and with --force this evicts jobs from
+    /// every node.
     Remove {
-        /// Node names: comma-separated list and/or hostlist range (e.g. "n1,n2", "n[1-4]")
+        /// Node names: ALL, a comma-separated list, and/or a hostlist range (e.g. "n1,n2", "n[1-4]")
         node: String,
         /// Force removal even if jobs are running (jobs will be failed with NODE_FAIL)
         #[arg(long)]
@@ -106,6 +110,11 @@ async fn cmd_label(controller: &str, node_pattern: String, label_args: Vec<Strin
     let (set_labels, remove_labels) = parse_label_args(&label_args)?;
     let nodes = expand_node_pattern(&node_pattern)?;
     let mut client = spur_proto::controller_client(crate::authclient::connect(controller).await?);
+    let nodes = if let Some(nodes) = nodes {
+        nodes
+    } else {
+        resolve_node_names(&mut client, &node_pattern).await?
+    };
 
     let mut failed: Vec<String> = Vec::new();
     for node in &nodes {
@@ -148,6 +157,11 @@ async fn cmd_label(controller: &str, node_pattern: String, label_args: Vec<Strin
 async fn cmd_drain(controller: &str, node_pattern: String, reason: Option<String>) -> Result<()> {
     let nodes = expand_node_pattern(&node_pattern)?;
     let mut client = spur_proto::controller_client(crate::authclient::connect(controller).await?);
+    let nodes = if let Some(nodes) = nodes {
+        nodes
+    } else {
+        resolve_node_names(&mut client, &node_pattern).await?
+    };
 
     let mut failed: Vec<String> = Vec::new();
     for node in &nodes {
@@ -198,6 +212,11 @@ async fn cmd_remove(
 ) -> Result<()> {
     let nodes = expand_node_pattern(&node_pattern)?;
     let mut client = spur_proto::controller_client(crate::authclient::connect(controller).await?);
+    let nodes = if let Some(nodes) = nodes {
+        nodes
+    } else {
+        resolve_node_names(&mut client, &node_pattern).await?
+    };
 
     let mut failed: Vec<String> = Vec::new();
     for node in &nodes {
@@ -245,8 +264,13 @@ async fn cmd_remove(
     Ok(())
 }
 
-fn expand_node_pattern(pattern: &str) -> Result<Vec<String>> {
-    spur_core::hostlist::expand(pattern).context("invalid node name pattern")
+fn expand_node_pattern(pattern: &str) -> Result<Option<Vec<String>>> {
+    if is_all_node_pattern(pattern) {
+        return Ok(None);
+    }
+    spur_core::hostlist::expand(pattern)
+        .map(Some)
+        .context("invalid node name pattern")
 }
 
 #[cfg(test)]
@@ -302,5 +326,78 @@ mod tests {
         let (set, remove) = parse_label_args(&args).unwrap();
         assert_eq!(set.get("env").unwrap(), "prod-");
         assert!(remove.is_empty());
+    }
+
+    #[tokio::test]
+    async fn label_all_resolves_registered_nodes_case_insensitively() {
+        for pattern in ["ALL", "all", "All"] {
+            let (addr, capture) = crate::mock_controller::spawn().await;
+            capture.set_get_node_names(vec!["n1".into(), "n2".into()]);
+
+            main_with_args(vec![
+                "node".into(),
+                "--controller".into(),
+                format!("http://{addr}"),
+                "label".into(),
+                pattern.into(),
+                "pool=gpu".into(),
+            ])
+            .await
+            .unwrap();
+
+            assert_eq!(capture.update_node_names(), vec!["n1", "n2"]);
+        }
+    }
+
+    #[tokio::test]
+    async fn label_all_rejects_an_empty_cluster() {
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        let err = main_with_args(vec![
+            "node".into(),
+            "--controller".into(),
+            format!("http://{addr}"),
+            "label".into(),
+            "ALL".into(),
+            "pool=gpu".into(),
+        ])
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("no nodes registered"));
+        assert!(capture.update_node_names().is_empty());
+    }
+
+    #[tokio::test]
+    async fn label_hostlist_does_not_query_all_nodes() {
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        main_with_args(vec![
+            "node".into(),
+            "--controller".into(),
+            format!("http://{addr}"),
+            "label".into(),
+            "node[1-2]".into(),
+            "pool=gpu".into(),
+        ])
+        .await
+        .unwrap();
+
+        assert_eq!(capture.update_node_names(), vec!["node1", "node2"]);
+    }
+
+    #[tokio::test]
+    async fn invalid_hostlist_is_rejected_before_connecting() {
+        let addr = crate::mock_controller::unreachable_addr().await;
+        let err = main_with_args(vec![
+            "node".into(),
+            "--controller".into(),
+            format!("http://{addr}"),
+            "label".into(),
+            "node[".into(),
+            "pool=gpu".into(),
+        ])
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("invalid node name pattern"));
     }
 }

--- a/crates/spur-cli/src/node.rs
+++ b/crates/spur-cli/src/node.rs
@@ -350,6 +350,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn drain_all_resolves_registered_nodes() {
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        capture.set_get_node_names(vec!["n1".into(), "n2".into()]);
+
+        main_with_args(vec![
+            "node".into(),
+            "--controller".into(),
+            format!("http://{addr}"),
+            "drain".into(),
+            "ALL".into(),
+        ])
+        .await
+        .unwrap();
+
+        assert_eq!(capture.drain_node_names(), vec!["n1", "n2"]);
+    }
+
+    #[tokio::test]
+    async fn remove_all_forces_every_registered_node() {
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        capture.set_get_node_names(vec!["n1".into(), "n2".into()]);
+
+        main_with_args(vec![
+            "node".into(),
+            "--controller".into(),
+            format!("http://{addr}"),
+            "remove".into(),
+            "ALL".into(),
+            "--force".into(),
+        ])
+        .await
+        .unwrap();
+
+        assert_eq!(
+            capture.deregister_node_calls(),
+            vec![("n1".to_string(), true), ("n2".to_string(), true)]
+        );
+    }
+
+    #[tokio::test]
     async fn label_all_rejects_an_empty_cluster() {
         let (addr, capture) = crate::mock_controller::spawn().await;
         let err = main_with_args(vec![

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -1238,15 +1238,19 @@ async fn parse_and_update(controller: &str, params: &[String]) -> Result<()> {
     .await
 }
 
+pub(crate) fn is_all_node_pattern(pattern: &str) -> bool {
+    pattern.eq_ignore_ascii_case("ALL")
+}
+
 /// Resolve a node name pattern to a list of individual node names.
 ///
 /// Supports Slurm-compatible hostlist expressions (`node[1-3]`),
 /// comma-separated lists (`node1,node2`), and the `ALL` keyword.
-async fn resolve_node_names(
+pub(crate) async fn resolve_node_names(
     client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
     pattern: &str,
 ) -> Result<Vec<String>> {
-    if pattern.eq_ignore_ascii_case("ALL") {
+    if is_all_node_pattern(pattern) {
         let resp = client
             .get_nodes(spur_proto::proto::GetNodesRequest {
                 nodelist: String::new(),


### PR DESCRIPTION
## Summary

- Make `spur node label`, `drain`, and `remove` resolve case-insensitive `ALL` to every registered node.
- Reuse `scontrol`'s existing resolver while validating ordinary hostlists before connecting.
- Document the `ALL` scope and add focused controller-backed regression coverage.

Closes #566.

## Behavior note

`spur node remove ALL --force` removes every registered node and may evict their jobs. This matches existing `scontrol` behavior and is documented in `spur node remove --help`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked -- -D warnings`
- `cargo test --workspace --exclude spurd --locked` (352 `spur-cli` tests and 626 workspace tests passed)

## Disclosure

This change was prepared with assistance from the radeon-issue automation and independently checked by a separately configured validation model. Maintainer review is still required.