### PR TITLE
fix(spur-cli): reject unresolved usernames

### DIFF
--- a/crates/spur-cli/src/exec.rs
+++ b/crates/spur-cli/src/exec.rs
@@ -46,7 +46,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .exec_in_job(ExecInJobRequest {
             job_id: args.job_id,
             command: args.command.clone(),
-            user: crate::interactive::current_user(),
+            user: crate::interactive::current_user()?,
         })
         .await
         .context("exec failed")?;

--- a/crates/spur-cli/src/interactive.rs
+++ b/crates/spur-cli/src/interactive.rs
@@ -18,11 +18,13 @@ pub async fn connect_agent(addr: &str) -> Result<SlurmAgentClient<tonic::transpo
         .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE))
 }
 
-/// Local username sent with exec/attach requests so the server can enforce job
-/// ownership. The fallback is deliberately not a legal UNIX username, so a
-/// lookup failure cannot collide with a real account and grant access.
-pub fn current_user() -> String {
-    whoami::username().unwrap_or_else(|_| "<lookup-failed>".into())
+/// Local username sent with authenticated job requests.
+///
+/// Refuse to continue when the operating system cannot resolve the caller:
+/// recording a sentinel can either collide with a real account or disagree
+/// with a later exec/attach request.
+pub fn current_user() -> Result<String> {
+    whoami::username().context("failed to determine current username")
 }
 
 pub fn get_terminal_size() -> spur_proto::proto::WindowSize {
@@ -51,6 +53,7 @@ pub async fn open_interactive_session(
     argv: Vec<String>,
     winsize: spur_proto::proto::WindowSize,
     overlap: bool,
+    user: &str,
 ) -> std::result::Result<InteractiveSessionHandle, tonic::Status> {
     let init = InteractiveInput {
         msg: Some(interactive_input::Msg::Init(InitSession {
@@ -61,7 +64,7 @@ pub async fn open_interactive_session(
             winsize: Some(winsize),
             argv,
             env: HashMap::new(),
-            user: current_user(),
+            user: user.to_string(),
         })),
     };
 
@@ -180,7 +183,8 @@ pub async fn run_interactive_session(
     winsize: spur_proto::proto::WindowSize,
     overlap: bool,
 ) -> Result<i32> {
-    let handle = open_interactive_session(agent, job_id, step_id, argv, winsize, overlap)
+    let user = current_user()?;
+    let handle = open_interactive_session(agent, job_id, step_id, argv, winsize, overlap, &user)
         .await
         .map_err(|status| anyhow::anyhow!("InteractiveSession RPC failed: {}", status.message()))?;
     drive_interactive_session(handle).await

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -119,6 +119,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     let controller = args.controller.clone();
     let job_spec = build_salloc_job_spec(&args, nodelist)?;
+    let user = job_spec.user.clone();
 
     let channel = spur_client::connect_channel(&controller)
         .await
@@ -137,7 +138,6 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         eprintln!("salloc: warning: {warning}");
     }
     let job_id = response.job_id;
-    let user = whoami::username().unwrap_or_else(|_| "unknown".into());
     eprintln!("salloc: Pending job allocation {}...", job_id);
 
     // Set up Ctrl+C handler to cancel the job on interrupt
@@ -175,7 +175,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 .cancel_job(CancelJobRequest {
                     job_id,
                     signal: 0,
-                    user: whoami::username().unwrap_or_default(),
+                    user: user.clone(),
                 })
                 .await;
             std::process::exit(1);
@@ -289,7 +289,7 @@ fn build_salloc_job_spec(args: &SallocArgs, nodelist: Option<String>) -> Result<
         partition: args.partition.clone().unwrap_or_default(),
         account: args.account.clone().unwrap_or_default(),
         qos: args.qos.clone().unwrap_or_default(),
-        user: whoami::username().unwrap_or_else(|_| "unknown".into()),
+        user: crate::interactive::current_user()?,
         uid: nix::unistd::getuid().as_raw(),
         gid: nix::unistd::getgid().as_raw(),
         num_nodes: args.nodes,

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -95,7 +95,7 @@ async fn stream_output_only(
         .stream_job_output(StreamJobOutputRequest {
             job_id,
             stream: stream_name.to_string(),
-            user: crate::interactive::current_user(),
+            user: crate::interactive::current_user()?,
         })
         .await
         .context("failed to start output stream")?

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -926,7 +926,7 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
         name,
         partition: args.partition.unwrap_or_default(),
         account: args.account.unwrap_or_default(),
-        user: whoami::username().unwrap_or_else(|_| "unknown".into()),
+        user: crate::interactive::current_user()?,
         uid: nix::unistd::getuid().as_raw(),
         gid: nix::unistd::getgid().as_raw(),
         num_nodes: args.nodes,

--- a/crates/spur-cli/src/scancel.rs
+++ b/crates/spur-cli/src/scancel.rs
@@ -70,9 +70,10 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     let signal = parse_signal(args.signal.as_deref())?;
 
-    let user = args
-        .user
-        .unwrap_or_else(|| whoami::username().unwrap_or_else(|_| "unknown".into()));
+    let user = match args.user {
+        Some(user) => user,
+        None => crate::interactive::current_user()?,
+    };
 
     let channel = spur_client::connect_channel(&args.controller)
         .await

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -340,7 +340,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 .cancel_job(spur_proto::proto::CancelJobRequest {
                     job_id,
                     signal: 0,
-                    user: whoami::username().unwrap_or_else(|_| "unknown".into()),
+                    user: crate::interactive::current_user()?,
                 })
                 .await
                 .context("requeue failed")?;
@@ -355,7 +355,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             client
                 .suspend_job(spur_proto::proto::SuspendJobRequest {
                     job_id,
-                    user: whoami::username().unwrap_or_else(|_| "unknown".into()),
+                    user: crate::interactive::current_user()?,
                 })
                 .await
                 .context("suspend failed")?;
@@ -370,7 +370,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             client
                 .resume_job(spur_proto::proto::ResumeJobRequest {
                     job_id,
-                    user: whoami::username().unwrap_or_else(|_| "unknown".into()),
+                    user: crate::interactive::current_user()?,
                 })
                 .await
                 .context("resume failed")?;
@@ -524,7 +524,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                     remove_users: split_csv(&remove_users),
                     add_accounts: split_csv(&add_accounts),
                     remove_accounts: split_csv(&remove_accounts),
-                    user: whoami::username().unwrap_or_else(|_| "unknown".into()),
+                    user: crate::interactive::current_user()?,
                 })
                 .await
                 .context("failed to update reservation")?;
@@ -1521,7 +1521,7 @@ async fn create_reservation(
             accounts: account_list,
             users: user_list,
             flags: flag_list,
-            user: whoami::username().unwrap_or_else(|_| "unknown".into()),
+            user: crate::interactive::current_user()?,
         })
         .await
         .context("failed to create reservation")?;
@@ -1540,7 +1540,7 @@ async fn delete_reservation(controller: &str, name: &str) -> Result<()> {
     client
         .delete_reservation(spur_proto::proto::DeleteReservationRequest {
             name: name.to_string(),
-            user: whoami::username().unwrap_or_else(|_| "unknown".into()),
+            user: crate::interactive::current_user()?,
         })
         .await
         .context("failed to delete reservation")?;

--- a/crates/spur-cli/src/scrontab.rs
+++ b/crates/spur-cli/src/scrontab.rs
@@ -63,8 +63,8 @@ fn crontab_file(user: Option<&str>) -> PathBuf {
     }
 }
 
-fn effective_user() -> String {
-    whoami::username().unwrap_or_else(|_| "unknown".into())
+fn effective_user() -> Result<String> {
+    crate::interactive::current_user()
 }
 
 fn list_crontab(path: &PathBuf) -> Result<()> {
@@ -75,12 +75,12 @@ fn list_crontab(path: &PathBuf) -> Result<()> {
                 .lines()
                 .all(|l| l.trim().is_empty() || l.starts_with('#'))
         {
-            eprintln!("no crontab entries for {}", effective_user());
+            eprintln!("no crontab entries for {}", effective_user()?);
         } else {
             print!("{}", content);
         }
     } else {
-        eprintln!("no crontab for {}", effective_user());
+        eprintln!("no crontab for {}", effective_user()?);
     }
     Ok(())
 }
@@ -117,11 +117,12 @@ fn edit_crontab(path: &PathBuf) -> Result<()> {
 }
 
 fn remove_crontab(path: &PathBuf) -> Result<()> {
+    let user = effective_user()?;
     if path.exists() {
         std::fs::remove_file(path)?;
-        eprintln!("crontab for {} removed", effective_user());
+        eprintln!("crontab for {user} removed");
     } else {
-        eprintln!("no crontab for {}", effective_user());
+        eprintln!("no crontab for {user}");
     }
     Ok(())
 }

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -219,8 +219,10 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             anyhow::bail!("--jobid requires --overlap");
         }
         let node = first_node(args.nodelist.as_deref().unwrap_or_default());
+        let user = crate::interactive::current_user()?;
         let exit_code =
-            run_interactive_pty(&args.controller, job_id, args.command.clone(), node).await?;
+            run_interactive_pty(&args.controller, job_id, args.command.clone(), node, &user)
+                .await?;
         std::process::exit(exit_code);
     }
 
@@ -561,7 +563,7 @@ fn build_srun_job_spec(
         partition: args.partition.clone().unwrap_or_default(),
         account: args.account.clone().unwrap_or_default(),
         qos: args.qos.clone().unwrap_or_default(),
-        user: whoami::username().unwrap_or_else(|_| "unknown".into()),
+        user: crate::interactive::current_user()?,
         uid: nix::unistd::getuid().as_raw(),
         gid: nix::unistd::getgid().as_raw(),
         num_nodes: args.nodes,
@@ -704,6 +706,7 @@ struct StepDispatchParams<'a> {
     work_dir: &'a str,
     io: &'a ResolvedIoPaths,
     mpi: &'a str,
+    user: &'a str,
 }
 
 async fn dispatch_step(
@@ -726,7 +729,7 @@ async fn dispatch_step(
             pty: false,
             winsize: None,
             node: String::new(),
-            user: crate::interactive::current_user(),
+            user: params.user.to_string(),
         })
         .await
         .context("failed to create job step")?
@@ -834,9 +837,8 @@ async fn run_standalone_srun(
         .await
         .context("failed to connect to spurctld")?;
     let mut client = SlurmControllerClient::new(channel);
-    let user = whoami::username().unwrap_or_else(|_| "unknown".into());
-
     let job_spec = build_srun_job_spec(args, work_dir, &io, mpi)?;
+    let user = job_spec.user.clone();
     let submit_resp = client
         .submit_job(SubmitJobRequest {
             spec: Some(job_spec),
@@ -866,6 +868,7 @@ async fn run_standalone_srun(
             job_id,
             args.command.clone(),
             String::new(),
+            &user,
         )
         .await;
         let _ = client
@@ -890,6 +893,7 @@ async fn run_standalone_srun(
             work_dir,
             io: &io,
             mpi,
+            user: &user,
         };
         let dispatch_result =
             dispatch_step_cancellable(&mut client, job_id, &step_params, true).await;
@@ -917,7 +921,7 @@ async fn run_standalone_srun(
     }
 
     let output_streamed = if io.stdout.is_empty() {
-        try_stream_output(&mut client, &nodelist, job_id).await
+        try_stream_output(&mut client, &nodelist, job_id, &user).await
     } else {
         false
     };
@@ -984,6 +988,7 @@ async fn try_stream_output(
     controller: &mut SlurmControllerClient<tonic::transport::Channel>,
     nodelist: &str,
     job_id: u32,
+    user: &str,
 ) -> bool {
     let first_node = nodelist.split(',').next().unwrap_or_default().trim();
     if first_node.is_empty() {
@@ -1011,7 +1016,7 @@ async fn try_stream_output(
         .stream_job_output(StreamJobOutputRequest {
             job_id,
             stream: "stdout".into(),
-            user: crate::interactive::current_user(),
+            user: user.to_string(),
         })
         .await
     {
@@ -1195,6 +1200,7 @@ async fn run_interactive_pty(
     job_id: u32,
     command: Vec<String>,
     node: String,
+    user: &str,
 ) -> Result<i32> {
     let channel = spur_client::connect_channel(controller)
         .await
@@ -1224,7 +1230,7 @@ async fn run_interactive_pty(
                     pty: true,
                     winsize: Some(winsize),
                     node: node.clone(),
-                    user: crate::interactive::current_user(),
+                    user: user.to_string(),
                 })
                 .await
             {
@@ -1261,6 +1267,7 @@ async fn run_interactive_pty(
             command.clone(),
             winsize,
             true,
+            user,
         )
         .await
         {
@@ -1307,12 +1314,14 @@ async fn run_as_step(
     }
 
     let io = resolve_io_paths(args);
+    let user = crate::interactive::current_user()?;
 
     let step_params = StepDispatchParams {
         args,
         work_dir,
         io: &io,
         mpi: step_mpi,
+        user: &user,
     };
     let dispatch_result =
         dispatch_step_cancellable(&mut client, job_id, &step_params, false).await?;
@@ -2113,6 +2122,7 @@ mod tests {
             work_dir: "/tmp",
             io: &io,
             mpi: spur_core::mpi::MPI_NONE,
+            user: "tester",
         };
         dispatch_step(client, 1, &params).await
     }


### PR DESCRIPTION
## Summary

- Fail closed when the current username cannot be resolved.
- Resolve the owner once per command entry point and reuse it for submission, step creation, PTY, output streaming, and cancellation.
- Rebase onto latest `main` while preserving response-warning handling.

Closes #567.

## Review follow-up

- Fixed the duplicate username lookup throughout the `srun` flow.
- Kept the `k8s.rs` fallback out of scope as agreed; tracked separately in #603.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked -- -D warnings`
- `cargo test --workspace --exclude spurd --locked`
- Unmapped-UID runtime checks fail closed and leave the crontab file intact.

## Disclosure

This change was prepared with assistance from the radeon-issue automation and independently checked by a separately configured validation model. Maintainer review is still required.