### PR TITLE
fix(spurctld): cool down a node that rejects a dispatch as resources-unavailable

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1264,7 +1264,8 @@ impl SlurmConfig {
                 ),
             });
         }
-        // Bounded so `Instant::now() + cooldown` cannot overflow and panic.
+        // Capped at the same 1-day ceiling as max_launch_backoff_secs — a longer
+        // dispatch cooldown has no legitimate operational use.
         if self.controller.dispatch_reject_cooldown_secs > MAX_LAUNCH_BACKOFF_SECS {
             return Err(ConfigError::InvalidValue {
                 field: "controller.dispatch_reject_cooldown_secs".into(),
@@ -2460,8 +2461,8 @@ terminal_job_retention_secs = {MAX_TERMINAL_JOB_RETENTION_SECS}
 
     #[test]
     fn controller_config_rejects_out_of_range_dispatch_reject_cooldown_secs() {
-        // Past this bound `Instant::now() + cooldown` overflows and panics, so
-        // it must be refused at load. Zero is valid (disables the cooldown).
+        // Past this bound load must reject rather than accept an unbounded
+        // dispatch cooldown. Zero is valid (disables the cooldown).
         let toml = format!(
             r#"
 cluster_name = "test"

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1156,6 +1156,16 @@ impl SlurmConfig {
                 ),
             });
         }
+        // Bounded so `Instant::now() + cooldown` cannot overflow and panic.
+        if self.controller.dispatch_reject_cooldown_secs > MAX_LAUNCH_BACKOFF_SECS {
+            return Err(ConfigError::InvalidValue {
+                field: "controller.dispatch_reject_cooldown_secs".into(),
+                value: format!(
+                    "{} (must be at most {})",
+                    self.controller.dispatch_reject_cooldown_secs, MAX_LAUNCH_BACKOFF_SECS
+                ),
+            });
+        }
         if self.cluster.enabled {
             if self.cluster.distro != "k0s" {
                 return Err(ConfigError::InvalidValue {
@@ -1930,6 +1940,41 @@ max_launch_backoff_secs = 0
         assert!(
             err.to_string().contains("max_launch_backoff_secs"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn controller_config_rejects_out_of_range_dispatch_reject_cooldown_secs() {
+        // Past this bound `Instant::now() + cooldown` overflows and panics, so
+        // it must be refused at load. Zero is valid (disables the cooldown).
+        let toml = format!(
+            r#"
+cluster_name = "test"
+
+[controller]
+dispatch_reject_cooldown_secs = {}
+"#,
+            MAX_LAUNCH_BACKOFF_SECS + 1
+        );
+        let err = SlurmConfig::load_from_str(&toml).unwrap_err();
+        assert!(
+            err.to_string().contains("dispatch_reject_cooldown_secs"),
+            "unexpected error: {err}"
+        );
+
+        let ok = r#"
+cluster_name = "test"
+
+[controller]
+dispatch_reject_cooldown_secs = 0
+"#;
+        assert_eq!(
+            SlurmConfig::load_from_str(ok)
+                .unwrap()
+                .controller
+                .dispatch_reject_cooldown_secs,
+            0,
+            "zero (disabled) must be accepted"
         );
     }
 

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -320,10 +320,19 @@ pub struct ControllerConfig {
     /// the inverse `SchedulerParameters=nohold_on_prolog_fail`.
     #[serde(default = "default_hold_on_prolog_fail")]
     pub hold_on_prolog_fail: bool,
+
+    /// Seconds a node is skipped for new dispatch after rejecting one as
+    /// resources-unavailable, so it isn't re-picked every tick (default 30, 0 disables).
+    #[serde(default = "default_dispatch_reject_cooldown_secs")]
+    pub dispatch_reject_cooldown_secs: u64,
 }
 
 fn default_max_batch_requeue() -> u32 {
     5
+}
+
+fn default_dispatch_reject_cooldown_secs() -> u64 {
+    30
 }
 
 fn default_hold_on_prolog_fail() -> bool {
@@ -374,6 +383,7 @@ impl Default for ControllerConfig {
             max_batch_requeue: default_max_batch_requeue(),
             max_launch_backoff_secs: default_max_launch_backoff_secs(),
             hold_on_prolog_fail: default_hold_on_prolog_fail(),
+            dispatch_reject_cooldown_secs: default_dispatch_reject_cooldown_secs(),
         }
     }
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -333,6 +333,11 @@ pub struct ControllerConfig {
     /// to the accounting reconcile interval so a job's DB row can be repaired first.
     #[serde(default = "default_terminal_job_retention_secs")]
     pub terminal_job_retention_secs: u64,
+
+    /// Seconds a node is skipped for new dispatch after rejecting one as
+    /// resources-unavailable, so it isn't re-picked every tick (default 30, 0 disables).
+    #[serde(default = "default_dispatch_reject_cooldown_secs")]
+    pub dispatch_reject_cooldown_secs: u64,
 }
 
 fn default_max_batch_requeue() -> u32 {
@@ -341,6 +346,10 @@ fn default_max_batch_requeue() -> u32 {
 
 fn default_terminal_job_retention_secs() -> u64 {
     3600
+}
+
+fn default_dispatch_reject_cooldown_secs() -> u64 {
+    30
 }
 
 fn default_hold_on_prolog_fail() -> bool {
@@ -396,6 +405,7 @@ impl Default for ControllerConfig {
             max_launch_backoff_secs: default_max_launch_backoff_secs(),
             hold_on_prolog_fail: default_hold_on_prolog_fail(),
             terminal_job_retention_secs: default_terminal_job_retention_secs(),
+            dispatch_reject_cooldown_secs: default_dispatch_reject_cooldown_secs(),
         }
     }
 }
@@ -1251,6 +1261,16 @@ impl SlurmConfig {
                 value: format!(
                     "{} (must be at most {})",
                     self.controller.terminal_job_retention_secs, MAX_TERMINAL_JOB_RETENTION_SECS
+                ),
+            });
+        }
+        // Bounded so `Instant::now() + cooldown` cannot overflow and panic.
+        if self.controller.dispatch_reject_cooldown_secs > MAX_LAUNCH_BACKOFF_SECS {
+            return Err(ConfigError::InvalidValue {
+                field: "controller.dispatch_reject_cooldown_secs".into(),
+                value: format!(
+                    "{} (must be at most {})",
+                    self.controller.dispatch_reject_cooldown_secs, MAX_LAUNCH_BACKOFF_SECS
                 ),
             });
         }
@@ -2435,6 +2455,41 @@ terminal_job_retention_secs = {MAX_TERMINAL_JOB_RETENTION_SECS}
                 .terminal_job_retention_secs,
             MAX_TERMINAL_JOB_RETENTION_SECS,
             "the bound itself must be accepted"
+        );
+    }
+
+    #[test]
+    fn controller_config_rejects_out_of_range_dispatch_reject_cooldown_secs() {
+        // Past this bound `Instant::now() + cooldown` overflows and panics, so
+        // it must be refused at load. Zero is valid (disables the cooldown).
+        let toml = format!(
+            r#"
+cluster_name = "test"
+
+[controller]
+dispatch_reject_cooldown_secs = {}
+"#,
+            MAX_LAUNCH_BACKOFF_SECS + 1
+        );
+        let err = SlurmConfig::load_from_str(&toml).unwrap_err();
+        assert!(
+            err.to_string().contains("dispatch_reject_cooldown_secs"),
+            "unexpected error: {err}"
+        );
+
+        let ok = r#"
+cluster_name = "test"
+
+[controller]
+dispatch_reject_cooldown_secs = 0
+"#;
+        assert_eq!(
+            SlurmConfig::load_from_str(ok)
+                .unwrap()
+                .controller
+                .dispatch_reject_cooldown_secs,
+            0,
+            "zero (disabled) must be accepted"
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -406,6 +406,9 @@ pub struct ClusterManager {
     /// reaper. Ephemeral soft state (like `Node::last_heartbeat`): keepalives
     /// arrive too often to persist, and on failover the reaper reseeds lazily.
     interactive_last_seen: RwLock<HashMap<JobId, DateTime<Utc>>>,
+    /// Nodes skipped for new dispatch until the given instant after a
+    /// resources-unavailable reject. Leader-local and transient, never persisted.
+    node_dispatch_cooldowns: RwLock<HashMap<String, std::time::Instant>>,
 }
 
 struct PendingJobClassification {
@@ -485,6 +488,7 @@ impl ClusterManager {
             scheduler_notify: Arc::new(Notify::new()),
             sched_stats: OnceLock::new(),
             interactive_last_seen: RwLock::new(HashMap::new()),
+            node_dispatch_cooldowns: RwLock::new(HashMap::new()),
         };
 
         info!("cluster manager initialized (state will be recovered via Raft)");
@@ -497,6 +501,27 @@ impl ClusterManager {
     /// from their point of view.
     pub fn config(&self) -> Arc<SlurmConfig> {
         self.config.read().clone()
+    }
+
+    /// Skip a node for new dispatch for the configured cooldown after it rejected
+    /// one as resources-unavailable, so the scheduler stops re-picking it each tick.
+    pub fn cool_down_node(&self, name: &str) {
+        let secs = self.config().controller.dispatch_reject_cooldown_secs;
+        if secs == 0 {
+            return;
+        }
+        let until = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+        self.node_dispatch_cooldowns
+            .write()
+            .insert(name.to_string(), until);
+    }
+
+    /// Names still within their dispatch cooldown, pruning any that have expired.
+    pub fn nodes_on_dispatch_cooldown(&self) -> HashSet<String> {
+        let now = std::time::Instant::now();
+        let mut cooldowns = self.node_dispatch_cooldowns.write();
+        cooldowns.retain(|_, &mut until| until > now);
+        cooldowns.keys().cloned().collect()
     }
 
     /// Submit a new job. If it has an array spec, expand into individual tasks.
@@ -6768,6 +6793,31 @@ mod tests {
             .expect("single-node raft did not self-elect within 5s");
         cm.set_raft(handle.raft);
         (cm, conf_path)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dispatch_cooldown_marks_then_expires_and_respects_disable() {
+        let dir = TempDir::new().unwrap();
+
+        // Enabled (default 30s): a cooled node is reported until it expires.
+        let cm = Arc::new(ClusterManager::new(test_config(), dir.path()).unwrap());
+        assert!(cm.nodes_on_dispatch_cooldown().is_empty());
+        cm.cool_down_node("worker1");
+        assert!(cm.nodes_on_dispatch_cooldown().contains("worker1"));
+
+        // A past instant is pruned on read, so an expired cooldown clears.
+        cm.node_dispatch_cooldowns.write().insert(
+            "worker1".into(),
+            std::time::Instant::now() - std::time::Duration::from_secs(1),
+        );
+        assert!(!cm.nodes_on_dispatch_cooldown().contains("worker1"));
+
+        // Disabled (0s): cool_down_node is a no-op.
+        let mut cfg = test_config();
+        cfg.controller.dispatch_reject_cooldown_secs = 0;
+        let cm0 = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
+        cm0.cool_down_node("worker1");
+        assert!(cm0.nodes_on_dispatch_cooldown().is_empty());
     }
 
     /// Consumer-driven: `maybe_requeue` must honor the new `max_batch_requeue`

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2101,13 +2101,23 @@ impl ClusterManager {
     }
 
     /// Nodes eligible for new placement this tick: all nodes minus those within
-    /// a dispatch cooldown after a resources-unavailable reject.
-    pub fn schedulable_nodes(&self) -> Vec<Node> {
+    /// a dispatch cooldown after a resources-unavailable reject — except a
+    /// cooling node explicitly named by a pending job's `--nodelist`, which has
+    /// nowhere else to go and would otherwise starve for the cooldown's
+    /// duration instead of being retried, the outcome the cooldown exists to
+    /// avoid only for jobs that actually have an alternative.
+    pub fn schedulable_nodes(&self, pending: &[Job]) -> Vec<Node> {
         let cooling = self.nodes_on_dispatch_cooldown();
+        let pinned: HashSet<String> = pending
+            .iter()
+            .filter_map(|j| j.spec.nodelist.as_deref())
+            .filter_map(|nl| spur_core::hostlist::expand(nl).ok())
+            .flatten()
+            .collect();
         self.nodes
             .read()
             .values()
-            .filter(|n| !cooling.contains(&n.name))
+            .filter(|n| !cooling.contains(&n.name) || pinned.contains(&n.name))
             .cloned()
             .collect()
     }
@@ -6820,7 +6830,11 @@ mod tests {
         assert!(cm.nodes_on_dispatch_cooldown().contains("worker1"));
 
         // The scheduler's node view excludes the cooled node, keeps the other.
-        let names: HashSet<String> = cm.schedulable_nodes().into_iter().map(|n| n.name).collect();
+        let names: HashSet<String> = cm
+            .schedulable_nodes(&[])
+            .into_iter()
+            .map(|n| n.name)
+            .collect();
         assert!(
             !names.contains("worker1"),
             "cooled node excluded from scheduling"
@@ -6834,7 +6848,9 @@ mod tests {
         );
         assert!(!cm.nodes_on_dispatch_cooldown().contains("worker1"));
         assert!(
-            cm.schedulable_nodes().iter().any(|n| n.name == "worker1"),
+            cm.schedulable_nodes(&[])
+                .iter()
+                .any(|n| n.name == "worker1"),
             "expired cooldown makes the node schedulable again"
         );
 
@@ -6844,6 +6860,47 @@ mod tests {
         let cm0 = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
         cm0.cool_down_node("worker1");
         assert!(cm0.nodes_on_dispatch_cooldown().is_empty());
+    }
+
+    /// GATE: a job's `--nodelist` pin is its only possible placement — cooling
+    /// that node down must not starve it for the whole cooldown window, or a
+    /// preempt-then-redispatch race against the same node (chronic preemption)
+    /// can never make progress within a job's own retry budget.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn schedulable_nodes_exempts_a_cooling_node_pinned_by_a_pending_job() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        register_node(&cm, "n2", 4, 8000);
+
+        cm.cool_down_node("n1");
+        assert!(cm.nodes_on_dispatch_cooldown().contains("n1"));
+
+        let mut spec = basic_spec("pinned");
+        spec.nodelist = Some("n1".into());
+        let job_id = submit_and_wait(&cm, spec);
+        let pinned_job = cm.get_job(job_id).unwrap();
+
+        let names: HashSet<String> = cm
+            .schedulable_nodes(std::slice::from_ref(&pinned_job))
+            .into_iter()
+            .map(|n| n.name)
+            .collect();
+        assert!(
+            names.contains("n1"),
+            "n1 is the pinned job's only candidate — must stay schedulable despite cooling"
+        );
+
+        // No pending job names the cooling node: back to excluded, as normal.
+        let names: HashSet<String> = cm
+            .schedulable_nodes(&[])
+            .into_iter()
+            .map(|n| n.name)
+            .collect();
+        assert!(
+            !names.contains("n1"),
+            "n1 must stay excluded when nothing pins to it"
+        );
     }
 
     /// Consumer-driven: `maybe_requeue` must honor the new `max_batch_requeue`

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2100,14 +2100,14 @@ impl ClusterManager {
         self.nodes.read().values().cloned().collect()
     }
 
-    /// Nodes eligible for new placement this tick: all nodes minus those within
-    /// a dispatch cooldown after a resources-unavailable reject — except a
-    /// cooling node explicitly named by a pending job's `--nodelist`, which has
-    /// nowhere else to go and would otherwise starve for the cooldown's
-    /// duration instead of being retried, the outcome the cooldown exists to
-    /// avoid only for jobs that actually have an alternative.
-    pub fn schedulable_nodes(&self, pending: &[Job]) -> Vec<Node> {
+    /// Nodes eligible for new placement this tick: all nodes minus those on a
+    /// dispatch cooldown, except a cooling node pinned by a pending job's
+    /// `--nodelist` (its only option). Exclusion is resource-agnostic by design.
+    pub fn nodes_off_dispatch_cooldown(&self, pending: &[Job]) -> Vec<Node> {
         let cooling = self.nodes_on_dispatch_cooldown();
+        if cooling.is_empty() {
+            return self.nodes.read().values().cloned().collect();
+        }
         let pinned: HashSet<String> = pending
             .iter()
             .filter_map(|j| j.spec.nodelist.as_deref())
@@ -6831,7 +6831,7 @@ mod tests {
 
         // The scheduler's node view excludes the cooled node, keeps the other.
         let names: HashSet<String> = cm
-            .schedulable_nodes(&[])
+            .nodes_off_dispatch_cooldown(&[])
             .into_iter()
             .map(|n| n.name)
             .collect();
@@ -6848,7 +6848,7 @@ mod tests {
         );
         assert!(!cm.nodes_on_dispatch_cooldown().contains("worker1"));
         assert!(
-            cm.schedulable_nodes(&[])
+            cm.nodes_off_dispatch_cooldown(&[])
                 .iter()
                 .any(|n| n.name == "worker1"),
             "expired cooldown makes the node schedulable again"
@@ -6867,7 +6867,7 @@ mod tests {
     /// preempt-then-redispatch race against the same node (chronic preemption)
     /// can never make progress within a job's own retry budget.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn schedulable_nodes_exempts_a_cooling_node_pinned_by_a_pending_job() {
+    async fn nodes_off_dispatch_cooldown_exempts_a_cooling_node_pinned_by_a_pending_job() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "n1", 4, 8000);
@@ -6882,7 +6882,7 @@ mod tests {
         let pinned_job = cm.get_job(job_id).unwrap();
 
         let names: HashSet<String> = cm
-            .schedulable_nodes(std::slice::from_ref(&pinned_job))
+            .nodes_off_dispatch_cooldown(std::slice::from_ref(&pinned_job))
             .into_iter()
             .map(|n| n.name)
             .collect();
@@ -6893,7 +6893,7 @@ mod tests {
 
         // No pending job names the cooling node: back to excluded, as normal.
         let names: HashSet<String> = cm
-            .schedulable_nodes(&[])
+            .nodes_off_dispatch_cooldown(&[])
             .into_iter()
             .map(|n| n.name)
             .collect();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1759,6 +1759,18 @@ impl ClusterManager {
         self.nodes.read().values().cloned().collect()
     }
 
+    /// Nodes eligible for new placement this tick: all nodes minus those within
+    /// a dispatch cooldown after a resources-unavailable reject.
+    pub fn schedulable_nodes(&self) -> Vec<Node> {
+        let cooling = self.nodes_on_dispatch_cooldown();
+        self.nodes
+            .read()
+            .values()
+            .filter(|n| !cooling.contains(&n.name))
+            .cloned()
+            .collect()
+    }
+
     /// Get a node by name.
     pub fn get_node(&self, name: &str) -> Option<Node> {
         self.nodes.read().get(name).cloned()
@@ -5983,10 +5995,20 @@ mod tests {
         let dir = TempDir::new().unwrap();
 
         // Enabled (default 30s): a cooled node is reported until it expires.
-        let cm = Arc::new(ClusterManager::new(test_config(), dir.path()).unwrap());
+        let cm = test_cluster_with_config(&dir, test_config()).await;
+        register_node(&cm, "worker1", 8, 16000);
+        register_node(&cm, "worker2", 8, 16000);
         assert!(cm.nodes_on_dispatch_cooldown().is_empty());
         cm.cool_down_node("worker1");
         assert!(cm.nodes_on_dispatch_cooldown().contains("worker1"));
+
+        // The scheduler's node view excludes the cooled node, keeps the other.
+        let names: HashSet<String> = cm.schedulable_nodes().into_iter().map(|n| n.name).collect();
+        assert!(
+            !names.contains("worker1"),
+            "cooled node excluded from scheduling"
+        );
+        assert!(names.contains("worker2"), "healthy node still schedulable");
 
         // A past instant is pruned on read, so an expired cooldown clears.
         cm.node_dispatch_cooldowns.write().insert(
@@ -5994,6 +6016,10 @@ mod tests {
             std::time::Instant::now() - std::time::Duration::from_secs(1),
         );
         assert!(!cm.nodes_on_dispatch_cooldown().contains("worker1"));
+        assert!(
+            cm.schedulable_nodes().iter().any(|n| n.name == "worker1"),
+            "expired cooldown makes the node schedulable again"
+        );
 
         // Disabled (0s): cool_down_node is a no-op.
         let mut cfg = test_config();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2100,6 +2100,18 @@ impl ClusterManager {
         self.nodes.read().values().cloned().collect()
     }
 
+    /// Nodes eligible for new placement this tick: all nodes minus those within
+    /// a dispatch cooldown after a resources-unavailable reject.
+    pub fn schedulable_nodes(&self) -> Vec<Node> {
+        let cooling = self.nodes_on_dispatch_cooldown();
+        self.nodes
+            .read()
+            .values()
+            .filter(|n| !cooling.contains(&n.name))
+            .cloned()
+            .collect()
+    }
+
     /// Get a node by name.
     pub fn get_node(&self, name: &str) -> Option<Node> {
         self.nodes.read().get(name).cloned()
@@ -6800,10 +6812,20 @@ mod tests {
         let dir = TempDir::new().unwrap();
 
         // Enabled (default 30s): a cooled node is reported until it expires.
-        let cm = Arc::new(ClusterManager::new(test_config(), dir.path()).unwrap());
+        let cm = test_cluster_with_config(&dir, test_config()).await;
+        register_node(&cm, "worker1", 8, 16000);
+        register_node(&cm, "worker2", 8, 16000);
         assert!(cm.nodes_on_dispatch_cooldown().is_empty());
         cm.cool_down_node("worker1");
         assert!(cm.nodes_on_dispatch_cooldown().contains("worker1"));
+
+        // The scheduler's node view excludes the cooled node, keeps the other.
+        let names: HashSet<String> = cm.schedulable_nodes().into_iter().map(|n| n.name).collect();
+        assert!(
+            !names.contains("worker1"),
+            "cooled node excluded from scheduling"
+        );
+        assert!(names.contains("worker2"), "healthy node still schedulable");
 
         // A past instant is pruned on read, so an expired cooldown clears.
         cm.node_dispatch_cooldowns.write().insert(
@@ -6811,6 +6833,10 @@ mod tests {
             std::time::Instant::now() - std::time::Duration::from_secs(1),
         );
         assert!(!cm.nodes_on_dispatch_cooldown().contains("worker1"));
+        assert!(
+            cm.schedulable_nodes().iter().any(|n| n.name == "worker1"),
+            "expired cooldown makes the node schedulable again"
+        );
 
         // Disabled (0s): cool_down_node is a no-op.
         let mut cfg = test_config();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -341,6 +341,9 @@ pub struct ClusterManager {
     /// Wake signal for the scheduler loop.
     pub(crate) scheduler_notify: Arc<Notify>,
     sched_stats: OnceLock<Arc<SchedStatsCollector>>,
+    /// Nodes skipped for new dispatch until the given instant after a
+    /// resources-unavailable reject. Leader-local and transient, never persisted.
+    node_dispatch_cooldowns: RwLock<HashMap<String, std::time::Instant>>,
 }
 
 struct PendingJobClassification {
@@ -400,6 +403,7 @@ impl ClusterManager {
             association_cache,
             scheduler_notify: Arc::new(Notify::new()),
             sched_stats: OnceLock::new(),
+            node_dispatch_cooldowns: RwLock::new(HashMap::new()),
         };
 
         info!("cluster manager initialized (state will be recovered via Raft)");
@@ -412,6 +416,27 @@ impl ClusterManager {
     /// from their point of view.
     pub fn config(&self) -> Arc<SlurmConfig> {
         self.config.read().clone()
+    }
+
+    /// Skip a node for new dispatch for the configured cooldown after it rejected
+    /// one as resources-unavailable, so the scheduler stops re-picking it each tick.
+    pub fn cool_down_node(&self, name: &str) {
+        let secs = self.config().controller.dispatch_reject_cooldown_secs;
+        if secs == 0 {
+            return;
+        }
+        let until = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+        self.node_dispatch_cooldowns
+            .write()
+            .insert(name.to_string(), until);
+    }
+
+    /// Names still within their dispatch cooldown, pruning any that have expired.
+    pub fn nodes_on_dispatch_cooldown(&self) -> HashSet<String> {
+        let now = std::time::Instant::now();
+        let mut cooldowns = self.node_dispatch_cooldowns.write();
+        cooldowns.retain(|_, &mut until| until > now);
+        cooldowns.keys().cloned().collect()
     }
 
     /// Submit a new job. If it has an array spec, expand into individual tasks.
@@ -5951,6 +5976,31 @@ mod tests {
             .expect("single-node raft did not self-elect within 5s");
         cm.set_raft(handle.raft);
         (cm, conf_path)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dispatch_cooldown_marks_then_expires_and_respects_disable() {
+        let dir = TempDir::new().unwrap();
+
+        // Enabled (default 30s): a cooled node is reported until it expires.
+        let cm = Arc::new(ClusterManager::new(test_config(), dir.path()).unwrap());
+        assert!(cm.nodes_on_dispatch_cooldown().is_empty());
+        cm.cool_down_node("worker1");
+        assert!(cm.nodes_on_dispatch_cooldown().contains("worker1"));
+
+        // A past instant is pruned on read, so an expired cooldown clears.
+        cm.node_dispatch_cooldowns.write().insert(
+            "worker1".into(),
+            std::time::Instant::now() - std::time::Duration::from_secs(1),
+        );
+        assert!(!cm.nodes_on_dispatch_cooldown().contains("worker1"));
+
+        // Disabled (0s): cool_down_node is a no-op.
+        let mut cfg = test_config();
+        cfg.controller.dispatch_reject_cooldown_secs = 0;
+        let cm0 = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
+        cm0.cool_down_node("worker1");
+        assert!(cm0.nodes_on_dispatch_cooldown().is_empty());
     }
 
     /// Consumer-driven: `maybe_requeue` must honor the new `max_batch_requeue`

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -152,7 +152,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         let reservations = cluster.get_reservations();
 
         if nodes.is_empty() {
-            debug!("no nodes registered, skipping scheduling cycle");
+            debug!("no schedulable nodes, skipping scheduling cycle");
             continue;
         }
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -147,7 +147,12 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
         let hit_depth_limit = pending.len() > max_jobs;
 
-        let nodes = cluster.get_nodes();
+        let cooling = cluster.nodes_on_dispatch_cooldown();
+        let nodes: Vec<spur_core::node::Node> = cluster
+            .get_nodes()
+            .into_iter()
+            .filter(|n| !cooling.contains(&n.name))
+            .collect();
         let partitions = cluster.get_partitions();
         let reservations = cluster.get_reservations();
 
@@ -874,6 +879,9 @@ enum DispatchError {
     /// own context, so the same failure recurs everywhere: Slurm drains the node
     /// and holds the job instead of retrying it onto the next one.
     PrologFailed(String),
+    /// The agent rejected the dispatch because the controller-allocated resources
+    /// are already in use locally — the controller's view of this node is stale.
+    ResourcesUnavailable,
     Other(anyhow::Error),
 }
 
@@ -881,6 +889,9 @@ impl std::fmt::Display for DispatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::PrologFailed(reason) => write!(f, "agent rejected job: {reason}"),
+            Self::ResourcesUnavailable => {
+                write!(f, "agent rejected job: allocated resources unavailable")
+            }
             Self::Other(e) => write!(f, "{e:#}"),
         }
     }
@@ -1033,7 +1044,11 @@ async fn dispatch_to_agent(
             task_fanout: params.task_fanout,
             pmix_prepared: params.pmix_prepared,
         })
-        .await?;
+        .await
+        .map_err(|s| match s.code() {
+            tonic::Code::ResourceExhausted => DispatchError::ResourcesUnavailable,
+            _ => DispatchError::Other(s.into()),
+        })?;
 
     let inner = response.into_inner();
     if !inner.success {
@@ -1531,8 +1546,12 @@ async fn confirm_dispatch_on_nodes(
             Ok((node_name, _, Err(e))) => {
                 error!(job_id, node = %node_name, error = %e, "dispatch confirmation failed");
                 failures += 1;
-                if let DispatchError::PrologFailed(reason) = e {
-                    prolog_failed.push((node_name, reason));
+                match e {
+                    DispatchError::PrologFailed(reason) => {
+                        prolog_failed.push((node_name, reason));
+                    }
+                    DispatchError::ResourcesUnavailable => cluster.cool_down_node(&node_name),
+                    DispatchError::Other(_) => {}
                 }
             }
             Err(e) => {
@@ -2598,6 +2617,9 @@ mod tests {
             release_pmix_calls: Arc<AtomicU32>,
             reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
             launch_delay: Duration,
+            /// launch_job returns a ResourceExhausted status, standing in for a
+            /// node whose local allocation table already holds the GPUs.
+            reject_resources: bool,
             /// Records each `LaunchJobRequest.task_fanout` this agent receives,
             /// so tests can assert on it without a real spurd behind the RPC.
             fanout_calls: Option<Arc<std::sync::Mutex<Vec<bool>>>>,
@@ -2617,6 +2639,11 @@ mod tests {
             {
                 if !self.launch_delay.is_zero() {
                     tokio::time::sleep(self.launch_delay).await;
+                }
+                if self.reject_resources {
+                    return Err(tonic::Status::resource_exhausted(
+                        "controller-allocated GPUs unavailable on this node",
+                    ));
                 }
                 if let Some(kind) = self.reject_launch_as {
                     return Ok(tonic::Response::new(spur_proto::proto::LaunchJobResponse {
@@ -2850,6 +2877,7 @@ mod tests {
                 release_pmix_calls: release_pmix_calls.clone(),
                 reject_launch_as,
                 launch_delay,
+                reject_resources: false,
                 fanout_calls: capture.then(|| fanout_calls.clone()),
             };
             tokio::spawn(async move {
@@ -2861,6 +2889,28 @@ mod tests {
                     .await;
             });
             (addr, cancel_calls, release_pmix_calls, fanout_calls)
+        }
+
+        /// Mock agent whose launch_job always rejects with ResourceExhausted.
+        async fn spawn_mock_agent_rejecting_resources() -> std::net::SocketAddr {
+            let incoming = TcpIncoming::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+            let addr = incoming.local_addr().unwrap();
+            let agent = MockAgent {
+                cancel_calls: Arc::new(AtomicU32::new(0)),
+                reject_launch_as: None,
+                launch_delay: Duration::ZERO,
+                reject_resources: true,
+                fanout_calls: None,
+            };
+            tokio::spawn(async move {
+                let _ = Server::builder()
+                    .add_service(
+                        spur_proto::proto::slurm_agent_server::SlurmAgentServer::new(agent),
+                    )
+                    .serve_with_incoming(incoming)
+                    .await;
+            });
+            addr
         }
 
         /// Reserve a localhost port with nothing listening on it, so a
@@ -4340,6 +4390,25 @@ mod tests {
                 cm.get_job(job_id).unwrap().state,
                 JobState::Cancelled,
                 "the job must stay exactly as the earlier, real cancel left it"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn resources_unavailable_reject_cools_down_the_node() {
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let addr = spawn_mock_agent_rejecting_resources().await;
+            register_node_at(&cm, "n1", addr);
+
+            let job_id = submit_and_wait(&cm, batch_spec("resource-reject", 1));
+
+            assert!(cm.nodes_on_dispatch_cooldown().is_empty());
+            let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
+            assert!(
+                cm.nodes_on_dispatch_cooldown().contains("n1"),
+                "a resources-unavailable reject must put the node on cooldown"
             );
         }
     }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -147,7 +147,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
         let hit_depth_limit = pending.len() > max_jobs;
 
-        let nodes = cluster.schedulable_nodes();
+        let nodes = cluster.schedulable_nodes(&pending);
         let partitions = cluster.get_partitions();
         let reservations = cluster.get_reservations();
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -147,7 +147,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
         let hit_depth_limit = pending.len() > max_jobs;
 
-        let nodes = cluster.schedulable_nodes(&pending);
+        let nodes = cluster.nodes_off_dispatch_cooldown(&pending);
         let partitions = cluster.get_partitions();
         let reservations = cluster.get_reservations();
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -135,7 +135,12 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
         let hit_depth_limit = pending.len() > max_jobs;
 
-        let nodes = cluster.get_nodes();
+        let cooling = cluster.nodes_on_dispatch_cooldown();
+        let nodes: Vec<spur_core::node::Node> = cluster
+            .get_nodes()
+            .into_iter()
+            .filter(|n| !cooling.contains(&n.name))
+            .collect();
         let partitions = cluster.get_partitions();
         let reservations = cluster.get_reservations();
 
@@ -853,6 +858,9 @@ enum DispatchError {
     /// own context, so the same failure recurs everywhere: Slurm drains the node
     /// and holds the job instead of retrying it onto the next one.
     PrologFailed(String),
+    /// The agent rejected the dispatch because the controller-allocated resources
+    /// are already in use locally — the controller's view of this node is stale.
+    ResourcesUnavailable,
     Other(anyhow::Error),
 }
 
@@ -860,6 +868,9 @@ impl std::fmt::Display for DispatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::PrologFailed(reason) => write!(f, "agent rejected job: {reason}"),
+            Self::ResourcesUnavailable => {
+                write!(f, "agent rejected job: allocated resources unavailable")
+            }
             Self::Other(e) => write!(f, "{e:#}"),
         }
     }
@@ -1023,7 +1034,11 @@ async fn dispatch_to_agent(
             pmix_plan,
             task_fanout: params.task_fanout,
         })
-        .await?;
+        .await
+        .map_err(|s| match s.code() {
+            tonic::Code::ResourceExhausted => DispatchError::ResourcesUnavailable,
+            _ => DispatchError::Other(s.into()),
+        })?;
 
     let inner = response.into_inner();
     if !inner.success {
@@ -1367,8 +1382,12 @@ async fn confirm_dispatch_on_nodes(
             Ok((node_name, _, Err(e))) => {
                 error!(job_id, node = %node_name, error = %e, "dispatch confirmation failed");
                 failures += 1;
-                if let DispatchError::PrologFailed(reason) = e {
-                    prolog_failed.push((node_name, reason));
+                match e {
+                    DispatchError::PrologFailed(reason) => {
+                        prolog_failed.push((node_name, reason));
+                    }
+                    DispatchError::ResourcesUnavailable => cluster.cool_down_node(&node_name),
+                    DispatchError::Other(_) => {}
                 }
             }
             Err(e) => {
@@ -2242,6 +2261,9 @@ mod tests {
             cancel_calls: Arc<AtomicU32>,
             reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
             launch_delay: Duration,
+            /// launch_job returns a ResourceExhausted status, standing in for a
+            /// node whose local allocation table already holds the GPUs.
+            reject_resources: bool,
             /// Records each `LaunchJobRequest.task_fanout` this agent receives,
             /// so tests can assert on it without a real spurd behind the RPC.
             fanout_calls: Option<Arc<std::sync::Mutex<Vec<bool>>>>,
@@ -2261,6 +2283,11 @@ mod tests {
             {
                 if !self.launch_delay.is_zero() {
                     tokio::time::sleep(self.launch_delay).await;
+                }
+                if self.reject_resources {
+                    return Err(tonic::Status::resource_exhausted(
+                        "controller-allocated GPUs unavailable on this node",
+                    ));
                 }
                 if let Some(kind) = self.reject_launch_as {
                     return Ok(tonic::Response::new(spur_proto::proto::LaunchJobResponse {
@@ -2460,6 +2487,7 @@ mod tests {
                 cancel_calls: cancel_calls.clone(),
                 reject_launch_as,
                 launch_delay,
+                reject_resources: false,
                 fanout_calls: capture.then(|| fanout_calls.clone()),
             };
             tokio::spawn(async move {
@@ -2471,6 +2499,28 @@ mod tests {
                     .await;
             });
             (addr, cancel_calls, fanout_calls)
+        }
+
+        /// Mock agent whose launch_job always rejects with ResourceExhausted.
+        async fn spawn_mock_agent_rejecting_resources() -> std::net::SocketAddr {
+            let incoming = TcpIncoming::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+            let addr = incoming.local_addr().unwrap();
+            let agent = MockAgent {
+                cancel_calls: Arc::new(AtomicU32::new(0)),
+                reject_launch_as: None,
+                launch_delay: Duration::ZERO,
+                reject_resources: true,
+                fanout_calls: None,
+            };
+            tokio::spawn(async move {
+                let _ = Server::builder()
+                    .add_service(
+                        spur_proto::proto::slurm_agent_server::SlurmAgentServer::new(agent),
+                    )
+                    .serve_with_incoming(incoming)
+                    .await;
+            });
+            addr
         }
 
         /// Reserve a localhost port with nothing listening on it, so a
@@ -3877,6 +3927,25 @@ mod tests {
                 cm.get_job(job_id).unwrap().state,
                 JobState::Cancelled,
                 "the job must stay exactly as the earlier, real cancel left it"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn resources_unavailable_reject_cools_down_the_node() {
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let addr = spawn_mock_agent_rejecting_resources().await;
+            register_node_at(&cm, "n1", addr);
+
+            let job_id = submit_and_wait(&cm, batch_spec("resource-reject", 1));
+
+            assert!(cm.nodes_on_dispatch_cooldown().is_empty());
+            let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
+            assert!(
+                cm.nodes_on_dispatch_cooldown().contains("n1"),
+                "a resources-unavailable reject must put the node on cooldown"
             );
         }
     }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -135,12 +135,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
         let hit_depth_limit = pending.len() > max_jobs;
 
-        let cooling = cluster.nodes_on_dispatch_cooldown();
-        let nodes: Vec<spur_core::node::Node> = cluster
-            .get_nodes()
-            .into_iter()
-            .filter(|n| !cooling.contains(&n.name))
-            .collect();
+        let nodes = cluster.schedulable_nodes();
         let partitions = cluster.get_partitions();
         let reservations = cluster.get_reservations();
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -147,12 +147,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
         let hit_depth_limit = pending.len() > max_jobs;
 
-        let cooling = cluster.nodes_on_dispatch_cooldown();
-        let nodes: Vec<spur_core::node::Node> = cluster
-            .get_nodes()
-            .into_iter()
-            .filter(|n| !cooling.contains(&n.name))
-            .collect();
+        let nodes = cluster.schedulable_nodes();
         let partitions = cluster.get_partitions();
         let reservations = cluster.get_reservations();
 
@@ -2900,6 +2895,7 @@ mod tests {
                 reject_launch_as: None,
                 launch_delay: Duration::ZERO,
                 reject_resources: true,
+                release_pmix_calls: Arc::new(AtomicU32::new(0)),
                 fanout_calls: None,
             };
             tokio::spawn(async move {


### PR DESCRIPTION
## What this fixes

When an agent rejects a batch dispatch because the controller-allocated GPUs are already in use in its local allocation table (a `ResourceExhausted` rejection), the controller's view of that node is stale. The scheduler kept selecting the same node on every tick, so the job hot-looped against it. A handful of desynced nodes could starve placement cluster-wide even while other nodes sat idle.

## Approach

On a resources-unavailable rejection, the controller now places the rejecting node on a short, self-expiring dispatch cooldown and excludes it from the scheduler's placement view until the cooldown lapses. This breaks the every-tick hot-loop while the node's actual state is re-learned.

- New config knob `controller.dispatch_reject_cooldown_secs` (default 30s, 0 disables), validated at load against an upper bound so it cannot overflow the cooldown deadline and panic the controller.
- The cooldown map is **leader-local and transient** — never replicated or persisted. Followers don't schedule, and a new leader after failover simply starts empty and re-learns on the next rejection (a one-tick re-dispatch). No wire-format or persisted-state change.
- Only the rejecting node(s) are cooled; a multi-node dispatch where one node rejects cools just that node. The cooldown affects only the scheduler's placement view — it does not drain the node, cancel running jobs, or hide it from `sinfo`/`squeue`.
- The rejection is still additionally handled by the existing job-level requeue/backoff; the node-level cooldown is complementary (it steers *other* pending jobs away from the stale node too).

## Known limitations (follow-ups)

- **Scope: batch dispatch path only.** The standalone srun/salloc allocation path returns the same rejection but is not yet wired to the cooldown (its error flows through an `anyhow` boundary that drops the status code). Threading a typed error through that path is a small follow-up; documenting the asymmetry here rather than expanding this change.
- This is a targeted stop-gap for the hot-loop. The deeper fix — reconciling the controller's per-node allocation view against the node as source of truth so the stale view is *corrected* rather than merely avoided — is a separate, larger effort.

## Tests

- Unit test covers the cooldown state machine: a node is marked on rejection, is excluded from the scheduler's node view, reappears once the cooldown expires, and the `0` setting disables it.
- A mock-agent test drives the real dispatch-confirmation path with an agent returning `ResourceExhausted` and asserts the node lands on cooldown.
- Config validation rejects an out-of-range cooldown and accepts `0`.
- All new tests were confirmed to fail against the unfixed code.

## How it was tested

Validated on an isolated deployment that a normal dispatch is unaffected (a job schedules and completes through the new node-selection path) and that an out-of-range cooldown value is rejected at config load rather than panicking. The rejection→cooldown→exclusion path is triggered by a GPU-allocation conflict, which cannot be induced on the GPU-less test nodes; that path is covered by the mock-agent unit test driving the real confirmation code with a genuine `ResourceExhausted` rejection.