### PR TITLE
fix(spur-cli): resolve first allocated node from compressed hostlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1317,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2725,7 +2725,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3032,7 +3032,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3090,7 +3090,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4127,7 +4127,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4976,7 +4976,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/spur-cli/src/nodelist.rs
+++ b/crates/spur-cli/src/nodelist.rs
@@ -5,6 +5,25 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
+/// Resolve the first allocated hostname from a controller-supplied `nodelist`.
+///
+/// The controller reports a job's nodes as a *compressed* Slurm-style hostlist
+/// (e.g. `node[001-002]`), not a raw comma-separated list, so a plain
+/// `split(',')` yields a bracket fragment rather than a hostname. Expanding the
+/// pattern (the inverse of the controller's `compress`) gives the true first
+/// node. Falls back to a comma-split if expansion fails, so a malformed pattern
+/// still yields something connectable instead of no node at all.
+pub fn first_allocated_node(nodelist: &str) -> Option<String> {
+    if let Ok(Some(host)) = spur_core::hostlist::expand_first(nodelist) {
+        return Some(host);
+    }
+    nodelist
+        .split(',')
+        .map(str::trim)
+        .find(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
 pub fn resolve(nodelist: Option<String>, nodefile: Option<String>) -> Result<Option<String>> {
     if let Some(path) = nodefile {
         return read(&path).map(Some);
@@ -40,6 +59,48 @@ mod tests {
         let path = directory.path().join("nodes.txt");
         std::fs::write(&path, contents).expect("write node file fixture");
         (directory, path.to_string_lossy().into_owned())
+    }
+
+    #[test]
+    fn first_allocated_node_expands_compressed_patterns() {
+        assert_eq!(
+            first_allocated_node("node[001-002]").as_deref(),
+            Some("node001")
+        );
+        assert_eq!(
+            first_allocated_node("node[001,003]").as_deref(),
+            Some("node001")
+        );
+        assert_eq!(
+            first_allocated_node("gpu[001-004],cpu[001-002]").as_deref(),
+            Some("gpu001")
+        );
+        assert_eq!(
+            first_allocated_node("node[9,010-011]").as_deref(),
+            Some("node9")
+        );
+    }
+
+    #[test]
+    fn first_allocated_node_handles_plain_and_single() {
+        assert_eq!(
+            first_allocated_node("node001,node002").as_deref(),
+            Some("node001")
+        );
+        assert_eq!(first_allocated_node("node007").as_deref(), Some("node007"));
+    }
+
+    #[test]
+    fn first_allocated_node_empty_is_none() {
+        assert_eq!(first_allocated_node(""), None);
+    }
+
+    #[test]
+    fn first_allocated_node_falls_back_on_malformed_pattern() {
+        assert_eq!(
+            first_allocated_node("node[001-002").as_deref(),
+            Some("node[001-002")
+        );
     }
 
     #[test]

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -72,8 +72,11 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         anyhow::bail!("sattach: job {} has no allocated nodes", job_id);
     }
 
-    // Connect to the first node's agent
-    let first_node = nodelist.split(',').next().unwrap_or(nodelist).trim();
+    // Connect to the first node's agent. The controller reports a compressed
+    // hostlist (e.g. `node[001-002]`), so expand it rather than comma-splitting.
+    let first_node = crate::nodelist::first_allocated_node(nodelist).with_context(|| {
+        format!("sattach: could not resolve a node from allocation '{nodelist}'")
+    })?;
     let agent_addr = format!("http://{}:6818", first_node);
     let mut agent = crate::interactive::connect_agent(&agent_addr).await?;
 

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -985,14 +985,13 @@ async fn try_stream_output(
     nodelist: &str,
     job_id: u32,
 ) -> bool {
-    let first_node = nodelist.split(',').next().unwrap_or_default().trim();
-    if first_node.is_empty() {
+    let Some(first_node) = crate::nodelist::first_allocated_node(nodelist) else {
         return false;
-    }
+    };
 
     if controller
         .get_node(GetNodeRequest {
-            name: first_node.to_string(),
+            name: first_node.clone(),
         })
         .await
         .is_err()

--- a/crates/spur-core/src/hostlist.rs
+++ b/crates/spur-core/src/hostlist.rs
@@ -28,6 +28,21 @@ pub fn expand(pattern: &str) -> Result<Vec<String>, HostlistError> {
     Ok(results)
 }
 
+/// Expand a hostlist pattern only far enough to yield its first hostname.
+///
+/// Equivalent to `expand(pattern)?.into_iter().next()`, but stops after the
+/// first name instead of materializing every host. Useful when only the first
+/// allocated node is needed (e.g. connecting to a job's primary node) and the
+/// allocation may span thousands of nodes.
+pub fn expand_first(pattern: &str) -> Result<Option<String>, HostlistError> {
+    for part in split_top_level(pattern) {
+        if let Some(host) = first_single(part.trim())? {
+            return Ok(Some(host));
+        }
+    }
+    Ok(None)
+}
+
 /// Compress a list of hostnames into a compact hostlist pattern.
 ///
 /// Example: `["node001", "node002", "node003", "node005"]` → `"node[001-003,005]"`
@@ -330,6 +345,52 @@ fn expand_single(pattern: &str, results: &mut Vec<String>) -> Result<(), Hostlis
     Ok(())
 }
 
+/// First hostname of a single term (no top-level commas), or `None` when the
+/// term expands to nothing (e.g. an empty string). Mirrors [`expand_single`]'s
+/// parsing but only resolves the first element of the leading range.
+fn first_single(pattern: &str) -> Result<Option<String>, HostlistError> {
+    if pattern.is_empty() {
+        return Ok(None);
+    }
+
+    let Some(bracket_start) = pattern.find('[') else {
+        return Ok(Some(pattern.to_string()));
+    };
+    let bracket_end = pattern
+        .find(']')
+        .ok_or_else(|| HostlistError::InvalidPattern("unmatched [".into()))?;
+
+    let prefix = &pattern[..bracket_start];
+    let range_str = &pattern[bracket_start + 1..bracket_end];
+    let suffix = &pattern[bracket_end + 1..];
+
+    let first_part = range_str.split(',').next().unwrap_or_default();
+    let first_value = if let Some(dash) = first_part.find('-') {
+        let start_str = &first_part[..dash];
+        let end_str = &first_part[dash + 1..];
+        let width = start_str.len();
+        let start: u64 = start_str
+            .parse()
+            .map_err(|_| HostlistError::InvalidRange(first_part.into()))?;
+        let end: u64 = end_str
+            .parse()
+            .map_err(|_| HostlistError::InvalidRange(first_part.into()))?;
+        if start > end {
+            return Err(HostlistError::InvalidRange(format!("{} > {}", start, end)));
+        }
+        format!("{:0>width$}", start, width = width)
+    } else {
+        first_part.to_string()
+    };
+
+    let name = format!("{prefix}{first_value}{suffix}");
+    if suffix.contains('[') {
+        first_single(&name)
+    } else {
+        Ok(Some(name))
+    }
+}
+
 /// Count the number of hosts in a hostlist pattern without expanding.
 pub fn count(pattern: &str) -> Result<usize, HostlistError> {
     // For now, just expand and count. Can optimize later.
@@ -572,6 +633,97 @@ mod tests {
         // Names that are entirely digits have no prefix; kept verbatim, deduped.
         assert_eq!(compress(&strings(&["12345"])), "12345");
         assert_eq!(compress(&strings(&["7", "7"])), "7");
+    }
+
+    #[test]
+    fn test_expand_first_range() {
+        assert_eq!(
+            expand_first("node[001-002]").unwrap().as_deref(),
+            Some("node001")
+        );
+    }
+
+    #[test]
+    fn test_expand_first_gap() {
+        assert_eq!(
+            expand_first("node[001,003]").unwrap().as_deref(),
+            Some("node001")
+        );
+    }
+
+    #[test]
+    fn test_expand_first_multi_prefix() {
+        assert_eq!(
+            expand_first("gpu[001-004],cpu[001-002]")
+                .unwrap()
+                .as_deref(),
+            Some("gpu001")
+        );
+    }
+
+    #[test]
+    fn test_expand_first_mixed_padding() {
+        assert_eq!(
+            expand_first("node[9,010-011]").unwrap().as_deref(),
+            Some("node9")
+        );
+    }
+
+    #[test]
+    fn test_expand_first_plain_list() {
+        assert_eq!(
+            expand_first("node001,node002").unwrap().as_deref(),
+            Some("node001")
+        );
+    }
+
+    #[test]
+    fn test_expand_first_single_host() {
+        assert_eq!(expand_first("node007").unwrap().as_deref(), Some("node007"));
+    }
+
+    #[test]
+    fn test_expand_first_empty_is_none() {
+        assert_eq!(expand_first("").unwrap(), None);
+        assert_eq!(expand_first(",,").unwrap(), None);
+    }
+
+    #[test]
+    fn test_expand_first_skips_leading_empty_terms() {
+        assert_eq!(
+            expand_first(",node1,node2").unwrap().as_deref(),
+            Some("node1")
+        );
+    }
+
+    #[test]
+    fn test_expand_first_suffix_bracket() {
+        assert_eq!(
+            expand_first("rack[1-2]-node[3-4]").unwrap().as_deref(),
+            Some("rack1-node3")
+        );
+    }
+
+    #[test]
+    fn test_expand_first_unmatched_bracket_errors() {
+        assert!(expand_first("node[1-2").is_err());
+    }
+
+    #[test]
+    fn test_expand_first_matches_expand() {
+        for pattern in [
+            "node[001-003,005,010-012]",
+            "rack[1-2]-node[1-2]",
+            "gpu[01-04],cpu[01-02]",
+            "node9,node010,node011",
+            "login01",
+        ] {
+            assert_eq!(
+                expand_first(pattern).unwrap(),
+                expand(pattern).unwrap().into_iter().next(),
+                "expand_first disagreed with expand for {pattern}"
+            );
+        }
     }
 
     #[test]

--- a/crates/spur-core/src/hostlist.rs
+++ b/crates/spur-core/src/hostlist.rs
@@ -295,6 +295,31 @@ fn split_top_level(s: &str) -> Vec<&str> {
     parts
 }
 
+/// Parse one bracket term (`start-end`, or a bare value) into numeric bounds.
+///
+/// Returns `Some((start, end, width))` for a range, where `width` is the
+/// zero-pad width taken from the start token; returns `None` for a non-range
+/// term, which the caller emits verbatim. Shared by `expand_single` and
+/// `first_single` so the range grammar and its error handling live in one place.
+fn parse_range_bounds(part: &str) -> Result<Option<(u64, u64, usize)>, HostlistError> {
+    let Some(dash) = part.find('-') else {
+        return Ok(None);
+    };
+    let start_str = &part[..dash];
+    let end_str = &part[dash + 1..];
+    let width = start_str.len();
+    let start: u64 = start_str
+        .parse()
+        .map_err(|_| HostlistError::InvalidRange(part.into()))?;
+    let end: u64 = end_str
+        .parse()
+        .map_err(|_| HostlistError::InvalidRange(part.into()))?;
+    if start > end {
+        return Err(HostlistError::InvalidRange(format!("{} > {}", start, end)));
+    }
+    Ok(Some((start, end, width)))
+}
+
 /// Expand a single hostlist term (no top-level commas).
 fn expand_single(pattern: &str, results: &mut Vec<String>) -> Result<(), HostlistError> {
     if let Some(bracket_start) = pattern.find('[') {
@@ -307,21 +332,7 @@ fn expand_single(pattern: &str, results: &mut Vec<String>) -> Result<(), Hostlis
         let suffix = &pattern[bracket_end + 1..];
 
         for range_part in range_str.split(',') {
-            if let Some(dash) = range_part.find('-') {
-                let start_str = &range_part[..dash];
-                let end_str = &range_part[dash + 1..];
-                let width = start_str.len();
-                let start: u64 = start_str
-                    .parse()
-                    .map_err(|_| HostlistError::InvalidRange(range_part.into()))?;
-                let end: u64 = end_str
-                    .parse()
-                    .map_err(|_| HostlistError::InvalidRange(range_part.into()))?;
-
-                if start > end {
-                    return Err(HostlistError::InvalidRange(format!("{} > {}", start, end)));
-                }
-
+            if let Some((start, end, width)) = parse_range_bounds(range_part)? {
                 for i in start..=end {
                     let name = format!("{}{:0>width$}{}", prefix, i, suffix, width = width);
                     if suffix.contains('[') {
@@ -365,22 +376,9 @@ fn first_single(pattern: &str) -> Result<Option<String>, HostlistError> {
     let suffix = &pattern[bracket_end + 1..];
 
     let first_part = range_str.split(',').next().unwrap_or_default();
-    let first_value = if let Some(dash) = first_part.find('-') {
-        let start_str = &first_part[..dash];
-        let end_str = &first_part[dash + 1..];
-        let width = start_str.len();
-        let start: u64 = start_str
-            .parse()
-            .map_err(|_| HostlistError::InvalidRange(first_part.into()))?;
-        let end: u64 = end_str
-            .parse()
-            .map_err(|_| HostlistError::InvalidRange(first_part.into()))?;
-        if start > end {
-            return Err(HostlistError::InvalidRange(format!("{} > {}", start, end)));
-        }
-        format!("{:0>width$}", start, width = width)
-    } else {
-        first_part.to_string()
+    let first_value = match parse_range_bounds(first_part)? {
+        Some((start, _end, width)) => format!("{:0>width$}", start, width = width),
+        None => first_part.to_string(),
     };
 
     let name = format!("{prefix}{first_value}{suffix}");


### PR DESCRIPTION
## What

`srun` and `sattach` connect directly to a job's first allocated node to stream
live output. They extracted that node from `JobInfo.nodelist` with
`nodelist.split(',').next()` — but the controller reports `nodelist` as a
*compressed* Slurm-style hostlist (built by `spur_core::hostlist::compress`),
not a raw comma list. For any job on 2+ nodes this yields a non-hostname:

- `node[001-002]` has no top-level comma, so the split returns the whole literal
  `node[001-002]`.
- `node[001,003]` has a comma only inside the brackets, so the split returns the
  broken fragment `node[001`.
- multi-prefix (`gpu[001-004],cpu[001-002]`) splits into the fragment `gpu[001-004`.

The result was used directly as a host: `sattach` dialed
`http://node[001-002]:6818` and failed to connect, and `srun`'s `get_node()`
probe failed so live output was silently skipped. Fixes ROCm/spur#575.

## Approach

- Add `spur_core::hostlist::expand_first`, which expands a pattern only far
  enough to yield its first hostname — the inverse of the controller's
  `compress`, and cheaper than `expand(..).next()` for large allocations.
- Add a shared `spur_cli::nodelist::first_allocated_node` helper that both call
  sites now use, replacing the duplicated `split(',')` logic. It falls back to a
  comma-split for a malformed pattern so a bad input still yields something
  connectable rather than nothing (mirroring `expand_hostlist_or_split`).
- Wire it into `sattach` (clear error if unresolvable) and `srun`
  `try_stream_output` (keeps the existing skip-on-failure behavior).

The unrelated `srun::first_node` helper (for user-typed `-w`, resolved
server-side) is intentionally left unchanged.

## Design choices

- Uses the exact inverse of what produced the string; [1] PR ROCm/spur#574
  hardened `compress()` and verified `expand(compress(x))` round-trips, so
  relying on `expand`/`expand_first` is guaranteed correct even for mixed
  zero-padding (`node[9,010-011]`) and multi-prefix lists.
- Client-side only: no proto, persisted Raft/WAL, or config change, so there is
  no upgrade/compat hazard.

## Testing

- Unit: new `expand_first` tests (range, gap, multi-prefix, mixed padding, plain
  list, single, empty, suffix bracket, unmatched-bracket error, and parity with
  `expand(..).next()`), plus `first_allocated_node` tests. `cargo clippy`
  (spur-core, spur-cli) clean; `cargo test` for spur-core and spur-cli pass.
- E2E on a 2-node LXD cluster with hostnames compressing to `spurnode[1-2]`:
  before the fix, `sattach` failed with a DNS error on `spurnode[1-2]`; after,
  `sattach` connects to `spurnode1` and streams live output, and `srun -N2`
  streams from both nodes with no controller-side connect errors.

Made with [Cursor](https://cursor.com)