### PR TITLE
fix(spurctld): enforce partition walltime limits and validate time config

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -433,15 +433,10 @@ impl Default for AccountingConfig {
     }
 }
 
-/// When partition limits (currently the wall-time limit) are enforced against a
-/// job's request. Mirrors Slurm's `EnforcePartLimits`.
-///
-/// - `No` (default): over-limit jobs are admitted and pend with a reason
-///   (`PartitionTimeLimit`), matching Slurm's default and preserving prior
-///   behavior on upgrade.
-/// - `All`: reject at submit unless the job fits every requested partition.
-/// - `Any`: reject at submit only when the job fits none of the requested
-///   partitions.
+/// Submit-time enforcement of partition wall-time limits (Slurm's
+/// `EnforcePartLimits`). `No` (default) admits over-limit jobs to pend; `All`
+/// rejects unless the job fits every requested partition; `Any` rejects only
+/// when it fits none.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Default)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum EnforcePartLimits {
@@ -1344,12 +1339,10 @@ impl SlurmConfig {
     }
 }
 
-/// Parse a partition time field, distinguishing UNLIMITED from a parse error.
-///
-/// `INFINITE`/`UNLIMITED` (case-insensitive) -> `Ok(None)` (no limit); a valid
-/// duration (Slurm grammar or a suffixed form like `"1h"`) -> `Ok(Some(minutes))`;
-/// anything else -> `Err`. Unlike [`parse_time_minutes`], a genuine typo like
-/// `"1 hour"` fails loudly instead of silently collapsing to UNLIMITED.
+/// Parse a partition time field, distinguishing UNLIMITED from a parse error:
+/// `INFINITE`/`UNLIMITED` -> `Ok(None)`, a valid duration -> `Ok(Some(minutes))`,
+/// anything else -> `Err`. Unlike [`parse_time_minutes`], a typo like `"1 hour"`
+/// fails loudly instead of collapsing to UNLIMITED.
 pub fn parse_partition_time(field: &str, s: &str) -> Result<Option<u32>, ConfigError> {
     let trimmed = s.trim();
     if trimmed.eq_ignore_ascii_case("INFINITE") || trimmed.eq_ignore_ascii_case("UNLIMITED") {
@@ -1364,12 +1357,9 @@ pub fn parse_partition_time(field: &str, s: &str) -> Result<Option<u32>, ConfigE
     }
 }
 
-/// Parse a time string to minutes.
-///
-/// Accepts Slurm grammar ("60" minutes, "H:MM", "H:MM:SS", "D-HH:MM:SS",
-/// "INFINITE"/"UNLIMITED") and, as a fallback, suffixed durations
-/// ("90m", "1h", "1h40m", "2d12h", "30s"). Sub-minute remainders round up to
-/// match the seconds-rounding of the "H:MM:SS" form.
+/// Parse a time string to minutes: Slurm grammar (`60`, `H:MM`, `H:MM:SS`,
+/// `D-HH:MM:SS`, `INFINITE`/`UNLIMITED`) or a suffixed duration (`90m`, `1h`,
+/// `2d12h`, `30s`). Sub-minute remainders round up.
 pub fn parse_time_minutes(s: &str) -> Option<u32> {
     let s = s.trim();
     if s.eq_ignore_ascii_case("INFINITE") || s.eq_ignore_ascii_case("UNLIMITED") {
@@ -1449,11 +1439,10 @@ fn parse_slurm_time_seconds(s: &str) -> Option<u64> {
 
 /// Parse a suffixed duration like "90m", "1h", "1h40m", "2d12h", "30s".
 ///
-/// Units are `d`/`h`/`m`/`s` (case-insensitive), each an integer, summed in any
-/// order. Requires at least one unit and must consume the whole string, so a
-/// bare number is rejected here (it means minutes via the Slurm grammar) and
-/// stray characters or trailing digits fail. This is the fallback that lets an
-/// operator write `max_time = "1h"` instead of `"01:00:00"`.
+/// Sum a suffixed duration like `1h40m` or `2d12h` to seconds. Units `d/h/m/s`
+/// (case-insensitive); requires at least one unit and must consume the whole
+/// string, so a bare number or trailing digits fail (the Slurm grammar owns
+/// bare numbers).
 fn parse_suffix_duration_seconds(s: &str) -> Option<u64> {
     let mut total: u64 = 0;
     let mut num: Option<u64> = None;
@@ -1530,6 +1519,26 @@ pub fn format_time(total_minutes: Option<u32>) -> String {
                 format!("{}-{:02}:{:02}:00", days, hours, minutes)
             } else {
                 format!("{:02}:{:02}:00", hours, minutes)
+            }
+        }
+    }
+}
+
+/// Format seconds as D-HH:MM:SS or HH:MM:SS. Unlike [`format_time`] this keeps
+/// second precision, so a sub-minute request is not rounded when reported.
+pub fn format_time_seconds(total_seconds: Option<i64>) -> String {
+    match total_seconds {
+        None => "UNLIMITED".into(),
+        Some(secs) => {
+            let secs = secs.max(0);
+            let days = secs / 86_400;
+            let hours = (secs % 86_400) / 3_600;
+            let minutes = (secs % 3_600) / 60;
+            let seconds = secs % 60;
+            if days > 0 {
+                format!("{days}-{hours:02}:{minutes:02}:{seconds:02}")
+            } else {
+                format!("{hours:02}:{minutes:02}:{seconds:02}")
             }
         }
     }
@@ -1941,6 +1950,39 @@ memory_mb = 1024000
         // A genuine typo still fails loudly.
         assert!(parse_partition_time("p.max_time", "1 hour").is_err());
         assert!(parse_partition_time("p.max_time", "banana").is_err());
+    }
+
+    #[test]
+    fn enforce_part_limits_parses_case_insensitively_and_yes_alias() {
+        #[derive(serde::Deserialize)]
+        struct W {
+            v: EnforcePartLimits,
+        }
+        let parse = |v: &str| toml::from_str::<W>(&format!("v = \"{v}\"")).unwrap().v;
+        assert_eq!(parse("no"), EnforcePartLimits::No);
+        assert_eq!(parse("all"), EnforcePartLimits::All);
+        assert_eq!(parse("ALL"), EnforcePartLimits::All);
+        assert_eq!(parse("Yes"), EnforcePartLimits::All);
+        assert_eq!(parse("any"), EnforcePartLimits::Any);
+        assert_eq!(parse("ANY"), EnforcePartLimits::Any);
+    }
+
+    #[test]
+    fn enforce_part_limits_rejects_unknown_value() {
+        #[derive(serde::Deserialize)]
+        struct W {
+            #[allow(dead_code)]
+            v: EnforcePartLimits,
+        }
+        assert!(toml::from_str::<W>("v = \"sometimes\"").is_err());
+    }
+
+    #[test]
+    fn format_time_seconds_keeps_second_precision() {
+        assert_eq!(format_time_seconds(Some(630)), "00:10:30");
+        assert_eq!(format_time_seconds(Some(3600)), "01:00:00");
+        assert_eq!(format_time_seconds(Some(90_061)), "1-01:01:01");
+        assert_eq!(format_time_seconds(None), "UNLIMITED");
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -433,10 +433,8 @@ impl Default for AccountingConfig {
     }
 }
 
-/// Submit-time enforcement of partition wall-time limits (Slurm's
-/// `EnforcePartLimits`). `No` (default) admits over-limit jobs to pend; `All`
-/// rejects unless the job fits every requested partition; `Any` rejects only
-/// when it fits none.
+/// Submit-time enforcement of partition wall-time (Slurm `EnforcePartLimits`):
+/// `No` admits over-limit jobs to pend, `All` needs all fit, `Any` needs one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Default)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum EnforcePartLimits {
@@ -479,10 +477,8 @@ pub struct SchedulerConfig {
     /// Fair-share decay half-life (days).
     #[serde(default = "default_halflife")]
     pub fairshare_halflife_days: u32,
-    /// Cluster-wide fallback wall-time (minutes) for a job that sets no `-t`
-    /// and lands on a partition with no `DefaultTime`. `0` (the default)
-    /// disables the fallback, leaving such jobs unbounded (prior behavior).
-    /// Set > 0 to bound otherwise-unlimited jobs so they cannot run forever.
+    /// Cluster-wide fallback wall-time (minutes) for a `-t`-less job on a partition
+    /// with no `DefaultTime`. `0` (default) leaves such jobs unbounded; > 0 bounds them.
     #[serde(default = "default_time_limit")]
     pub default_time_limit_minutes: u32,
     /// Whether to reject over-limit jobs at submit (Slurm `EnforcePartLimits`).
@@ -1290,11 +1286,27 @@ impl SlurmConfig {
         // treating them as UNLIMITED (a typo like "1 hour" must fail, not
         // remove the cap).
         for pc in &self.partitions {
-            if let Some(ref t) = pc.max_time {
-                parse_partition_time(&format!("partitions.{}.max_time", pc.name), t)?;
-            }
-            if let Some(ref t) = pc.default_time {
-                parse_partition_time(&format!("partitions.{}.default_time", pc.name), t)?;
+            let max = pc
+                .max_time
+                .as_ref()
+                .map(|t| parse_partition_time(&format!("partitions.{}.max_time", pc.name), t))
+                .transpose()?
+                .flatten();
+            let default = pc
+                .default_time
+                .as_ref()
+                .map(|t| parse_partition_time(&format!("partitions.{}.default_time", pc.name), t))
+                .transpose()?
+                .flatten();
+            // A finite DefaultTime above the partition's finite MaxTime would hand
+            // a -t-less job a limit its own partition rejects, so it pends forever.
+            if let (Some(max), Some(default)) = (max, default) {
+                if default > max {
+                    return Err(ConfigError::InvalidValue {
+                        field: format!("partitions.{}.default_time", pc.name),
+                        value: format!("{default}m exceeds max_time {max}m"),
+                    });
+                }
             }
         }
         Ok(())
@@ -1437,12 +1449,9 @@ fn parse_slurm_time_seconds(s: &str) -> Option<u64> {
     }
 }
 
-/// Parse a suffixed duration like "90m", "1h", "1h40m", "2d12h", "30s".
-///
-/// Sum a suffixed duration like `1h40m` or `2d12h` to seconds. Units `d/h/m/s`
-/// (case-insensitive); requires at least one unit and must consume the whole
-/// string, so a bare number or trailing digits fail (the Slurm grammar owns
-/// bare numbers).
+/// Sum a suffixed duration like `90m`, `1h40m`, `2d12h`, or `30s` to seconds.
+/// Units `d/h/m/s` (case-insensitive); a bare number or trailing digits fail
+/// (the Slurm grammar owns bare numbers).
 fn parse_suffix_duration_seconds(s: &str) -> Option<u64> {
     let mut total: u64 = 0;
     let mut num: Option<u64> = None;
@@ -2068,6 +2077,57 @@ default_time = "INFINITE"
         let parts = config.build_partitions();
         assert_eq!(parts[0].max_time_minutes, None);
         assert_eq!(parts[0].default_time_minutes, None);
+    }
+
+    #[test]
+    fn load_rejects_default_time_above_max_time() {
+        // A finite DefaultTime over MaxTime would auto-fill a -t-less job past the
+        // partition's own cap, pending it forever. Reject at load.
+        let toml = r#"
+cluster_name = "test"
+
+[[partitions]]
+name = "gpu"
+max_time = "01:00:00"
+default_time = "02:00:00"
+"#;
+        let err = SlurmConfig::load_from_str(toml).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref field, .. } if field.contains("default_time")),
+            "expected InvalidValue for default_time, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn load_accepts_default_time_equal_to_max_time() {
+        let toml = r#"
+cluster_name = "test"
+
+[[partitions]]
+name = "gpu"
+max_time = "01:00:00"
+default_time = "01:00:00"
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        let parts = config.build_partitions();
+        assert_eq!(parts[0].default_time_minutes, Some(60));
+    }
+
+    #[test]
+    fn load_accepts_default_time_with_unlimited_max_time() {
+        // UNLIMITED MaxTime caps nothing, so any finite DefaultTime is coherent.
+        let toml = r#"
+cluster_name = "test"
+
+[[partitions]]
+name = "gpu"
+max_time = "UNLIMITED"
+default_time = "02:00:00"
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        let parts = config.build_partitions();
+        assert_eq!(parts[0].max_time_minutes, None);
+        assert_eq!(parts[0].default_time_minutes, Some(120));
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -433,6 +433,43 @@ impl Default for AccountingConfig {
     }
 }
 
+/// When partition limits (currently the wall-time limit) are enforced against a
+/// job's request. Mirrors Slurm's `EnforcePartLimits`.
+///
+/// - `No` (default): over-limit jobs are admitted and pend with a reason
+///   (`PartitionTimeLimit`), matching Slurm's default and preserving prior
+///   behavior on upgrade.
+/// - `All`: reject at submit unless the job fits every requested partition.
+/// - `Any`: reject at submit only when the job fits none of the requested
+///   partitions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Default)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum EnforcePartLimits {
+    #[default]
+    No,
+    All,
+    Any,
+}
+
+// Case-insensitive, and accepts Slurm's `YES` alias for `ALL`, so a value like
+// `enforce_part_limits = "all"` in spur.conf does not fail controller startup.
+impl<'de> Deserialize<'de> for EnforcePartLimits {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.trim().to_ascii_uppercase().as_str() {
+            "NO" => Ok(Self::No),
+            "ALL" | "YES" => Ok(Self::All),
+            "ANY" => Ok(Self::Any),
+            other => Err(serde::de::Error::custom(format!(
+                "invalid enforce_part_limits '{other}' (expected NO, ALL, or ANY)"
+            ))),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SchedulerConfig {
     /// Scheduler plugin name.
@@ -447,9 +484,15 @@ pub struct SchedulerConfig {
     /// Fair-share decay half-life (days).
     #[serde(default = "default_halflife")]
     pub fairshare_halflife_days: u32,
-    /// Default job time limit (minutes), if not set per-partition.
+    /// Cluster-wide fallback wall-time (minutes) for a job that sets no `-t`
+    /// and lands on a partition with no `DefaultTime`. `0` (the default)
+    /// disables the fallback, leaving such jobs unbounded (prior behavior).
+    /// Set > 0 to bound otherwise-unlimited jobs so they cannot run forever.
     #[serde(default = "default_time_limit")]
     pub default_time_limit_minutes: u32,
+    /// Whether to reject over-limit jobs at submit (Slurm `EnforcePartLimits`).
+    #[serde(default)]
+    pub enforce_part_limits: EnforcePartLimits,
     /// Max seconds to wait in COMPLETING before force-finishing the job.
     #[serde(default = "default_complete_wait")]
     pub complete_wait_secs: u32,
@@ -468,7 +511,7 @@ fn default_halflife() -> u32 {
     14
 }
 fn default_time_limit() -> u32 {
-    60
+    0
 }
 fn default_complete_wait() -> u32 {
     300
@@ -481,7 +524,8 @@ impl Default for SchedulerConfig {
             interval_secs: 1,
             max_jobs_per_cycle: 10000,
             fairshare_halflife_days: 14,
-            default_time_limit_minutes: 60,
+            default_time_limit_minutes: 0,
+            enforce_part_limits: EnforcePartLimits::No,
             complete_wait_secs: 300,
             resv_overrun_minutes: 0,
         }
@@ -1246,10 +1290,24 @@ impl SlurmConfig {
                 }
             }
         }
+
+        // Reject malformed partition time strings at load rather than silently
+        // treating them as UNLIMITED (a typo like "1 hour" must fail, not
+        // remove the cap).
+        for pc in &self.partitions {
+            if let Some(ref t) = pc.max_time {
+                parse_partition_time(&format!("partitions.{}.max_time", pc.name), t)?;
+            }
+            if let Some(ref t) = pc.default_time {
+                parse_partition_time(&format!("partitions.{}.default_time", pc.name), t)?;
+            }
+        }
         Ok(())
     }
 
-    /// Convert partition configs to Partition structs.
+    /// Convert partition configs to Partition structs. Time strings are assumed
+    /// valid here; [`Self::validate`] rejects malformed ones at load, so a stray
+    /// `None` below only ever means UNLIMITED, never a swallowed parse error.
     pub fn build_partitions(&self) -> Vec<Partition> {
         self.partitions
             .iter()
@@ -1286,13 +1344,44 @@ impl SlurmConfig {
     }
 }
 
-/// Parse a time string like "72:00:00", "4-00:00:00", "INFINITE", "60" (minutes).
+/// Parse a partition time field, distinguishing UNLIMITED from a parse error.
+///
+/// `INFINITE`/`UNLIMITED` (case-insensitive) -> `Ok(None)` (no limit); a valid
+/// duration (Slurm grammar or a suffixed form like `"1h"`) -> `Ok(Some(minutes))`;
+/// anything else -> `Err`. Unlike [`parse_time_minutes`], a genuine typo like
+/// `"1 hour"` fails loudly instead of silently collapsing to UNLIMITED.
+pub fn parse_partition_time(field: &str, s: &str) -> Result<Option<u32>, ConfigError> {
+    let trimmed = s.trim();
+    if trimmed.eq_ignore_ascii_case("INFINITE") || trimmed.eq_ignore_ascii_case("UNLIMITED") {
+        return Ok(None);
+    }
+    match parse_time_minutes(trimmed) {
+        Some(minutes) => Ok(Some(minutes)),
+        None => Err(ConfigError::InvalidValue {
+            field: field.into(),
+            value: s.into(),
+        }),
+    }
+}
+
+/// Parse a time string to minutes.
+///
+/// Accepts Slurm grammar ("60" minutes, "H:MM", "H:MM:SS", "D-HH:MM:SS",
+/// "INFINITE"/"UNLIMITED") and, as a fallback, suffixed durations
+/// ("90m", "1h", "1h40m", "2d12h", "30s"). Sub-minute remainders round up to
+/// match the seconds-rounding of the "H:MM:SS" form.
 pub fn parse_time_minutes(s: &str) -> Option<u32> {
     let s = s.trim();
     if s.eq_ignore_ascii_case("INFINITE") || s.eq_ignore_ascii_case("UNLIMITED") {
         return None; // No limit
     }
+    parse_slurm_time_minutes(s).or_else(|| {
+        let secs = parse_suffix_duration_seconds(s)?;
+        u32::try_from(secs.div_ceil(60)).ok()
+    })
+}
 
+fn parse_slurm_time_minutes(s: &str) -> Option<u32> {
     // days-hours:minutes:seconds
     if let Some((days, rest)) = s.split_once('-') {
         let days: u32 = days.parse().ok()?;
@@ -1309,21 +1398,25 @@ pub fn parse_time_minutes(s: &str) -> Option<u32> {
             let m: u32 = parts[1].parse().ok()?;
             Some(h * 60 + m)
         }
-        3 => Some(parse_hms(s)?),
+        3 => parse_hms(s),
         _ => None,
     }
 }
 
 /// Parse a time string to total seconds (not minutes).
 ///
-/// Same Slurm-compatible format as `parse_time_minutes` but with second
-/// granularity: "N" → N minutes, "H:MM" → hours+minutes, "H:MM:SS" → exact.
+/// Same accepted formats as [`parse_time_minutes`] (Slurm grammar plus suffixed
+/// durations), but with second granularity: "N" → N minutes, "H:MM" →
+/// hours+minutes, "H:MM:SS" → exact, "90s" → 90 seconds.
 pub fn parse_time_seconds(s: &str) -> Option<u64> {
     let s = s.trim();
     if s.eq_ignore_ascii_case("INFINITE") || s.eq_ignore_ascii_case("UNLIMITED") {
         return None;
     }
+    parse_slurm_time_seconds(s).or_else(|| parse_suffix_duration_seconds(s))
+}
 
+fn parse_slurm_time_seconds(s: &str) -> Option<u64> {
     // days-hours:minutes:seconds
     if let Some((days, rest)) = s.split_once('-') {
         let days: u64 = days.parse().ok()?;
@@ -1352,6 +1445,44 @@ pub fn parse_time_seconds(s: &str) -> Option<u64> {
         }
         _ => None,
     }
+}
+
+/// Parse a suffixed duration like "90m", "1h", "1h40m", "2d12h", "30s".
+///
+/// Units are `d`/`h`/`m`/`s` (case-insensitive), each an integer, summed in any
+/// order. Requires at least one unit and must consume the whole string, so a
+/// bare number is rejected here (it means minutes via the Slurm grammar) and
+/// stray characters or trailing digits fail. This is the fallback that lets an
+/// operator write `max_time = "1h"` instead of `"01:00:00"`.
+fn parse_suffix_duration_seconds(s: &str) -> Option<u64> {
+    let mut total: u64 = 0;
+    let mut num: Option<u64> = None;
+    let mut saw_unit = false;
+    for c in s.chars() {
+        if let Some(digit) = c.to_digit(10) {
+            num = Some(
+                num.unwrap_or(0)
+                    .checked_mul(10)?
+                    .checked_add(digit as u64)?,
+            );
+            continue;
+        }
+        let unit_secs: u64 = match c.to_ascii_lowercase() {
+            'd' => 86_400,
+            'h' => 3_600,
+            'm' => 60,
+            's' => 1,
+            _ => return None,
+        };
+        let value = num.take()?;
+        total = total.checked_add(value.checked_mul(unit_secs)?)?;
+        saw_unit = true;
+    }
+    // Trailing digits without a unit, or no unit at all, is not a duration.
+    if num.is_some() || !saw_unit {
+        return None;
+    }
+    Some(total)
 }
 
 fn parse_hms_seconds(s: &str) -> Option<u64> {
@@ -1788,6 +1919,113 @@ memory_mb = 1024000
         let parts = config.build_partitions();
         assert_eq!(parts[0].name, "gpu");
         assert_eq!(parts[0].max_time_minutes, Some(4320));
+    }
+
+    #[test]
+    fn parse_partition_time_distinguishes_unlimited_from_invalid() {
+        assert_eq!(
+            parse_partition_time("p.max_time", "UNLIMITED").unwrap(),
+            None
+        );
+        assert_eq!(
+            parse_partition_time("p.max_time", "infinite").unwrap(),
+            None
+        );
+        assert_eq!(
+            parse_partition_time("p.max_time", "01:00:00").unwrap(),
+            Some(60)
+        );
+        // Suffixed durations are accepted (honor intent instead of failing).
+        assert_eq!(parse_partition_time("p.max_time", "1h").unwrap(), Some(60));
+        assert_eq!(parse_partition_time("p.max_time", "90m").unwrap(), Some(90));
+        // A genuine typo still fails loudly.
+        assert!(parse_partition_time("p.max_time", "1 hour").is_err());
+        assert!(parse_partition_time("p.max_time", "banana").is_err());
+    }
+
+    #[test]
+    fn parse_time_minutes_accepts_suffixed_durations() {
+        assert_eq!(parse_time_minutes("1h"), Some(60));
+        assert_eq!(parse_time_minutes("90m"), Some(90));
+        assert_eq!(parse_time_minutes("1h40m"), Some(100));
+        assert_eq!(parse_time_minutes("2d"), Some(2880));
+        assert_eq!(parse_time_minutes("1d12h30m"), Some(2190));
+        // Sub-minute remainders round up, matching the "H:MM:SS" seconds rule.
+        assert_eq!(parse_time_minutes("30s"), Some(1));
+        assert_eq!(parse_time_minutes("1h15s"), Some(61));
+        // Slurm grammar is unchanged and still takes precedence.
+        assert_eq!(parse_time_minutes("60"), Some(60));
+        assert_eq!(parse_time_minutes("01:00:00"), Some(60));
+        assert_eq!(parse_time_minutes("1-00:00:00"), Some(1440));
+        // Non-durations are rejected, not silently accepted.
+        assert_eq!(parse_time_minutes("1 hour"), None);
+        assert_eq!(parse_time_minutes("1.5h"), None);
+        assert_eq!(parse_time_minutes("1h30"), None);
+        assert_eq!(parse_time_minutes("h"), None);
+        assert_eq!(parse_time_minutes("1x"), None);
+    }
+
+    #[test]
+    fn parse_time_seconds_accepts_suffixed_durations() {
+        assert_eq!(parse_time_seconds("1h"), Some(3600));
+        assert_eq!(parse_time_seconds("90m"), Some(5400));
+        assert_eq!(parse_time_seconds("30s"), Some(30));
+        assert_eq!(parse_time_seconds("1h30m15s"), Some(5415));
+        // Slurm grammar unchanged.
+        assert_eq!(parse_time_seconds("60"), Some(3600));
+        assert_eq!(parse_time_seconds("00:00:30"), Some(30));
+    }
+
+    #[test]
+    fn load_accepts_suffixed_partition_max_time() {
+        // "1h" is honored as a 60-minute cap rather than failing or silently
+        // becoming UNLIMITED.
+        let toml = r#"
+cluster_name = "test"
+
+[[partitions]]
+name = "gpu"
+max_time = "1h"
+default_time = "30m"
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        let parts = config.build_partitions();
+        assert_eq!(parts[0].max_time_minutes, Some(60));
+        assert_eq!(parts[0].default_time_minutes, Some(30));
+    }
+
+    #[test]
+    fn load_rejects_invalid_partition_max_time() {
+        // A value that is neither Slurm grammar nor a suffixed duration must
+        // fail loudly rather than silently becoming UNLIMITED.
+        let toml = r#"
+cluster_name = "test"
+
+[[partitions]]
+name = "gpu"
+max_time = "1 hour"
+"#;
+        let err = SlurmConfig::load_from_str(toml).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref field, .. } if field.contains("max_time")),
+            "expected InvalidValue for max_time, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn load_accepts_unlimited_partition_max_time() {
+        let toml = r#"
+cluster_name = "test"
+
+[[partitions]]
+name = "gpu"
+max_time = "UNLIMITED"
+default_time = "INFINITE"
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        let parts = config.build_partitions();
+        assert_eq!(parts[0].max_time_minutes, None);
+        assert_eq!(parts[0].default_time_minutes, None);
     }
 
     #[test]

--- a/crates/spur-tests/src/t52_config.rs
+++ b/crates/spur-tests/src/t52_config.rs
@@ -184,7 +184,7 @@ plugin = "backfill"
 
         assert_eq!(config.scheduler.max_jobs_per_cycle, 10000);
         assert_eq!(config.scheduler.fairshare_halflife_days, 14);
-        assert_eq!(config.scheduler.default_time_limit_minutes, 60);
+        assert_eq!(config.scheduler.default_time_limit_minutes, 0);
     }
 
     // ── T52.15–17: listen_addr from config (#37) ──────────────────

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -416,11 +416,27 @@ impl ClusterManager {
 
     /// Submit a new job. If it has an array spec, expand into individual tasks.
     pub fn submit_job(&self, mut spec: JobSpec) -> Result<SubmitOutcome, SubmitError> {
-        apply_default_partition(&mut spec, &self.partitions.read());
+        // One config/partitions snapshot for the whole submit path, so defaulting
+        // and enforcement can't observe a concurrent reconfigure() mid-submit.
         let config = self.config();
+        let partitions = self.partitions.read().clone();
+
+        apply_default_partition(&mut spec, &partitions);
+
+        // EnforcePartLimits mirrors Slurm: only a wall-time the user actually
+        // requested is subject to submit-time rejection, never one we auto-fill.
+        let user_requested_time = spec.time_limit.is_some();
+        if let Some(tl) = spec.time_limit.as_ref() {
+            if tl.num_seconds() < 0 {
+                return Err(SubmitError::invalid(
+                    "requested time limit must not be negative",
+                ));
+            }
+        }
+
         apply_default_time_limit(
             &mut spec,
-            &self.partitions.read(),
+            &partitions,
             config.scheduler.default_time_limit_minutes,
         );
         apply_default_account(&mut spec, &self.association_cache);
@@ -466,8 +482,15 @@ impl ClusterManager {
         self.validate_partition_node_bounds(&spec)?;
 
         // Reject an over-MaxTime wall-time at submit when EnforcePartLimits is on
-        // (default off keeps Slurm's admit-and-pend behavior).
-        self.validate_partition_time_limit(&spec)?;
+        // (default off keeps Slurm's admit-and-pend behavior). Only a
+        // user-requested `-t` is enforced; an auto-filled default never rejects.
+        if user_requested_time {
+            validate_partition_time_limit(
+                &spec,
+                config.scheduler.enforce_part_limits,
+                &partitions,
+            )?;
+        }
 
         let mpi = spec.mpi.as_deref().unwrap_or(spur_core::mpi::MPI_NONE);
         spur_core::mpi::validate_single_node_pmix(mpi, spec.num_nodes)
@@ -550,56 +573,6 @@ impl ClusterManager {
         Err(SubmitError::invalid(format!(
             "requested node count {nodes} is outside partition '{}' limits (min {}, max {})",
             part.name, part.min_nodes, max
-        )))
-    }
-
-    /// Reject a job whose wall-time exceeds the requested partition's `MaxTime`,
-    /// gated on `EnforcePartLimits` (Slurm semantics). When disabled (the
-    /// default), over-limit jobs are admitted and pend with `PartitionTimeLimit`.
-    fn validate_partition_time_limit(&self, spec: &JobSpec) -> Result<(), SubmitError> {
-        let mode = self.config().scheduler.enforce_part_limits;
-        if mode == EnforcePartLimits::No {
-            return Ok(());
-        }
-        let Some(time_limit) = spec.time_limit.as_ref() else {
-            return Ok(());
-        };
-        let Some(partition_spec) = spec.partition.as_deref().filter(|p| !p.is_empty()) else {
-            return Ok(());
-        };
-
-        let partitions = self.partitions.read();
-        let requested: Vec<&Partition> = requested_partition_names(Some(partition_spec))
-            .filter_map(|name| partitions.iter().find(|part| part.name == name))
-            .collect();
-        // Existence was already checked in validate_partition.
-        if requested.is_empty() {
-            return Ok(());
-        }
-
-        let allows = |part: &&Partition| partition_time_allows(part, Some(time_limit));
-        let satisfied = match mode {
-            // ALL: the job must fit every requested partition.
-            EnforcePartLimits::All => requested.iter().all(allows),
-            // ANY: the job must fit at least one requested partition.
-            EnforcePartLimits::Any => requested.iter().any(allows),
-            EnforcePartLimits::No => true,
-        };
-        if satisfied {
-            return Ok(());
-        }
-
-        let offending = requested
-            .iter()
-            .find(|p| !allows(p))
-            .unwrap_or(&requested[0]);
-        let requested_str =
-            spur_core::config::format_time(Some(time_limit.num_minutes().max(0) as u32));
-        let max_str = spur_core::config::format_time(offending.max_time_minutes);
-        Err(SubmitError::invalid(format!(
-            "Requested time limit is invalid (missing or exceeds some limit): \
-             {requested_str} exceeds MaxTime {max_str} of partition '{}'",
-            offending.name
         )))
     }
 
@@ -5361,9 +5334,10 @@ fn account_block_with(
 }
 
 /// For a partition OR-list, returns `None` when any requested partition is Up
-/// and permits the request. Unknown names and limits rejected by every Up
-/// alternative return `PartitionConfig`; all-inactive alternatives return
-/// `PartitionInactive`.
+/// and permits the request. When every Up alternative rejects it, returns that
+/// block reason (`PartitionTimeLimit` for a wall-time cap, else
+/// `PartitionConfig`); unknown names return `PartitionConfig` and all-inactive
+/// alternatives return `PartitionInactive`.
 fn partition_block(job: &Job, partitions: &[Partition]) -> Option<spur_core::job::PendingReason> {
     use spur_core::job::PendingReason;
     use spur_core::partition::PartitionState;
@@ -5403,6 +5377,56 @@ fn partition_block(job: &Job, partitions: &[Partition]) -> Option<spur_core::job
     } else {
         PendingReason::PartitionInactive
     })
+}
+
+/// Reject a job whose (user-requested) wall-time exceeds a requested partition's
+/// `MaxTime`, per `EnforcePartLimits`. `All` requires every requested partition
+/// to fit; `Any` requires at least one. `No` never rejects.
+fn validate_partition_time_limit(
+    spec: &JobSpec,
+    mode: EnforcePartLimits,
+    partitions: &[Partition],
+) -> Result<(), SubmitError> {
+    if mode == EnforcePartLimits::No {
+        return Ok(());
+    }
+    let Some(time_limit) = spec.time_limit.as_ref() else {
+        return Ok(());
+    };
+    let Some(partition_spec) = spec.partition.as_deref().filter(|p| !p.is_empty()) else {
+        return Ok(());
+    };
+
+    // Existence was already checked in validate_partition.
+    let requested = spur_core::partition::matched_partitions(Some(partition_spec), partitions);
+    if requested.is_empty() {
+        return Ok(());
+    }
+
+    let allows = |part: &&Partition| partition_time_allows(part, Some(time_limit));
+    let satisfied = if mode == EnforcePartLimits::All {
+        requested.iter().all(allows)
+    } else {
+        requested.iter().any(allows)
+    };
+    if satisfied {
+        return Ok(());
+    }
+
+    let offending = requested
+        .iter()
+        .find(|p| !allows(p))
+        .unwrap_or(&requested[0]);
+    let requested_str =
+        spur_core::config::format_time_seconds(Some(time_limit.num_seconds().max(0)));
+    let max_str = spur_core::config::format_time_seconds(
+        offending.max_time_minutes.map(|m| i64::from(m) * 60),
+    );
+    Err(SubmitError::invalid(format!(
+        "Requested time limit is invalid (missing or exceeds some limit): \
+         {requested_str} exceeds MaxTime {max_str} of partition '{}'",
+        offending.name
+    )))
 }
 
 /// True when a job's wall-time fits the partition's `MaxTime`. `None` `MaxTime`
@@ -5678,14 +5702,11 @@ fn apply_default_partition(spec: &mut JobSpec, partitions: &[Partition]) {
     }
 }
 
-/// Fill in a job's wall-time when none was requested.
-///
-/// Partition `DefaultTime` always applies (prior behavior). Beyond that, the
-/// `DefaultTime -> MaxTime -> cluster default` fallback is opt-in and bounds
-/// otherwise-unlimited jobs only when `scheduler.default_time_limit_minutes`
-/// is set (> 0). With the default of 0 the fallback is disabled, so behavior
-/// is unchanged on upgrade: a job with no `-t` on a partition with no
-/// `DefaultTime` stays unbounded.
+/// Fill in a job's wall-time when none was requested. Each requested partition
+/// resolves to `DefaultTime`, else (only when `cluster_default_minutes > 0`) its
+/// `MaxTime`, else the cluster fallback. The smallest resulting limit is chosen
+/// so the default fits every requested partition; if any requested partition
+/// resolves to no bound the job stays unbounded (unchanged upgrade behavior).
 fn apply_default_time_limit(
     spec: &mut JobSpec,
     partitions: &[Partition],
@@ -5694,29 +5715,51 @@ fn apply_default_time_limit(
     if spec.time_limit.is_some() {
         return;
     }
-    // Resolve against the first *requested* partition (a job may list several,
-    // e.g. "gpu,cpu"); fall back to the default/first partition when unset.
-    let partition = spec
+
+    // A job may list several partitions (e.g. "gpu,cpu"); fall back to the
+    // default/first partition when the field is unset or names nothing known.
+    let matched = spec
         .partition
         .as_deref()
-        .and_then(|spec| requested_partition_names(Some(spec)).next())
-        .and_then(|name| partitions.iter().find(|p| p.name == name))
-        .or_else(|| partitions.iter().find(|p| p.is_default))
-        .or_else(|| partitions.first());
-
-    if let Some(minutes) = partition.and_then(|p| p.default_time_minutes) {
-        spec.time_limit = Some(chrono::Duration::minutes(minutes as i64));
+        .map(|p| spur_core::partition::matched_partitions(Some(p), partitions))
+        .unwrap_or_default();
+    let requested: Vec<&Partition> = if matched.is_empty() {
+        partitions
+            .iter()
+            .find(|p| p.is_default)
+            .or_else(|| partitions.first())
+            .into_iter()
+            .collect()
+    } else {
+        matched
+    };
+    if requested.is_empty() {
         return;
     }
 
-    // Opt-in reclamation: only bound the job when a cluster fallback is set.
-    if cluster_default_minutes == 0 {
-        return;
+    let resolve = |part: &Partition| -> Option<u32> {
+        if let Some(minutes) = part.default_time_minutes {
+            return Some(minutes);
+        }
+        // Opt-in reclamation: only bound the job when a cluster fallback is set.
+        if cluster_default_minutes == 0 {
+            return None;
+        }
+        Some(part.max_time_minutes.unwrap_or(cluster_default_minutes))
+    };
+
+    let mut chosen: Option<u32> = None;
+    for part in &requested {
+        match resolve(part) {
+            // An unbounded requested partition means the job may run unlimited
+            // there, so don't impose a default.
+            None => return,
+            Some(minutes) => chosen = Some(chosen.map_or(minutes, |c| c.min(minutes))),
+        }
     }
-    let minutes = partition
-        .and_then(|p| p.max_time_minutes)
-        .unwrap_or(cluster_default_minutes);
-    spec.time_limit = Some(chrono::Duration::minutes(minutes as i64));
+    if let Some(minutes) = chosen {
+        spec.time_limit = Some(chrono::Duration::minutes(i64::from(minutes)));
+    }
 }
 
 /// Resolve the submitting user's default account from the association cache
@@ -9534,6 +9577,43 @@ mod tests {
         spec.partition = Some("default,roomy".into());
         spec.time_limit = Some(chrono::Duration::hours(1));
         assert!(cm.submit_job(spec).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_multi_partition_all_admits_untimed_job() {
+        // Regression: a `-t`-less job to two partitions under ALL must not be
+        // rejected by a wall-time we auto-assign. The default is derived from the
+        // smaller MaxTime so it fits both, and an auto-default is never enforced.
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.partitions[0].max_time = Some("02:00:00".into());
+        let mut small = cfg.partitions[0].clone();
+        small.name = "small".into();
+        small.default = false;
+        small.max_time = Some("01:00:00".into());
+        cfg.partitions.push(small);
+        cfg.scheduler.enforce_part_limits = EnforcePartLimits::All;
+        cfg.scheduler.default_time_limit_minutes = 90;
+        let cm = test_cluster_with_config(&dir, cfg).await;
+
+        let mut spec = basic_spec("untimed");
+        spec.partition = Some("default,small".into());
+        spec.time_limit = None;
+        assert!(cm.submit_job(spec).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_rejects_negative_time_limit() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster_with_config(&dir, test_config()).await;
+
+        let mut spec = basic_spec("neg");
+        spec.time_limit = Some(chrono::Duration::minutes(-5));
+        let err = cm.submit_job(spec).unwrap_err();
+        let SubmitError::InvalidArgument(msg) = err else {
+            panic!("expected InvalidArgument, got {err:?}");
+        };
+        assert!(msg.contains("negative"), "got: {msg}");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -13860,6 +13940,72 @@ mod tests {
         }];
         super::apply_default_time_limit(&mut spec, &partitions, 0);
         assert!(spec.time_limit.is_none());
+    }
+
+    #[test]
+    fn apply_default_time_limit_multi_partition_uses_min_across_requested() {
+        // A `-t`-less job to two partitions gets the smaller MaxTime so the
+        // default fits both (and would pass EnforcePartLimits=ALL).
+        let mut spec = basic_spec("j");
+        spec.partition = Some("big,small".into());
+        spec.time_limit = None;
+        let partitions = vec![
+            Partition {
+                name: "big".into(),
+                default_time_minutes: None,
+                max_time_minutes: Some(120),
+                ..Default::default()
+            },
+            Partition {
+                name: "small".into(),
+                default_time_minutes: None,
+                max_time_minutes: Some(60),
+                ..Default::default()
+            },
+        ];
+        super::apply_default_time_limit(&mut spec, &partitions, 60);
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(60)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_unbounded_partition_leaves_job_unbounded() {
+        // With the cluster fallback disabled, a requested partition that resolves
+        // to no bound keeps the whole job unbounded even if a sibling is bounded.
+        let mut spec = basic_spec("j");
+        spec.partition = Some("bounded,unlimited".into());
+        spec.time_limit = None;
+        let partitions = vec![
+            Partition {
+                name: "bounded".into(),
+                default_time_minutes: Some(30),
+                ..Default::default()
+            },
+            Partition {
+                name: "unlimited".into(),
+                default_time_minutes: None,
+                max_time_minutes: None,
+                ..Default::default()
+            },
+        ];
+        super::apply_default_time_limit(&mut spec, &partitions, 0);
+        assert!(spec.time_limit.is_none());
+    }
+
+    #[test]
+    fn apply_default_time_limit_prefers_default_over_smaller_max_time() {
+        // DefaultTime wins the fallback chain even when MaxTime is smaller and a
+        // cluster default is set.
+        let mut spec = basic_spec("j");
+        spec.partition = Some("gpu".into());
+        spec.time_limit = None;
+        let partitions = vec![Partition {
+            name: "gpu".into(),
+            default_time_minutes: Some(45),
+            max_time_minutes: Some(30),
+            ..Default::default()
+        }];
+        super::apply_default_time_limit(&mut spec, &partitions, 60);
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(45)));
     }
 
     #[test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -5402,10 +5402,8 @@ fn validate_partition_time_limit(
         return Ok(());
     };
 
-    // Slurm validates every requested partition's configured limits regardless of
-    // current state, so a DOWN/DRAINED partition's MaxTime still counts; this keeps
-    // the outcome deterministic at submit instead of dependent on transient state.
-    // Existence was already checked in validate_partition.
+    // Check every requested partition regardless of state (Slurm parity), so the
+    // outcome doesn't depend on transient Down/Drain. Existence checked upstream.
     let requested = spur_core::partition::matched_partitions(Some(partition_spec), partitions);
     if requested.is_empty() {
         return Ok(());

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -5385,8 +5385,8 @@ fn partition_block(job: &Job, partitions: &[Partition]) -> Option<spur_core::job
     })
 }
 
-/// Reject a user-requested wall-time exceeding a requested `Up` partition's
-/// `MaxTime`, per `EnforcePartLimits` (`All` = all must fit, `Any` = one).
+/// Reject a user-requested wall-time exceeding a requested partition's `MaxTime`,
+/// per `EnforcePartLimits` (`All` = all must fit, `Any` = at least one).
 fn validate_partition_time_limit(
     spec: &JobSpec,
     mode: EnforcePartLimits,
@@ -5402,14 +5402,11 @@ fn validate_partition_time_limit(
         return Ok(());
     };
 
-    // Only Up partitions can schedule the job, so enforce against those alone
-    // (matching partition_block); a Down partition's MaxTime must not reject a
-    // job that would just pend. Existence was already checked in validate_partition.
-    let requested: Vec<&Partition> =
-        spur_core::partition::matched_partitions(Some(partition_spec), partitions)
-            .into_iter()
-            .filter(|p| p.state == spur_core::partition::PartitionState::Up)
-            .collect();
+    // Slurm validates every requested partition's configured limits regardless of
+    // current state, so a DOWN/DRAINED partition's MaxTime still counts; this keeps
+    // the outcome deterministic at submit instead of dependent on transient state.
+    // Existence was already checked in validate_partition.
+    let requested = spur_core::partition::matched_partitions(Some(partition_spec), partitions);
     if requested.is_empty() {
         return Ok(());
     }
@@ -14043,9 +14040,9 @@ mod tests {
     }
 
     #[test]
-    fn validate_partition_time_limit_ignores_down_partitions() {
-        // Under ALL, a Down partition's smaller MaxTime must not reject a job
-        // that fits the Up partition; the job pends on the Up one instead.
+    fn validate_partition_time_limit_enforces_down_partitions_under_all() {
+        // Slurm parity: under ALL, a requested Down partition's stricter MaxTime
+        // still rejects, regardless of its state (deterministic at submit).
         let mut spec = basic_spec("j");
         spec.partition = Some("up_big,down_small".into());
         spec.time_limit = Some(chrono::Duration::minutes(90));
@@ -14068,25 +14065,35 @@ mod tests {
             spur_core::config::EnforcePartLimits::All,
             &partitions,
         )
-        .is_ok());
+        .is_err());
     }
 
     #[test]
-    fn validate_partition_time_limit_ok_when_all_requested_inactive() {
-        // Every requested partition is Down: nothing schedulable here, so enforce
-        // nothing at submit and let it pend (PartitionInactive) instead of
-        // printing a misleading "exceeds MaxTime".
-        let mut spec = basic_spec("j");
-        spec.partition = Some("down_small".into());
-        spec.time_limit = Some(chrono::Duration::minutes(90));
+    fn validate_partition_time_limit_enforces_inactive_only_request() {
+        // A request naming only a Down partition is still checked (not silently
+        // admitted): an over-limit `-t` is rejected, a within-limit one passes.
         let partitions = vec![Partition {
             name: "down_small".into(),
             state: spur_core::partition::PartitionState::Down,
             max_time_minutes: Some(10),
             ..Default::default()
         }];
+
+        let mut over = basic_spec("over");
+        over.partition = Some("down_small".into());
+        over.time_limit = Some(chrono::Duration::minutes(90));
         assert!(super::validate_partition_time_limit(
-            &spec,
+            &over,
+            spur_core::config::EnforcePartLimits::All,
+            &partitions,
+        )
+        .is_err());
+
+        let mut within = basic_spec("within");
+        within.partition = Some("down_small".into());
+        within.time_limit = Some(chrono::Duration::minutes(5));
+        assert!(super::validate_partition_time_limit(
+            &within,
             spur_core::config::EnforcePartLimits::All,
             &partitions,
         )
@@ -14095,8 +14102,6 @@ mod tests {
 
     #[test]
     fn validate_partition_time_limit_rejects_over_limit_up_partition() {
-        // The Up filter must not weaken enforcement: an over-limit Up partition
-        // still rejects under ALL.
         let mut spec = basic_spec("j");
         spec.partition = Some("up_small".into());
         spec.time_limit = Some(chrono::Duration::minutes(90));

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -14,7 +14,7 @@ use tracing::{debug, info, warn};
 use spur_core::account_limits::{check_account_limits, AccountCheckResult};
 use spur_core::accounting::{Qos, TresRecord, TresType};
 use spur_core::burst_buffer::BbStageState;
-use spur_core::config::SlurmConfig;
+use spur_core::config::{EnforcePartLimits, SlurmConfig};
 use spur_core::job::{
     effective_gpus, effective_memory_mb, Job, JobId, JobSpec, JobState, NodeCompleteError,
     PendingReason, TransitionOutcome, DEFAULT_PRIORITY,
@@ -417,10 +417,14 @@ impl ClusterManager {
     /// Submit a new job. If it has an array spec, expand into individual tasks.
     pub fn submit_job(&self, mut spec: JobSpec) -> Result<SubmitOutcome, SubmitError> {
         apply_default_partition(&mut spec, &self.partitions.read());
-        apply_default_time_limit(&mut spec, &self.partitions.read());
+        let config = self.config();
+        apply_default_time_limit(
+            &mut spec,
+            &self.partitions.read(),
+            config.scheduler.default_time_limit_minutes,
+        );
         apply_default_account(&mut spec, &self.association_cache);
         validate_user_account(&spec, &self.association_cache)?;
-        let config = self.config();
         // Default QoS must resolve before the partition ACL, or `allow_qos` sees
         // an empty QoS and wrongly rejects a user's inherited default.
         apply_default_qos(
@@ -460,6 +464,10 @@ impl ClusterManager {
         // Reject a node count outside the partition's bounds at submit, matching
         // Slurm, instead of accepting a job that would pend forever.
         self.validate_partition_node_bounds(&spec)?;
+
+        // Reject an over-MaxTime wall-time at submit when EnforcePartLimits is on
+        // (default off keeps Slurm's admit-and-pend behavior).
+        self.validate_partition_time_limit(&spec)?;
 
         let mpi = spec.mpi.as_deref().unwrap_or(spur_core::mpi::MPI_NONE);
         spur_core::mpi::validate_single_node_pmix(mpi, spec.num_nodes)
@@ -542,6 +550,56 @@ impl ClusterManager {
         Err(SubmitError::invalid(format!(
             "requested node count {nodes} is outside partition '{}' limits (min {}, max {})",
             part.name, part.min_nodes, max
+        )))
+    }
+
+    /// Reject a job whose wall-time exceeds the requested partition's `MaxTime`,
+    /// gated on `EnforcePartLimits` (Slurm semantics). When disabled (the
+    /// default), over-limit jobs are admitted and pend with `PartitionTimeLimit`.
+    fn validate_partition_time_limit(&self, spec: &JobSpec) -> Result<(), SubmitError> {
+        let mode = self.config().scheduler.enforce_part_limits;
+        if mode == EnforcePartLimits::No {
+            return Ok(());
+        }
+        let Some(time_limit) = spec.time_limit.as_ref() else {
+            return Ok(());
+        };
+        let Some(partition_spec) = spec.partition.as_deref().filter(|p| !p.is_empty()) else {
+            return Ok(());
+        };
+
+        let partitions = self.partitions.read();
+        let requested: Vec<&Partition> = requested_partition_names(Some(partition_spec))
+            .filter_map(|name| partitions.iter().find(|part| part.name == name))
+            .collect();
+        // Existence was already checked in validate_partition.
+        if requested.is_empty() {
+            return Ok(());
+        }
+
+        let allows = |part: &&Partition| partition_time_allows(part, Some(time_limit));
+        let satisfied = match mode {
+            // ALL: the job must fit every requested partition.
+            EnforcePartLimits::All => requested.iter().all(allows),
+            // ANY: the job must fit at least one requested partition.
+            EnforcePartLimits::Any => requested.iter().any(allows),
+            EnforcePartLimits::No => true,
+        };
+        if satisfied {
+            return Ok(());
+        }
+
+        let offending = requested
+            .iter()
+            .find(|p| !allows(p))
+            .unwrap_or(&requested[0]);
+        let requested_str =
+            spur_core::config::format_time(Some(time_limit.num_minutes().max(0) as u32));
+        let max_str = spur_core::config::format_time(offending.max_time_minutes);
+        Err(SubmitError::invalid(format!(
+            "Requested time limit is invalid (missing or exceeds some limit): \
+             {requested_str} exceeds MaxTime {max_str} of partition '{}'",
+            offending.name
         )))
     }
 
@@ -5326,38 +5384,54 @@ fn partition_block(job: &Job, partitions: &[Partition]) -> Option<spur_core::job
     }
 
     let mut has_up_partition = false;
+    let mut block_reason: Option<PendingReason> = None;
     for part in requested {
         if part.state != PartitionState::Up {
             continue;
         }
         has_up_partition = true;
-        if partition_limits_allow(job, part) {
-            return None;
+        match partition_limit_block(job, part) {
+            None => return None,
+            Some(reason) => {
+                block_reason.get_or_insert(reason);
+            }
         }
     }
 
     Some(if has_up_partition {
-        PendingReason::PartitionConfig
+        block_reason.unwrap_or(PendingReason::PartitionConfig)
     } else {
         PendingReason::PartitionInactive
     })
 }
 
-fn partition_limits_allow(job: &Job, part: &Partition) -> bool {
+/// True when a job's wall-time fits the partition's `MaxTime`. `None` `MaxTime`
+/// (UNLIMITED) or `None` time limit always fits. Compared at second precision so
+/// a request just over the cap is not truncated down to an allowed minute.
+fn partition_time_allows(part: &Partition, time_limit: Option<&chrono::Duration>) -> bool {
+    match (part.max_time_minutes, time_limit) {
+        (Some(max_mins), Some(tl)) => tl.num_seconds() <= i64::from(max_mins) * 60,
+        _ => true,
+    }
+}
+
+/// The reason a partition cannot ever schedule this job (static limits), or
+/// `None` if it can. Node-count violations report `PartitionConfig`; wall-time
+/// violations report the more specific `PartitionTimeLimit` (Slurm parity).
+fn partition_limit_block(job: &Job, part: &Partition) -> Option<spur_core::job::PendingReason> {
+    use spur_core::job::PendingReason;
     if let Some(max) = part.max_nodes {
         if job.spec.num_nodes > max {
-            return false;
+            return Some(PendingReason::PartitionConfig);
         }
     }
     if part.min_nodes > 0 && job.spec.num_nodes < part.min_nodes {
-        return false;
+        return Some(PendingReason::PartitionConfig);
     }
-    if let (Some(max_mins), Some(tl)) = (part.max_time_minutes, &job.spec.time_limit) {
-        if tl.num_minutes() > i64::from(max_mins) {
-            return false;
-        }
+    if !partition_time_allows(part, job.spec.time_limit.as_ref()) {
+        return Some(PendingReason::PartitionTimeLimit);
     }
-    true
+    None
 }
 
 fn sum_running_tres(jobs: &HashMap<JobId, Job>, pred: impl Fn(&Job) -> bool) -> TresRecord {
@@ -5604,19 +5678,45 @@ fn apply_default_partition(spec: &mut JobSpec, partitions: &[Partition]) {
     }
 }
 
-fn apply_default_time_limit(spec: &mut JobSpec, partitions: &[Partition]) {
+/// Fill in a job's wall-time when none was requested.
+///
+/// Partition `DefaultTime` always applies (prior behavior). Beyond that, the
+/// `DefaultTime -> MaxTime -> cluster default` fallback is opt-in and bounds
+/// otherwise-unlimited jobs only when `scheduler.default_time_limit_minutes`
+/// is set (> 0). With the default of 0 the fallback is disabled, so behavior
+/// is unchanged on upgrade: a job with no `-t` on a partition with no
+/// `DefaultTime` stays unbounded.
+fn apply_default_time_limit(
+    spec: &mut JobSpec,
+    partitions: &[Partition],
+    cluster_default_minutes: u32,
+) {
     if spec.time_limit.is_some() {
         return;
     }
+    // Resolve against the first *requested* partition (a job may list several,
+    // e.g. "gpu,cpu"); fall back to the default/first partition when unset.
     let partition = spec
         .partition
         .as_deref()
+        .and_then(|spec| requested_partition_names(Some(spec)).next())
         .and_then(|name| partitions.iter().find(|p| p.name == name))
         .or_else(|| partitions.iter().find(|p| p.is_default))
         .or_else(|| partitions.first());
+
     if let Some(minutes) = partition.and_then(|p| p.default_time_minutes) {
         spec.time_limit = Some(chrono::Duration::minutes(minutes as i64));
+        return;
     }
+
+    // Opt-in reclamation: only bound the job when a cluster fallback is set.
+    if cluster_default_minutes == 0 {
+        return;
+    }
+    let minutes = partition
+        .and_then(|p| p.max_time_minutes)
+        .unwrap_or(cluster_default_minutes);
+    spec.time_limit = Some(chrono::Duration::minutes(minutes as i64));
 }
 
 /// Resolve the submitting user's default account from the association cache
@@ -9139,16 +9239,18 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn tag_blocked_sets_partition_config_for_time_and_min_nodes() {
-        // max_time and min_nodes are independent PartitionConfig triggers.
+    async fn tag_blocked_sets_time_limit_and_config_reasons() {
+        // A max_time violation reports the specific PartitionTimeLimit reason;
+        // a min_nodes violation reports the generic PartitionConfig reason.
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
         config.partitions[0].max_time = Some("00:10:00".into()); // 10 min cap
         config.partitions[0].min_nodes = 2;
         let cm = test_cluster_with_config(&dir, config).await;
 
-        // Meets min_nodes but exceeds max_time: the time cap is not a
-        // submit-time bound, so this is admitted and pends with PartitionConfig.
+        // Meets min_nodes but exceeds max_time: with EnforcePartLimits off
+        // (the default) the time cap is not a submit-time bound, so this is
+        // admitted and pends with the specific PartitionTimeLimit reason.
         let mut over_time = basic_spec("overtime");
         over_time.partition = Some("default".into());
         over_time.num_nodes = 2;
@@ -9171,8 +9273,8 @@ mod tests {
         cm.tag_blocked_pending_reasons();
         assert_eq!(
             cm.get_job(t_id).unwrap().pending_reason,
-            PendingReason::PartitionConfig,
-            "time_limit over partition max_time -> PartitionConfig"
+            PendingReason::PartitionTimeLimit,
+            "time_limit over partition max_time -> PartitionTimeLimit"
         );
         assert_eq!(
             cm.get_job(n_id).unwrap().pending_reason,
@@ -9319,6 +9421,118 @@ mod tests {
             .insert_default_account("testuser", "research");
 
         let spec = basic_spec("defaultacct");
+        assert!(cm.submit_job(spec).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_admits_over_maxtime_when_enforcement_off() {
+        // Default EnforcePartLimits=No: an over-MaxTime job is admitted (and
+        // will pend with PartitionTimeLimit), not rejected at submit.
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.partitions[0].max_time = Some("00:10:00".into());
+        let cm = test_cluster_with_config(&dir, cfg).await;
+
+        let mut spec = basic_spec("overtime");
+        spec.time_limit = Some(chrono::Duration::hours(1));
+        assert!(cm.submit_job(spec).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_rejects_over_maxtime_when_enforcement_all() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.partitions[0].max_time = Some("00:10:00".into());
+        cfg.scheduler.enforce_part_limits = EnforcePartLimits::All;
+        let cm = test_cluster_with_config(&dir, cfg).await;
+
+        let mut spec = basic_spec("overtime");
+        spec.time_limit = Some(chrono::Duration::hours(1));
+        let err = cm.submit_job(spec).unwrap_err();
+        let SubmitError::InvalidArgument(msg) = err else {
+            panic!("expected InvalidArgument, got {err:?}");
+        };
+        assert!(
+            msg.contains("Requested time limit is invalid"),
+            "expected Slurm-style message, got: {msg}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_accepts_within_maxtime_when_enforcement_all() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.partitions[0].max_time = Some("01:00:00".into());
+        cfg.scheduler.enforce_part_limits = EnforcePartLimits::All;
+        let cm = test_cluster_with_config(&dir, cfg).await;
+
+        let mut spec = basic_spec("withintime");
+        spec.time_limit = Some(chrono::Duration::minutes(30));
+        assert!(cm.submit_job(spec).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_unlimited_partition_accepts_any_time_under_enforcement() {
+        // UNLIMITED MaxTime imposes no cap even with enforcement on (Slurm parity).
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.partitions[0].max_time = Some("UNLIMITED".into());
+        cfg.scheduler.enforce_part_limits = EnforcePartLimits::All;
+        // Disable the cluster fallback so the huge request survives to submit.
+        cfg.scheduler.default_time_limit_minutes = 0;
+        let cm = test_cluster_with_config(&dir, cfg).await;
+
+        let mut spec = basic_spec("yearlong");
+        spec.time_limit = Some(chrono::Duration::days(365));
+        assert!(cm.submit_job(spec).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_enforcement_any_rejects_when_no_partition_fits() {
+        // ANY rejects only when the request fits none of the requested
+        // partitions; the error names the offending partition.
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.partitions[0].max_time = Some("00:10:00".into());
+        let mut other = cfg.partitions[0].clone();
+        other.name = "other".into();
+        other.default = false;
+        other.max_time = Some("00:20:00".into());
+        cfg.partitions.push(other);
+        cfg.scheduler.enforce_part_limits = EnforcePartLimits::Any;
+        let cm = test_cluster_with_config(&dir, cfg).await;
+
+        let mut spec = basic_spec("toolong");
+        spec.partition = Some("default,other".into());
+        spec.time_limit = Some(chrono::Duration::hours(1));
+        let err = cm.submit_job(spec).unwrap_err();
+        let SubmitError::InvalidArgument(msg) = err else {
+            panic!("expected InvalidArgument, got {err:?}");
+        };
+        assert!(
+            msg.contains("Requested time limit is invalid") && msg.contains("partition"),
+            "error must name the offending partition: {msg}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_enforcement_any_accepts_if_one_partition_fits() {
+        // Two partitions: one 10-min cap, one 2-hour cap. A 1-hour job fits the
+        // second, so ANY admits it; ALL would reject it.
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.partitions[0].max_time = Some("00:10:00".into());
+        let mut roomy = cfg.partitions[0].clone();
+        roomy.name = "roomy".into();
+        roomy.default = false;
+        roomy.max_time = Some("02:00:00".into());
+        cfg.partitions.push(roomy);
+        cfg.scheduler.enforce_part_limits = EnforcePartLimits::Any;
+        let cm = test_cluster_with_config(&dir, cfg).await;
+
+        let mut spec = basic_spec("multi");
+        spec.partition = Some("default,roomy".into());
+        spec.time_limit = Some(chrono::Duration::hours(1));
         assert!(cm.submit_job(spec).is_ok());
     }
 
@@ -13567,7 +13781,7 @@ mod tests {
             default_time_minutes: Some(30),
             ..Default::default()
         }];
-        super::apply_default_time_limit(&mut spec, &partitions);
+        super::apply_default_time_limit(&mut spec, &partitions, 0);
         assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(30)));
     }
 
@@ -13580,7 +13794,7 @@ mod tests {
             default_time_minutes: Some(30),
             ..Default::default()
         }];
-        super::apply_default_time_limit(&mut spec, &partitions);
+        super::apply_default_time_limit(&mut spec, &partitions, 0);
         assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(5)));
     }
 
@@ -13594,7 +13808,57 @@ mod tests {
             default_time_minutes: None,
             ..Default::default()
         }];
-        super::apply_default_time_limit(&mut spec, &partitions);
+        super::apply_default_time_limit(&mut spec, &partitions, 0);
+        assert!(spec.time_limit.is_none());
+    }
+
+    #[test]
+    fn apply_default_time_limit_falls_back_to_partition_max_time() {
+        // No DefaultTime but a finite MaxTime: Slurm uses MaxTime as the default.
+        let mut spec = basic_spec("j");
+        spec.partition = Some("gpu".into());
+        spec.time_limit = None;
+        let partitions = vec![Partition {
+            name: "gpu".into(),
+            default_time_minutes: None,
+            max_time_minutes: Some(120),
+            ..Default::default()
+        }];
+        super::apply_default_time_limit(&mut spec, &partitions, 60);
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(120)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_falls_back_to_cluster_default_on_unlimited() {
+        // UNLIMITED partition (no DefaultTime, no MaxTime): the cluster-wide
+        // default bounds the job so it cannot run forever.
+        let mut spec = basic_spec("j");
+        spec.partition = Some("gpu".into());
+        spec.time_limit = None;
+        let partitions = vec![Partition {
+            name: "gpu".into(),
+            default_time_minutes: None,
+            max_time_minutes: None,
+            ..Default::default()
+        }];
+        super::apply_default_time_limit(&mut spec, &partitions, 60);
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(60)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_unlimited_when_cluster_default_disabled() {
+        // cluster default 0 = disabled: an UNLIMITED partition leaves the job
+        // with no wall-time (opt-out escape hatch).
+        let mut spec = basic_spec("j");
+        spec.partition = Some("gpu".into());
+        spec.time_limit = None;
+        let partitions = vec![Partition {
+            name: "gpu".into(),
+            default_time_minutes: None,
+            max_time_minutes: None,
+            ..Default::default()
+        }];
+        super::apply_default_time_limit(&mut spec, &partitions, 0);
         assert!(spec.time_limit.is_none());
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -449,7 +449,7 @@ impl ClusterManager {
             &self.qos_cache,
             &config.accounting,
         )?;
-        self.validate_partition(&spec)?;
+        self.validate_partition(&spec, &partitions)?;
 
         // Fewer tasks than nodes cannot use the surplus nodes; cap at the task
         // count so reported node/GPU counts match the allocation (unless a
@@ -479,7 +479,7 @@ impl ClusterManager {
 
         // Reject a node count outside the partition's bounds at submit, matching
         // Slurm, instead of accepting a job that would pend forever.
-        self.validate_partition_node_bounds(&spec)?;
+        self.validate_partition_node_bounds(&spec, &partitions)?;
 
         // Reject an over-MaxTime wall-time at submit when EnforcePartLimits is on
         // (default off keeps Slurm's admit-and-pend behavior). Only a
@@ -541,12 +541,15 @@ impl ClusterManager {
     /// bounds of every requested partition. Matches Slurm, which rejects such
     /// jobs at submit rather than leaving them permanently pending. A partition
     /// list is accepted if any one partition can hold the request.
-    fn validate_partition_node_bounds(&self, spec: &JobSpec) -> Result<(), SubmitError> {
+    fn validate_partition_node_bounds(
+        &self,
+        spec: &JobSpec,
+        partitions: &[Partition],
+    ) -> Result<(), SubmitError> {
         let Some(partition_spec) = spec.partition.as_deref().filter(|p| !p.is_empty()) else {
             return Ok(());
         };
 
-        let partitions = self.partitions.read();
         let requested: Vec<&Partition> = requested_partition_names(Some(partition_spec))
             .filter_map(|name| partitions.iter().find(|part| part.name == name))
             .collect();
@@ -577,13 +580,16 @@ impl ClusterManager {
     }
 
     /// Validate partition constraints: access control and node limits.
-    pub(crate) fn validate_partition(&self, spec: &JobSpec) -> Result<(), SubmitError> {
+    pub(crate) fn validate_partition(
+        &self,
+        spec: &JobSpec,
+        partitions: &[Partition],
+    ) -> Result<(), SubmitError> {
         let partition_spec = match spec.partition.as_deref() {
             Some(p) if !p.is_empty() => p,
             _ => return Ok(()), // Unset or empty partition name — nothing to validate
         };
 
-        let partitions = self.partitions.read();
         let requested = requested_partition_names(Some(partition_spec))
             .map(|name| {
                 partitions
@@ -5379,9 +5385,8 @@ fn partition_block(job: &Job, partitions: &[Partition]) -> Option<spur_core::job
     })
 }
 
-/// Reject a job whose (user-requested) wall-time exceeds a requested partition's
-/// `MaxTime`, per `EnforcePartLimits`. `All` requires every requested partition
-/// to fit; `Any` requires at least one. `No` never rejects.
+/// Reject a user-requested wall-time exceeding a requested `Up` partition's
+/// `MaxTime`, per `EnforcePartLimits` (`All` = all must fit, `Any` = one).
 fn validate_partition_time_limit(
     spec: &JobSpec,
     mode: EnforcePartLimits,
@@ -5397,8 +5402,14 @@ fn validate_partition_time_limit(
         return Ok(());
     };
 
-    // Existence was already checked in validate_partition.
-    let requested = spur_core::partition::matched_partitions(Some(partition_spec), partitions);
+    // Only Up partitions can schedule the job, so enforce against those alone
+    // (matching partition_block); a Down partition's MaxTime must not reject a
+    // job that would just pend. Existence was already checked in validate_partition.
+    let requested: Vec<&Partition> =
+        spur_core::partition::matched_partitions(Some(partition_spec), partitions)
+            .into_iter()
+            .filter(|p| p.state == spur_core::partition::PartitionState::Up)
+            .collect();
     if requested.is_empty() {
         return Ok(());
     }
@@ -14009,6 +14020,101 @@ mod tests {
     }
 
     #[test]
+    fn apply_default_time_limit_multi_partition_uses_min_across_default_times() {
+        // Two partitions each with a distinct DefaultTime: the smaller wins so
+        // the auto-default fits both.
+        let mut spec = basic_spec("j");
+        spec.partition = Some("a,b".into());
+        spec.time_limit = None;
+        let partitions = vec![
+            Partition {
+                name: "a".into(),
+                default_time_minutes: Some(45),
+                ..Default::default()
+            },
+            Partition {
+                name: "b".into(),
+                default_time_minutes: Some(20),
+                ..Default::default()
+            },
+        ];
+        super::apply_default_time_limit(&mut spec, &partitions, 0);
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(20)));
+    }
+
+    #[test]
+    fn validate_partition_time_limit_ignores_down_partitions() {
+        // Under ALL, a Down partition's smaller MaxTime must not reject a job
+        // that fits the Up partition; the job pends on the Up one instead.
+        let mut spec = basic_spec("j");
+        spec.partition = Some("up_big,down_small".into());
+        spec.time_limit = Some(chrono::Duration::minutes(90));
+        let partitions = vec![
+            Partition {
+                name: "up_big".into(),
+                state: spur_core::partition::PartitionState::Up,
+                max_time_minutes: Some(120),
+                ..Default::default()
+            },
+            Partition {
+                name: "down_small".into(),
+                state: spur_core::partition::PartitionState::Down,
+                max_time_minutes: Some(10),
+                ..Default::default()
+            },
+        ];
+        assert!(super::validate_partition_time_limit(
+            &spec,
+            spur_core::config::EnforcePartLimits::All,
+            &partitions,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn validate_partition_time_limit_ok_when_all_requested_inactive() {
+        // Every requested partition is Down: nothing schedulable here, so enforce
+        // nothing at submit and let it pend (PartitionInactive) instead of
+        // printing a misleading "exceeds MaxTime".
+        let mut spec = basic_spec("j");
+        spec.partition = Some("down_small".into());
+        spec.time_limit = Some(chrono::Duration::minutes(90));
+        let partitions = vec![Partition {
+            name: "down_small".into(),
+            state: spur_core::partition::PartitionState::Down,
+            max_time_minutes: Some(10),
+            ..Default::default()
+        }];
+        assert!(super::validate_partition_time_limit(
+            &spec,
+            spur_core::config::EnforcePartLimits::All,
+            &partitions,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn validate_partition_time_limit_rejects_over_limit_up_partition() {
+        // The Up filter must not weaken enforcement: an over-limit Up partition
+        // still rejects under ALL.
+        let mut spec = basic_spec("j");
+        spec.partition = Some("up_small".into());
+        spec.time_limit = Some(chrono::Duration::minutes(90));
+        let partitions = vec![Partition {
+            name: "up_small".into(),
+            state: spur_core::partition::PartitionState::Up,
+            max_time_minutes: Some(10),
+            ..Default::default()
+        }];
+        assert!(super::validate_partition_time_limit(
+            &spec,
+            spur_core::config::EnforcePartLimits::All,
+            &partitions,
+        )
+        .is_err());
+    }
+
+    #[test]
     fn apply_default_partition_falls_back_to_first() {
         let mut spec = basic_spec("j");
         spec.partition = None;
@@ -16432,7 +16538,7 @@ mod tests {
         spec.partition = Some("restricted".into());
         spec.qos = Some("cheap".into());
         assert!(
-            cm.validate_partition(&spec).is_err(),
+            cm.validate_partition(&spec, &cm.get_partitions()).is_err(),
             "QoS not in allow_qos must fail validation"
         );
 
@@ -16441,7 +16547,7 @@ mod tests {
         spec.partition = Some("restricted".into());
         spec.qos = Some("premium".into());
         assert!(
-            cm.validate_partition(&spec).is_ok(),
+            cm.validate_partition(&spec, &cm.get_partitions()).is_ok(),
             "QoS in allow_qos must pass validation"
         );
 
@@ -16450,7 +16556,7 @@ mod tests {
         spec.partition = Some("restricted".into());
         spec.qos = None;
         assert!(
-            cm.validate_partition(&spec).is_err(),
+            cm.validate_partition(&spec, &cm.get_partitions()).is_err(),
             "absent QoS must fail when allow_qos is non-empty"
         );
     }
@@ -16476,7 +16582,7 @@ mod tests {
         spec.partition = Some("nodebug".into());
         spec.qos = Some("debug".into());
         assert!(
-            cm.validate_partition(&spec).is_err(),
+            cm.validate_partition(&spec, &cm.get_partitions()).is_err(),
             "denied QoS must fail validation"
         );
 
@@ -16485,7 +16591,7 @@ mod tests {
         spec.partition = Some("nodebug".into());
         spec.qos = Some("premium".into());
         assert!(
-            cm.validate_partition(&spec).is_ok(),
+            cm.validate_partition(&spec, &cm.get_partitions()).is_ok(),
             "non-denied QoS must pass validation"
         );
 
@@ -16494,7 +16600,7 @@ mod tests {
         spec.partition = Some("nodebug".into());
         spec.qos = None;
         assert!(
-            cm.validate_partition(&spec).is_ok(),
+            cm.validate_partition(&spec, &cm.get_partitions()).is_ok(),
             "absent QoS must not be blocked by deny_qos"
         );
     }
@@ -16519,7 +16625,7 @@ mod tests {
         spec.partition = Some("open".into());
         spec.qos = Some("whatever".into());
         assert!(
-            cm.validate_partition(&spec).is_ok(),
+            cm.validate_partition(&spec, &cm.get_partitions()).is_ok(),
             "empty allow_qos must not restrict any QoS"
         );
     }

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -240,6 +240,13 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
      - Cluster-wide fallback wall-time (minutes) for a job that sets no ``-t`` and
        lands on a partition with no ``DefaultTime``. ``0`` disables the fallback,
        leaving such jobs unbounded. Set > 0 to bound otherwise-unlimited jobs.
+       When enabled, a ``-t``-less job on a partition that has a finite ``MaxTime``
+       but no ``DefaultTime`` defaults to that partition's ``MaxTime`` (for a
+       multi-partition request, the smallest ``MaxTime`` among them), not this
+       flat value. Prior to this release the setting was inert (never applied);
+       it now takes effect, and its default changed from ``60`` to ``0`` so
+       ``-t``-less jobs stay unbounded exactly as before. A site that had set it
+       expecting an effect will now see that effect.
    * - ``enforce_part_limits``
      - string
      - ``NO``

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -236,9 +236,17 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
      - Fairshare usage decay half-life, in days.
    * - ``default_time_limit_minutes``
      - integer
-     - ``60``
-     - Default job time limit (minutes) when neither the job nor its partition sets
-       one.
+     - ``0``
+     - Cluster-wide fallback wall-time (minutes) for a job that sets no ``-t`` and
+       lands on a partition with no ``DefaultTime``. ``0`` disables the fallback,
+       leaving such jobs unbounded. Set > 0 to bound otherwise-unlimited jobs.
+   * - ``enforce_part_limits``
+     - string
+     - ``NO``
+     - Whether partition wall-time limits are enforced at submit. ``NO`` admits
+       over-limit jobs and lets them pend with a ``PartitionTimeLimit`` reason.
+       ``ALL`` rejects unless the job fits every requested partition; ``ANY``
+       rejects only when it fits none. Mirrors Slurm's ``EnforcePartLimits``.
    * - ``complete_wait_secs``
      - integer
      - ``300``
@@ -323,7 +331,8 @@ is the union of the ``nodes`` hostlist pattern and the ``selector`` label match.
      - string
      - UNLIMITED
      - Maximum wall time. Slurm format: ``"72:00:00"``, ``"7-00:00:00"``, ``"60"``
-       (minutes), or ``INFINITE`` / ``UNLIMITED``.
+       (minutes), or ``INFINITE`` / ``UNLIMITED``. Suffixed durations are also
+       accepted: ``"1h"``, ``"90m"``, ``"1h40m"``, ``"2d12h"``, ``"30s"``.
    * - ``default_time``
      - string
      - UNLIMITED

--- a/tests/native_host/e2e/test_partitions.py
+++ b/tests/native_host/e2e/test_partitions.py
@@ -1093,3 +1093,43 @@ class TestReconfigure:
             # Restore conf so later tests see the original config on disk.
             node.write_file(conf_path, original)
             cluster.scontrol("reconfigure")
+
+
+class TestEnforcePartLimits:
+    """With EnforcePartLimits=ALL, an over-MaxTime request is rejected at
+    submit (Slurm parity) instead of being admitted and left pending."""
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {"scheduler": {"enforce_part_limits": "ALL"}}
+
+    def test_over_maxtime_rejected_at_submit(self, cluster):
+        name = _unique("capped")
+        node = cluster.node_names[0]
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--state=UP",
+            "--max-time=00:01:00",
+        )
+
+        with pytest.raises(RuntimeError) as exc:
+            cluster.sbatch(["-p", name, "-t", "01:00:00", "--wrap", "true"])
+        assert "Requested time limit is invalid" in str(exc.value)
+
+    def test_within_maxtime_accepted(self, cluster):
+        name = _unique("capped-ok")
+        node = cluster.node_names[0]
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--state=UP",
+            "--max-time=01:00:00",
+        )
+
+        job_id = parse_job_id(
+            cluster.sbatch(["-p", name, "-t", "00:05:00", "--wrap", "true"])
+        )
+        assert job_id, "within-limit job must be accepted at submit"


### PR DESCRIPTION
## What this fixes

Partition `MaxTime` was never enforced, and invalid time strings in config silently became `UNLIMITED`. Jobs could exceed a partition's wall-time cap, and a typo like `max_time = "1h"` quietly removed the cap instead of applying it. Refs SPUR-122.

This is Group 1 of the fix (submit/schedule-time validation and defaulting). Group 2 (interactive allocation reaping via `InactiveLimit`) is a follow-up.

## Approach

- **`enforce_part_limits` (`NO`/`ALL`/`ANY`, default `NO`)**: gates submit-time rejection of over-limit jobs, mirroring Slurm's `EnforcePartLimits`. `ALL` rejects unless the job fits every requested partition; `ANY` rejects only when it fits none. Default `NO` keeps the prior admit-and-pend behavior. Deserialization is case-insensitive and accepts Slurm's `YES` alias.
- **Specific pending reason**: time violations now report `PartitionTimeLimit` instead of the generic `PartitionConfig`.
- **Loud config validation**: `SlurmConfig::validate()` rejects malformed partition `max_time`/`default_time` at load rather than silently dropping the cap.
- **Default-time fallback (opt-in)**: `apply_default_time_limit` follows `DefaultTime -> MaxTime -> scheduler.default_time_limit_minutes`. That cluster fallback now defaults to `0` (disabled), so on upgrade a `-t`-less job on an unlimited partition stays unbounded. Sites opt into reclamation by setting it `> 0`.
- **Suffixed durations**: time strings now accept `1h`, `90m`, `1h40m`, `2d12h`, `30s` in addition to Slurm grammar, across config, CLI `-t`, `scontrol`, and REST. Slurm grammar is tried first (disjoint, no reinterpretation of existing values) and output still renders `HH:MM:SS`.

## Backward compatibility

Non-breaking and backward compatible by default. With an unchanged config (`enforce_part_limits = NO`, `default_time_limit_minutes = 0`) no submit-time rejections are added and no job gets a wall-time it wouldn't have had before. No persisted-state, proto, or CLI/REST-output changes.

One intended behavior change worth a release note: a deployed `max_time = "1h"` was previously silently `UNLIMITED`; it now parses as a 60-minute cap (honoring intent). A genuinely invalid string (e.g. `"1 hour"`) now fails loudly at startup instead of removing the cap.

## Testing

- Unit tests for enforcement (`ALL`/`ANY` accept/reject incl. no-partition-fits), the default-time fallback branches, config validation, and suffixed-duration parsing (plus updated existing tests). Full suite green; clippy clean.
- E2E: `TestEnforcePartLimits` in `tests/native_host/e2e/test_partitions.py`.
- Bare-metal (4 nodes): confirmed `ALL` rejects `-t 2h`/`-t 90m` on a 1h partition and accepts `-t 45m`/`-t 1h`; `default_time = "10m"` applies to `-t`-less jobs; `default_time_limit_minutes = 0` leaves unlimited-partition jobs unbounded while `= 60` bounds them; `max_time = "1h"` loads as a 60-min cap; and `"1 hour"` fails startup loudly.

## Review follow-ups

Two rounds of review addressed in later commits:

- Submit-time enforcement runs only for a user-supplied `-t` (never an auto-filled default), and the `-t`-less default derives from the minimum resolved limit across all requested partitions. Error messages render at second precision.
- Submit-time enforcement checks every requested partition's configured `MaxTime` regardless of its `Up`/`Down`/`Drain` state, matching Slurm's `EnforcePartLimits` (limits are configured values, not current state). This keeps the outcome deterministic (independent of transient partition state) and avoids silently admitting an over-limit job whose only requested partition is down.
- `submit_job`'s config/partitions snapshot is threaded through all validators, so the whole submit path sees one consistent view under a concurrent `reconfigure()`.
- `validate()` rejects a partition whose finite `default_time` exceeds its finite `max_time` (which would otherwise auto-fill a `-t`-less job past its own cap and pend it forever).

Follow-up [#604](https://github.com/ROCm/spur/issues/604) tracks moving to Slurm-style per-partition default resolution at schedule time.

