### PR TITLE
feat(spurctld): export k0s cluster and node metrics at /metrics/k8s

### DIFF
--- a/crates/spur-k8s/src/heartbeat.rs
+++ b/crates/spur-k8s/src/heartbeat.rs
@@ -63,6 +63,7 @@ impl HeartbeatManager {
                             running_jobs: vec![],
                             node_token: String::new(),
                             wg_pubkey: String::new(), // virtual agents are not on the mesh
+                            k0s_status: None,         // virtual agents run no k0s unit
                         };
                         match client.heartbeat(req).await {
                             Ok(_) => debug!(node = %name, "heartbeat sent"),

--- a/crates/spur-metrics/src/export/k8s_cluster.rs
+++ b/crates/spur-metrics/src/export/k8s_cluster.rs
@@ -188,4 +188,23 @@ mod tests {
         assert!(body.contains("spur_k8s_install_duration_seconds_count"));
         assert!(body.ends_with("# EOF\n"));
     }
+
+    #[test]
+    fn remove_node_evicts_all_per_node_series() {
+        let metrics = K8sMetrics::new();
+        metrics.set_node_up("prod", "gone", true);
+        metrics.set_node_restart_total("prod", "gone", 4);
+        metrics.observe_node_install_duration("prod", "gone", 1.0);
+        metrics.set_node_up("prod", "keep", true);
+
+        assert!(encode_k8s_metrics(&sample(), &metrics).contains("node=\"gone\""));
+
+        metrics.remove_node("prod", "gone");
+        let body = encode_k8s_metrics(&sample(), &metrics);
+        assert!(
+            !body.contains("node=\"gone\""),
+            "evicted node must not export"
+        );
+        assert!(body.contains("node=\"keep\""), "other nodes are unaffected");
+    }
 }

--- a/crates/spur-metrics/src/export/k8s_cluster.rs
+++ b/crates/spur-metrics/src/export/k8s_cluster.rs
@@ -163,7 +163,7 @@ mod tests {
         metrics.record_phase_transition("prod", K0sPhase::Down, K0sPhase::Provisioning);
         metrics.record_reconcile_error("prod");
         metrics.observe_reconcile_duration("prod", 0.02);
-        metrics.set_node_up("prod", "node-a", K0sRole::Worker, true);
+        metrics.set_node_up("prod", "node-a", true);
         metrics.set_node_restart_total("prod", "node-a", 2);
         metrics.observe_node_install_duration("prod", "node-a", 3.0);
 
@@ -180,7 +180,7 @@ mod tests {
         ));
         assert!(body.contains("spur_k8s_reconcile_duration_seconds_count"));
         assert!(body.contains(
-            "spur_k8s_node_up{distribution=\"k0s\",cluster=\"prod\",node=\"node-a\",role=\"worker\"} 1\n"
+            "spur_k8s_node_up{distribution=\"k0s\",cluster=\"prod\",node=\"node-a\"} 1\n"
         ));
         assert!(body.contains(
             "spur_k8s_node_restart_total{distribution=\"k0s\",cluster=\"prod\",node=\"node-a\"} 2\n"

--- a/crates/spur-metrics/src/export/k8s_cluster.rs
+++ b/crates/spur-metrics/src/export/k8s_cluster.rs
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! k0s cluster + node metric registration for `/metrics/k8s`.
+
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::registry::Registry;
+use std::sync::atomic::AtomicU64;
+
+use crate::export::encode_registered;
+use crate::k8s::{
+    phase_label, role_label, BaseLabel, K8sClusterMetricsSnapshot, K8sMetrics, ALL_PHASES,
+};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct PhaseLabel {
+    distribution: String,
+    cluster: String,
+    phase: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct RoleLabel {
+    distribution: String,
+    cluster: String,
+    role: String,
+}
+
+fn base_gauge(
+    registry: &mut Registry,
+    name: &str,
+    help: &str,
+    snap: &K8sClusterMetricsSnapshot,
+    v: u64,
+) {
+    let family = Family::<BaseLabel, Gauge<u64, AtomicU64>>::default();
+    family
+        .get_or_create(&BaseLabel {
+            distribution: snap.distribution.clone(),
+            cluster: snap.cluster.clone(),
+        })
+        .set(v);
+    registry.register(name, help, family);
+}
+
+/// Register the cluster-level gauges from `snap`.
+pub fn register_k8s_cluster(registry: &mut Registry, snap: &K8sClusterMetricsSnapshot) {
+    let phase_family = Family::<PhaseLabel, Gauge<u64, AtomicU64>>::default();
+    for phase in ALL_PHASES {
+        phase_family
+            .get_or_create(&PhaseLabel {
+                distribution: snap.distribution.clone(),
+                cluster: snap.cluster.clone(),
+                phase: phase_label(phase).into(),
+            })
+            .set(u64::from(phase == snap.phase));
+    }
+    registry.register(
+        "spur_k8s_cluster_phase",
+        "Current k0s cluster phase as a one-hot state set (value 1 on the active phase)",
+        phase_family,
+    );
+
+    base_gauge(
+        registry,
+        "spur_k8s_cluster_up",
+        "Whether the k0s cluster is Ready (1) or not (0)",
+        snap,
+        snap.up(),
+    );
+    base_gauge(
+        registry,
+        "spur_k8s_control_plane_replicas",
+        "Configured k0s control-plane replica count",
+        snap,
+        snap.control_plane_replicas,
+    );
+    base_gauge(
+        registry,
+        "spur_k8s_nodes_total",
+        "Total nodes with a k0s role assigned",
+        snap,
+        snap.nodes_total,
+    );
+
+    let role_family = Family::<RoleLabel, Gauge<u64, AtomicU64>>::default();
+    for (role, count) in snap.nodes_by_role {
+        role_family
+            .get_or_create(&RoleLabel {
+                distribution: snap.distribution.clone(),
+                cluster: snap.cluster.clone(),
+                role: role_label(role).into(),
+            })
+            .set(count);
+    }
+    registry.register(
+        "spur_k8s_nodes_by_role",
+        "k0s node count per role",
+        role_family,
+    );
+}
+
+/// Encode `/metrics/k8s`: cluster gauges from `snap` plus the long-lived lifecycle/node metrics.
+pub fn encode_k8s_metrics(snap: &K8sClusterMetricsSnapshot, metrics: &K8sMetrics) -> String {
+    metrics.ensure_series(&snap.cluster);
+    encode_registered(|registry| {
+        register_k8s_cluster(registry, snap);
+        metrics.register(registry);
+    })
+}
+
+/// Encode only the cluster gauges (used by tests and callers without a live accumulator).
+pub fn encode_k8s_cluster_metrics(snap: &K8sClusterMetricsSnapshot) -> String {
+    encode_registered(|registry| register_k8s_cluster(registry, snap))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::k8s::K8sMetrics;
+    use spur_core::k0s::{K0sPhase, K0sRole};
+
+    fn sample() -> K8sClusterMetricsSnapshot {
+        K8sClusterMetricsSnapshot::collect(
+            "prod",
+            3,
+            K0sPhase::Ready,
+            [
+                Some(K0sRole::Controller),
+                Some(K0sRole::Worker),
+                Some(K0sRole::Worker),
+            ],
+        )
+    }
+
+    #[test]
+    fn cluster_gauges_render_expected_series() {
+        let body = encode_k8s_cluster_metrics(&sample());
+        assert!(body.contains(
+            "spur_k8s_cluster_phase{distribution=\"k0s\",cluster=\"prod\",phase=\"ready\"} 1\n"
+        ));
+        assert!(body.contains(
+            "spur_k8s_cluster_phase{distribution=\"k0s\",cluster=\"prod\",phase=\"down\"} 0\n"
+        ));
+        assert!(body.contains("spur_k8s_cluster_up{distribution=\"k0s\",cluster=\"prod\"} 1\n"));
+        assert!(body.contains(
+            "spur_k8s_control_plane_replicas{distribution=\"k0s\",cluster=\"prod\"} 3\n"
+        ));
+        assert!(body.contains("spur_k8s_nodes_total{distribution=\"k0s\",cluster=\"prod\"} 3\n"));
+        assert!(body.contains(
+            "spur_k8s_nodes_by_role{distribution=\"k0s\",cluster=\"prod\",role=\"worker\"} 2\n"
+        ));
+        assert!(body.ends_with("# EOF\n"));
+    }
+
+    #[test]
+    fn combined_export_includes_lifecycle_and_node_metrics() {
+        let metrics = K8sMetrics::new();
+        metrics.record_provision_attempt("prod");
+        metrics.record_provision_failure("prod");
+        metrics.record_phase_transition("prod", K0sPhase::Down, K0sPhase::Provisioning);
+        metrics.record_reconcile_error("prod");
+        metrics.observe_reconcile_duration("prod", 0.02);
+        metrics.set_node_up("prod", "node-a", K0sRole::Worker, true);
+        metrics.set_node_restart_total("prod", "node-a", 2);
+        metrics.observe_node_install_duration("prod", "node-a", 3.0);
+
+        let body = encode_k8s_metrics(&sample(), &metrics);
+        assert!(body.contains(
+            "spur_k8s_provision_attempts_total{distribution=\"k0s\",cluster=\"prod\"} 1\n"
+        ));
+        assert!(body.contains(
+            "spur_k8s_provision_failures_total{distribution=\"k0s\",cluster=\"prod\"} 1\n"
+        ));
+        assert!(body.contains("from=\"down\",to=\"provisioning\"} 1\n"));
+        assert!(body.contains(
+            "spur_k8s_reconcile_errors_total{distribution=\"k0s\",cluster=\"prod\"} 1\n"
+        ));
+        assert!(body.contains("spur_k8s_reconcile_duration_seconds_count"));
+        assert!(body.contains(
+            "spur_k8s_node_up{distribution=\"k0s\",cluster=\"prod\",node=\"node-a\",role=\"worker\"} 1\n"
+        ));
+        assert!(body.contains(
+            "spur_k8s_node_restart_total{distribution=\"k0s\",cluster=\"prod\",node=\"node-a\"} 2\n"
+        ));
+        assert!(body.contains("spur_k8s_install_duration_seconds_count"));
+        assert!(body.ends_with("# EOF\n"));
+    }
+}

--- a/crates/spur-metrics/src/export/k8s_cluster.rs
+++ b/crates/spur-metrics/src/export/k8s_cluster.rs
@@ -9,7 +9,7 @@ use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::registry::Registry;
 use std::sync::atomic::AtomicU64;
 
-use crate::export::encode_registered;
+use crate::export::{concat_encoded, encode_registered};
 use crate::k8s::{
     phase_label, role_label, BaseLabel, K8sClusterMetricsSnapshot, K8sMetrics, ALL_PHASES,
 };
@@ -103,12 +103,14 @@ pub fn register_k8s_cluster(registry: &mut Registry, snap: &K8sClusterMetricsSna
 }
 
 /// Encode `/metrics/k8s`: cluster gauges from `snap` plus the long-lived lifecycle/node metrics.
+/// The gauges are re-registered fresh each scrape (they reflect a point-in-time snapshot); the
+/// accumulator was registered once at construction (see `K8sMetrics::encode`) and is just read.
 pub fn encode_k8s_metrics(snap: &K8sClusterMetricsSnapshot, metrics: &K8sMetrics) -> String {
     metrics.ensure_series(&snap.cluster);
-    encode_registered(|registry| {
-        register_k8s_cluster(registry, snap);
-        metrics.register(registry);
-    })
+    concat_encoded([
+        encode_registered(|registry| register_k8s_cluster(registry, snap)),
+        metrics.encode(),
+    ])
 }
 
 /// Encode only the cluster gauges (used by tests and callers without a live accumulator).
@@ -187,6 +189,9 @@ mod tests {
         ));
         assert!(body.contains("spur_k8s_install_duration_seconds_count"));
         assert!(body.ends_with("# EOF\n"));
+        // The gauge and accumulator halves are encoded separately then merged; a strict
+        // OpenMetrics parser stops at the first `# EOF`, so exactly one may appear.
+        assert_eq!(body.matches("# EOF").count(), 1);
     }
 
     #[test]

--- a/crates/spur-metrics/src/export/mod.rs
+++ b/crates/spur-metrics/src/export/mod.rs
@@ -14,6 +14,7 @@ pub const CONTENT_TYPE: &str = "application/openmetrics-text; version=1.0.0; cha
 
 pub mod jobs;
 pub mod jobs_users_accts;
+pub mod k8s_cluster;
 pub mod nodes;
 pub mod partitions;
 pub mod rpc;

--- a/crates/spur-metrics/src/export/mod.rs
+++ b/crates/spur-metrics/src/export/mod.rs
@@ -47,3 +47,38 @@ where
     encode_openmetrics(&mut body, &registry).expect("in-memory encode");
     body
 }
+
+/// Merge independently-encoded OpenMetrics 1.0 bodies into one valid exposition. Each input ends
+/// in its own `# EOF` terminator, which per spec ends the exposition — concatenating raw bodies
+/// would leave everything after the first `# EOF` unparsed by a strict scraper. Strips every
+/// trailing marker and appends exactly one.
+pub fn concat_encoded(bodies: impl IntoIterator<Item = String>) -> String {
+    let mut out = String::new();
+    for body in bodies {
+        out.push_str(body.strip_suffix("# EOF\n").unwrap_or(&body));
+    }
+    out.push_str("# EOF\n");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn concat_encoded_keeps_exactly_one_eof_marker() {
+        let a = "metric_a 1\n# EOF\n".to_string();
+        let b = "metric_b 2\n# EOF\n".to_string();
+
+        let merged = concat_encoded([a, b]);
+
+        assert_eq!(merged, "metric_a 1\nmetric_b 2\n# EOF\n");
+        assert_eq!(merged.matches("# EOF").count(), 1);
+    }
+
+    #[test]
+    fn concat_encoded_of_one_body_is_unchanged() {
+        let body = "metric_a 1\n# EOF\n".to_string();
+        assert_eq!(concat_encoded([body.clone()]), body);
+    }
+}

--- a/crates/spur-metrics/src/k8s.rs
+++ b/crates/spur-metrics/src/k8s.rs
@@ -1,0 +1,350 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Snapshot of k0s cluster + node state for `/metrics/k8s` gauge export, plus the long-lived
+//! `K8sMetrics` accumulator for lifecycle counters/histograms and heartbeat-fed node metrics.
+
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::metrics::histogram::{exponential_buckets, Histogram};
+use prometheus_client::registry::Registry;
+
+use spur_core::k0s::{K0sPhase, K0sRole};
+
+/// Distribution label value. All current implementations are k0s; the label exists so future
+/// distributions can share the `spur_k8s_*` metric surface.
+pub const DEFAULT_DISTRIBUTION: &str = "k0s";
+
+/// All phases in state-set order, for exporting `spur_k8s_cluster_phase` as a one-hot label set.
+pub const ALL_PHASES: [K0sPhase; 4] = [
+    K0sPhase::Down,
+    K0sPhase::Provisioning,
+    K0sPhase::Ready,
+    K0sPhase::Degraded,
+];
+
+/// Lower-case label value for a phase (matches the serde `snake_case` wire form).
+pub fn phase_label(phase: K0sPhase) -> &'static str {
+    match phase {
+        K0sPhase::Down => "down",
+        K0sPhase::Provisioning => "provisioning",
+        K0sPhase::Ready => "ready",
+        K0sPhase::Degraded => "degraded",
+    }
+}
+
+/// Lower-case label value for a role.
+pub fn role_label(role: K0sRole) -> &'static str {
+    match role {
+        K0sRole::Controller => "controller",
+        K0sRole::Worker => "worker",
+        K0sRole::Single => "single",
+    }
+}
+
+/// Current k0s cluster-level state, rebuilt from live controller state on each scrape.
+#[derive(Debug, Clone)]
+pub struct K8sClusterMetricsSnapshot {
+    pub cluster: String,
+    pub distribution: String,
+    pub phase: K0sPhase,
+    pub control_plane_replicas: u64,
+    pub nodes_total: u64,
+    pub nodes_by_role: [(K0sRole, u64); 3],
+}
+
+impl Default for K8sClusterMetricsSnapshot {
+    fn default() -> Self {
+        Self {
+            cluster: String::new(),
+            distribution: DEFAULT_DISTRIBUTION.into(),
+            phase: K0sPhase::Down,
+            control_plane_replicas: 0,
+            nodes_total: 0,
+            nodes_by_role: [
+                (K0sRole::Controller, 0),
+                (K0sRole::Worker, 0),
+                (K0sRole::Single, 0),
+            ],
+        }
+    }
+}
+
+impl K8sClusterMetricsSnapshot {
+    /// Build a snapshot from the cluster name, replica count, phase, and the assigned roles of all
+    /// nodes that currently hold a k0s role (`None` roles are ignored).
+    pub fn collect(
+        cluster: impl Into<String>,
+        control_plane_replicas: u64,
+        phase: K0sPhase,
+        node_roles: impl IntoIterator<Item = Option<K0sRole>>,
+    ) -> Self {
+        let mut controller = 0;
+        let mut worker = 0;
+        let mut single = 0;
+        for role in node_roles.into_iter().flatten() {
+            match role {
+                K0sRole::Controller => controller += 1,
+                K0sRole::Worker => worker += 1,
+                K0sRole::Single => single += 1,
+            }
+        }
+        let nodes_total = controller + worker + single;
+        Self {
+            cluster: cluster.into(),
+            distribution: DEFAULT_DISTRIBUTION.into(),
+            phase,
+            control_plane_replicas,
+            nodes_total,
+            nodes_by_role: [
+                (K0sRole::Controller, controller),
+                (K0sRole::Worker, worker),
+                (K0sRole::Single, single),
+            ],
+        }
+    }
+
+    /// 1 when the cluster phase is Ready (the primary alerting signal), else 0.
+    pub fn up(&self) -> u64 {
+        u64::from(self.phase == K0sPhase::Ready)
+    }
+}
+
+/// Base `distribution` + `cluster` labels carried by every k8s metric.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct BaseLabel {
+    pub distribution: String,
+    pub cluster: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct TransitionLabel {
+    distribution: String,
+    cluster: String,
+    from: String,
+    to: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct NodeLabel {
+    distribution: String,
+    cluster: String,
+    node: String,
+    role: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct NodeBaseLabel {
+    distribution: String,
+    cluster: String,
+    node: String,
+}
+
+/// Long-lived accumulator for k0s lifecycle counters/histograms and heartbeat-fed node metrics.
+///
+/// Cumulative and event-timed metrics cannot be rebuilt from a plain snapshot each scrape the way
+/// gauges are, so the controller holds one `Arc<K8sMetrics>` for the process lifetime and the
+/// `/metrics/k8s` handler registers clones (Arc-shared inner state) into the response registry.
+#[derive(Debug, Clone)]
+pub struct K8sMetrics {
+    provision_attempts: Family<BaseLabel, Counter>,
+    provision_failures: Family<BaseLabel, Counter>,
+    phase_transitions: Family<TransitionLabel, Counter>,
+    reconcile_errors: Family<BaseLabel, Counter>,
+    reconcile_duration: Family<BaseLabel, Histogram>,
+    node_up: Family<NodeLabel, Gauge>,
+    node_restarts: Family<NodeBaseLabel, Counter>,
+    node_install_duration: Family<NodeBaseLabel, Histogram>,
+}
+
+impl Default for K8sMetrics {
+    fn default() -> Self {
+        // Reconcile loop and install both span sub-second to tens of seconds.
+        let reconcile_buckets = || Histogram::new(exponential_buckets(0.005, 2.0, 12));
+        let install_buckets = || Histogram::new(exponential_buckets(0.5, 2.0, 10));
+        Self {
+            provision_attempts: Family::default(),
+            provision_failures: Family::default(),
+            phase_transitions: Family::default(),
+            reconcile_errors: Family::default(),
+            reconcile_duration: Family::new_with_constructor(reconcile_buckets),
+            node_up: Family::default(),
+            node_restarts: Family::default(),
+            node_install_duration: Family::new_with_constructor(install_buckets),
+        }
+    }
+}
+
+impl K8sMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn base(&self, cluster: &str) -> BaseLabel {
+        BaseLabel {
+            distribution: DEFAULT_DISTRIBUTION.into(),
+            cluster: cluster.to_string(),
+        }
+    }
+
+    /// Record a provisioning attempt (a Down→Provisioning transition).
+    pub fn record_provision_attempt(&self, cluster: &str) {
+        self.provision_attempts
+            .get_or_create(&self.base(cluster))
+            .inc();
+    }
+
+    /// Record a provisioning failure (failed to reach Ready).
+    pub fn record_provision_failure(&self, cluster: &str) {
+        self.provision_failures
+            .get_or_create(&self.base(cluster))
+            .inc();
+    }
+
+    /// Record a phase transition from `from` to `to`.
+    pub fn record_phase_transition(&self, cluster: &str, from: K0sPhase, to: K0sPhase) {
+        self.phase_transitions
+            .get_or_create(&TransitionLabel {
+                distribution: DEFAULT_DISTRIBUTION.into(),
+                cluster: cluster.to_string(),
+                from: phase_label(from).into(),
+                to: phase_label(to).into(),
+            })
+            .inc();
+    }
+
+    /// Record a reconcile-loop error (token minting, RPC to node agents, etc.).
+    pub fn record_reconcile_error(&self, cluster: &str) {
+        self.reconcile_errors
+            .get_or_create(&self.base(cluster))
+            .inc();
+    }
+
+    /// Record the wall time of one reconcile-loop iteration.
+    pub fn observe_reconcile_duration(&self, cluster: &str, seconds: f64) {
+        self.reconcile_duration
+            .get_or_create(&self.base(cluster))
+            .observe(seconds);
+    }
+
+    /// Set a node's k0s unit up/down gauge (1 active, 0 otherwise).
+    pub fn set_node_up(&self, cluster: &str, node: &str, role: K0sRole, active: bool) {
+        self.node_up
+            .get_or_create(&NodeLabel {
+                distribution: DEFAULT_DISTRIBUTION.into(),
+                cluster: cluster.to_string(),
+                node: node.to_string(),
+                role: role_label(role).into(),
+            })
+            .set(i64::from(active));
+    }
+
+    /// Absolute cumulative restart count reported by a node; advances the counter by any positive
+    /// delta so a monotonic counter is preserved across scrapes.
+    pub fn set_node_restart_total(&self, cluster: &str, node: &str, total: u64) {
+        let counter = self.node_restarts.get_or_create(&NodeBaseLabel {
+            distribution: DEFAULT_DISTRIBUTION.into(),
+            cluster: cluster.to_string(),
+            node: node.to_string(),
+        });
+        let current = counter.get();
+        if total > current {
+            counter.inc_by(total - current);
+        }
+    }
+
+    /// Observe a node's k0s install duration (once per successful install).
+    pub fn observe_node_install_duration(&self, cluster: &str, node: &str, seconds: f64) {
+        self.node_install_duration
+            .get_or_create(&NodeBaseLabel {
+                distribution: DEFAULT_DISTRIBUTION.into(),
+                cluster: cluster.to_string(),
+                node: node.to_string(),
+            })
+            .observe(seconds);
+    }
+
+    /// Ensure the base-labeled counter/histogram series exist at zero for `cluster`, so a fresh
+    /// controller still exposes them (alerting rules reference the series before the first event).
+    pub fn ensure_series(&self, cluster: &str) {
+        let base = self.base(cluster);
+        let _ = self.provision_attempts.get_or_create(&base);
+        let _ = self.provision_failures.get_or_create(&base);
+        let _ = self.reconcile_errors.get_or_create(&base);
+        let _ = self.reconcile_duration.get_or_create(&base);
+    }
+
+    /// Register the accumulator's metrics (Arc-shared clones) into a response registry.
+    pub fn register(&self, registry: &mut Registry) {
+        registry.register(
+            "spur_k8s_provision_attempts",
+            "k0s provisioning attempts (Down to Provisioning transitions)",
+            self.provision_attempts.clone(),
+        );
+        registry.register(
+            "spur_k8s_provision_failures",
+            "k0s provisioning attempts that failed to reach Ready",
+            self.provision_failures.clone(),
+        );
+        registry.register(
+            "spur_k8s_phase_transitions",
+            "k0s cluster phase transitions labeled by source and destination",
+            self.phase_transitions.clone(),
+        );
+        registry.register(
+            "spur_k8s_reconcile_errors",
+            "Errors during a k0s reconcile-loop iteration",
+            self.reconcile_errors.clone(),
+        );
+        registry.register(
+            "spur_k8s_reconcile_duration_seconds",
+            "Wall time of each k0s reconcile-loop iteration",
+            self.reconcile_duration.clone(),
+        );
+        registry.register(
+            "spur_k8s_node_up",
+            "Whether a node's k0s systemd unit reports active (1) or not (0)",
+            self.node_up.clone(),
+        );
+        registry.register(
+            "spur_k8s_node_restart",
+            "Cumulative k0s unit restarts per node",
+            self.node_restarts.clone(),
+        );
+        registry.register(
+            "spur_k8s_install_duration_seconds",
+            "Time to install k0s and bring the unit active, per node",
+            self.node_install_duration.clone(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_counts_roles_and_ignores_unassigned() {
+        let roles = [
+            Some(K0sRole::Controller),
+            Some(K0sRole::Worker),
+            Some(K0sRole::Worker),
+            None,
+        ];
+        let snap = K8sClusterMetricsSnapshot::collect("c1", 1, K0sPhase::Ready, roles);
+        assert_eq!(snap.nodes_total, 3);
+        assert_eq!(snap.nodes_by_role[0], (K0sRole::Controller, 1));
+        assert_eq!(snap.nodes_by_role[1], (K0sRole::Worker, 2));
+        assert_eq!(snap.nodes_by_role[2], (K0sRole::Single, 0));
+        assert_eq!(snap.up(), 1);
+    }
+
+    #[test]
+    fn up_is_zero_when_not_ready() {
+        let snap = K8sClusterMetricsSnapshot::collect("c1", 3, K0sPhase::Degraded, [None]);
+        assert_eq!(snap.up(), 0);
+        assert_eq!(snap.control_plane_replicas, 3);
+    }
+}

--- a/crates/spur-metrics/src/k8s.rs
+++ b/crates/spur-metrics/src/k8s.rs
@@ -221,27 +221,29 @@ impl K8sMetrics {
             .observe(seconds);
     }
 
+    fn node_label(&self, cluster: &str, node: &str) -> NodeBaseLabel {
+        NodeBaseLabel {
+            distribution: DEFAULT_DISTRIBUTION.into(),
+            cluster: cluster.to_string(),
+            node: node.to_string(),
+        }
+    }
+
     /// Set a node's k0s unit up/down gauge (1 active, 0 otherwise). Role is intentionally not a
     /// label here (it would churn/leak series on a role change); per-role counts live in the
     /// fresh-per-scrape `spur_k8s_nodes_by_role` gauge.
     pub fn set_node_up(&self, cluster: &str, node: &str, active: bool) {
         self.node_up
-            .get_or_create(&NodeBaseLabel {
-                distribution: DEFAULT_DISTRIBUTION.into(),
-                cluster: cluster.to_string(),
-                node: node.to_string(),
-            })
+            .get_or_create(&self.node_label(cluster, node))
             .set(i64::from(active));
     }
 
     /// Absolute cumulative restart count reported by a node; advances the counter by any positive
     /// delta so a monotonic counter is preserved across scrapes.
     pub fn set_node_restart_total(&self, cluster: &str, node: &str, total: u64) {
-        let counter = self.node_restarts.get_or_create(&NodeBaseLabel {
-            distribution: DEFAULT_DISTRIBUTION.into(),
-            cluster: cluster.to_string(),
-            node: node.to_string(),
-        });
+        let counter = self
+            .node_restarts
+            .get_or_create(&self.node_label(cluster, node));
         let current = counter.get();
         if total > current {
             counter.inc_by(total - current);
@@ -251,12 +253,17 @@ impl K8sMetrics {
     /// Observe a node's k0s install duration (once per successful install).
     pub fn observe_node_install_duration(&self, cluster: &str, node: &str, seconds: f64) {
         self.node_install_duration
-            .get_or_create(&NodeBaseLabel {
-                distribution: DEFAULT_DISTRIBUTION.into(),
-                cluster: cluster.to_string(),
-                node: node.to_string(),
-            })
+            .get_or_create(&self.node_label(cluster, node))
             .observe(seconds);
+    }
+
+    /// Drop all per-node series for a node that left k0s inventory (deregistered or role cleared),
+    /// so decommissioned names don't accumulate and export stale values forever.
+    pub fn remove_node(&self, cluster: &str, node: &str) {
+        let label = self.node_label(cluster, node);
+        self.node_up.remove(&label);
+        self.node_restarts.remove(&label);
+        self.node_install_duration.remove(&label);
     }
 
     /// Ensure the base-labeled counter/histogram series exist at zero for `cluster`, so a fresh

--- a/crates/spur-metrics/src/k8s.rs
+++ b/crates/spur-metrics/src/k8s.rs
@@ -128,14 +128,6 @@ struct TransitionLabel {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
-struct NodeLabel {
-    distribution: String,
-    cluster: String,
-    node: String,
-    role: String,
-}
-
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct NodeBaseLabel {
     distribution: String,
     cluster: String,
@@ -154,7 +146,7 @@ pub struct K8sMetrics {
     phase_transitions: Family<TransitionLabel, Counter>,
     reconcile_errors: Family<BaseLabel, Counter>,
     reconcile_duration: Family<BaseLabel, Histogram>,
-    node_up: Family<NodeLabel, Gauge>,
+    node_up: Family<NodeBaseLabel, Gauge>,
     node_restarts: Family<NodeBaseLabel, Counter>,
     node_install_duration: Family<NodeBaseLabel, Histogram>,
 }
@@ -229,14 +221,15 @@ impl K8sMetrics {
             .observe(seconds);
     }
 
-    /// Set a node's k0s unit up/down gauge (1 active, 0 otherwise).
-    pub fn set_node_up(&self, cluster: &str, node: &str, role: K0sRole, active: bool) {
+    /// Set a node's k0s unit up/down gauge (1 active, 0 otherwise). Role is intentionally not a
+    /// label here (it would churn/leak series on a role change); per-role counts live in the
+    /// fresh-per-scrape `spur_k8s_nodes_by_role` gauge.
+    pub fn set_node_up(&self, cluster: &str, node: &str, active: bool) {
         self.node_up
-            .get_or_create(&NodeLabel {
+            .get_or_create(&NodeBaseLabel {
                 distribution: DEFAULT_DISTRIBUTION.into(),
                 cluster: cluster.to_string(),
                 node: node.to_string(),
-                role: role_label(role).into(),
             })
             .set(i64::from(active));
     }

--- a/crates/spur-metrics/src/k8s.rs
+++ b/crates/spur-metrics/src/k8s.rs
@@ -4,6 +4,7 @@
 //! Snapshot of k0s cluster + node state for `/metrics/k8s` gauge export, plus the long-lived
 //! `K8sMetrics` accumulator for lifecycle counters/histograms and heartbeat-fed node metrics.
 
+use prometheus_client::encoding::text::encode as encode_openmetrics;
 use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
@@ -74,7 +75,8 @@ impl Default for K8sClusterMetricsSnapshot {
 
 impl K8sClusterMetricsSnapshot {
     /// Build a snapshot from the cluster name, replica count, phase, and the assigned roles of all
-    /// nodes that currently hold a k0s role (`None` roles are ignored).
+    /// nodes that currently hold a k0s role (`None` roles are ignored). Scans `node_roles` once;
+    /// prefer `from_role_counts` when the caller already maintains per-role counts.
     pub fn collect(
         cluster: impl Into<String>,
         control_plane_replicas: u64,
@@ -91,13 +93,31 @@ impl K8sClusterMetricsSnapshot {
                 K0sRole::Single => single += 1,
             }
         }
-        let nodes_total = controller + worker + single;
+        Self::from_role_counts(
+            cluster,
+            control_plane_replicas,
+            phase,
+            controller,
+            worker,
+            single,
+        )
+    }
+
+    /// Build a snapshot directly from already-known per-role node counts, skipping a node scan.
+    pub fn from_role_counts(
+        cluster: impl Into<String>,
+        control_plane_replicas: u64,
+        phase: K0sPhase,
+        controller: u64,
+        worker: u64,
+        single: u64,
+    ) -> Self {
         Self {
             cluster: cluster.into(),
             distribution: DEFAULT_DISTRIBUTION.into(),
             phase,
             control_plane_replicas,
-            nodes_total,
+            nodes_total: controller + worker + single,
             nodes_by_role: [
                 (K0sRole::Controller, controller),
                 (K0sRole::Worker, worker),
@@ -137,9 +157,11 @@ struct NodeBaseLabel {
 /// Long-lived accumulator for k0s lifecycle counters/histograms and heartbeat-fed node metrics.
 ///
 /// Cumulative and event-timed metrics cannot be rebuilt from a plain snapshot each scrape the way
-/// gauges are, so the controller holds one `Arc<K8sMetrics>` for the process lifetime and the
-/// `/metrics/k8s` handler registers clones (Arc-shared inner state) into the response registry.
-#[derive(Debug, Clone)]
+/// gauges are, so the controller holds one `Arc<K8sMetrics>` for the process lifetime. Its
+/// families are registered into `registry` once, at construction, rather than on every scrape:
+/// `Family` is `Arc`-backed, so the registered clones stay live and `encode()` always reads
+/// current values without repeating the registration bookkeeping per request.
+#[derive(Debug)]
 pub struct K8sMetrics {
     provision_attempts: Family<BaseLabel, Counter>,
     provision_failures: Family<BaseLabel, Counter>,
@@ -149,6 +171,7 @@ pub struct K8sMetrics {
     node_up: Family<NodeBaseLabel, Gauge>,
     node_restarts: Family<NodeBaseLabel, Counter>,
     node_install_duration: Family<NodeBaseLabel, Histogram>,
+    registry: Registry,
 }
 
 impl Default for K8sMetrics {
@@ -156,15 +179,69 @@ impl Default for K8sMetrics {
         // Reconcile loop and install both span sub-second to tens of seconds.
         let reconcile_buckets = || Histogram::new(exponential_buckets(0.005, 2.0, 12));
         let install_buckets = || Histogram::new(exponential_buckets(0.5, 2.0, 10));
+        let provision_attempts = Family::default();
+        let provision_failures = Family::default();
+        let phase_transitions = Family::default();
+        let reconcile_errors = Family::default();
+        let reconcile_duration: Family<BaseLabel, Histogram> =
+            Family::new_with_constructor(reconcile_buckets);
+        let node_up = Family::default();
+        let node_restarts = Family::default();
+        let node_install_duration: Family<NodeBaseLabel, Histogram> =
+            Family::new_with_constructor(install_buckets);
+
+        let mut registry = Registry::default();
+        registry.register(
+            "spur_k8s_provision_attempts",
+            "k0s provisioning attempts (Down to Provisioning transitions)",
+            provision_attempts.clone(),
+        );
+        registry.register(
+            "spur_k8s_provision_failures",
+            "k0s provisioning attempts that failed to reach Ready",
+            provision_failures.clone(),
+        );
+        registry.register(
+            "spur_k8s_phase_transitions",
+            "k0s cluster phase transitions labeled by source and destination",
+            phase_transitions.clone(),
+        );
+        registry.register(
+            "spur_k8s_reconcile_errors",
+            "Errors during a k0s reconcile-loop iteration",
+            reconcile_errors.clone(),
+        );
+        registry.register(
+            "spur_k8s_reconcile_duration_seconds",
+            "Wall time of each k0s reconcile-loop iteration",
+            reconcile_duration.clone(),
+        );
+        registry.register(
+            "spur_k8s_node_up",
+            "Whether a node's k0s systemd unit reports active (1) or not (0)",
+            node_up.clone(),
+        );
+        registry.register(
+            "spur_k8s_node_restart",
+            "Cumulative k0s unit restarts per node",
+            node_restarts.clone(),
+        );
+        registry.register(
+            "spur_k8s_install_duration_seconds",
+            "Time to install k0s and bring the unit active, per node",
+            node_install_duration.clone(),
+        );
+
         Self {
-            provision_attempts: Family::default(),
-            provision_failures: Family::default(),
-            phase_transitions: Family::default(),
-            reconcile_errors: Family::default(),
-            reconcile_duration: Family::new_with_constructor(reconcile_buckets),
-            node_up: Family::default(),
-            node_restarts: Family::default(),
-            node_install_duration: Family::new_with_constructor(install_buckets),
+            provision_attempts,
+            provision_failures,
+            phase_transitions,
+            reconcile_errors,
+            reconcile_duration,
+            node_up,
+            node_restarts,
+            node_install_duration,
+            registry,
         }
     }
 }
@@ -276,48 +353,12 @@ impl K8sMetrics {
         let _ = self.reconcile_duration.get_or_create(&base);
     }
 
-    /// Register the accumulator's metrics (Arc-shared clones) into a response registry.
-    pub fn register(&self, registry: &mut Registry) {
-        registry.register(
-            "spur_k8s_provision_attempts",
-            "k0s provisioning attempts (Down to Provisioning transitions)",
-            self.provision_attempts.clone(),
-        );
-        registry.register(
-            "spur_k8s_provision_failures",
-            "k0s provisioning attempts that failed to reach Ready",
-            self.provision_failures.clone(),
-        );
-        registry.register(
-            "spur_k8s_phase_transitions",
-            "k0s cluster phase transitions labeled by source and destination",
-            self.phase_transitions.clone(),
-        );
-        registry.register(
-            "spur_k8s_reconcile_errors",
-            "Errors during a k0s reconcile-loop iteration",
-            self.reconcile_errors.clone(),
-        );
-        registry.register(
-            "spur_k8s_reconcile_duration_seconds",
-            "Wall time of each k0s reconcile-loop iteration",
-            self.reconcile_duration.clone(),
-        );
-        registry.register(
-            "spur_k8s_node_up",
-            "Whether a node's k0s systemd unit reports active (1) or not (0)",
-            self.node_up.clone(),
-        );
-        registry.register(
-            "spur_k8s_node_restart",
-            "Cumulative k0s unit restarts per node",
-            self.node_restarts.clone(),
-        );
-        registry.register(
-            "spur_k8s_install_duration_seconds",
-            "Time to install k0s and bring the unit active, per node",
-            self.node_install_duration.clone(),
-        );
+    /// Encode the accumulator's families from the registry built once at construction — no
+    /// per-scrape registration, just a read of current values.
+    pub fn encode(&self) -> String {
+        let mut body = String::new();
+        encode_openmetrics(&mut body, &self.registry).expect("in-memory encode");
+        body
     }
 }
 
@@ -346,5 +387,20 @@ mod tests {
         let snap = K8sClusterMetricsSnapshot::collect("c1", 3, K0sPhase::Degraded, [None]);
         assert_eq!(snap.up(), 0);
         assert_eq!(snap.control_plane_replicas, 3);
+    }
+
+    #[test]
+    fn encode_reads_live_values_from_the_registry_built_at_construction() {
+        let metrics = K8sMetrics::new();
+        assert!(!metrics.encode().contains("node=\"a\""));
+
+        // The registry is built once in `new()`; a value set afterward must still show up,
+        // proving the registered families are the same live Arc-shared instances.
+        metrics.set_node_up("prod", "a", true);
+        let body = metrics.encode();
+        assert!(
+            body.contains("spur_k8s_node_up{distribution=\"k0s\",cluster=\"prod\",node=\"a\"} 1\n")
+        );
+        assert!(body.ends_with("# EOF\n"));
     }
 }

--- a/crates/spur-metrics/src/lib.rs
+++ b/crates/spur-metrics/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod export;
 pub mod job;
+pub mod k8s;
 pub mod node;
 pub mod partition;
 pub mod rpc;
@@ -13,11 +14,13 @@ pub mod user_acct;
 
 pub use export::jobs::{encode_job_metrics, job_state_metric_suffix};
 pub use export::jobs_users_accts::encode_jobs_users_accts_metrics;
+pub use export::k8s_cluster::{encode_k8s_cluster_metrics, encode_k8s_metrics};
 pub use export::nodes::encode_nodes_metrics;
 pub use export::partitions::encode_partitions_metrics;
 pub use export::rpc::encode_rpc_metrics;
 pub use export::scheduler::encode_scheduler_metrics;
 pub use export::CONTENT_TYPE;
+pub use k8s::{K8sClusterMetricsSnapshot, K8sMetrics};
 pub use node::node_state_metric_suffix;
 pub use partition::PartitionMetricsSnapshot;
 pub use rpc::{RpcOperationSnapshot, RpcStatsSnapshot};

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2192,10 +2192,12 @@ impl ClusterManager {
             let cluster = self.config().cluster_name.clone();
             self.k8s_metrics
                 .record_phase_transition(&cluster, from, phase);
-            if phase == K0sPhase::Provisioning && from != K0sPhase::Provisioning {
+            if phase == K0sPhase::Provisioning {
                 self.k8s_metrics.record_provision_attempt(&cluster);
             }
-            if phase == K0sPhase::Degraded {
+            // Only a provisioning attempt that gives up counts as a provisioning failure; a
+            // Ready -> Degraded runtime fault does not.
+            if phase == K0sPhase::Degraded && from == K0sPhase::Provisioning {
                 self.k8s_metrics.record_provision_failure(&cluster);
             }
         }
@@ -12950,6 +12952,71 @@ mod tests {
         });
 
         assert!(cm.set_node_k0s_error("ghost", Some("x".into())).is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reconcile_phase_reports_no_error_for_down_and_degraded() {
+        use spur_core::k0s::K0sPhase;
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let net = crate::cluster_k8s::ClusterNetworking {
+            mesh_cidr: "10.44.0.0/16".into(),
+            pod_cidr: "10.42.0.0/16".into(),
+            service_cidr: "10.43.0.0/16".into(),
+            cni_mtu: 1450,
+            cni: "kuberouter".into(),
+            control_plane_node: None,
+        };
+        let mut tokens = std::collections::HashMap::new();
+
+        let down = spur_core::k0s::K0sClusterState {
+            phase: K0sPhase::Down,
+            ..Default::default()
+        };
+        assert!(!crate::cluster_k8s::reconcile_phase(&cm, &net, &down, &mut tokens).await);
+
+        let degraded = spur_core::k0s::K0sClusterState {
+            phase: K0sPhase::Degraded,
+            ..Default::default()
+        };
+        assert!(!crate::cluster_k8s::reconcile_phase(&cm, &net, &degraded, &mut tokens).await);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn set_k0s_phase_counts_attempts_and_transitions() {
+        use spur_core::k0s::K0sPhase;
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        cm.set_k0s_phase(K0sPhase::Provisioning, Some("n1".into()), Vec::new(), false)
+            .unwrap();
+        wait_for("provisioning", || {
+            cm.k0s_state().phase == K0sPhase::Provisioning
+        });
+        cm.set_k0s_phase(K0sPhase::Ready, Some("n1".into()), Vec::new(), false)
+            .unwrap();
+        wait_for("ready", || cm.k0s_state().phase == K0sPhase::Ready);
+        // Re-provision: a second attempt.
+        cm.set_k0s_phase(K0sPhase::Provisioning, Some("n1".into()), Vec::new(), false)
+            .unwrap();
+        wait_for("provisioning again", || {
+            cm.k0s_state().phase == K0sPhase::Provisioning
+        });
+        // A no-op set to the same phase must not double-count.
+        cm.set_k0s_phase(K0sPhase::Provisioning, Some("n1".into()), Vec::new(), false)
+            .unwrap();
+
+        let body = spur_metrics::encode_k8s_metrics(&cm.k8s_cluster_metrics(), &cm.k8s_metrics());
+        assert!(body.contains(
+            "spur_k8s_provision_attempts_total{distribution=\"k0s\",cluster=\"test\"} 2\n"
+        ));
+        assert!(body.contains("from=\"down\",to=\"provisioning\"} 1\n"));
+        assert!(body.contains("from=\"provisioning\",to=\"ready\"} 1\n"));
+        assert!(body.contains("from=\"ready\",to=\"provisioning\"} 1\n"));
+        // Nothing set Degraded, so no provisioning failure was recorded.
+        assert!(body.contains(
+            "spur_k8s_provision_failures_total{distribution=\"k0s\",cluster=\"test\"} 0\n"
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use chrono::{DateTime, Utc};
@@ -285,6 +285,59 @@ pub enum PreemptOutcome {
     Suspended,
 }
 
+/// Per-role node counts backing `/metrics/k8s`'s `spur_k8s_nodes_by_role`. Kept in sync with
+/// `Node.k0s_role` incrementally in `apply()` (every replica, so a promoted follower is already
+/// correct); `recompute_from` is the only O(n) path, used once on snapshot restore/startup.
+#[derive(Default)]
+struct K0sRoleCounts {
+    controller: AtomicU64,
+    worker: AtomicU64,
+    single: AtomicU64,
+}
+
+impl K0sRoleCounts {
+    fn counter(&self, role: spur_core::k0s::K0sRole) -> &AtomicU64 {
+        use spur_core::k0s::K0sRole;
+        match role {
+            K0sRole::Controller => &self.controller,
+            K0sRole::Worker => &self.worker,
+            K0sRole::Single => &self.single,
+        }
+    }
+
+    fn inc(&self, role: spur_core::k0s::K0sRole) {
+        self.counter(role).fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn dec(&self, role: spur_core::k0s::K0sRole) {
+        self.counter(role).fetch_sub(1, Ordering::Relaxed);
+    }
+
+    /// (controller, worker, single).
+    fn snapshot(&self) -> (u64, u64, u64) {
+        (
+            self.controller.load(Ordering::Relaxed),
+            self.worker.load(Ordering::Relaxed),
+            self.single.load(Ordering::Relaxed),
+        )
+    }
+
+    fn recompute_from(&self, roles: impl Iterator<Item = Option<spur_core::k0s::K0sRole>>) {
+        use spur_core::k0s::K0sRole;
+        let (mut controller, mut worker, mut single) = (0u64, 0u64, 0u64);
+        for role in roles.flatten() {
+            match role {
+                K0sRole::Controller => controller += 1,
+                K0sRole::Worker => worker += 1,
+                K0sRole::Single => single += 1,
+            }
+        }
+        self.controller.store(controller, Ordering::Relaxed);
+        self.worker.store(worker, Ordering::Relaxed);
+        self.single.store(single, Ordering::Relaxed);
+    }
+}
+
 /// Central cluster state manager.
 ///
 /// Thread-safe via RwLock. The scheduler and gRPC server both access this.
@@ -336,6 +389,8 @@ pub struct ClusterManager {
     k0s: RwLock<spur_core::k0s::K0sClusterState>,
     /// Long-lived k0s lifecycle/node metric accumulator exported at `/metrics/k8s`.
     k8s_metrics: Arc<spur_metrics::K8sMetrics>,
+    /// Per-role node counts for `/metrics/k8s`, avoiding a full node scan every scrape.
+    k0s_role_counts: K0sRoleCounts,
     /// Serializes k0s phase-transition accounting so concurrent `set_k0s_phase` callers can't both
     /// read the same prior phase and double-count the edge.
     k0s_phase_accounting: parking_lot::Mutex<()>,
@@ -400,6 +455,7 @@ impl ClusterManager {
             tokens: RwLock::new(HashMap::new()),
             k0s: RwLock::new(spur_core::k0s::K0sClusterState::default()),
             k8s_metrics: Arc::new(spur_metrics::K8sMetrics::new()),
+            k0s_role_counts: K0sRoleCounts::default(),
             k0s_phase_accounting: parking_lot::Mutex::new(()),
             raft: RwLock::new(None),
             accounting: RwLock::new(None),
@@ -2224,21 +2280,19 @@ impl ClusterManager {
         self.k8s_metrics.clone()
     }
 
-    /// Current k0s cluster gauges, rebuilt from live state on each scrape.
+    /// Current k0s cluster gauges. Role counts come from the incrementally-maintained
+    /// `k0s_role_counts` cache rather than a full node scan (see its doc comment).
     pub fn k8s_cluster_metrics(&self) -> spur_metrics::K8sClusterMetricsSnapshot {
         let config = self.config();
         let phase = self.k0s.read().phase;
-        let roles = self
-            .nodes
-            .read()
-            .values()
-            .map(|n| n.k0s_role)
-            .collect::<Vec<_>>();
-        spur_metrics::K8sClusterMetricsSnapshot::collect(
+        let (controller, worker, single) = self.k0s_role_counts.snapshot();
+        spur_metrics::K8sClusterMetricsSnapshot::from_role_counts(
             config.cluster_name.clone(),
             u64::from(config.cluster.control_plane_replicas),
             phase,
-            roles,
+            controller,
+            worker,
+            single,
         )
     }
 
@@ -4748,6 +4802,10 @@ impl ClusterManager {
                             "removing node with nonzero allocations"
                         );
                     }
+                    // A node can be force-removed while still k0s-assigned (no prior `k8s down`).
+                    if let Some(role) = node.k0s_role {
+                        self.k0s_role_counts.dec(role);
+                    }
                 }
                 nodes.remove(name);
                 info!(
@@ -4989,6 +5047,12 @@ impl ClusterManager {
             } => {
                 // Reuses the `nodes` write guard from the top of this fn.
                 if let Some(node) = nodes.get_mut(name) {
+                    if node.k0s_role != Some(*role) {
+                        if let Some(old) = node.k0s_role {
+                            self.k0s_role_counts.dec(old);
+                        }
+                        self.k0s_role_counts.inc(*role);
+                    }
                     node.k0s_role = Some(*role);
                     node.k0s_mesh_ip = Some(mesh_ip.clone());
                     node.k0s_pod_cidr = Some(pod_cidr.clone());
@@ -4996,7 +5060,9 @@ impl ClusterManager {
             }
             WalOperation::NodeK0sClear { name } => {
                 if let Some(node) = nodes.get_mut(name) {
-                    node.k0s_role = None;
+                    if let Some(old) = node.k0s_role.take() {
+                        self.k0s_role_counts.dec(old);
+                    }
                     node.k0s_mesh_ip = None;
                     node.k0s_pod_cidr = None;
                     node.k0s_last_error = None;
@@ -5180,6 +5246,8 @@ impl StateMachineApply for ClusterManager {
         for node in snap.nodes {
             nodes.insert(node.name.clone(), node);
         }
+        self.k0s_role_counts
+            .recompute_from(nodes.values().map(|n| n.k0s_role));
 
         *self.reservations.write() = snap.reservations;
 
@@ -13022,6 +13090,56 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn k8s_cluster_metrics_role_counts_track_assign_clear_and_remove() {
+        use spur_core::k0s::K0sRole;
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "node-a", 4, 8000);
+        register_node(&cm, "node-b", 4, 8000);
+        wait_for("both registered", || {
+            cm.get_node("node-a").is_some() && cm.get_node("node-b").is_some()
+        });
+
+        let counts = |cm: &ClusterManager| {
+            let snap = cm.k8s_cluster_metrics();
+            (snap.nodes_total, snap.nodes_by_role)
+        };
+        assert_eq!(counts(&cm).0, 0, "no roles assigned yet");
+
+        cm.assign_node_k0s("node-a", K0sRole::Controller, "10.44.0.2", "10.42.2.0/24")
+            .unwrap();
+        cm.assign_node_k0s("node-b", K0sRole::Worker, "10.44.0.3", "10.42.3.0/24")
+            .unwrap();
+        let (total, by_role) = counts(&cm);
+        assert_eq!(total, 2);
+        assert_eq!(by_role[0], (K0sRole::Controller, 1));
+        assert_eq!(by_role[1], (K0sRole::Worker, 1));
+
+        // Re-assigning the same role to the same node must not double-count.
+        cm.assign_node_k0s("node-a", K0sRole::Controller, "10.44.0.2", "10.42.2.0/24")
+            .unwrap();
+        assert_eq!(
+            counts(&cm).0,
+            2,
+            "idempotent re-assign must not inflate the total"
+        );
+
+        cm.clear_node_k0s("node-a").unwrap();
+        let (total, by_role) = counts(&cm);
+        assert_eq!(total, 1);
+        assert_eq!(by_role[0], (K0sRole::Controller, 0));
+        assert_eq!(by_role[1], (K0sRole::Worker, 1));
+
+        // A force-removed node that still holds a role must not leak into the count.
+        cm.remove_node("node-b", true, None).unwrap();
+        assert_eq!(
+            counts(&cm).0,
+            0,
+            "removing an assigned node must release its role count"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn set_k0s_phase_counts_attempts_and_transitions() {
         use spur_core::k0s::K0sPhase;
         let dir = TempDir::new().unwrap();
@@ -13354,6 +13472,29 @@ mod tests {
             !cm2.get_partitions().iter().any(|p| p.name == "gpu"),
             "stale live partition must be gone after restore"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn restore_from_snapshot_rebuilds_k0s_role_counts() {
+        // The target never applies the source's NodeK0sAssign op itself — it only loads the
+        // already-assigned Node from the snapshot's node list — so this only passes if restore
+        // recomputes k0s_role_counts from scratch rather than relying on incremental apply().
+        use spur_core::k0s::K0sRole;
+        let src = TempDir::new().unwrap();
+        let cm = test_cluster(&src).await;
+        register_node(&cm, "node-a", 4, 8000);
+        wait_for("registered", || cm.get_node("node-a").is_some());
+        cm.assign_node_k0s("node-a", K0sRole::Controller, "10.44.0.2", "10.42.2.0/24")
+            .unwrap();
+        let data = cm.snapshot_state().unwrap();
+
+        let dst = TempDir::new().unwrap();
+        let cm2 = test_cluster(&dst).await;
+        cm2.restore_from_snapshot(&data).unwrap();
+
+        let snap = cm2.k8s_cluster_metrics();
+        assert_eq!(snap.nodes_total, 1);
+        assert_eq!(snap.nodes_by_role[0], (K0sRole::Controller, 1));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -13063,7 +13063,9 @@ mod tests {
             phase: K0sPhase::Degraded,
             ..Default::default()
         };
-        assert!(!crate::cluster_k8s::reconcile_phase(&cm, &net, &degraded, &mut tokens, false).await);
+        assert!(
+            !crate::cluster_k8s::reconcile_phase(&cm, &net, &degraded, &mut tokens, false).await
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -334,6 +334,8 @@ pub struct ClusterManager {
     tokens: RwLock<HashMap<String, spur_core::admission::AdmissionToken>>,
     /// Native k0s cluster state (phase, control-plane node, join-token metadata).
     k0s: RwLock<spur_core::k0s::K0sClusterState>,
+    /// Long-lived k0s lifecycle/node metric accumulator exported at `/metrics/k8s`.
+    k8s_metrics: Arc<spur_metrics::K8sMetrics>,
     raft: RwLock<Option<SpurRaft>>,
     accounting: RwLock<Option<AccountingNotifier>>,
     fairshare_cache: Arc<FairshareCache>,
@@ -394,6 +396,7 @@ impl ClusterManager {
             burst_buffer_total_gb: RwLock::new(burst_buffer_total_gb),
             tokens: RwLock::new(HashMap::new()),
             k0s: RwLock::new(spur_core::k0s::K0sClusterState::default()),
+            k8s_metrics: Arc::new(spur_metrics::K8sMetrics::new()),
             raft: RwLock::new(None),
             accounting: RwLock::new(None),
             fairshare_cache,
@@ -2176,6 +2179,8 @@ impl ClusterManager {
         member_nodes: Vec<String>,
         reset_requested: bool,
     ) -> anyhow::Result<()> {
+        use spur_core::k0s::K0sPhase;
+        let from = self.k0s.read().phase;
         self.propose(WalOperation::K0sSetPhase {
             phase,
             control_plane_node,
@@ -2183,6 +2188,17 @@ impl ClusterManager {
             member_nodes,
             reset_requested,
         })?;
+        if from != phase {
+            let cluster = self.config().cluster_name.clone();
+            self.k8s_metrics
+                .record_phase_transition(&cluster, from, phase);
+            if phase == K0sPhase::Provisioning && from != K0sPhase::Provisioning {
+                self.k8s_metrics.record_provision_attempt(&cluster);
+            }
+            if phase == K0sPhase::Degraded {
+                self.k8s_metrics.record_provision_failure(&cluster);
+            }
+        }
         info!(?phase, "k0s cluster phase set");
         Ok(())
     }
@@ -2190,6 +2206,29 @@ impl ClusterManager {
     /// snapshot of the current cluster-wide k0s state.
     pub fn k0s_state(&self) -> spur_core::k0s::K0sClusterState {
         self.k0s.read().clone()
+    }
+
+    /// The long-lived k0s lifecycle/node metric accumulator.
+    pub fn k8s_metrics(&self) -> Arc<spur_metrics::K8sMetrics> {
+        self.k8s_metrics.clone()
+    }
+
+    /// Current k0s cluster gauges, rebuilt from live state on each scrape.
+    pub fn k8s_cluster_metrics(&self) -> spur_metrics::K8sClusterMetricsSnapshot {
+        let config = self.config();
+        let phase = self.k0s.read().phase;
+        let roles = self
+            .nodes
+            .read()
+            .values()
+            .map(|n| n.k0s_role)
+            .collect::<Vec<_>>();
+        spur_metrics::K8sClusterMetricsSnapshot::collect(
+            config.cluster_name.clone(),
+            u64::from(config.cluster.control_plane_replicas),
+            phase,
+            roles,
+        )
     }
 
     /// Reconcile node liveness state with heartbeat data.

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -336,6 +336,9 @@ pub struct ClusterManager {
     k0s: RwLock<spur_core::k0s::K0sClusterState>,
     /// Long-lived k0s lifecycle/node metric accumulator exported at `/metrics/k8s`.
     k8s_metrics: Arc<spur_metrics::K8sMetrics>,
+    /// Serializes k0s phase-transition accounting so concurrent `set_k0s_phase` callers can't both
+    /// read the same prior phase and double-count the edge.
+    k0s_phase_accounting: parking_lot::Mutex<()>,
     raft: RwLock<Option<SpurRaft>>,
     accounting: RwLock<Option<AccountingNotifier>>,
     fairshare_cache: Arc<FairshareCache>,
@@ -397,6 +400,7 @@ impl ClusterManager {
             tokens: RwLock::new(HashMap::new()),
             k0s: RwLock::new(spur_core::k0s::K0sClusterState::default()),
             k8s_metrics: Arc::new(spur_metrics::K8sMetrics::new()),
+            k0s_phase_accounting: parking_lot::Mutex::new(()),
             raft: RwLock::new(None),
             accounting: RwLock::new(None),
             fairshare_cache,
@@ -2149,6 +2153,8 @@ impl ClusterManager {
         self.propose(WalOperation::NodeK0sClear {
             name: name.to_string(),
         })?;
+        self.k8s_metrics
+            .remove_node(&self.config().cluster_name, name);
         info!(node = %name, "node k0s role cleared");
         Ok(())
     }
@@ -2180,6 +2186,9 @@ impl ClusterManager {
         reset_requested: bool,
     ) -> anyhow::Result<()> {
         use spur_core::k0s::K0sPhase;
+        // Serialize prior-phase read, commit, and edge accounting so two concurrent callers can't
+        // both observe the same prior phase and double-count the transition.
+        let _accounting = self.k0s_phase_accounting.lock();
         let from = self.k0s.read().phase;
         self.propose(WalOperation::K0sSetPhase {
             phase,
@@ -2263,6 +2272,10 @@ impl ClusterManager {
                         admin_locked,
                     }) {
                         Ok(resp) => {
+                            // A node that stopped heartbeating won't refresh its k0s unit gauge, so
+                            // reflect the unreachable unit as down rather than leaving a stale 1.
+                            self.k8s_metrics
+                                .set_node_up(&self.config().cluster_name, &name, false);
                             self.run_all_finalized_side_effects(&resp);
                             evicted.extend(resp.jobs_finalized);
                         }
@@ -2369,6 +2382,8 @@ impl ClusterManager {
             name: name.to_string(),
             reason,
         })?;
+        self.k8s_metrics
+            .remove_node(&self.config().cluster_name, name);
         self.run_all_finalized_side_effects(&resp);
         Ok(resp.jobs_finalized)
     }
@@ -12966,6 +12981,7 @@ mod tests {
             cni_mtu: 1450,
             cni: "kuberouter".into(),
             control_plane_node: None,
+            provisioning_timeout: std::time::Duration::from_secs(600),
         };
         let mut tokens = std::collections::HashMap::new();
 
@@ -12973,13 +12989,36 @@ mod tests {
             phase: K0sPhase::Down,
             ..Default::default()
         };
-        assert!(!crate::cluster_k8s::reconcile_phase(&cm, &net, &down, &mut tokens).await);
+        assert!(!crate::cluster_k8s::reconcile_phase(&cm, &net, &down, &mut tokens, false).await);
 
         let degraded = spur_core::k0s::K0sClusterState {
             phase: K0sPhase::Degraded,
             ..Default::default()
         };
-        assert!(!crate::cluster_k8s::reconcile_phase(&cm, &net, &degraded, &mut tokens).await);
+        assert!(!crate::cluster_k8s::reconcile_phase(&cm, &net, &degraded, &mut tokens, false).await);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clearing_node_k0s_evicts_its_metric_series() {
+        use spur_core::k0s::K0sRole;
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "node-a", 4, 8000);
+        wait_for("registered", || cm.get_node("node-a").is_some());
+        cm.assign_node_k0s("node-a", K0sRole::Worker, "10.44.0.2", "10.42.2.0/24")
+            .unwrap();
+        // Feed node metrics as a heartbeat would.
+        cm.k8s_metrics().set_node_up("test", "node-a", true);
+        cm.k8s_metrics().set_node_restart_total("test", "node-a", 1);
+        let body = spur_metrics::encode_k8s_metrics(&cm.k8s_cluster_metrics(), &cm.k8s_metrics());
+        assert!(body.contains("node=\"node-a\""));
+
+        cm.clear_node_k0s("node-a").unwrap();
+        let body = spur_metrics::encode_k8s_metrics(&cm.k8s_cluster_metrics(), &cm.k8s_metrics());
+        assert!(
+            !body.contains("node=\"node-a\""),
+            "cleared node's series must be evicted"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -12988,23 +13027,47 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
 
-        cm.set_k0s_phase(K0sPhase::Provisioning, Some("n1".into()), Vec::new(), false)
-            .unwrap();
+        cm.set_k0s_phase(
+            K0sPhase::Provisioning,
+            Some("n1".into()),
+            Vec::new(),
+            Vec::new(),
+            false,
+        )
+        .unwrap();
         wait_for("provisioning", || {
             cm.k0s_state().phase == K0sPhase::Provisioning
         });
-        cm.set_k0s_phase(K0sPhase::Ready, Some("n1".into()), Vec::new(), false)
-            .unwrap();
+        cm.set_k0s_phase(
+            K0sPhase::Ready,
+            Some("n1".into()),
+            Vec::new(),
+            Vec::new(),
+            false,
+        )
+        .unwrap();
         wait_for("ready", || cm.k0s_state().phase == K0sPhase::Ready);
         // Re-provision: a second attempt.
-        cm.set_k0s_phase(K0sPhase::Provisioning, Some("n1".into()), Vec::new(), false)
-            .unwrap();
+        cm.set_k0s_phase(
+            K0sPhase::Provisioning,
+            Some("n1".into()),
+            Vec::new(),
+            Vec::new(),
+            false,
+        )
+        .unwrap();
         wait_for("provisioning again", || {
             cm.k0s_state().phase == K0sPhase::Provisioning
         });
         // A no-op set to the same phase must not double-count.
-        cm.set_k0s_phase(K0sPhase::Provisioning, Some("n1".into()), Vec::new(), false)
-            .unwrap();
+        cm.set_k0s_phase(
+            K0sPhase::Provisioning,
+            Some("n1".into()),
+            Vec::new(),
+            Vec::new(),
+            false,
+        )
+        .unwrap();
 
         let body = spur_metrics::encode_k8s_metrics(&cm.k8s_cluster_metrics(), &cm.k8s_metrics());
         assert!(body.contains(

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -102,7 +102,15 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>, net: Clust
         }
         last_mesh = mesh.nodes.clone();
 
-        reconcile_phase(&cluster, &net, &state, &mut join_tokens, timed_out).await;
+        let started = Instant::now();
+        let errored = reconcile_phase(&cluster, &net, &state, &mut join_tokens, timed_out).await;
+        let cluster_name = cluster.config().cluster_name.clone();
+        cluster
+            .k8s_metrics()
+            .observe_reconcile_duration(&cluster_name, started.elapsed().as_secs_f64());
+        if errored {
+            cluster.k8s_metrics().record_reconcile_error(&cluster_name);
+        }
     }
 }
 
@@ -136,12 +144,12 @@ pub(crate) async fn reconcile_phase(
     state: &K0sClusterState,
     join_tokens: &mut HashMap<String, String>,
     timed_out: bool,
-) {
+) -> bool {
     match state.phase {
         K0sPhase::Ready | K0sPhase::Provisioning => {
             if let Err(e) = provision_assignments(cluster, net, state) {
                 warn!(error = %e, "k0s provisioning assignment failed; will retry next tick");
-                return;
+                return true;
             }
             converge_provisioning(cluster, net, join_tokens).await;
             // converge may have flipped us to Ready this tick; only degrade a still-provisioning
@@ -149,9 +157,16 @@ pub(crate) async fn reconcile_phase(
             if timed_out && cluster.k0s_state().phase == K0sPhase::Provisioning {
                 degrade_stuck_cluster(cluster, net, join_tokens).await;
             }
+            false
         }
-        K0sPhase::Down => stop_all_components(cluster, state.reset_requested).await,
-        K0sPhase::Degraded => warn!("k0s cluster degraded"),
+        K0sPhase::Down => {
+            stop_all_components(cluster, state.reset_requested).await;
+            false
+        }
+        K0sPhase::Degraded => {
+            warn!("k0s cluster degraded");
+            false
+        }
     }
 }
 

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -151,13 +151,13 @@ pub(crate) async fn reconcile_phase(
                 warn!(error = %e, "k0s provisioning assignment failed; will retry next tick");
                 return true;
             }
-            converge_provisioning(cluster, net, join_tokens).await;
+            let errors = converge_provisioning(cluster, net, join_tokens).await;
             // converge may have flipped us to Ready this tick; only degrade a still-provisioning
             // cluster that has blown its deadline.
             if timed_out && cluster.k0s_state().phase == K0sPhase::Provisioning {
                 degrade_stuck_cluster(cluster, net, join_tokens).await;
             }
-            false
+            errors > 0
         }
         K0sPhase::Down => {
             stop_all_components(cluster, state.reset_requested).await;
@@ -675,11 +675,14 @@ fn controller_k0s_config(net: &ClusterNetworking, node: &spur_core::node::Node) 
 
 /// Start any assigned component that is not yet active; when all are active, mark the cluster Ready.
 /// `join_tokens` caches each worker's minted join token across ticks so we mint once per join.
+/// Returns the number of errors encountered this iteration (currently join-token mint failures),
+/// so the reconcile loop can surface them via `spur_k8s_reconcile_errors_total`.
 async fn converge_provisioning(
     cluster: &ClusterManager,
     net: &ClusterNetworking,
     join_tokens: &mut HashMap<String, String>,
-) {
+) -> u64 {
+    let mut errors = 0u64;
     let assigned: Vec<_> = cluster
         .get_nodes()
         .into_iter()
@@ -687,7 +690,7 @@ async fn converge_provisioning(
         .collect();
     if assigned.is_empty() {
         join_tokens.clear();
-        return;
+        return errors;
     }
     let bootstrap = cluster.k0s_state().bootstrap();
     let mut all_active = true;
@@ -717,7 +720,7 @@ async fn converge_provisioning(
     // Don't touch secondary CPs / workers until the bootstrap's etcd is seeded and its API answers:
     // a controller token minted before then would race the quorum. Retry on the next tick.
     if !bootstrap_active {
-        return;
+        return errors;
     }
     // Secondary CPs join the etcd quorum with a `controller` token, then workers with a `worker`
     // token; both mint from a healthy CP agent, and a minting error just retries next tick.
@@ -761,6 +764,7 @@ async fn converge_provisioning(
                 }
                 Err(e) => {
                     warn!(node = %node.name, error = %e, "could not mint {token_role} join token yet; will retry");
+                    errors += 1;
                     continue;
                 }
             },
@@ -775,6 +779,7 @@ async fn converge_provisioning(
             Err(e) => warn!(error = %e, "failed to mark k0s cluster Ready"),
         }
     }
+    errors
 }
 
 /// Drop a node's stale degrade reason once it is healthy again, so status reports honestly on retry.

--- a/crates/spurctld/src/metrics_server.rs
+++ b/crates/spurctld/src/metrics_server.rs
@@ -12,7 +12,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
 use spur_metrics::{
-    encode_job_metrics, encode_jobs_users_accts_metrics, encode_nodes_metrics,
+    encode_job_metrics, encode_jobs_users_accts_metrics, encode_k8s_metrics, encode_nodes_metrics,
     encode_partitions_metrics, encode_rpc_metrics, encode_scheduler_metrics, CONTENT_TYPE,
 };
 use tracing::info;
@@ -51,6 +51,7 @@ pub async fn serve(
         .route("/metrics/partitions", get(metrics_partitions))
         .route("/metrics/rpc", get(metrics_rpc))
         .route("/metrics/scheduler", get(metrics_scheduler))
+        .route("/metrics/k8s", get(metrics_k8s))
         .route("/metrics/jobs-users-accts", get(metrics_jobs_users_accts))
         .with_state(state);
 
@@ -96,6 +97,16 @@ async fn metrics_scheduler(State(state): State<Arc<MetricsState>>) -> Response {
         return not_leader_response();
     }
     metrics_response(encode_scheduler_metrics(&state.sched_stats.snapshot()))
+}
+
+async fn metrics_k8s(State(state): State<Arc<MetricsState>>) -> Response {
+    if !state.raft.is_leader() {
+        return not_leader_response();
+    }
+    metrics_response(encode_k8s_metrics(
+        &state.cluster.k8s_cluster_metrics(),
+        &state.cluster.k8s_metrics(),
+    ))
 }
 
 async fn metrics_jobs_users_accts(State(state): State<Arc<MetricsState>>) -> Response {
@@ -213,6 +224,7 @@ mod tests {
             .route("/metrics/partitions", get(metrics_partitions))
             .route("/metrics/rpc", get(metrics_rpc))
             .route("/metrics/scheduler", get(metrics_scheduler))
+            .route("/metrics/k8s", get(metrics_k8s))
             .route("/metrics/jobs-users-accts", get(metrics_jobs_users_accts))
             .with_state(state);
         (app, dir)
@@ -358,6 +370,31 @@ mod tests {
             resp.headers().get(header::CONTENT_TYPE).unwrap(),
             CONTENT_TYPE
         );
+    }
+
+    #[tokio::test]
+    async fn metrics_k8s_returns_ok_with_expected_series() {
+        let (app, _dir) = test_app().await;
+        let resp = app
+            .oneshot(
+                axum::http::Request::get("/metrics/k8s")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            CONTENT_TYPE
+        );
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("spur_k8s_cluster_phase{distribution=\"k0s\",cluster=\"test\""));
+        assert!(text.contains("spur_k8s_cluster_up{distribution=\"k0s\",cluster=\"test\"}"));
+        assert!(text.contains("spur_k8s_provision_attempts_total"));
+        assert!(text.contains("spur_k8s_reconcile_duration_seconds_count"));
+        assert!(text.ends_with("# EOF\n"));
     }
 
     #[tokio::test]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -262,6 +262,22 @@ impl ControllerService {
         });
     }
 
+    /// Feed a node's heartbeat-reported k0s status into the metric accumulator.
+    fn record_k0s_node_status(&self, node: &str, status: &spur_proto::proto::K0sNodeStatus) {
+        let role = self
+            .cluster
+            .get_node(node)
+            .and_then(|n| n.k0s_role)
+            .unwrap_or(spur_core::k0s::K0sRole::Worker);
+        let cluster = self.cluster.config().cluster_name.clone();
+        let metrics = self.cluster.k8s_metrics();
+        metrics.set_node_up(&cluster, node, role, status.unit_active);
+        metrics.set_node_restart_total(&cluster, node, status.restart_count);
+        if status.install_duration_seconds > 0.0 {
+            metrics.observe_node_install_duration(&cluster, node, status.install_duration_seconds);
+        }
+    }
+
     /// Reads never require the leader (every node applies the committed log),
     /// so forwarding is only an optional freshness hop. Skipping already-
     /// forwarded requests avoids forward loops between non-leaders.
@@ -1332,6 +1348,9 @@ impl SlurmController for ControllerService {
                 info!(node = %req.hostname, "learned updated WireGuard mesh key from heartbeat");
             }
             self.reclaim_stale_agent_jobs(&req.hostname, &req.running_jobs);
+            if let Some(k0s) = &req.k0s_status {
+                self.record_k0s_node_status(&req.hostname, k0s);
+            }
             Ok(Response::new(HeartbeatResponse {}))
         } else {
             Err(Status::not_found(format!(

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -264,14 +264,9 @@ impl ControllerService {
 
     /// Feed a node's heartbeat-reported k0s status into the metric accumulator.
     fn record_k0s_node_status(&self, node: &str, status: &spur_proto::proto::K0sNodeStatus) {
-        let role = self
-            .cluster
-            .get_node(node)
-            .and_then(|n| n.k0s_role)
-            .unwrap_or(spur_core::k0s::K0sRole::Worker);
         let cluster = self.cluster.config().cluster_name.clone();
         let metrics = self.cluster.k8s_metrics();
-        metrics.set_node_up(&cluster, node, role, status.unit_active);
+        metrics.set_node_up(&cluster, node, status.unit_active);
         metrics.set_node_restart_total(&cluster, node, status.restart_count);
         if status.install_duration_seconds > 0.0 {
             metrics.observe_node_install_duration(&cluster, node, status.install_duration_seconds);

--- a/crates/spurd/src/cluster.rs
+++ b/crates/spurd/src/cluster.rs
@@ -22,8 +22,9 @@
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use tokio::process::Command;
@@ -277,6 +278,18 @@ impl ClusterSupervisor {
             .unwrap_or_else(|| "unknown".to_string())
     }
 
+    /// systemd `NRestarts` for the unit (cumulative auto-restarts); 0 when unknown/unavailable.
+    async fn unit_restart_count(&self) -> u64 {
+        let unit = self.unit_file_name();
+        Command::new("systemctl")
+            .args(["show", &unit, "-p", "NRestarts", "--value"])
+            .output()
+            .await
+            .ok()
+            .and_then(|o| String::from_utf8_lossy(&o.stdout).trim().parse().ok())
+            .unwrap_or(0)
+    }
+
     fn role(&self) -> ClusterRole {
         self.cfg.role
     }
@@ -505,6 +518,58 @@ async fn remove_cdi_spec() {
     let _ = tokio::fs::remove_file(CDI_SPEC_PATH).await;
 }
 
+/// k0s node status this agent surfaces to the controller on each heartbeat, for `spur_k8s_node_*`
+/// metrics. `install_secs` is one-shot: `take_install_secs` returns it once after an install, then
+/// clears it, so the controller observes each install duration exactly once.
+#[derive(Debug, Default)]
+pub struct K0sNodeState {
+    unit_active: AtomicBool,
+    restart_count: AtomicU64,
+    /// Milliseconds; `u64::MAX` sentinel means "nothing to report".
+    install_ms: AtomicU64,
+}
+
+impl K0sNodeState {
+    const NO_INSTALL: u64 = u64::MAX;
+
+    pub fn new() -> Self {
+        Self {
+            unit_active: AtomicBool::new(false),
+            restart_count: AtomicU64::new(0),
+            install_ms: AtomicU64::new(Self::NO_INSTALL),
+        }
+    }
+
+    fn set_unit_active(&self, active: bool) {
+        self.unit_active.store(active, Ordering::Relaxed);
+    }
+
+    fn set_restart_count(&self, count: u64) {
+        self.restart_count.store(count, Ordering::Relaxed);
+    }
+
+    fn record_install(&self, dur: Duration) {
+        self.install_ms
+            .store(dur.as_millis() as u64, Ordering::Relaxed);
+    }
+
+    /// Current unit-active + cumulative restarts, plus any pending one-shot install duration in
+    /// seconds (0.0 once already drained). Called by the reporter per heartbeat.
+    pub fn take_for_heartbeat(&self) -> (bool, u64, f64) {
+        let install_ms = self.install_ms.swap(Self::NO_INSTALL, Ordering::Relaxed);
+        let install_secs = if install_ms == Self::NO_INSTALL {
+            0.0
+        } else {
+            install_ms as f64 / 1000.0
+        };
+        (
+            self.unit_active.load(Ordering::Relaxed),
+            self.restart_count.load(Ordering::Relaxed),
+            install_secs,
+        )
+    }
+}
+
 /// RPC-driven owner of this node's k0s component. The spurctld controller
 /// (`cluster_k8s`) drives it via the SlurmAgent Start/Stop/GetClusterComponentStatus RPCs. It
 /// holds the currently-desired `ClusterSupervisor` and heals its unit from a background loop.
@@ -522,6 +587,7 @@ pub struct K0sAgent {
     /// systemd/k0s — the documented contract for the flag ([`ClusterConfig::enabled`]).
     enabled: bool,
     active: Mutex<Option<ClusterSupervisor>>,
+    status: Arc<K0sNodeState>,
 }
 
 impl K0sAgent {
@@ -536,7 +602,13 @@ impl K0sAgent {
             local_path_dir: cfg.local_path_dir.clone(),
             enabled: cfg.enabled,
             active: Mutex::new(None),
+            status: Arc::new(K0sNodeState::new()),
         }
+    }
+
+    /// Shared node-status handle the reporter reads for `spur_k8s_node_*` heartbeat fields.
+    pub fn node_state(&self) -> Arc<K0sNodeState> {
+        self.status.clone()
     }
 
     /// Re-adopt an already-running spurd-owned k0s unit at startup. A spurd restart leaves the k0s
@@ -604,12 +676,16 @@ impl K0sAgent {
         // Make a fresh bare-metal node self-contained: install the pinned/configured k0s if the
         // binary is missing. No-op (no network) when it is already present. A failure here is fatal
         // to start — the systemd unit's ConditionFileIsExecutable would otherwise silently skip.
+        let install_started = Instant::now();
         match spur_update::k0s::ensure_k0s(&self.k0s_version, &self.k0s_binary).await {
-            Ok(Some(info)) => info!(
-                version = %info.version,
-                path = %info.path.display(),
-                "installed k0s"
-            ),
+            Ok(Some(info)) => {
+                self.status.record_install(install_started.elapsed());
+                info!(
+                    version = %info.version,
+                    path = %info.path.display(),
+                    "installed k0s"
+                );
+            }
             Ok(None) => {}
             Err(e) => anyhow::bail!(
                 "k0s not present at {} and auto-install (version {}) failed: {e}",
@@ -663,6 +739,9 @@ impl K0sAgent {
         let sup = ClusterSupervisor::new(cfg);
         sup.reconcile_once().await?;
         let state = sup.component_state().await;
+        self.status.set_unit_active(state == "active");
+        self.status
+            .set_restart_count(sup.unit_restart_count().await);
         *self.active.lock().await = Some(sup);
         info!(role = role.as_str(), state = %state, "k0s component started");
         Ok(state)
@@ -882,6 +961,10 @@ impl K0sAgent {
                 if let Err(e) = sup.reconcile_once().await {
                     warn!(error = %e, "k0s component reconcile failed");
                 }
+                self.status
+                    .set_unit_active(sup.unit_status_is(&["is-active"], "active").await);
+                self.status
+                    .set_restart_count(sup.unit_restart_count().await);
             }
         }
     }
@@ -890,6 +973,33 @@ impl K0sAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn node_state_install_duration_is_one_shot() {
+        let state = K0sNodeState::new();
+        state.set_unit_active(true);
+        state.set_restart_count(3);
+        state.record_install(Duration::from_millis(2500));
+
+        let (active, restarts, install) = state.take_for_heartbeat();
+        assert!(active);
+        assert_eq!(restarts, 3);
+        assert_eq!(install, 2.5);
+
+        // Drained: a second read reports 0 install seconds but retains active/restarts.
+        let (active2, restarts2, install2) = state.take_for_heartbeat();
+        assert!(active2);
+        assert_eq!(restarts2, 3);
+        assert_eq!(install2, 0.0);
+    }
+
+    #[test]
+    fn node_state_defaults_report_nothing_pending() {
+        let (active, restarts, install) = K0sNodeState::new().take_for_heartbeat();
+        assert!(!active);
+        assert_eq!(restarts, 0);
+        assert_eq!(install, 0.0);
+    }
 
     #[test]
     fn renders_controller_unit_with_validated_directives() {

--- a/crates/spurd/src/cluster.rs
+++ b/crates/spurd/src/cluster.rs
@@ -785,6 +785,8 @@ impl K0sAgent {
             Some(sup) => sup.stop(reset).await?,
             None => self.stop_untracked(reset).await?,
         }
+        // Only after a successful stop — supervise() won't refresh this once `active` is empty.
+        self.status.set_unit_active(false);
         remove_cdi_spec().await;
         info!(reset, "k0s component stopped");
         Ok(())
@@ -1166,6 +1168,20 @@ mod tests {
         assert!(
             sup.unit_status_is(&["is-active"], "active").await,
             "active again after re-write"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_clears_unit_active_even_with_no_tracked_supervisor() {
+        let agent = K0sAgent::from_config(&spur_core::config::ClusterConfig::default());
+        agent.status.set_unit_active(true);
+
+        agent.stop(false).await.unwrap();
+
+        let (active, _, _) = agent.status.take_for_heartbeat();
+        assert!(
+            !active,
+            "stop() must clear unit_active so heartbeats stop reporting node_up=1"
         );
     }
 

--- a/crates/spurd/src/cluster.rs
+++ b/crates/spurd/src/cluster.rs
@@ -676,23 +676,24 @@ impl K0sAgent {
         // Make a fresh bare-metal node self-contained: install the pinned/configured k0s if the
         // binary is missing. No-op (no network) when it is already present. A failure here is fatal
         // to start — the systemd unit's ConditionFileIsExecutable would otherwise silently skip.
-        let install_started = Instant::now();
-        match spur_update::k0s::ensure_k0s(&self.k0s_version, &self.k0s_binary).await {
-            Ok(Some(info)) => {
-                self.status.record_install(install_started.elapsed());
-                info!(
-                    version = %info.version,
-                    path = %info.path.display(),
-                    "installed k0s"
-                );
-            }
-            Ok(None) => {}
-            Err(e) => anyhow::bail!(
-                "k0s not present at {} and auto-install (version {}) failed: {e}",
-                self.k0s_binary.display(),
-                self.k0s_version
-            ),
-        }
+        let start_began = Instant::now();
+        let did_install =
+            match spur_update::k0s::ensure_k0s(&self.k0s_version, &self.k0s_binary).await {
+                Ok(Some(info)) => {
+                    info!(
+                        version = %info.version,
+                        path = %info.path.display(),
+                        "installed k0s"
+                    );
+                    true
+                }
+                Ok(None) => false,
+                Err(e) => anyhow::bail!(
+                    "k0s not present at {} and auto-install (version {}) failed: {e}",
+                    self.k0s_binary.display(),
+                    self.k0s_version
+                ),
+            };
 
         tokio::fs::create_dir_all(&self.config_dir)
             .await
@@ -742,6 +743,11 @@ impl K0sAgent {
         self.status.set_unit_active(state == "active");
         self.status
             .set_restart_count(sup.unit_restart_count().await);
+        // Record the install→active span only when an install actually happened and the unit came
+        // up, so a later start failure never emits a spurious sample.
+        if did_install && state == "active" {
+            self.status.record_install(start_began.elapsed());
+        }
         *self.active.lock().await = Some(sup);
         info!(role = role.as_str(), state = %state, "k0s component started");
         Ok(state)

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -323,7 +323,11 @@ async fn main() -> anyhow::Result<()> {
     // Re-adopt an already-running k0s unit (spurd restart leaves it running) so status/heal are
     // correct immediately, then spawn the heal loop.
     let k0s = agent_service.k0s();
-    reporter.set_k0s_status(k0s.node_state());
+    // Only report k0s node status when this node actually supervises a k0s unit, so non-k0s
+    // deployments don't emit spur_k8s_node_* series.
+    if cluster_config.enabled {
+        reporter.set_k0s_status(k0s.node_state());
+    }
     k0s.adopt_running_unit().await;
     tokio::spawn(k0s.supervise());
 

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -323,6 +323,7 @@ async fn main() -> anyhow::Result<()> {
     // Re-adopt an already-running k0s unit (spurd restart leaves it running) so status/heal are
     // correct immediately, then spawn the heal loop.
     let k0s = agent_service.k0s();
+    reporter.set_k0s_status(k0s.node_state());
     k0s.adopt_running_unit().await;
     tokio::spawn(k0s.supervise());
 

--- a/crates/spurd/src/reporter.rs
+++ b/crates/spurd/src/reporter.rs
@@ -45,6 +45,8 @@ pub struct NodeReporter {
     /// Job ids this node holds, reported each heartbeat so the controller can
     /// reclaim allocations it no longer tracks. Shares the agent's running map.
     held_jobs: Arc<dyn HeldJobs>,
+    /// k0s node status the heartbeat carries; wired once after the K0sAgent is built.
+    k0s_status: std::sync::OnceLock<Arc<crate::cluster::K0sNodeState>>,
 }
 
 impl NodeReporter {
@@ -71,7 +73,14 @@ impl NodeReporter {
             wg_iface,
             node_token: RwLock::new(String::new()),
             held_jobs,
+            k0s_status: std::sync::OnceLock::new(),
         }
+    }
+
+    /// Wire the k0s node-status source so heartbeats carry `spur_k8s_node_*` fields. Called once,
+    /// after the K0sAgent is constructed. No-op on a node without k0s (field stays unset).
+    pub fn set_k0s_status(&self, status: Arc<crate::cluster::K0sNodeState>) {
+        let _ = self.k0s_status.set(status);
     }
 
     /// This node's current WireGuard mesh public key (empty if the interface has no key / no mesh).
@@ -171,6 +180,15 @@ impl NodeReporter {
                             running_jobs,
                             node_token: current_token,
                             wg_pubkey: self.wg_pubkey(),
+                            k0s_status: self.k0s_status.get().map(|s| {
+                                let (unit_active, restart_count, install_secs) =
+                                    s.take_for_heartbeat();
+                                spur_proto::proto::K0sNodeStatus {
+                                    unit_active,
+                                    restart_count,
+                                    install_duration_seconds: install_secs,
+                                }
+                            }),
                         })
                         .await
                     {

--- a/docs/user-guide/monitoring-jobs.rst
+++ b/docs/user-guide/monitoring-jobs.rst
@@ -378,6 +378,9 @@ Endpoints
    * - ``/metrics/scheduler``
      - Planned
      - Route exists but currently returns an empty body.
+   * - ``/metrics/k8s``
+     - Live
+     - Spur-managed k0s cluster lifecycle and per-node health (``spur_k8s_*``).
    * - ``/metrics/jobs-users-accts``
      - Planned
      - Per-user/per-account breakdown. Returns ``404`` until implemented, even
@@ -443,17 +446,51 @@ All gauges. Cluster-wide totals carry no labels; per-node gauges carry a
    * - ``spur_node_free_memory_bytes``
      - Free memory (bytes) reported by the node agent.
 
-k0s cluster metrics *(incoming)*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+k0s metrics from spurctld — ``/metrics/k8s``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When Spur manages a k0s cluster (``spur k8s up``, see
+:doc:`/deployment/managed-kubernetes`), ``spurctld`` exports its own view of the
+cluster lifecycle and per-node health at ``/metrics/k8s``. Every series carries
+``distribution="k0s"`` and ``cluster="<cluster-name>"``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 46 54
+
+   * - Metric
+     - Description
+   * - ``spur_k8s_cluster_phase{phase}``
+     - Current cluster phase as a one-hot set (``down``, ``provisioning``,
+       ``ready``, ``degraded``); value 1 on the active phase.
+   * - ``spur_k8s_cluster_up``
+     - 1 when the cluster phase is Ready (primary alerting signal).
+   * - ``spur_k8s_control_plane_replicas``
+     - Configured control-plane replica count.
+   * - ``spur_k8s_nodes_total`` / ``spur_k8s_nodes_by_role{role}``
+     - Total nodes with a k0s role, and the per-role count.
+   * - ``spur_k8s_provision_attempts_total`` / ``spur_k8s_provision_failures_total``
+     - Provisioning attempts and attempts that gave up before Ready.
+   * - ``spur_k8s_phase_transitions_total{from,to}``
+     - Phase transitions labeled by source and destination.
+   * - ``spur_k8s_reconcile_duration_seconds`` / ``spur_k8s_reconcile_errors_total``
+     - Reconcile-loop iteration wall time (histogram) and error count.
+   * - ``spur_k8s_node_up{node}``
+     - Whether a node's k0s systemd unit reports active.
+   * - ``spur_k8s_node_restart_total{node}`` / ``spur_k8s_install_duration_seconds{node}``
+     - Per-node k0s unit restarts and install time (histogram).
+
+k0s component metrics *(incoming)*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. note::
 
-   The endpoints in this section are **incoming / in progress**. When Spur owns
-   a Kubernetes cluster (``spur k8s up``, see
-   :doc:`/deployment/managed-kubernetes`), the bundled k0s components each expose
-   their own upstream Kubernetes ``/metrics`` endpoint. Spur does not yet
-   aggregate or proxy these — the ports and paths below are the standard
-   Kubernetes surfaces documented here for planning a scrape configuration.
+   The endpoints in this section are **incoming / in progress** and are separate
+   from the ``spurctld`` ``/metrics/k8s`` surface above. The bundled k0s
+   components each expose their own upstream Kubernetes ``/metrics`` endpoint;
+   Spur does not yet aggregate or proxy these — the ports and paths below are the
+   standard Kubernetes surfaces documented here for planning a scrape
+   configuration.
 
 These endpoints are served by the k0s-managed components, not by ``spurctld``.
 Control-plane endpoints live on the control-plane node; the kubelet endpoints

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -685,8 +685,9 @@ message HeartbeatRequest {
 // Per-node k0s supervision status, reported on the heartbeat for spur_k8s_node_* metrics.
 message K0sNodeStatus {
   bool unit_active = 1;               // node's k0s systemd unit currently reports active
-  uint64 restart_count = 2;           // cumulative k0s unit restarts since agent start
-  double install_duration_seconds = 3; // time to install k0s and reach active; 0 until installed
+  // systemd NRestarts for the k0s unit: persists across spurd restarts, resets when the unit is recreated.
+  uint64 restart_count = 2;
+  double install_duration_seconds = 3; // install-to-active seconds, reported once after an install
 }
 
 message RunningJobStatus {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -678,6 +678,15 @@ message HeartbeatRequest {
   // learns a key that appears/changes after registration (late mesh, spur0 recreated) and can
   // include the node in ApplyMesh without a spurd restart. Empty when the node has no mesh key.
   string wg_pubkey = 6;
+  // k0s supervision status; present only when the node runs a k0s unit ([cluster].enabled).
+  optional K0sNodeStatus k0s_status = 7;
+}
+
+// Per-node k0s supervision status, reported on the heartbeat for spur_k8s_node_* metrics.
+message K0sNodeStatus {
+  bool unit_active = 1;               // node's k0s systemd unit currently reports active
+  uint64 restart_count = 2;           // cumulative k0s unit restarts since agent start
+  double install_duration_seconds = 3; // time to install k0s and reach active; 0 until installed
 }
 
 message RunningJobStatus {


### PR DESCRIPTION
## Summary

Adds Prometheus/OpenMetrics export for the Spur-managed k0s Kubernetes subsystem, which previously emitted zero metrics — operators had to grep logs to tell whether a cluster was stuck provisioning or degraded. Metrics are served at a new `/metrics/k8s` route on the controller's existing metrics server, alongside `spur_jobs_*`, `spur_nodes_*`, etc.

Every series carries `distribution="k0s"` and `cluster="<cluster-name>"` so the surface generalizes to future distributions.

## Metrics

**Cluster gauges** (rebuilt from live state each scrape):
- `spur_k8s_cluster_phase{phase}` — one-hot state set (down/provisioning/ready/degraded)
- `spur_k8s_cluster_up` — 1 when Ready (primary alerting signal)
- `spur_k8s_control_plane_replicas`, `spur_k8s_nodes_total`, `spur_k8s_nodes_by_role{role}`

**Lifecycle counters/histogram** (accumulated on the leader):
- `spur_k8s_provision_attempts_total`, `spur_k8s_provision_failures_total`
- `spur_k8s_phase_transitions_total{from,to}`
- `spur_k8s_reconcile_duration_seconds` (histogram), `spur_k8s_reconcile_errors_total`

**Per-node** (reported by the agent on the heartbeat):
- `spur_k8s_node_up{node}`, `spur_k8s_node_restart_total{node}`, `spur_k8s_install_duration_seconds{node}` (histogram)

## Approach

- Cluster gauges follow the existing `export/nodes.rs` snapshot pattern. Lifecycle counters/histograms cannot be rebuilt from a plain snapshot (prometheus-client histograms have no set-buckets API), so a long-lived `K8sMetrics` accumulator is held on the controller and its Arc-shared metric families are registered into the response registry per scrape — mirroring how the scheduler/RPC stats collectors work.
- Node status flows agent→controller via a new **additive** `HeartbeatRequest.k0s_status` field (new `K0sNodeStatus` message, new tags only — backward/forward compatible, not persisted state). `install_duration_seconds` is one-shot: the agent reports it once after an install so the histogram isn't inflated by repeated heartbeats.
- Lifecycle counters increment on the leader (the metrics endpoint is leader-gated, matching the other routes); across failover the new leader's accumulator restarts at zero, which Prometheus handles as a normal counter reset.
- The base counter/histogram series are seeded at zero for the configured cluster so alerting rules referencing them resolve before the first event.

## Endpoint choice

Added as a dedicated `/metrics/k8s` route for consistency with Spur's existing per-domain split. The broader Prometheus convention is a single `/metrics` per target with domain labels; collapsing the existing per-domain routes into one labeled endpoint would be a reasonable separate cleanup, out of scope here. A scraper hits the split trivially with an extra `metrics_path` job.

## Review fixes applied

A review pass surfaced and this PR fixes: dropped the `role` label from `spur_k8s_node_up` (it churned/leaked per-node series on a role change; role is still available via `spur_k8s_nodes_by_role`); gated node-status reporting on `[cluster].enabled` so non-k0s deployments don't emit node series; scoped the provisioning-failure count to a Provisioning→Degraded transition; added tests for the phase-counting and reconcile paths.

## Known limitations / follow-ups

- **node restart count** is derived from systemd `NRestarts`; a full k0s unit teardown+reup resets that value, so restarts after such a cycle are undercounted until it climbs past the retained maximum. Acceptable for a restart-health signal; a more precise scheme would track per-node last-seen absolute values.
- The one-shot install-duration sample is drained at heartbeat-build time, so it is lost if that specific heartbeat RPC fails. Install is a once-per-node event, so the window is small; a drain-on-success refinement is a possible follow-up.
- `Degraded` is currently only reachable operationally; wiring an automatic provisioning-deadline escalation into `Degraded` is future work.

## Testing

- Unit tests: metric registration + exact OpenMetrics output (names, `_total`/histogram suffixes, labels, one-hot phase), the `/metrics/k8s` route through the real handler, `set_k0s_phase` counting across phase edges, the reconcile path's error signal, and the agent's one-shot install reporting.
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` clean; `cargo fmt --all --check` clean.
- Validated end-to-end on an isolated single-controller deployment: `/metrics/k8s` returns 200 with the expected `spur_k8s_*` series, config-derived replica count, and correctly seeded zero counters/histogram.