### PR TITLE
fix(srun): honor step node selection

### DIFF
--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -31,6 +31,8 @@ pub(crate) const MOCK_EXIT_CODE: i32 = 7;
 #[derive(Clone, Default)]
 pub(crate) struct StepCapture {
     create_step_num_tasks: Arc<AtomicU32>,
+    create_step_num_nodes: Arc<Mutex<Option<u32>>>,
+    create_step_node: Arc<Mutex<String>>,
     run_step_step_id: Arc<AtomicU32>,
     run_step_calls: Arc<AtomicU32>,
     update_node_names: Arc<Mutex<Vec<String>>>,
@@ -42,6 +44,14 @@ impl StepCapture {
     /// Task count carried by the most recent `CreateJobStep`.
     pub(crate) fn create_step_num_tasks(&self) -> u32 {
         self.create_step_num_tasks.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn create_step_num_nodes(&self) -> Option<u32> {
+        *self.create_step_num_nodes.lock().unwrap()
+    }
+
+    pub(crate) fn create_step_node(&self) -> String {
+        self.create_step_node.lock().unwrap().clone()
     }
 
     /// Step id carried by the most recent `RunStep`.
@@ -97,12 +107,16 @@ mock_controller_impl! {
             &self,
             request: tonic::Request<proto::CreateJobStepRequest>,
         ) -> Result<tonic::Response<proto::CreateJobStepResponse>, tonic::Status> {
+            let request = request.into_inner();
             self.capture
                 .create_step_num_tasks
-                .store(request.into_inner().num_tasks, Ordering::SeqCst);
+                .store(request.num_tasks, Ordering::SeqCst);
+            *self.capture.create_step_num_nodes.lock().unwrap() = request.num_nodes;
+            *self.capture.create_step_node.lock().unwrap() = request.node;
             Ok(tonic::Response::new(proto::CreateJobStepResponse {
                 step_id: MOCK_STEP_ID,
                 node_addr: String::new(),
+                warnings: Vec::new(),
             }))
         }
 

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -522,8 +522,7 @@ struct StepLayout {
 }
 
 fn resolve_step_layout(matches: &ArgMatches, args: &SrunArgs) -> StepLayout {
-    let node_count_requested = was_cli_set(matches, "nodes")
-        || crate::env_defaults::env_first(NODE_COUNT_ENV_NAMES).is_some();
+    let node_count_requested = was_cli_set(matches, "nodes");
     StepLayout {
         num_tasks: crate::sbatch::effective_ntasks(args.ntasks, args.ntasks_per_node, args.nodes),
         num_nodes: node_count_requested.then_some(args.nodes),

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -15,6 +15,15 @@ use spur_proto::proto::{
 use std::collections::HashMap;
 use std::io::Write as _;
 
+const NODE_COUNT_ENV_NAMES: &[&str] = &[
+    "SPUR_JOB_NUM_NODES",
+    "SPUR_NNODES",
+    "SLURM_JOB_NUM_NODES",
+    "SLURM_NNODES",
+];
+const TASK_COUNT_ENV_NAMES: &[&str] =
+    &["SPUR_NTASKS", "SPUR_NPROCS", "SLURM_NTASKS", "SLURM_NPROCS"];
+
 /// Run a parallel job (interactive or allocation-based).
 #[derive(Parser, Debug)]
 #[command(name = "srun", about = "Run a parallel job")]
@@ -212,6 +221,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let mut args = SrunArgs::from_arg_matches(&matches)?;
     resolve_srun_env(&matches, &mut args)?;
     args.nodelist = crate::nodelist::resolve(args.nodelist.take(), args.nodefile.take())?;
+    let step_layout = resolve_step_layout(&matches, &args);
 
     // --jobid --overlap: exec into a running job (interactive PTY session)
     if let Some(job_id) = args.jobid {
@@ -268,7 +278,15 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     // Step mode: if running inside an allocation, create a step instead of a new job
     if let Ok(parent_job_id) = std::env::var("SPUR_JOB_ID") {
         if let Ok(job_id) = parent_job_id.parse::<u32>() {
-            return run_as_step(&args, job_id, &hooks, &work_dir, &resolved_mpi).await;
+            return run_as_step(
+                &args,
+                job_id,
+                &hooks,
+                &work_dir,
+                &resolved_mpi,
+                &step_layout,
+            )
+            .await;
         }
     }
 
@@ -293,6 +311,10 @@ fn resolve_srun_mpi(args: &SrunArgs, matches: &ArgMatches, step_mode: bool) -> R
 /// allocation's output vars), a few read genuine `SRUN_*`, and each also
 /// accepts its `SPUR_*` native twin. CLI always overrides env.
 fn resolve_srun_env(matches: &ArgMatches, args: &mut SrunArgs) -> Result<()> {
+    let nodes_from_env = !was_cli_set(matches, "nodes")
+        && crate::env_defaults::env_first(NODE_COUNT_ENV_NAMES).is_some();
+    let ntasks_from_env = !was_cli_set(matches, "ntasks")
+        && crate::env_defaults::env_first(TASK_COUNT_ENV_NAMES).is_some();
     apply_str(
         matches,
         "job_name",
@@ -327,23 +349,8 @@ fn resolve_srun_env(matches: &ArgMatches, args: &mut SrunArgs) -> Result<()> {
         &["SPUR_QOS", "SPUR_JOB_QOS", "SLURM_QOS", "SLURM_JOB_QOS"],
         &mut args.qos,
     );
-    apply_num(
-        matches,
-        "nodes",
-        &[
-            "SPUR_NNODES",
-            "SPUR_JOB_NUM_NODES",
-            "SLURM_NNODES",
-            "SLURM_JOB_NUM_NODES",
-        ],
-        &mut args.nodes,
-    )?;
-    apply_num_opt(
-        matches,
-        "ntasks",
-        &["SPUR_NTASKS", "SPUR_NPROCS", "SLURM_NTASKS", "SLURM_NPROCS"],
-        &mut args.ntasks,
-    )?;
+    apply_num(matches, "nodes", NODE_COUNT_ENV_NAMES, &mut args.nodes)?;
+    apply_num_opt(matches, "ntasks", TASK_COUNT_ENV_NAMES, &mut args.ntasks)?;
     apply_num(
         matches,
         "cpus_per_task",
@@ -470,6 +477,10 @@ fn resolve_srun_env(matches: &ArgMatches, args: &mut SrunArgs) -> Result<()> {
         &mut args.epilog,
     );
 
+    if args.ntasks_per_node.is_some_and(|tasks| tasks > 0) && ntasks_from_env && !nodes_from_env {
+        args.ntasks = None;
+    }
+
     Ok(())
 }
 
@@ -501,6 +512,23 @@ fn resolve_io_paths(args: &SrunArgs) -> ResolvedIoPaths {
 #[derive(Debug)]
 struct StepDispatchResult {
     exit_code: i32,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StepLayout {
+    num_tasks: u32,
+    num_nodes: Option<u32>,
+    node: String,
+}
+
+fn resolve_step_layout(matches: &ArgMatches, args: &SrunArgs) -> StepLayout {
+    let node_count_requested = was_cli_set(matches, "nodes")
+        || crate::env_defaults::env_first(NODE_COUNT_ENV_NAMES).is_some();
+    StepLayout {
+        num_tasks: crate::sbatch::effective_ntasks(args.ntasks, args.ntasks_per_node, args.nodes),
+        num_nodes: node_count_requested.then_some(args.nodes),
+        node: args.nodelist.clone().unwrap_or_default(),
+    }
 }
 
 fn srun_dispatch_environment(args: &SrunArgs) -> HashMap<String, String> {
@@ -701,6 +729,7 @@ async fn emit_step_output(
 
 struct StepDispatchParams<'a> {
     args: &'a SrunArgs,
+    layout: &'a StepLayout,
     work_dir: &'a str,
     io: &'a ResolvedIoPaths,
     mpi: &'a str,
@@ -715,8 +744,8 @@ async fn dispatch_step(
     let work_dir = params.work_dir;
     let io = params.io;
     let step_mpi = params.mpi;
-    let ntasks = crate::sbatch::effective_ntasks(args.ntasks, args.ntasks_per_node, args.nodes);
-    let step_id = client
+    let ntasks = params.layout.num_tasks;
+    let step = client
         .create_job_step(CreateJobStepRequest {
             job_id,
             command: args.command.clone(),
@@ -725,13 +754,17 @@ async fn dispatch_step(
             overlap: false,
             pty: false,
             winsize: None,
-            node: String::new(),
+            node: params.layout.node.clone(),
             user: crate::interactive::current_user(),
+            num_nodes: params.layout.num_nodes,
         })
         .await
         .context("failed to create job step")?
-        .into_inner()
-        .step_id;
+        .into_inner();
+    for warning in &step.warnings {
+        eprintln!("srun: warning: {warning}");
+    }
+    let step_id = step.step_id;
 
     if args.input.is_some() {
         eprintln!("srun: warning: --input is not supported in step mode, ignoring");
@@ -885,8 +918,14 @@ async fn run_standalone_srun(
         .into_inner();
 
     if job.srun_step_dispatch {
+        let allocation_layout = StepLayout {
+            num_tasks: job.num_tasks.max(1),
+            num_nodes: None,
+            node: String::new(),
+        };
         let step_params = StepDispatchParams {
             args,
+            layout: &allocation_layout,
             work_dir,
             io: &io,
             mpi,
@@ -1225,6 +1264,7 @@ async fn run_interactive_pty(
                     winsize: Some(winsize),
                     node: node.clone(),
                     user: crate::interactive::current_user(),
+                    num_nodes: None,
                 })
                 .await
             {
@@ -1296,6 +1336,7 @@ async fn run_as_step(
     hooks: &HooksConfig,
     work_dir: &str,
     step_mpi: &str,
+    step_layout: &StepLayout,
 ) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
@@ -1310,6 +1351,7 @@ async fn run_as_step(
 
     let step_params = StepDispatchParams {
         args,
+        layout: step_layout,
         work_dir,
         io: &io,
         mpi: step_mpi,
@@ -1842,9 +1884,9 @@ mod tests {
         env.set("SLURM_JOB_NUM_NODES", "3");
         assert_eq!(resolve_from(&["srun", "hostname"]).nodes, 3);
 
-        // SLURM_NNODES is listed before SLURM_JOB_NUM_NODES, so it wins.
+        // The allocation-scoped name wins over the legacy step-scoped alias.
         env.set("SLURM_NNODES", "5");
-        assert_eq!(resolve_from(&["srun", "hostname"]).nodes, 5);
+        assert_eq!(resolve_from(&["srun", "hostname"]).nodes, 3);
     }
 
     #[test]
@@ -2057,8 +2099,8 @@ mod tests {
             3
         );
 
-        // An inherited allocation task count is a direct request, so it wins
-        // over the per-node derivation.
+        // Slurm discards an inherited task count when an explicit node count
+        // and tasks-per-node together fully size the step.
         env.set("SLURM_NTASKS", "5");
         let inherited = resolve_from(&["srun", "-N", "4", "--ntasks-per-node=8", "hostname"]);
         assert_eq!(
@@ -2066,6 +2108,18 @@ mod tests {
                 inherited.ntasks,
                 inherited.ntasks_per_node,
                 inherited.nodes
+            ),
+            32
+        );
+
+        // An inherited node count keeps the inherited task count authoritative.
+        env.set("SLURM_JOB_NUM_NODES", "4");
+        let inherited_both = resolve_from(&["srun", "--ntasks-per-node=8", "hostname"]);
+        assert_eq!(
+            crate::sbatch::effective_ntasks(
+                inherited_both.ntasks,
+                inherited_both.ntasks_per_node,
+                inherited_both.nodes
             ),
             5
         );
@@ -2106,10 +2160,17 @@ mod tests {
         client: &mut SlurmControllerClient<tonic::transport::Channel>,
         cli: &[&str],
     ) -> Result<StepDispatchResult> {
-        let args = SrunArgs::try_parse_from(cli).expect("parse failed");
+        let matches = SrunArgs::command()
+            .try_get_matches_from(cli)
+            .expect("parse failed");
+        let mut args = SrunArgs::from_arg_matches(&matches).expect("from_arg_matches failed");
+        resolve_srun_env(&matches, &mut args).expect("resolve failed");
+        args.nodelist = crate::nodelist::resolve(args.nodelist.take(), args.nodefile.take())?;
+        let layout = resolve_step_layout(&matches, &args);
         let io = empty_io();
         let params = StepDispatchParams {
             args: &args,
+            layout: &layout,
             work_dir: "/tmp",
             io: &io,
             mpi: spur_core::mpi::MPI_NONE,
@@ -2130,6 +2191,7 @@ mod tests {
             .expect("dispatch should succeed");
 
         assert_eq!(capture.create_step_num_tasks(), 3);
+        assert_eq!(capture.create_step_num_nodes(), Some(3));
         assert_eq!(capture.run_step_calls(), 1);
         assert_eq!(
             capture.run_step_step_id(),
@@ -2151,6 +2213,56 @@ mod tests {
             .expect("dispatch should succeed");
 
         assert_eq!(capture.create_step_num_tasks(), 2);
+        assert_eq!(capture.create_step_num_nodes(), Some(3));
+    }
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn dispatch_step_keeps_inherited_tasks_when_nodes_are_overridden() {
+        let env = EnvGuard::new();
+        env.set("SPUR_NTASKS", "2");
+        env.set("SPUR_JOB_NUM_NODES", "2");
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        let mut client = crate::mock_controller::client(addr).await;
+
+        dispatch_with(&mut client, &["srun", "-N", "1", "hostname"])
+            .await
+            .expect("dispatch should succeed");
+
+        assert_eq!(capture.create_step_num_tasks(), 2);
+        assert_eq!(capture.create_step_num_nodes(), Some(1));
+    }
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn dispatch_step_forwards_requested_nodelist() {
+        let _env = EnvGuard::new();
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        let mut client = crate::mock_controller::client(addr).await;
+
+        dispatch_with(
+            &mut client,
+            &["srun", "-N", "2", "-w", "node[002-003]", "hostname"],
+        )
+        .await
+        .expect("dispatch should succeed");
+
+        assert_eq!(capture.create_step_num_nodes(), Some(2));
+        assert_eq!(capture.create_step_node(), "node[002-003]");
+    }
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn dispatch_step_leaves_unspecified_node_count_unset() {
+        let _env = EnvGuard::new();
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        let mut client = crate::mock_controller::client(addr).await;
+
+        dispatch_with(&mut client, &["srun", "hostname"])
+            .await
+            .expect("dispatch should succeed");
+
+        assert_eq!(capture.create_step_num_nodes(), None);
     }
 
     /// The per-node default feeds cpu-bind validation, so a `map_cpu` list

--- a/crates/spur-core/src/spur_env.rs
+++ b/crates/spur-core/src/spur_env.rs
@@ -73,6 +73,7 @@ impl SpurEnv {
         step_num_tasks: u32,
         node_id: u32,
         num_nodes: u32,
+        job_num_nodes: u32,
     ) {
         senv.set_with_slurm_twin("SPUR_STEP_ID", step_id);
         senv.set_with_slurm_twin("SPUR_STEPID", step_id);
@@ -81,7 +82,8 @@ impl SpurEnv {
         senv.set_with_slurm_twin("SPUR_NPROCS", step_num_tasks);
         senv.set_with_slurm_twin("SPUR_NODEID", node_id);
         senv.set_with_slurm_twin("SPUR_NNODES", num_nodes);
-        senv.set_with_slurm_twin("SPUR_JOB_NUM_NODES", num_nodes);
+        senv.set_with_slurm_twin("SPUR_STEP_NUM_NODES", num_nodes);
+        senv.set_with_slurm_twin("SPUR_JOB_NUM_NODES", job_num_nodes);
         senv.set_with_slurm_twin("SPUR_JOB_ID", job_id);
         senv.set_with_slurm_twin("SPUR_JOBID", job_id);
     }
@@ -219,7 +221,7 @@ mod tests {
     #[test]
     fn apply_step_scope_sets_step_id_twins() {
         let mut env = SpurEnv::new();
-        SpurEnv::apply_step_scope(&mut env, 42, 3, 8, 1, 2);
+        SpurEnv::apply_step_scope(&mut env, 42, 3, 8, 1, 2, 4);
         let map = env.into_map();
         assert_eq!(map["SPUR_STEP_ID"], "3");
         assert_eq!(map["SLURM_STEP_ID"], "3");
@@ -227,5 +229,7 @@ mod tests {
         assert_eq!(map["SLURM_NTASKS"], "8");
         assert_eq!(map["SPUR_NODEID"], "1");
         assert_eq!(map["SPUR_NNODES"], "2");
+        assert_eq!(map["SPUR_STEP_NUM_NODES"], "2");
+        assert_eq!(map["SPUR_JOB_NUM_NODES"], "4");
     }
 }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1454,16 +1454,26 @@ impl SlurmController for ControllerService {
             )));
         }
 
-        let target_node =
-            select_step_node(&job.allocated_nodes, &req.node).map_err(Status::invalid_argument)?;
+        let selection = select_step_nodes(
+            &job.allocated_nodes,
+            req.num_nodes,
+            &req.node,
+            req.num_tasks,
+        )
+        .map_err(Status::invalid_argument)?;
+        let target_node = selection
+            .nodes
+            .first()
+            .ok_or_else(|| Status::internal("step node selection returned no nodes"))?
+            .clone();
 
         // Resolve the target agent address BEFORE creating the step: an unregistered node returns a
         // retryable Unavailable and the client retries the whole call, so resolving first keeps a
         // failed attempt from leaking a step per retry.
-        let node = self.cluster.get_node(target_node).ok_or_else(|| {
+        let node = self.cluster.get_node(&target_node).ok_or_else(|| {
             Status::unavailable(format!("node {target_node} is not currently registered"))
         })?;
-        let node_addr = node_comm_socket(&node, target_node)?;
+        let node_addr = node_comm_socket(&node, &target_node)?;
 
         let existing_steps = self.cluster.get_steps(job_id);
         let step_id = existing_steps
@@ -1479,7 +1489,7 @@ impl SlurmController for ControllerService {
             num_tasks: req.num_tasks.max(1),
             cpus_per_task: req.cpus_per_task.max(1),
             resources: spur_core::resource::ResourceAllocations::default(),
-            nodes: job.allocated_nodes.clone(),
+            nodes: selection.nodes,
             distribution: spur_core::step::TaskDistribution::Block,
             start_time: Some(chrono::Utc::now()),
             end_time: None,
@@ -1490,7 +1500,11 @@ impl SlurmController for ControllerService {
             .create_step(step)
             .map_err(|e| Status::internal(format!("failed to create job step: {e}")))?;
 
-        Ok(Response::new(CreateJobStepResponse { step_id, node_addr }))
+        Ok(Response::new(CreateJobStepResponse {
+            step_id,
+            node_addr,
+            warnings: selection.warnings,
+        }))
     }
 
     async fn create_partition(
@@ -2014,7 +2028,14 @@ impl SlurmController for ControllerService {
                 Status::not_found(format!("step {} not found for job {}", req.step_id, job_id))
             })?;
 
-        let num_nodes = job.allocated_nodes.len() as u32;
+        if step.nodes.is_empty() {
+            return Err(Status::failed_precondition(format!(
+                "step {} for job {} has no allocated nodes",
+                req.step_id, job_id
+            )));
+        }
+
+        let num_nodes = step.nodes.len() as u32;
         let plan = build_step_task_plan(step.num_tasks, num_nodes, step.distribution);
         if plan.is_empty() {
             return Err(Status::failed_precondition(format!(
@@ -2024,6 +2045,7 @@ impl SlurmController for ControllerService {
         }
 
         let step_num_tasks = step.num_tasks;
+        let step_nodelist = step.nodes.join(",");
         let command = req.command.clone();
         let work_dir = req.work_dir.clone();
         let environment = req.environment.clone();
@@ -2047,14 +2069,15 @@ impl SlurmController for ControllerService {
         let mut dispatch_errors = Vec::new();
 
         for node_tasks in plan {
-            let node_name = match job.allocated_nodes.get(node_tasks.node_index as usize) {
+            let node_name = match step.nodes.get(node_tasks.node_index as usize) {
                 Some(name) => name.clone(),
                 None => {
                     dispatch_errors.push(format!(
-                        "step plan references node index {} but job {} has {} nodes",
+                        "step plan references node index {} but step {} for job {} has {} nodes",
                         node_tasks.node_index,
+                        req.step_id,
                         job_id,
-                        job.allocated_nodes.len()
+                        step.nodes.len()
                     ));
                     continue;
                 }
@@ -2087,6 +2110,7 @@ impl SlurmController for ControllerService {
             let environment = environment.clone();
             let pmix_tmpdir = pmix_tmpdir.clone();
             let step_mpi = mpi.clone();
+            let step_nodelist = step_nodelist.clone();
             let pmix_plan = spur_core::mpi::maybe_local_pmix_plan(
                 step_mpi.as_str(),
                 spur_core::mpi::PmixLocalDispatch {
@@ -2124,6 +2148,7 @@ impl SlurmController for ControllerService {
                         label,
                         pmix_plan,
                         mpi: step_mpi,
+                        step_nodelist,
                     })
                     .await
                     .map_err(|e| {
@@ -2439,20 +2464,102 @@ pub async fn serve(
     Ok(())
 }
 
-/// Resolve the target node for a job step. Empty = first allocated (legacy
-/// default); a named node must be one the job holds, else it targets outside it.
-fn select_step_node<'a>(allocated: &'a [String], requested: &str) -> Result<&'a str, String> {
-    if requested.is_empty() {
-        return allocated
-            .first()
-            .map(String::as_str)
-            .ok_or_else(|| "job has no allocated nodes".to_string());
+#[derive(Debug, PartialEq, Eq)]
+struct StepNodeSelection {
+    nodes: Vec<String>,
+    warnings: Vec<String>,
+}
+
+fn select_step_nodes(
+    allocated: &[String],
+    requested_count: Option<u32>,
+    requested_hostlist: &str,
+    num_tasks: u32,
+) -> Result<StepNodeSelection, String> {
+    if allocated.is_empty() {
+        return Err("job has no allocated nodes".to_string());
     }
-    allocated
+
+    let mut listed = Vec::new();
+    let mut seen = HashSet::new();
+    if !requested_hostlist.trim().is_empty() {
+        for node in spur_sched::node_match::expand_hostlist_or_split(requested_hostlist) {
+            if seen.insert(node.clone()) {
+                listed.push(node);
+            }
+        }
+    }
+
+    let requested_limit = requested_count.map(|count| count.max(1) as usize);
+    if let Some(limit) = requested_limit {
+        if listed.len() > limit {
+            return Err(format!(
+                "requested node list contains {} nodes but -N allows at most {limit}",
+                listed.len()
+            ));
+        }
+    }
+
+    let default_nodes = if listed.is_empty() {
+        allocated.len()
+    } else {
+        listed.len()
+    };
+    let requested_nodes = requested_limit.unwrap_or(default_nodes);
+    let task_count = num_tasks.max(1) as usize;
+    let effective_count = requested_nodes.min(task_count);
+
+    if effective_count > allocated.len() {
+        return Err(format!(
+            "requested {effective_count} nodes but job allocation contains only {}",
+            allocated.len()
+        ));
+    }
+    if requested_count.is_some() && listed.len() > effective_count {
+        return Err(format!(
+            "requested node list contains {} nodes but the step can use at most {effective_count}",
+            listed.len()
+        ));
+    }
+    if requested_count.is_none() {
+        listed.truncate(effective_count);
+    }
+    for node in &listed {
+        if !allocated.contains(node) {
+            return Err(format!("node {node} is not allocated to this job"));
+        }
+    }
+
+    let mut warnings = Vec::new();
+    if requested_nodes > effective_count
+        && (requested_count.is_some() || !requested_hostlist.trim().is_empty())
+    {
+        warnings.push(format!(
+            "can't run {task_count} processes on {requested_nodes} nodes, \
+             setting nnodes to {effective_count}"
+        ));
+    }
+
+    let mut selected = listed;
+    if selected.len() < effective_count {
+        selected.extend(
+            allocated
+                .iter()
+                .filter(|node| !seen.contains(node.as_str()))
+                .take(effective_count - selected.len())
+                .cloned(),
+        );
+    } else {
+        selected.truncate(effective_count);
+    }
+    let selected: HashSet<_> = selected.into_iter().collect();
+    let nodes = allocated
         .iter()
-        .find(|n| n.as_str() == requested)
-        .map(String::as_str)
-        .ok_or_else(|| format!("node {requested} is not allocated to this job"))
+        .filter(|node| selected.contains(node.as_str()))
+        .cloned()
+        .collect();
+
+    Ok(StepNodeSelection { nodes, warnings })
 }
 
 // ---- Proto conversion helpers ----
@@ -3079,6 +3186,7 @@ mod tests {
     use chrono::Duration;
     use spur_core::job::{JobState, NodeCompleteError};
     use spur_core::reservation::ReservationFlags;
+    use std::collections::HashMap;
     use tonic::Code;
 
     #[test]
@@ -3586,6 +3694,267 @@ mod tests {
         }
     }
 
+    struct StepAgent {
+        requests: Arc<std::sync::Mutex<Vec<RunCommandRequest>>>,
+    }
+
+    #[tonic::async_trait]
+    impl spur_proto::proto::slurm_agent_server::SlurmAgent for StepAgent {
+        type StreamJobOutputStream = tonic::codegen::BoxStream<StreamJobOutputChunk>;
+        type InteractiveSessionStream = tonic::codegen::BoxStream<InteractiveOutput>;
+
+        async fn launch_job(
+            &self,
+            _request: Request<LaunchJobRequest>,
+        ) -> Result<Response<LaunchJobResponse>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn cancel_job(
+            &self,
+            _request: Request<AgentCancelJobRequest>,
+        ) -> Result<Response<()>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn suspend_job(
+            &self,
+            _request: Request<AgentSuspendJobRequest>,
+        ) -> Result<Response<()>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn get_node_resources(
+            &self,
+            _request: Request<()>,
+        ) -> Result<Response<NodeResourcesResponse>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn exec_in_job(
+            &self,
+            _request: Request<ExecInJobRequest>,
+        ) -> Result<Response<ExecInJobResponse>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn run_command(
+            &self,
+            request: Request<RunCommandRequest>,
+        ) -> Result<Response<RunCommandResponse>, Status> {
+            self.requests.lock().unwrap().push(request.into_inner());
+            Ok(Response::new(RunCommandResponse::default()))
+        }
+
+        async fn register_job_allocation(
+            &self,
+            _request: Request<RegisterJobAllocationRequest>,
+        ) -> Result<Response<RegisterJobAllocationResponse>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn stream_job_output(
+            &self,
+            _request: Request<StreamJobOutputRequest>,
+        ) -> Result<Response<Self::StreamJobOutputStream>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn interactive_session(
+            &self,
+            _request: Request<tonic::Streaming<InteractiveInput>>,
+        ) -> Result<Response<Self::InteractiveSessionStream>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn start_cluster_component(
+            &self,
+            _request: Request<StartClusterComponentRequest>,
+        ) -> Result<Response<StartClusterComponentResponse>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn stop_cluster_component(
+            &self,
+            _request: Request<StopClusterComponentRequest>,
+        ) -> Result<Response<StopClusterComponentResponse>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn get_cluster_component_status(
+            &self,
+            _request: Request<GetClusterComponentStatusRequest>,
+        ) -> Result<Response<GetClusterComponentStatusResponse>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn create_k0s_join_token(
+            &self,
+            _request: Request<CreateK0sJoinTokenRequest>,
+        ) -> Result<Response<CreateK0sJoinTokenResponse>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn get_kubeconfig(
+            &self,
+            _request: Request<GetKubeconfigRequest>,
+        ) -> Result<Response<GetKubeconfigResponse>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+
+        async fn apply_mesh(
+            &self,
+            _request: Request<MeshMembership>,
+        ) -> Result<Response<ApplyMeshResponse>, Status> {
+            Err(Status::unimplemented("not used in step tests"))
+        }
+    }
+
+    async fn spawn_step_agent() -> (
+        std::net::SocketAddr,
+        Arc<std::sync::Mutex<Vec<RunCommandRequest>>>,
+    ) {
+        use tonic::transport::server::TcpIncoming;
+
+        let incoming = TcpIncoming::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+        let addr = incoming.local_addr().unwrap();
+        let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let agent = StepAgent {
+            requests: requests.clone(),
+        };
+        tokio::spawn(async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(spur_proto::proto::slurm_agent_server::SlurmAgentServer::new(agent))
+                .serve_with_incoming(incoming)
+                .await;
+        });
+        (addr, requests)
+    }
+
+    async fn running_two_node_job(
+        svc: &ControllerService,
+        first_port: u16,
+        second_port: u16,
+    ) -> u32 {
+        use spur_core::resource::{ResourceAllocations, ResourceSet};
+
+        for (name, port) in [("n1", first_port), ("n2", second_port)] {
+            svc.cluster
+                .register_node(
+                    name.into(),
+                    name.into(),
+                    ResourceSet {
+                        cpus: 8,
+                        memory_mb: 16000,
+                        ..Default::default()
+                    },
+                    "127.0.0.1".into(),
+                    port,
+                    String::new(),
+                    String::new(),
+                    spur_core::node::NodeSource::NativeHost,
+                    HashMap::new(),
+                )
+                .unwrap();
+        }
+        for _ in 0..200 {
+            if svc.cluster.get_node("n1").is_some() && svc.cluster.get_node("n2").is_some() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        let job_id = svc
+            .cluster
+            .submit_job(spur_core::job::JobSpec {
+                name: "step-subset".into(),
+                user: "u".into(),
+                num_nodes: 2,
+                num_tasks: 2,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                srun_job: true,
+                ..Default::default()
+            })
+            .unwrap()
+            .job_id;
+        let resources = ResourceAllocations::with_scalar(2, 4000);
+        let per_node = [
+            ("n1".to_string(), resources.clone()),
+            ("n2".to_string(), resources.clone()),
+        ]
+        .into_iter()
+        .collect();
+        svc.cluster
+            .start_job(job_id, vec!["n1".into(), "n2".into()], resources, per_node)
+            .unwrap();
+        for _ in 0..200 {
+            if svc.cluster.get_job(job_id).map(|job| job.state) == Some(JobState::Running) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        job_id
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_step_dispatches_only_to_the_selected_nodes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let (first_addr, first_requests) = spawn_step_agent().await;
+        let (second_addr, second_requests) = spawn_step_agent().await;
+        let job_id = running_two_node_job(&svc, first_addr.port(), second_addr.port()).await;
+
+        let created = svc
+            .create_job_step(Request::new(CreateJobStepRequest {
+                job_id,
+                command: vec!["hostname".into()],
+                num_tasks: 2,
+                cpus_per_task: 1,
+                overlap: false,
+                pty: false,
+                winsize: None,
+                node: "n2".into(),
+                user: "u".into(),
+                num_nodes: Some(1),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        let stored_step = svc
+            .cluster
+            .get_steps(job_id)
+            .into_iter()
+            .find(|step| step.step_id == created.step_id)
+            .unwrap();
+        assert_eq!(stored_step.nodes, ["n2"]);
+
+        let response = svc
+            .run_step(Request::new(RunStepRequest {
+                job_id,
+                command: vec!["hostname".into()],
+                uid: 0,
+                gid: 0,
+                work_dir: "/tmp".into(),
+                environment: HashMap::new(),
+                step_id: created.step_id,
+                label: false,
+                mpi: String::new(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.node, "n2");
+        assert!(first_requests.lock().unwrap().is_empty());
+        let requests = second_requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].num_tasks, 2);
+        assert_eq!(requests[0].step_num_tasks, 2);
+        assert_eq!(requests[0].step_nodelist, "n2");
+    }
+
     // A step must NOT be created when the target node is allocated but unregistered: address
     // resolution runs first and returns a retryable Unavailable, so the client's retries can't
     // each leak a step.
@@ -3663,6 +4032,7 @@ mod tests {
                     winsize: None,
                     node: "ghost".into(),
                     user: "u".into(),
+                    num_nodes: None,
                 }))
                 .await
                 .expect_err("unregistered target must fail");
@@ -3737,6 +4107,7 @@ mod tests {
                 pty: false,
                 winsize: None,
                 node: String::new(),
+                num_nodes: None,
             }))
             .await
             .expect_err("a still-Pending job must not accept a new step");
@@ -3854,6 +4225,7 @@ mod tests {
                 winsize: None,
                 node: String::new(),
                 user: "rsikande".into(),
+                num_nodes: None,
             }))
             .await
             .expect_err("a non-owner must not attach to another user's job");
@@ -3883,6 +4255,7 @@ mod tests {
                 winsize: None,
                 node: String::new(),
                 user: "ubuntu".into(),
+                num_nodes: None,
             }))
             .await
             .expect("the owner must be allowed to attach");
@@ -4142,35 +4515,153 @@ mod tests {
     }
 
     #[test]
-    fn select_step_node_empty_request_uses_first_allocated() {
+    fn select_step_nodes_honors_explicit_count_below_task_count() {
         let allocated = vec!["node001".to_string(), "node002".to_string()];
-        assert_eq!(select_step_node(&allocated, ""), Ok("node001"));
+        let selection = select_step_nodes(&allocated, Some(1), "", 2).unwrap();
+        assert_eq!(selection.nodes, ["node001"]);
+        assert!(selection.warnings.is_empty());
     }
 
     #[test]
-    fn select_step_node_named_request_targets_that_node() {
-        let allocated = vec!["node001".to_string(), "node002".to_string()];
-        assert_eq!(select_step_node(&allocated, "node002"), Ok("node002"));
+    fn select_step_nodes_keeps_listed_nodes_and_fills_from_allocation() {
+        let allocated = vec![
+            "node001".to_string(),
+            "node002".to_string(),
+            "node003".to_string(),
+        ];
+        let selection = select_step_nodes(&allocated, Some(2), "node003", 2).unwrap();
+        assert_eq!(selection.nodes, ["node001", "node003"]);
+        assert!(selection.warnings.is_empty());
     }
 
     #[test]
-    fn select_step_node_rejects_node_outside_allocation() {
+    fn select_step_nodes_rejects_node_outside_allocation() {
         let allocated = vec!["node001".to_string(), "node002".to_string()];
-        let err = select_step_node(&allocated, "node999").unwrap_err();
+        let err = select_step_nodes(&allocated, Some(1), "node999", 1).unwrap_err();
         assert!(err.contains("node999"));
         assert!(err.contains("not allocated"));
     }
 
     #[test]
-    fn select_step_node_empty_request_no_nodes_errors() {
-        let allocated: Vec<String> = Vec::new();
-        assert!(select_step_node(&allocated, "").is_err());
+    fn select_step_nodes_caps_at_task_count_with_warning() {
+        let allocated = vec![
+            "node001".to_string(),
+            "node002".to_string(),
+            "node003".to_string(),
+        ];
+        let selection = select_step_nodes(&allocated, Some(3), "", 2).unwrap();
+        assert_eq!(selection.nodes, ["node001", "node002"]);
+        assert_eq!(selection.warnings.len(), 1);
+        assert!(selection.warnings[0].contains("can't run 2 processes on 3 nodes"));
+        assert!(selection.warnings[0].contains("setting nnodes to 2"));
     }
 
     #[test]
-    fn select_step_node_rejects_comma_joined_request() {
+    fn select_step_nodes_rejects_count_larger_than_allocation() {
         let allocated = vec!["node001".to_string(), "node002".to_string()];
-        assert!(select_step_node(&allocated, "node001,node002").is_err());
+        let err = select_step_nodes(&allocated, Some(3), "", 3).unwrap_err();
+        assert!(err.contains("requested 3 nodes"));
+        assert!(err.contains("only 2"));
+    }
+
+    #[test]
+    fn select_step_nodes_rejects_list_larger_than_explicit_count() {
+        let allocated = vec![
+            "node001".to_string(),
+            "node002".to_string(),
+            "node003".to_string(),
+        ];
+        let err = select_step_nodes(&allocated, Some(2), "node[001-003]", 3).unwrap_err();
+        assert!(err.contains("contains 3 nodes"));
+        assert!(err.contains("at most 2"));
+    }
+
+    #[test]
+    fn select_step_nodes_rejects_explicit_list_after_task_cap() {
+        let allocated = vec![
+            "node001".to_string(),
+            "node002".to_string(),
+            "node003".to_string(),
+        ];
+        let err = select_step_nodes(&allocated, Some(3), "node[003,002,001]", 2).unwrap_err();
+        assert!(err.contains("contains 3 nodes"));
+        assert!(err.contains("at most 2"));
+    }
+
+    #[test]
+    fn select_step_nodes_truncates_unbounded_list_after_task_cap() {
+        let allocated = vec![
+            "node001".to_string(),
+            "node002".to_string(),
+            "node003".to_string(),
+        ];
+        let selection = select_step_nodes(&allocated, None, "node[003,002,001]", 2).unwrap();
+        assert_eq!(selection.nodes, ["node002", "node003"]);
+        assert_eq!(selection.warnings.len(), 1);
+    }
+
+    #[test]
+    fn select_step_nodes_ignores_unbounded_hosts_beyond_task_cap() {
+        let allocated = vec!["node001".to_string(), "node002".to_string()];
+        let selection = select_step_nodes(&allocated, None, "node001,node002,node999", 2).unwrap();
+        assert_eq!(selection.nodes, ["node001", "node002"]);
+        assert_eq!(selection.warnings.len(), 1);
+    }
+
+    #[test]
+    fn select_step_nodes_uses_allocation_order_for_named_nodes() {
+        let allocated = vec![
+            "node001".to_string(),
+            "node002".to_string(),
+            "node003".to_string(),
+        ];
+        let selection = select_step_nodes(&allocated, Some(2), "node003,node001", 2).unwrap();
+        assert_eq!(selection.nodes, ["node001", "node003"]);
+    }
+
+    #[test]
+    fn select_step_nodes_without_explicit_count_uses_allocation_capped_by_tasks() {
+        let allocated = vec![
+            "node001".to_string(),
+            "node002".to_string(),
+            "node003".to_string(),
+        ];
+        let selection = select_step_nodes(&allocated, None, "", 2).unwrap();
+        assert_eq!(selection.nodes, ["node001", "node002"]);
+        assert!(selection.warnings.is_empty());
+    }
+
+    #[test]
+    fn select_step_nodes_without_explicit_count_does_not_exceed_allocation() {
+        let allocated = vec!["node001".to_string(), "node002".to_string()];
+        let selection = select_step_nodes(&allocated, None, "", 4).unwrap();
+        assert_eq!(selection.nodes, ["node001", "node002"]);
+        assert!(selection.warnings.is_empty());
+    }
+
+    #[test]
+    fn select_step_nodes_without_count_uses_hostlist_cardinality() {
+        let allocated = vec![
+            "node001".to_string(),
+            "node002".to_string(),
+            "node003".to_string(),
+        ];
+        let selection = select_step_nodes(&allocated, None, "node003", 2).unwrap();
+        assert_eq!(selection.nodes, ["node003"]);
+        assert!(selection.warnings.is_empty());
+    }
+
+    #[test]
+    fn select_step_nodes_normalizes_zero_count_to_one() {
+        let allocated = vec!["node001".to_string(), "node002".to_string()];
+        let selection = select_step_nodes(&allocated, Some(0), "", 2).unwrap();
+        assert_eq!(selection.nodes, ["node001"]);
+        assert!(selection.warnings.is_empty());
+    }
+
+    #[test]
+    fn select_step_nodes_rejects_empty_allocation() {
+        assert!(select_step_nodes(&[], Some(1), "", 1).is_err());
     }
 
     #[test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1684,7 +1684,7 @@ impl SlurmAgent for AgentService {
         // node already confirmed via LaunchJob (confirm_dispatch_on_nodes) — so a
         // miss is a wrong job/node pairing, not a launch race. The one uncovered
         // case is a spurd restart mid-job, which starts `running` empty.
-        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi) = {
+        let (gpu_devices, partition, cpus, memory_mb, job_nodelist, job_mpi) = {
             let jobs = self.running.lock().await;
             let tracked = jobs.get(&job_id).ok_or_else(|| {
                 Status::not_found(format!("job {} not running on this node", job_id))
@@ -1706,9 +1706,19 @@ impl SlurmAgent for AgentService {
             )
         };
 
+        let step_nodelist = if req.step_nodelist.is_empty() {
+            job_nodelist.clone()
+        } else {
+            req.step_nodelist.clone()
+        };
         let agent_hostname = self.reporter.hostname.clone();
-        let node_names: Vec<&str> = nodelist.split(',').filter(|s| !s.is_empty()).collect();
+        let node_names: Vec<&str> = step_nodelist.split(',').filter(|s| !s.is_empty()).collect();
         let num_nodes = node_names.len().max(1) as u32;
+        let job_num_nodes = job_nodelist
+            .split(',')
+            .filter(|node| !node.is_empty())
+            .count()
+            .max(1) as u32;
         let node_id = node_names
             .iter()
             .position(|n| *n == agent_hostname)
@@ -1733,8 +1743,9 @@ impl SlurmAgent for AgentService {
         senv.set_with_slurm_twin("SPUR_JOB_ID", job_id);
         senv.set_with_slurm_twin("SPUR_JOBID", job_id);
         senv.set_with_slurm_twin("SPUR_JOB_PARTITION", &partition);
-        senv.set_with_slurm_twin("SPUR_NODELIST", &nodelist);
-        senv.set_with_slurm_twin("SPUR_JOB_NODELIST", &nodelist);
+        senv.set_with_slurm_twin("SPUR_NODELIST", &job_nodelist);
+        senv.set_with_slurm_twin("SPUR_STEP_NODELIST", &step_nodelist);
+        senv.set_with_slurm_twin("SPUR_JOB_NODELIST", &job_nodelist);
         senv.set_with_slurm_twin("SPUR_CPUS_ON_NODE", cpus);
         senv.extend(&gpu_env);
         let mut bind_env = HashMap::new();
@@ -1761,6 +1772,7 @@ impl SlurmAgent for AgentService {
             step_num_tasks,
             node_id,
             num_nodes,
+            job_num_nodes,
         );
         if req.label {
             senv.set("SPUR_LABEL", "1");
@@ -1847,7 +1859,7 @@ impl SlurmAgent for AgentService {
                 uid: req.uid,
                 gid: req.gid,
                 partition: partition.clone(),
-                nodelist: nodelist.clone(),
+                nodelist: job_nodelist.clone(),
                 script_context: "prolog_task".into(),
                 gpu_devices: gpu_devices.clone(),
                 cpus,
@@ -1917,7 +1929,7 @@ impl SlurmAgent for AgentService {
                 uid: req.uid,
                 gid: req.gid,
                 partition,
-                nodelist,
+                nodelist: job_nodelist,
                 script_context: "epilog_task".into(),
                 gpu_devices,
                 cpus,
@@ -3334,6 +3346,97 @@ mod tests {
         let resp = svc.run_command(req).await.unwrap().into_inner();
         assert_eq!(resp.exit_code, 0);
         assert_eq!(resp.stdout.trim(), "step-dispatched");
+    }
+
+    #[tokio::test]
+    async fn run_command_scopes_node_environment_to_the_step() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let job_id = 101;
+        let mut tracked = TrackedJob::dummy(0);
+        tracked.nodelist = "node-a,test-node,node-c".into();
+        svc.insert_test_job(job_id, tracked).await;
+
+        let req = Request::new(RunCommandRequest {
+            command: vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                concat!(
+                    "printf '%s\\n' \"",
+                    "$SPUR_NODELIST|$SLURM_NODELIST|",
+                    "$SPUR_STEP_NODELIST|$SLURM_STEP_NODELIST|",
+                    "$SPUR_JOB_NODELIST|$SLURM_JOB_NODELIST|",
+                    "$SPUR_NNODES|$SLURM_NNODES|",
+                    "$SPUR_STEP_NUM_NODES|$SLURM_STEP_NUM_NODES|",
+                    "$SPUR_JOB_NUM_NODES|$SLURM_JOB_NUM_NODES|",
+                    "$SPUR_NODEID|$SLURM_NODEID\"",
+                )
+                .into(),
+            ],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+            job_id,
+            step_nodelist: "node-a,test-node".into(),
+            ..Default::default()
+        });
+
+        let resp = svc.run_command(req).await.unwrap().into_inner();
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(
+            resp.stdout.trim(),
+            concat!(
+                "node-a,test-node,node-c|node-a,test-node,node-c|",
+                "node-a,test-node|node-a,test-node|",
+                "node-a,test-node,node-c|node-a,test-node,node-c|",
+                "2|2|2|2|3|3|1|1"
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn run_command_without_step_nodelist_uses_the_allocation() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let job_id = 102;
+        let mut tracked = TrackedJob::dummy(0);
+        tracked.nodelist = "node-a,test-node,node-c".into();
+        svc.insert_test_job(job_id, tracked).await;
+
+        let req = Request::new(RunCommandRequest {
+            command: vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                concat!(
+                    "printf '%s\\n' \"",
+                    "$SPUR_NODELIST|$SPUR_JOB_NODELIST|",
+                    "$SPUR_NNODES|$SPUR_JOB_NUM_NODES|$SPUR_NODEID\""
+                )
+                .into(),
+            ],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+            job_id,
+            ..Default::default()
+        });
+
+        let resp = svc.run_command(req).await.unwrap().into_inner();
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(
+            resp.stdout.trim(),
+            "node-a,test-node,node-c|node-a,test-node,node-c|3|3|1"
+        );
     }
 
     #[tokio::test]

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -947,6 +947,7 @@ message RunCommandRequest {
   bool label = 11;             // Prefix output with [rank] inside wrapper
   PmixLaunchPlan pmix_plan = 12;
   string mpi = 13;             // Resolved step MPI type: "none" or "pmix"
+  string step_nodelist = 14;   // Nodes participating in this step
 }
 
 // Register a srun-only allocation on an agent without starting a batch process.
@@ -1269,13 +1270,15 @@ message CreateJobStepRequest {
   bool overlap = 5;           // Share resources with existing step (--overlap)
   bool pty = 6;               // Allocate a PTY for the step
   WindowSize winsize = 7;     // Initial terminal dimensions
-  string node = 8;            // Target node (-w); empty = first allocated node
+  string node = 8;            // Target node list (-w); empty = controller-selected nodes
   string user = 9;            // Requesting user; must own the job (empty/root bypasses)
+  optional uint32 num_nodes = 10; // Requested step node count (-N); unset = derive from tasks/allocation
 }
 
 message CreateJobStepResponse {
   uint32 step_id = 1;
   string node_addr = 2;        // Address of the selected node (-w target, else first allocated); host:port for agent
+  repeated string warnings = 3;
 }
 
 // ============================================================

--- a/tests/native_host/e2e/test_srun_multi_node.py
+++ b/tests/native_host/e2e/test_srun_multi_node.py
@@ -7,7 +7,7 @@ import re
 import shlex
 import time
 
-from cluster import job_state, parse_job_id, wait_job, wait_job_state
+from cluster import parse_job_id, wait_job, wait_job_state
 
 
 class TestStandaloneSrun:
@@ -34,6 +34,26 @@ class TestStandaloneSrun:
 
         ranks = {ln.split("rank=")[1].strip() for ln in lines}
         assert ranks == {"0", "1"}, f"expected ranks 0 and 1, got {ranks}:\n{out}"
+
+    def test_srun_candidate_nodelist_is_not_reapplied_to_the_step(
+        self, multi_node_cluster
+    ):
+        cluster = multi_node_cluster
+        candidates = ",".join(cluster.node_names)
+        code, out = cluster.srun_with_exit(
+            [
+                "-n",
+                "1",
+                "-w",
+                candidates,
+                "bash",
+                "-c",
+                'echo "candidate_host=$(hostname)"',
+            ]
+        )
+        assert code == 0, f"srun failed (exit {code}):\n{out}"
+        lines = [ln for ln in out.splitlines() if ln.startswith("candidate_host=")]
+        assert len(lines) == 1, f"expected one task line, got {len(lines)}:\n{out}"
 
     def test_srun_holds_allocation_until_step_finishes(self, multi_node_cluster):
         cluster = multi_node_cluster
@@ -104,11 +124,127 @@ class TestSrunInBatch:
             "#!/bin/bash\n"
             "srun -n 2 bash -c 'echo host=$(hostname) rank=${SPUR_PROCID}'\n",
         )
-        sb = cluster.sbatch(["-J", "srun-step", "-N", "2", "-n", "2", "-o", out_path, script])
+        sb = cluster.sbatch(
+            ["-J", "srun-step", "-N", "2", "-n", "2", "-o", out_path, script]
+        )
         job_id = parse_job_id(sb)
         assert job_id is not None
 
         wait_job(cluster, job_id, timeout=90)
         content = cluster.read_output_on_any_node(out_path)
         lines = sorted({ln for ln in content.splitlines() if ln.startswith("host=")})
-        assert len(lines) == 2, f"expected 2 step task lines in batch output:\n{content}"
+        assert len(lines) == 2, (
+            f"expected 2 step task lines in batch output:\n{content}"
+        )
+
+    def test_explicit_node_count_keeps_inherited_tasks_on_one_node(
+        self, multi_node_cluster
+    ):
+        cluster = multi_node_cluster
+        out_path = f"{cluster.remote_dir}/srun-step-one-node.out"
+        script = cluster.write_file(
+            "srun-step-one-node.sh",
+            "#!/bin/bash\n"
+            "srun -N 1 bash -c "
+            "'echo subset_host=$(hostname) rank=${SPUR_PROCID}'\n",
+        )
+        sb = cluster.sbatch(
+            ["-J", "srun-step-one-node", "-N", "2", "-n", "2", "-o", out_path, script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        wait_job(cluster, job_id, timeout=90)
+        content = cluster.read_output_on_any_node(out_path)
+        lines = [ln for ln in content.splitlines() if ln.startswith("subset_host=")]
+        assert len(lines) == 2, f"expected both inherited tasks to run:\n{content}"
+
+        hosts = {ln.split("subset_host=")[1].split()[0] for ln in lines}
+        assert len(hosts) == 1, (
+            f"expected both tasks on one node, got {hosts}:\n{content}"
+        )
+
+        ranks = {ln.split("rank=")[1].strip() for ln in lines}
+        assert ranks == {"0", "1"}, f"expected ranks 0 and 1, got {ranks}:\n{content}"
+
+    def test_step_nodelist_targets_requested_allocated_node(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        target = cluster.node_names[1]
+        expected_hostname = cluster.nodes[1].exec("hostname").strip()
+        out_path = f"{cluster.remote_dir}/srun-step-nodelist.out"
+        script = cluster.write_file(
+            "srun-step-nodelist.sh",
+            "#!/bin/bash\n"
+            f"srun -n 1 -w {shlex.quote(target)} bash -c "
+            "'echo targeted_host=$(hostname)'\n",
+        )
+        sb = cluster.sbatch(
+            ["-J", "srun-step-nodelist", "-N", "2", "-n", "2", "-o", out_path, script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        wait_job(cluster, job_id, timeout=90)
+        content = cluster.read_output_on_any_node(out_path)
+        lines = [ln for ln in content.splitlines() if ln.startswith("targeted_host=")]
+        assert lines == [f"targeted_host={expected_hostname}"], (
+            f"expected step to run only on {target}, got:\n{content}"
+        )
+
+    def test_step_reduces_nodes_to_inherited_task_count_with_warning(
+        self, multi_node_cluster
+    ):
+        cluster = multi_node_cluster
+        out_path = f"{cluster.remote_dir}/srun-step-reduced-nodes.out"
+        script = cluster.write_file(
+            "srun-step-reduced-nodes.sh",
+            "#!/bin/bash\n"
+            "srun -N 3 bash -c "
+            "'echo reduced_host=$(hostname) rank=${SPUR_PROCID}'\n",
+        )
+        sb = cluster.sbatch(
+            ["-J", "srun-step-reduced", "-N", "2", "-n", "2", "-o", out_path, script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        wait_job(cluster, job_id, timeout=90)
+        content = cluster.read_output_on_any_node(out_path)
+        assert (
+            "srun: warning: can't run 2 processes on 3 nodes, setting nnodes to 2"
+            in content
+        )
+
+        lines = [ln for ln in content.splitlines() if ln.startswith("reduced_host=")]
+        assert len(lines) == 2, f"expected both inherited tasks to run:\n{content}"
+        hosts = {ln.split("reduced_host=")[1].split()[0] for ln in lines}
+        assert len(hosts) == 2, f"expected one task on each allocated node:\n{content}"
+
+        ranks = {ln.split("rank=")[1].strip() for ln in lines}
+        assert ranks == {"0", "1"}, f"expected ranks 0 and 1, got {ranks}:\n{content}"
+
+    def test_step_rejects_more_nodes_than_allocation(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        out_path = f"{cluster.remote_dir}/srun-step-too-many-nodes.out"
+        script = cluster.write_file(
+            "srun-step-too-many-nodes.sh",
+            "#!/bin/bash\n"
+            "srun -N 3 -n 3 bash -c 'echo impossible_step_ran=$(hostname)'\n"
+            "echo impossible_step_status=$?\n",
+        )
+        sb = cluster.sbatch(
+            ["-J", "srun-step-too-many", "-N", "2", "-n", "2", "-o", out_path, script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        wait_job(cluster, job_id, timeout=90)
+        content = cluster.read_output_on_any_node(out_path)
+        status = re.search(r"^impossible_step_status=(\d+)$", content, re.MULTILINE)
+        assert status is not None, f"missing nested srun exit status:\n{content}"
+        assert int(status.group(1)) != 0, (
+            f"impossible step unexpectedly succeeded:\n{content}"
+        )
+        assert "impossible_step_ran=" not in content, (
+            f"command ran despite requesting more nodes than allocated:\n{content}"
+        )


### PR DESCRIPTION
Closes #597.

Inside an allocation, `srun -N 1` still fanned out across every allocated node, and `-w` was dropped before step creation.

This keeps step node count separate from task count through the CLI and controller. The controller validates the requested count and hostlist against the parent allocation, stores the selected nodes on the step, and dispatches only to that subset. Slurm-style node-count warnings are returned to `srun` instead of silently clamping.

Agents now receive both the allocation and step nodelists. `SLURM_JOB_*` stays allocation-scoped, while `SLURM_STEP_*` and `SLURM_NNODES` describe the step. empty step nodelist falls back to the allocation for compatibility with older controllers.

Tested locally:

- `cargo test -p spur-cli --locked`
- `cargo test -p spurctld --locked`, including a live two-agent loopback dispatch test
- `cargo test -p spur-core spur_env::tests --locked`
- `cargo clippy -p spur-core -p spur-cli -p spurctld --all-targets --locked -- -D warnings`
- Ruff, Python compilation, formatting, license headers, and diff checks

I could not run two node native-host E2E coverage b/c i'm on macos
