### PR TITLE
test(e2e): wait for etcd quorum convergence in k0s multi-cp test

### DIFF
--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -548,6 +548,18 @@ class SpurCluster:
                 return len(members)
         return 0
 
+    def wait_etcd_members(self, count: int, timeout: int = 120) -> int:
+        """Poll until etcd reports `count` members. The `ready` phase only means every
+        k0scontroller unit is systemd-active; etcd quorum converges shortly after."""
+        deadline = time.time() + timeout
+        last = 0
+        while time.time() < deadline:
+            last = self.etcd_member_count()
+            if last >= count:
+                return last
+            time.sleep(3)
+        return last
+
     def sacct(self, args: list[str]) -> str:
         return self.cli(["sacct"] + args)
 

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -555,6 +555,18 @@ class SpurCluster:
                 return len(members)
         return 0
 
+    def wait_etcd_members(self, count: int, timeout: int = 120) -> int:
+        """Poll until etcd reports `count` members. The `ready` phase only means every
+        k0scontroller unit is systemd-active; etcd quorum converges shortly after."""
+        deadline = time.time() + timeout
+        last = 0
+        while time.time() < deadline:
+            last = self.etcd_member_count()
+            if last >= count:
+                return last
+            time.sleep(3)
+        return last
+
     def sacct(self, args: list[str]) -> str:
         return self.cli(["sacct"] + args)
 

--- a/tests/native_host/e2e/test_k8s_multicp.py
+++ b/tests/native_host/e2e/test_k8s_multicp.py
@@ -25,9 +25,11 @@ class TestK8sMultiControlPlane:
         active = cluster.k8s_active_controllers()
         assert len(active) == 3, f"expected 3 active controllers, got {active}"
 
-        # Ground truth: the embedded etcd formed a real 3-member quorum.
-        assert cluster.etcd_member_count() == 3, (
-            f"expected a 3-member etcd quorum\n{cluster.k8s_status()}"
+        # Ground truth: the embedded etcd formed a real 3-member quorum. etcd
+        # membership converges shortly after the cluster reports ready.
+        members = cluster.wait_etcd_members(3)
+        assert members == 3, (
+            f"expected a 3-member etcd quorum, got {members}\n{cluster.k8s_status()}"
         )
 
     def test_even_replica_count_rejected(self, k8s_multicp_cluster):


### PR DESCRIPTION
## What this fixes

The native-k0s multi-control-plane E2E test `test_three_control_planes_form_etcd_quorum` is intermittently red in the `E2E / native-host` job:

```
assert 2 == 3   where 2 = etcd_member_count()
```

The surrounding CI runs pass, so it's a flaky convergence race, not a regression.

## Root cause

The cluster's `phase: ready` is set as soon as every `k0scontroller` unit is systemd-active (`converge_provisioning` gates on each node's component state reported as `active`, which is the unit's `systemctl ActiveState`). Systemd-active precedes the embedded etcd finishing quorum formation: a secondary control-plane's unit is `active` the moment the k0s process starts, but its etcd member joins the quorum a short moment later.

The test asserted `etcd_member_count() == 3` in a single shot immediately after `wait_k8s_phase("ready")`, with no settle window, so it could observe etcd mid-join (2 of 3). The failing run's own output confirms this: phase `ready`, all three control planes assigned, all three controllers `active`, but etcd had only 2 members at that instant.

This is a test-only timing gap. Marking the cluster ready on unit-active (then self-healing) is reasonable product behavior; etcd quorum is eventually-consistent behind it. Only the test treated the two as synchronous.

## Approach

Add a `wait_etcd_members(count, timeout=120)` helper to the harness that polls `etcd_member_count()` until it reaches the target, mirroring the existing `wait_k8s_phase` poller, and use it in place of the one-shot read.

The test keeps its diagnostic value: a permanent stall below the target returns the last observed count, so `assert members == 3` still fails (with the observed count in the message), and an over-count also fails rather than being masked.

## How it was tested

- The helper is pure poll logic; its behavior was verified deterministically against the real function (patching only the member-count source and the clock): converges and early-returns on 1→2→3, runs to timeout and returns 2 on a permanent stall (assertion would fail), ignores transient zero-count RPC blips without short-circuiting, and surfaces an over-count.
- The full 3-node etcd path needs a 3-control-plane cluster, which CI provides; that end-to-end path was not run locally.