### PR TITLE
feat(spurctld): reap abandoned interactive allocations via client keepalive

### DIFF
--- a/crates/spur-cli/src/interactive.rs
+++ b/crates/spur-cli/src/interactive.rs
@@ -3,10 +3,67 @@
 
 use anyhow::{Context, Result};
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
-use spur_proto::proto::{interactive_input, interactive_output, InitSession, InteractiveInput};
+use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
+use spur_proto::proto::{
+    interactive_input, interactive_output, InitSession, InteractiveInput, JobKeepaliveRequest,
+};
 use std::collections::HashMap;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::signal::unix::{signal, SignalKind};
+
+/// Keeps an interactive allocation attended by pinging the controller on a
+/// fixed interval, and stops the pings when dropped. Aborting on `Drop` means
+/// an early `?` return on the caller's path can't leak the task.
+pub struct KeepaliveGuard(tokio::task::JoinHandle<()>);
+
+impl Drop for KeepaliveGuard {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// Spawn the keepalive loop for `job_id`. `tool` prefixes the warning printed
+/// when a ping fails (e.g. "salloc", "srun"). A blocking client sends no other
+/// traffic, so without these pings the controller's InactiveLimit reaper would
+/// reclaim a live allocation.
+pub fn spawn_keepalive(
+    client: SlurmControllerClient<tonic::transport::Channel>,
+    job_id: u32,
+    user: String,
+    tool: &'static str,
+) -> KeepaliveGuard {
+    let handle = tokio::spawn(async move {
+        let mut client = client;
+        let mut tick = tokio::time::interval(std::time::Duration::from_secs(
+            spur_core::config::KEEPALIVE_INTERVAL_SECS,
+        ));
+        // Warn once per failure streak: a persistent failure stays visible
+        // without printing a line every interval.
+        let mut warned = false;
+        loop {
+            tick.tick().await;
+            match client
+                .job_keepalive(JobKeepaliveRequest {
+                    job_id,
+                    user: user.clone(),
+                })
+                .await
+            {
+                Ok(_) => warned = false,
+                Err(e) if !warned => {
+                    eprintln!(
+                        "{tool}: warning: keepalive to controller failed ({}); \
+                         allocation may be reaped if this persists",
+                        e.message()
+                    );
+                    warned = true;
+                }
+                Err(_) => {}
+            }
+        }
+    });
+    KeepaliveGuard(handle)
+}
 
 /// Connect to a spurd agent, applying the standard gRPC size limits.
 pub async fn connect_agent(addr: &str) -> Result<SlurmAgentClient<tonic::transport::Channel>> {

--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -140,6 +140,7 @@ mock_controller_impl! {
         get_job(proto::GetJobRequest) -> proto::JobInfo;
         cancel_job(proto::CancelJobRequest) -> ();
         complete_job(proto::CompleteJobRequest) -> ();
+        job_keepalive(proto::JobKeepaliveRequest) -> proto::JobKeepaliveResponse;
         suspend_job(proto::SuspendJobRequest) -> ();
         resume_job(proto::ResumeJobRequest) -> ();
         update_job(proto::UpdateJobRequest) -> ();

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -5,8 +5,14 @@ use crate::env_defaults::{apply_csv, apply_flag, apply_str, apply_string};
 use anyhow::{Context, Result};
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
 use spur_core::spur_env::SpurEnv;
-use spur_proto::proto::{CancelJobRequest, GetJobRequest, JobSpec, SubmitJobRequest};
+use spur_proto::proto::{
+    CancelJobRequest, GetJobRequest, JobKeepaliveRequest, JobSpec, SubmitJobRequest,
+};
 use std::collections::HashMap;
+
+/// How often an interactive client pings the controller to keep its allocation
+/// attended. Must stay well below any configured `inactive_limit_secs`.
+const KEEPALIVE_INTERVAL_SECS: u64 = 30;
 
 /// Allocate resources for an interactive job.
 #[derive(Parser, Debug)]
@@ -230,6 +236,27 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     env.set_with_slurm_twin("SPUR_CPUS_PER_TASK", job_info.cpus_per_task);
     env.set_with_slurm_twin("SPUR_SUBMIT_DIR", &job_info.work_dir);
 
+    // Keep the allocation attended while the shell is open: absence of these
+    // pings past the controller's InactiveLimit is what lets it reap an
+    // abandoned allocation.
+    let keepalive = {
+        let mut client = client.clone();
+        let user = user.clone();
+        tokio::spawn(async move {
+            let mut tick =
+                tokio::time::interval(tokio::time::Duration::from_secs(KEEPALIVE_INTERVAL_SECS));
+            loop {
+                tick.tick().await;
+                let _ = client
+                    .job_keepalive(JobKeepaliveRequest {
+                        job_id,
+                        user: user.clone(),
+                    })
+                    .await;
+            }
+        })
+    };
+
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".into());
     let mut cmd = tokio::process::Command::new(&shell);
     for (k, v) in env.into_map() {
@@ -242,6 +269,8 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .status()
         .await
         .context("failed to spawn shell")?;
+
+    keepalive.abort();
 
     // Shell exited — cancel allocation
     eprintln!("salloc: Relinquishing job allocation {}", job_id);

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -5,14 +5,8 @@ use crate::env_defaults::{apply_csv, apply_flag, apply_str, apply_string};
 use anyhow::{Context, Result};
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
 use spur_core::spur_env::SpurEnv;
-use spur_proto::proto::{
-    CancelJobRequest, GetJobRequest, JobKeepaliveRequest, JobSpec, SubmitJobRequest,
-};
+use spur_proto::proto::{CancelJobRequest, GetJobRequest, JobSpec, SubmitJobRequest};
 use std::collections::HashMap;
-
-/// How often an interactive client pings the controller to keep its allocation
-/// attended. Must stay well below any configured `inactive_limit_secs`.
-const KEEPALIVE_INTERVAL_SECS: u64 = 30;
 
 /// Allocate resources for an interactive job.
 #[derive(Parser, Debug)]
@@ -238,24 +232,9 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     // Keep the allocation attended while the shell is open: absence of these
     // pings past the controller's InactiveLimit is what lets it reap an
-    // abandoned allocation.
-    let keepalive = {
-        let mut client = client.clone();
-        let user = user.clone();
-        tokio::spawn(async move {
-            let mut tick =
-                tokio::time::interval(tokio::time::Duration::from_secs(KEEPALIVE_INTERVAL_SECS));
-            loop {
-                tick.tick().await;
-                let _ = client
-                    .job_keepalive(JobKeepaliveRequest {
-                        job_id,
-                        user: user.clone(),
-                    })
-                    .await;
-            }
-        })
-    };
+    // abandoned allocation. The guard stops the pings on drop.
+    let _keepalive =
+        crate::interactive::spawn_keepalive(client.clone(), job_id, user.clone(), "salloc");
 
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".into());
     let mut cmd = tokio::process::Command::new(&shell);
@@ -270,7 +249,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .await
         .context("failed to spawn shell")?;
 
-    keepalive.abort();
+    drop(_keepalive);
 
     // Shell exited — cancel allocation
     eprintln!("salloc: Relinquishing job allocation {}", job_id);

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -500,6 +500,7 @@ mod tests {
         get_job(pb::GetJobRequest) -> pb::JobInfo;
         cancel_job(pb::CancelJobRequest) -> ();
         complete_job(pb::CompleteJobRequest) -> ();
+        job_keepalive(pb::JobKeepaliveRequest) -> pb::JobKeepaliveResponse;
         suspend_job(pb::SuspendJobRequest) -> ();
         resume_job(pb::ResumeJobRequest) -> ();
         update_job(pb::UpdateJobRequest) -> ();

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -10,8 +10,7 @@ use spur_core::config::HooksConfig;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
     CancelJobRequest, CompleteJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest,
-    JobKeepaliveRequest, JobSpec, JobState, RunStepRequest, StreamJobOutputRequest,
-    SubmitJobRequest,
+    JobSpec, JobState, RunStepRequest, StreamJobOutputRequest, SubmitJobRequest,
 };
 use std::collections::HashMap;
 use std::io::Write as _;
@@ -628,32 +627,6 @@ fn install_ctrl_c_cancel(
     })
 }
 
-/// How often srun pings the controller to keep its allocation attended. A
-/// blocking `srun <cmd>` sends no other traffic for the command's duration, so
-/// without this the InactiveLimit reaper would reclaim a live allocation.
-const KEEPALIVE_INTERVAL_SECS: u64 = 30;
-
-fn install_keepalive(
-    client: SlurmControllerClient<tonic::transport::Channel>,
-    job_id: u32,
-    user: String,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut client = client;
-        let mut tick =
-            tokio::time::interval(tokio::time::Duration::from_secs(KEEPALIVE_INTERVAL_SECS));
-        loop {
-            tick.tick().await;
-            let _ = client
-                .job_keepalive(JobKeepaliveRequest {
-                    job_id,
-                    user: user.clone(),
-                })
-                .await;
-        }
-    })
-}
-
 async fn wait_for_job_running(
     client: &mut SlurmControllerClient<tonic::transport::Channel>,
     job_id: u32,
@@ -879,7 +852,9 @@ async fn run_standalone_srun(
     eprintln!("srun: Pending job allocation {}...", job_id);
 
     let ctrl_c_handle = install_ctrl_c_cancel(client.clone(), job_id, user.clone());
-    let keepalive = install_keepalive(client.clone(), job_id, user.clone());
+    // Guard drops (and stops pinging) on every return path, including `?`.
+    let _keepalive =
+        crate::interactive::spawn_keepalive(client.clone(), job_id, user.clone(), "srun");
 
     let nodelist = wait_for_job_running(&mut client, job_id).await?;
     if !nodelist.is_empty() {
@@ -959,7 +934,6 @@ async fn run_standalone_srun(
     )
     .await;
 
-    keepalive.abort();
     Ok(())
 }
 

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -10,7 +10,8 @@ use spur_core::config::HooksConfig;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
     CancelJobRequest, CompleteJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest,
-    JobSpec, JobState, RunStepRequest, StreamJobOutputRequest, SubmitJobRequest,
+    JobKeepaliveRequest, JobSpec, JobState, RunStepRequest, StreamJobOutputRequest,
+    SubmitJobRequest,
 };
 use std::collections::HashMap;
 use std::io::Write as _;
@@ -627,6 +628,32 @@ fn install_ctrl_c_cancel(
     })
 }
 
+/// How often srun pings the controller to keep its allocation attended. A
+/// blocking `srun <cmd>` sends no other traffic for the command's duration, so
+/// without this the InactiveLimit reaper would reclaim a live allocation.
+const KEEPALIVE_INTERVAL_SECS: u64 = 30;
+
+fn install_keepalive(
+    client: SlurmControllerClient<tonic::transport::Channel>,
+    job_id: u32,
+    user: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut client = client;
+        let mut tick =
+            tokio::time::interval(tokio::time::Duration::from_secs(KEEPALIVE_INTERVAL_SECS));
+        loop {
+            tick.tick().await;
+            let _ = client
+                .job_keepalive(JobKeepaliveRequest {
+                    job_id,
+                    user: user.clone(),
+                })
+                .await;
+        }
+    })
+}
+
 async fn wait_for_job_running(
     client: &mut SlurmControllerClient<tonic::transport::Channel>,
     job_id: u32,
@@ -852,6 +879,7 @@ async fn run_standalone_srun(
     eprintln!("srun: Pending job allocation {}...", job_id);
 
     let ctrl_c_handle = install_ctrl_c_cancel(client.clone(), job_id, user.clone());
+    let keepalive = install_keepalive(client.clone(), job_id, user.clone());
 
     let nodelist = wait_for_job_running(&mut client, job_id).await?;
     if !nodelist.is_empty() {
@@ -931,6 +959,7 @@ async fn run_standalone_srun(
     )
     .await;
 
+    keepalive.abort();
     Ok(())
 }
 

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -479,6 +479,11 @@ pub struct SchedulerConfig {
     pub inactive_limit_secs: u32,
 }
 
+/// How often an interactive client (`salloc`/`srun`) pings the controller to
+/// keep its allocation attended. Shared with the CLI so `inactive_limit_secs`
+/// can be validated against it.
+pub const KEEPALIVE_INTERVAL_SECS: u64 = 30;
+
 fn default_scheduler_plugin() -> String {
     "backfill".into()
 }
@@ -1199,6 +1204,18 @@ impl SlurmConfig {
                 ),
             });
         }
+        // A limit below the client's ping interval would reap a live client
+        // between its own keepalives. Require at least two intervals of slack.
+        let inactive = self.scheduler.inactive_limit_secs;
+        if inactive > 0 && u64::from(inactive) < 2 * KEEPALIVE_INTERVAL_SECS {
+            return Err(ConfigError::InvalidValue {
+                field: "scheduler.inactive_limit_secs".into(),
+                value: format!(
+                    "{inactive} (0 disables reaping; otherwise must be >= {})",
+                    2 * KEEPALIVE_INTERVAL_SECS
+                ),
+            });
+        }
         if self.cluster.enabled {
             if self.cluster.distro != "k0s" {
                 return Err(ConfigError::InvalidValue {
@@ -1894,6 +1911,35 @@ max_batch_requeue = 7
 "#;
         let config = SlurmConfig::load_from_str(toml).unwrap();
         assert_eq!(config.controller.max_batch_requeue, 7);
+    }
+
+    #[test]
+    fn scheduler_config_rejects_inactive_limit_below_floor() {
+        let toml = r#"
+cluster_name = "test"
+
+[scheduler]
+inactive_limit_secs = 20
+"#;
+        let err = SlurmConfig::load_from_str(toml).unwrap_err();
+        assert!(
+            err.to_string().contains("inactive_limit_secs"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn scheduler_config_accepts_disabled_or_ample_inactive_limit() {
+        // 0 disables reaping and is always allowed.
+        SlurmConfig::load_from_str(
+            "cluster_name = \"test\"\n[scheduler]\ninactive_limit_secs = 0\n",
+        )
+        .expect("0 (disabled) must be accepted");
+        // A value at the floor (2x the keepalive interval) is accepted.
+        SlurmConfig::load_from_str(
+            "cluster_name = \"test\"\n[scheduler]\ninactive_limit_secs = 60\n",
+        )
+        .expect("a value at the floor must be accepted");
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -472,6 +472,11 @@ pub struct SchedulerConfig {
     /// Grace minutes after a reservation ends before cancelling its running jobs.
     #[serde(default)]
     pub resv_overrun_minutes: u32,
+    /// Reap an interactive allocation (salloc/srun) whose client has sent no
+    /// keepalive for this many seconds. `0` (the default) disables reaping, so
+    /// abandoned allocations behave as before. Mirrors Slurm's `InactiveLimit`.
+    #[serde(default)]
+    pub inactive_limit_secs: u32,
 }
 
 fn default_scheduler_plugin() -> String {
@@ -500,6 +505,7 @@ impl Default for SchedulerConfig {
             default_time_limit_minutes: 60,
             complete_wait_secs: 300,
             resv_overrun_minutes: 0,
+            inactive_limit_secs: 0,
         }
     }
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -6094,6 +6094,12 @@ mod tests {
         // allocation is no longer running) rather than reaped.
         cm.record_job_keepalive_at(1, t0);
         assert!(cm.interactive_reap_candidates(&[], t0, 0).is_empty());
+        // The prune actually happened: job 1's timer is gone, not just skipped
+        // by the disabled early return.
+        assert!(
+            cm.interactive_last_seen.read().is_empty(),
+            "pruning must drop entries for allocations no longer running"
+        );
 
         // Because the old entry was pruned, job 1 reappearing reseeds to `now`
         // and is not immediately reaped despite the original stale timestamp.

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -342,6 +342,10 @@ pub struct ClusterManager {
     /// Wake signal for the scheduler loop.
     pub(crate) scheduler_notify: Arc<Notify>,
     sched_stats: OnceLock<Arc<SchedStatsCollector>>,
+    /// Last keepalive time per interactive allocation, used by the InactiveLimit
+    /// reaper. Ephemeral soft state (like `Node::last_heartbeat`): keepalives
+    /// arrive too often to persist, and on failover the reaper reseeds lazily.
+    interactive_last_seen: RwLock<HashMap<JobId, DateTime<Utc>>>,
 }
 
 struct PendingJobClassification {
@@ -401,6 +405,7 @@ impl ClusterManager {
             association_cache,
             scheduler_notify: Arc::new(Notify::new()),
             sched_stats: OnceLock::new(),
+            interactive_last_seen: RwLock::new(HashMap::new()),
         };
 
         info!("cluster manager initialized (state will be recovered via Raft)");
@@ -1703,6 +1708,42 @@ impl ClusterManager {
         } else {
             false
         }
+    }
+
+    /// Record a keepalive from an interactive allocation's client. In-memory
+    /// soft state, mirroring `update_heartbeat`; the InactiveLimit reaper reads
+    /// it to detect an abandoned allocation.
+    pub fn record_job_keepalive(&self, job_id: JobId) {
+        self.record_job_keepalive_at(job_id, Utc::now());
+    }
+
+    fn record_job_keepalive_at(&self, job_id: JobId, at: DateTime<Utc>) {
+        self.interactive_last_seen.write().insert(job_id, at);
+    }
+
+    /// Prune the keepalive map to the given live interactive allocations and
+    /// return those idle past `limit_secs`. A missing entry is seeded to `now`
+    /// (so a just-promoted leader or a newly-seen allocation gets a full window
+    /// before it can be reaped). `limit_secs == 0` disables reaping: the map is
+    /// still pruned, but nothing is returned.
+    pub(crate) fn interactive_reap_candidates(
+        &self,
+        running_ids: &[JobId],
+        now: DateTime<Utc>,
+        limit_secs: u32,
+    ) -> Vec<JobId> {
+        let live: HashSet<JobId> = running_ids.iter().copied().collect();
+        let mut seen = self.interactive_last_seen.write();
+        seen.retain(|id, _| live.contains(id));
+        if limit_secs == 0 {
+            return Vec::new();
+        }
+        let limit = chrono::Duration::seconds(i64::from(limit_secs));
+        running_ids
+            .iter()
+            .copied()
+            .filter(|id| now - *seen.entry(*id).or_insert(now) > limit)
+            .collect()
     }
 
     /// Update a node's WireGuard mesh public key from a heartbeat when it appears or changes (mesh
@@ -6026,6 +6067,38 @@ mod tests {
             .expect("single-node raft did not self-elect within 5s");
         cm.set_raft(handle.raft);
         cm
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn interactive_reap_candidates_reaps_only_idle_allocations() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let t0 = Utc::now();
+
+        // First sighting seeds each allocation's timer; nothing is reaped yet.
+        assert!(cm.interactive_reap_candidates(&[1, 2], t0, 60).is_empty());
+
+        // Job 2 pings recently; job 1 stays silent past the limit.
+        cm.record_job_keepalive_at(2, t0 + chrono::Duration::seconds(55));
+        let later = t0 + chrono::Duration::seconds(61);
+        assert_eq!(cm.interactive_reap_candidates(&[1, 2], later, 60), vec![1]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn interactive_reap_candidates_disabled_only_prunes() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let t0 = Utc::now();
+
+        // A stale entry exists, but with the limit disabled it is pruned (the
+        // allocation is no longer running) rather than reaped.
+        cm.record_job_keepalive_at(1, t0);
+        assert!(cm.interactive_reap_candidates(&[], t0, 0).is_empty());
+
+        // Because the old entry was pruned, job 1 reappearing reseeds to `now`
+        // and is not immediately reaped despite the original stale timestamp.
+        let later = t0 + chrono::Duration::seconds(3600);
+        assert!(cm.interactive_reap_candidates(&[1], later, 60).is_empty());
     }
 
     fn basic_spec(name: &str) -> JobSpec {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1721,6 +1721,12 @@ impl ClusterManager {
         self.interactive_last_seen.write().insert(job_id, at);
     }
 
+    /// Clear keepalive last-seen on leadership (re)gain: a follower records
+    /// none, so carried-over stale entries would otherwise reap live allocations.
+    pub(crate) fn reset_interactive_last_seen(&self) {
+        self.interactive_last_seen.write().clear();
+    }
+
     #[cfg(test)]
     pub(crate) fn keepalive_last_seen(&self, job_id: JobId) -> Option<DateTime<Utc>> {
         self.interactive_last_seen.read().get(&job_id).copied()
@@ -6110,6 +6116,34 @@ mod tests {
         // and is not immediately reaped despite the original stale timestamp.
         let later = t0 + chrono::Duration::seconds(3600);
         assert!(cm.interactive_reap_candidates(&[1], later, 60).is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reset_interactive_last_seen_reseeds_on_leadership_regain() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let t0 = Utc::now();
+
+        // A prior stint's timestamp for a still-running allocation, frozen at
+        // t0 because a follower records no keepalives.
+        cm.record_job_keepalive_at(1, t0);
+
+        // On regain the stale entry is present, so seed-to-now can't correct
+        // it and the live allocation looks idle past the limit.
+        let later = t0 + chrono::Duration::seconds(3600);
+        assert_eq!(
+            cm.interactive_reap_candidates(&[1], later, 60),
+            vec![1],
+            "a stale carried-over entry would reap a live allocation"
+        );
+
+        // The reaper's follower -> leader reset clears the map, so the next
+        // check reseeds job 1 to `now` and exempts it.
+        cm.reset_interactive_last_seen();
+        assert!(
+            cm.interactive_reap_candidates(&[1], later, 60).is_empty(),
+            "after reset, a live allocation is reseeded and not reaped"
+        );
     }
 
     fn basic_spec(name: &str) -> JobSpec {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1721,6 +1721,11 @@ impl ClusterManager {
         self.interactive_last_seen.write().insert(job_id, at);
     }
 
+    #[cfg(test)]
+    pub(crate) fn keepalive_last_seen(&self, job_id: JobId) -> Option<DateTime<Utc>> {
+        self.interactive_last_seen.read().get(&job_id).copied()
+    }
+
     /// Prune the keepalive map to the given live interactive allocations and
     /// return those idle past `limit_secs`. A missing entry is seeded to `now`
     /// (so a just-promoted leader or a newly-seen allocation gets a full window

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1732,11 +1732,24 @@ async fn enforce_inactive_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHan
     // touches it); lost on restart, which merely restarts the grace.
     let mut signaled: HashMap<JobId, DateTime<Utc>> = HashMap::new();
 
+    // Neither map is tied to a leadership term, so reset them on a
+    // follower -> leader transition (below) to drop a prior stint's stale state.
+    let mut was_leader = false;
+
     loop {
         interval.tick().await;
 
         if !raft.is_leader() {
+            was_leader = false;
             continue;
+        }
+
+        if !was_leader {
+            // (Re)gained leadership: drop stale timers so the reap check below
+            // reseeds every running allocation to a full grace window.
+            signaled.clear();
+            cluster.reset_interactive_last_seen();
+            was_leader = true;
         }
 
         let limit_secs = cluster.config().scheduler.inactive_limit_secs;

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -56,6 +56,11 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
     tokio::spawn(async move {
         manage_power(power_cluster, power_raft).await;
     });
+    let inactive_cluster = cluster.clone();
+    let inactive_raft = raft.clone();
+    tokio::spawn(async move {
+        enforce_inactive_limits(inactive_cluster, inactive_raft).await;
+    });
     // Captured once at loop start: the tick interval, per-cycle job cap, and
     // topology tree are baked into loop-local state and are NOT picked up by
     // `scontrol reconfigure` — changing them needs a controller restart.
@@ -1703,6 +1708,60 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
             if let Err(e) = cluster.complete_job(job.job_id, -1, spur_core::job::JobState::Timeout)
             {
                 warn!(job_id = job.job_id, error = %e, "failed to mark job as timed out");
+                continue;
+            }
+
+            send_cancel_to_agents(&cluster, job, 9).await; // SIGKILL
+        }
+    }
+}
+
+/// Reap interactive allocations (salloc/srun) whose client stopped sending
+/// keepalives, mirroring Slurm's `InactiveLimit`. Finalizes via the same
+/// TIMEOUT path as wall-time expiry. Disabled when `inactive_limit_secs == 0`
+/// (the reaper still runs, only to prune the keepalive map).
+async fn enforce_inactive_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
+
+    loop {
+        interval.tick().await;
+
+        if !raft.is_leader() {
+            continue;
+        }
+
+        let limit_secs = cluster.config().scheduler.inactive_limit_secs;
+        let now = Utc::now();
+
+        let running: Vec<_> = cluster
+            .get_jobs(
+                &[spur_core::job::JobState::Running],
+                None,
+                None,
+                None,
+                None,
+                &[],
+            )
+            .into_iter()
+            .filter(|j| j.spec.interactive || j.spec.srun_job)
+            .collect();
+        let ids: Vec<spur_core::job::JobId> = running.iter().map(|j| j.job_id).collect();
+
+        // Prunes the keepalive map every tick; returns candidates only when
+        // the limit is enabled.
+        let stale = cluster.interactive_reap_candidates(&ids, now, limit_secs);
+        for job_id in stale {
+            let Some(job) = running.iter().find(|j| j.job_id == job_id) else {
+                continue;
+            };
+
+            info!(
+                job_id,
+                limit_secs, "interactive allocation idle past InactiveLimit — reaping"
+            );
+
+            if let Err(e) = cluster.complete_job(job_id, -1, spur_core::job::JobState::Timeout) {
+                warn!(job_id, error = %e, "failed to reap inactive allocation");
                 continue;
             }
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use tracing::{debug, error, info, warn};
 
 use spur_core::node::{Node, NodeSource};
@@ -1717,11 +1717,19 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
 }
 
 /// Reap interactive allocations (salloc/srun) whose client stopped sending
-/// keepalives, mirroring Slurm's `InactiveLimit`. Finalizes via the same
-/// TIMEOUT path as wall-time expiry. Disabled when `inactive_limit_secs == 0`
-/// (the reaper still runs, only to prune the keepalive map).
+/// keepalives, mirroring Slurm's `InactiveLimit`. Idle allocations get a
+/// SIGTERM -> grace -> SIGKILL sequence (like `enforce_time_limits`) and are
+/// finalized via the TIMEOUT path. Disabled when `inactive_limit_secs == 0`.
 async fn enforce_inactive_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
+    use spur_core::job::{JobId, JobState};
+
+    const GRACE_PERIOD_SECS: i64 = 30;
     let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
+
+    // Jobs that were sent SIGTERM and are in their grace window, keyed by
+    // job id -> when SIGTERM was sent. Local to this task (only the reaper
+    // touches it); lost on restart, which merely restarts the grace.
+    let mut signaled: HashMap<JobId, DateTime<Utc>> = HashMap::new();
 
     loop {
         interval.tick().await;
@@ -1734,38 +1742,69 @@ async fn enforce_inactive_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHan
         let now = Utc::now();
 
         let running: Vec<_> = cluster
-            .get_jobs(
-                &[spur_core::job::JobState::Running],
-                None,
-                None,
-                None,
-                None,
-                &[],
-            )
+            .get_jobs(&[JobState::Running], None, None, None, None, &[])
             .into_iter()
             .filter(|j| j.spec.interactive || j.spec.srun_job)
             .collect();
-        let ids: Vec<spur_core::job::JobId> = running.iter().map(|j| j.job_id).collect();
+        let ids: Vec<JobId> = running.iter().map(|j| j.job_id).collect();
 
         // Prunes the keepalive map every tick; returns candidates only when
         // the limit is enabled.
         let stale = cluster.interactive_reap_candidates(&ids, now, limit_secs);
+        let stale_set: HashSet<JobId> = stale.iter().copied().collect();
+        // Drop grace timers for jobs that recovered (pinged again) or are gone,
+        // so a client that comes back during the grace aborts the kill.
+        signaled.retain(|id, _| stale_set.contains(id));
+
+        let by_id: HashMap<JobId, &spur_core::job::Job> =
+            running.iter().map(|j| (j.job_id, j)).collect();
+
         for job_id in stale {
-            let Some(job) = running.iter().find(|j| j.job_id == job_id) else {
+            let Some(job) = by_id.get(&job_id) else {
                 continue;
             };
 
-            info!(
-                job_id,
-                limit_secs, "interactive allocation idle past InactiveLimit — reaping"
-            );
+            match signaled.get(&job_id) {
+                None => {
+                    info!(
+                        job_id,
+                        limit_secs,
+                        grace_secs = GRACE_PERIOD_SECS,
+                        "interactive allocation idle past InactiveLimit — sending SIGTERM, grace period starts"
+                    );
+                    send_cancel_to_agents(&cluster, job, 15).await; // SIGTERM
+                    signaled.insert(job_id, now);
+                }
+                Some(signaled_at) if (now - *signaled_at).num_seconds() < GRACE_PERIOD_SECS => {}
+                Some(_) => {
+                    // Re-fetch before finalizing: if the job was requeued and
+                    // redispatched as a new run under the same id since the
+                    // snapshot, `complete_job`'s terminal-state guard would not
+                    // catch it and the SIGKILL could hit the new run.
+                    let Some(fresh) = cluster.get_job(job_id) else {
+                        signaled.remove(&job_id);
+                        continue;
+                    };
+                    if fresh.state != JobState::Running || fresh.run_attempt != job.run_attempt {
+                        signaled.remove(&job_id);
+                        continue;
+                    }
 
-            if let Err(e) = cluster.complete_job(job_id, -1, spur_core::job::JobState::Timeout) {
-                warn!(job_id, error = %e, "failed to reap inactive allocation");
-                continue;
+                    info!(
+                        job_id,
+                        "InactiveLimit grace expired — force-killing allocation"
+                    );
+
+                    if let Err(e) = cluster.complete_job(job_id, -1, JobState::Timeout) {
+                        warn!(job_id, error = %e, "failed to reap inactive allocation");
+                        continue;
+                    }
+
+                    // SIGKILL on the run's current nodes, not the stale snapshot.
+                    send_cancel_to_nodes(&cluster, job_id, &fresh.allocated_nodes, 9).await;
+                    signaled.remove(&job_id);
+                }
             }
-
-            send_cancel_to_agents(&cluster, job, 9).await; // SIGKILL
         }
     }
 }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -29,6 +29,10 @@ use crate::raft::RaftHandle;
 /// unreachable agent.
 const CANCEL_RPC_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Grace between SIGTERM and SIGKILL when force-finishing a job. The time-limit
+/// and inactive-limit watchdogs share it so the two windows can't drift apart.
+const GRACE_PERIOD_SECS: i64 = 30;
+
 fn node_comm_socket(node: &Node) -> Option<String> {
     let host = node.comm_addr()?;
     Some(spur_net::format_comm_socket(host, node.port))
@@ -1617,8 +1621,6 @@ async fn confirm_dispatch_on_nodes(
 ///
 /// Runs every 10 seconds.
 async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
-    const GRACE_PERIOD_SECS: i64 = 30;
-
     let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
 
     loop {
@@ -1723,7 +1725,6 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
 async fn enforce_inactive_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
     use spur_core::job::{JobId, JobState};
 
-    const GRACE_PERIOD_SECS: i64 = 30;
     let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
 
     // Jobs that were sent SIGTERM and are in their grace window, keyed by

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -624,12 +624,25 @@ impl SlurmController for ControllerService {
         }
 
         let req = request.into_inner();
+        // A real keepalive always carries the caller's username. Reject an empty
+        // one explicitly: `check_job_owner` treats empty as authorized, which
+        // would let anyone hold any allocation open forever.
+        if req.user.is_empty() {
+            return Err(Status::permission_denied(
+                "keepalive requires a user".to_string(),
+            ));
+        }
         let job = self
             .cluster
             .get_job(req.job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", req.job_id)))?;
         spur_core::auth::check_job_owner(&req.user, &job.spec.user, "send keepalive for")
             .map_err(|e| Status::permission_denied(e.to_string()))?;
+
+        // Only interactive allocations are reaped, so only they need tracking.
+        if !(job.spec.interactive || job.spec.srun_job) {
+            return Ok(Response::new(JobKeepaliveResponse {}));
+        }
 
         self.cluster.record_job_keepalive(req.job_id);
         Ok(Response::new(JobKeepaliveResponse {}))
@@ -4026,6 +4039,56 @@ mod tests {
             }))
             .await
             .expect_err("empty-owner jobs run as root; non-root must be denied");
+
+        assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn job_keepalive_rejects_unknown_job() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+
+        let err = svc
+            .job_keepalive(Request::new(JobKeepaliveRequest {
+                job_id: 999_999,
+                user: "ubuntu".into(),
+            }))
+            .await
+            .expect_err("keepalive for a nonexistent job must fail");
+
+        assert_eq!(err.code(), Code::NotFound);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn job_keepalive_denies_non_owner() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        let err = svc
+            .job_keepalive(Request::new(JobKeepaliveRequest {
+                job_id,
+                user: "rsikande".into(),
+            }))
+            .await
+            .expect_err("a non-owner must not keep another user's allocation alive");
+
+        assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn job_keepalive_rejects_empty_user() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        let err = svc
+            .job_keepalive(Request::new(JobKeepaliveRequest {
+                job_id,
+                user: String::new(),
+            }))
+            .await
+            .expect_err("an empty user must be rejected, not treated as authorized");
 
         assert_eq!(err.code(), Code::PermissionDenied);
     }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -3952,6 +3952,20 @@ mod tests {
 
     /// Submit and start a single-node job owned by `owner`, returning its id.
     async fn running_job_owned_by(svc: &ControllerService, owner: &str) -> u32 {
+        running_job_owned_by_inner(svc, owner, false).await
+    }
+
+    /// Like `running_job_owned_by`, but flags the job as interactive so the
+    /// keepalive handler treats it as reapable (and thus records last-seen).
+    async fn running_interactive_job_owned_by(svc: &ControllerService, owner: &str) -> u32 {
+        running_job_owned_by_inner(svc, owner, true).await
+    }
+
+    async fn running_job_owned_by_inner(
+        svc: &ControllerService,
+        owner: &str,
+        interactive: bool,
+    ) -> u32 {
         use spur_core::resource::{ResourceAllocations, ResourceSet};
 
         svc.cluster
@@ -3985,6 +3999,7 @@ mod tests {
             num_tasks: 1,
             cpus_per_task: 1,
             work_dir: "/tmp".into(),
+            interactive,
             ..Default::default()
         };
         let job_id = svc.cluster.submit_job(spec).unwrap().job_id;
@@ -4091,6 +4106,49 @@ mod tests {
             .expect_err("an empty user must be rejected, not treated as authorized");
 
         assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn job_keepalive_records_interactive() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_interactive_job_owned_by(&svc, "ubuntu").await;
+
+        assert!(
+            svc.cluster.keepalive_last_seen(job_id).is_none(),
+            "no keepalive recorded before the RPC"
+        );
+
+        svc.job_keepalive(Request::new(JobKeepaliveRequest {
+            job_id,
+            user: "ubuntu".into(),
+        }))
+        .await
+        .expect("owner keepalive on an interactive job must succeed");
+
+        assert!(
+            svc.cluster.keepalive_last_seen(job_id).is_some(),
+            "a successful keepalive must record last-seen for the reaper"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn job_keepalive_skips_non_interactive() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        svc.job_keepalive(Request::new(JobKeepaliveRequest {
+            job_id,
+            user: "ubuntu".into(),
+        }))
+        .await
+        .expect("keepalive on a non-interactive job must not error");
+
+        assert!(
+            svc.cluster.keepalive_last_seen(job_id).is_none(),
+            "a non-interactive job must not be tracked for reaping"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -603,6 +603,38 @@ impl SlurmController for ControllerService {
         Ok(Response::new(()))
     }
 
+    async fn job_keepalive(
+        &self,
+        request: Request<JobKeepaliveRequest>,
+    ) -> Result<Response<JobKeepaliveResponse>, Status> {
+        // Recorded only on the leader, where the reaper reads it.
+        if let Err(status) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            match proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut fwd = Request::new(request.into_inner());
+                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    return client.job_keepalive(fwd).await;
+                }
+                Err(e) => {
+                    warn!("failed to forward job_keepalive to leader: {e}");
+                    return Err(status);
+                }
+            }
+        }
+
+        let req = request.into_inner();
+        let job = self
+            .cluster
+            .get_job(req.job_id)
+            .ok_or_else(|| Status::not_found(format!("job {} not found", req.job_id)))?;
+        spur_core::auth::check_job_owner(&req.user, &job.spec.user, "send keepalive for")
+            .map_err(|e| Status::permission_denied(e.to_string()))?;
+
+        self.cluster.record_job_keepalive(req.job_id);
+        Ok(Response::new(JobKeepaliveResponse {}))
+    }
+
     async fn suspend_job(
         &self,
         request: Request<SuspendJobRequest>,

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -247,8 +247,13 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
      - integer
      - ``0``
      - Reap an interactive allocation (``salloc``/``srun``) whose client has sent
-       no keepalive for this many seconds, freeing the nodes. ``0`` disables
-       reaping. Mirrors Slurm's ``InactiveLimit``.
+       no keepalive for this many seconds, freeing the nodes. ``0`` (the default)
+       disables reaping. Mirrors Slurm's ``InactiveLimit``. Once enabled, *every*
+       interactive allocation is subject to reaping regardless of client version:
+       a client too old to send keepalives is reaped once idle past the limit, so
+       upgrade all ``spur`` CLI clients before enabling this. Must be at least
+       twice the client keepalive interval (60 seconds); smaller non-zero values
+       are rejected at startup so a live client is never reaped between pings.
    * - ``resv_overrun_minutes``
      - integer
      - ``0``

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -243,6 +243,12 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
      - integer
      - ``300``
      - Maximum seconds a job may sit in COMPLETING before it is force-finished.
+   * - ``inactive_limit_secs``
+     - integer
+     - ``0``
+     - Reap an interactive allocation (``salloc``/``srun``) whose client has sent
+       no keepalive for this many seconds, freeing the nodes. ``0`` disables
+       reaping. Mirrors Slurm's ``InactiveLimit``.
    * - ``resv_overrun_minutes``
      - integer
      - ``0``

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -310,6 +310,8 @@ service SlurmController {
   rpc CancelJob(CancelJobRequest) returns (google.protobuf.Empty);
   // Finish a standalone srun allocation after its step completes.
   rpc CompleteJob(CompleteJobRequest) returns (google.protobuf.Empty);
+  // Keepalive from an interactive client so an abandoned allocation can be reaped.
+  rpc JobKeepalive(JobKeepaliveRequest) returns (JobKeepaliveResponse);
   rpc SuspendJob(SuspendJobRequest) returns (google.protobuf.Empty);
   rpc ResumeJob(ResumeJobRequest) returns (google.protobuf.Empty);
   rpc UpdateJob(UpdateJobRequest) returns (google.protobuf.Empty);
@@ -495,6 +497,15 @@ message CompleteJobRequest {
   int32 exit_code = 2;
   string user = 3;   // For authorization
 }
+
+// Liveness ping from an interactive client (salloc/srun) so the controller
+// knows the allocation is still attended. Absence past InactiveLimit reaps it.
+message JobKeepaliveRequest {
+  uint32 job_id = 1;
+  string user = 2;   // For authorization (owner or root required).
+}
+
+message JobKeepaliveResponse {}
 
 message SuspendJobRequest {
   uint32 job_id = 1;


### PR DESCRIPTION
## What

Interactive allocations (`salloc`/`srun`) that lose their client (crash, network drop, closed laptop) previously stayed `RUNNING` forever, holding compute nodes indefinitely. This adds opt-in reaping modeled on Slurm's `InactiveLimit`.

Part of SPUR-122 (walltime/limit enforcement). Independent of [#593](https://github.com/ROCm/spur/pull/593) (partition walltime limits), which is the other half of the same effort. Both branch off `main` and touch `config.rs`/`configuration.rst` in non-overlapping spots.

## Approach

- **Client keepalive**: new `JobKeepalive` RPC on `SlurmController`. `salloc` and `srun` send it every 30s while they hold an allocation, then stop when the shell/step exits.
- **Ephemeral last-seen state**: the controller records the last keepalive time per interactive job in an in-memory map on `ClusterManager`. Never persisted to Raft/WAL (mirrors `Node::last_heartbeat`), so no log spam and no snapshot growth.
- **Leader-gated reaper**: a periodic task (10s cadence, same as time-limit enforcement) finalizes any interactive allocation idle past `scheduler.inactive_limit_secs`. It reuses the existing TIMEOUT path (`complete_job(.., Timeout)` + SIGKILL to agents) instead of a raw cancel, inheriting epoch gating and sidestepping the requeue race.
- **Failover-safe**: a newly promoted leader seeds each running allocation's last-seen to \"now\", giving clients a grace period to re-ping before they can be reaped.

## Backward compatibility

`inactive_limit_secs` defaults to `0` (disabled). No behavior change on upgrade. Reaping requires both the config knob set and keepalive-capable clients. Proto change is purely additive (new messages + RPC, no renumbering).

## Example

```toml
# spur.conf
[scheduler]
inactive_limit_secs = 60
```

1. `srun --pty bash` → allocation goes `RUNNING`, client pings every 30s.
2. Client stays alive (or user is actively working): allocation is never reaped.
3. Client dies / connection drops: no more keepalives.
4. After 60s of silence the reaper logs `interactive allocation idle past InactiveLimit — reaping`, finalizes the job as `TIMEOUT`, SIGKILLs any step on the node, and the node returns to idle.

## Testing

- Unit tests for the reaper predicate (reaps only idle allocations; disabled mode only prunes state).
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` clean.
- `cargo test --locked` green (610 spurctld, 455 spur-core).
- Bare-metal 4-node cluster:
  - Attended `srun sleep 600` survived well past the 60s limit (keepalives kept it alive).
  - Abandoned allocation (client killed) was reaped to `TIMEOUT` and the node freed.
  - With default `inactive_limit_secs = 0`, an abandoned allocation stayed `RUNNING` (confirms non-breaking default).