### PR TITLE
fix(spur-cli): reject unresolved k8s callers

### DIFF
--- a/crates/spur-cli/src/k8s.rs
+++ b/crates/spur-cli/src/k8s.rs
@@ -119,6 +119,13 @@ pub async fn main() -> Result<()> {
 }
 
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
+    main_with_args_and_user_resolver(args, crate::interactive::current_user).await
+}
+
+async fn main_with_args_and_user_resolver(
+    args: Vec<String>,
+    current_user: impl Fn() -> Result<String>,
+) -> Result<()> {
     let parsed = K8sArgs::try_parse_from(args)?;
     let controller = parsed.controller;
     match parsed.command {
@@ -130,8 +137,10 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             partition,
             selector,
         } => {
+            let caller = current_user()?;
             cmd_up(
                 &controller,
+                caller,
                 control_plane_node,
                 replicas,
                 control_plane_nodes,
@@ -151,9 +160,11 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             drain_timeout,
             force,
         } => cmd_remove_nodes(&controller, nodes, drain_timeout, force).await,
-        K8sCommand::Down { reset } => cmd_down(&controller, reset).await,
+        K8sCommand::Down { reset } => cmd_down(&controller, current_user()?, reset).await,
         K8sCommand::Status => cmd_status(&controller).await,
-        K8sCommand::Kubeconfig { user, admin } => cmd_kubeconfig(&controller, user, admin).await,
+        K8sCommand::Kubeconfig { user, admin } => {
+            cmd_kubeconfig(&controller, current_user()?, user, admin).await
+        }
         K8sCommand::InstallK0s {
             version,
             path,
@@ -214,6 +225,7 @@ async fn cmd_install_k0s(version: &str, path: &str, force: bool) -> Result<()> {
 #[allow(clippy::too_many_arguments)]
 async fn cmd_up(
     controller: &str,
+    caller: String,
     control_plane_node: Option<String>,
     replicas: Option<u32>,
     control_plane_nodes: Vec<String>,
@@ -228,7 +240,7 @@ async fn cmd_up(
             control_plane_node,
             control_plane_replicas: replicas,
             control_plane_nodes,
-            caller: effective_user(),
+            caller,
             nodes: nodes.unwrap_or_default(),
             partition: partition.unwrap_or_default(),
             selector,
@@ -301,13 +313,10 @@ async fn cmd_remove_nodes(
     Ok(())
 }
 
-async fn cmd_down(controller: &str, reset: bool) -> Result<()> {
+async fn cmd_down(controller: &str, caller: String, reset: bool) -> Result<()> {
     let mut client = SlurmControllerClient::new(crate::authclient::connect(controller).await?);
     let resp = client
-        .cluster_down(ClusterDownRequest {
-            reset,
-            caller: effective_user(),
-        })
+        .cluster_down(ClusterDownRequest { reset, caller })
         .await?
         .into_inner();
     if resp.accepted {
@@ -352,12 +361,17 @@ async fn cmd_status(controller: &str) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_kubeconfig(controller: &str, user: Option<String>, admin: bool) -> Result<()> {
+async fn cmd_kubeconfig(
+    controller: &str,
+    caller: String,
+    user: Option<String>,
+    admin: bool,
+) -> Result<()> {
     let mut client = SlurmControllerClient::new(crate::authclient::connect(controller).await?);
     let resp = client
         .cluster_kubeconfig(ClusterKubeconfigRequest {
             user: user.unwrap_or_default(),
-            caller: effective_user(),
+            caller,
             admin,
         })
         .await?
@@ -555,6 +569,131 @@ mod tests {
             err.kind(),
             clap::error::ErrorKind::ArgumentConflict,
             "--admin and --user must be mutually exclusive"
+        );
+    }
+
+    #[tokio::test]
+    async fn authenticated_commands_fail_before_dispatch_when_user_lookup_fails() {
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        let controller = format!("http://{addr}");
+
+        for command in [vec!["up"], vec!["down"], vec!["kubeconfig"]] {
+            let mut args = vec!["k8s".to_string(), "--controller".into(), controller.clone()];
+            args.extend(command.into_iter().map(str::to_string));
+
+            let error = main_with_args_and_user_resolver(args, || {
+                Err(anyhow::anyhow!("failed to determine current username"))
+            })
+            .await
+            .unwrap_err();
+
+            assert_eq!(error.to_string(), "failed to determine current username");
+        }
+
+        assert!(capture.k8s_requests().is_empty());
+    }
+
+    #[tokio::test]
+    async fn authenticated_commands_send_the_resolved_caller() {
+        use crate::mock_controller::K8sRequest;
+
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        let controller = format!("http://{addr}");
+
+        main_with_args_and_user_resolver(
+            vec![
+                "k8s".into(),
+                "--controller".into(),
+                controller.clone(),
+                "up".into(),
+                "--replicas".into(),
+                "3".into(),
+            ],
+            || Ok("fixture-user".into()),
+        )
+        .await
+        .unwrap();
+        main_with_args_and_user_resolver(
+            vec![
+                "k8s".into(),
+                "--controller".into(),
+                controller.clone(),
+                "down".into(),
+                "--reset".into(),
+            ],
+            || Ok("fixture-user".into()),
+        )
+        .await
+        .unwrap();
+        main_with_args_and_user_resolver(
+            vec![
+                "k8s".into(),
+                "--controller".into(),
+                controller,
+                "kubeconfig".into(),
+                "--user".into(),
+                "target-user".into(),
+            ],
+            || Ok("fixture-user".into()),
+        )
+        .await
+        .unwrap();
+
+        let requests = capture.k8s_requests();
+        match requests.as_slice() {
+            [K8sRequest::Up(up), K8sRequest::Down(down), K8sRequest::Kubeconfig(kubeconfig)] => {
+                assert_eq!(up.caller, "fixture-user");
+                assert_eq!(up.control_plane_replicas, Some(3));
+                assert_eq!(down.caller, "fixture-user");
+                assert!(down.reset);
+                assert_eq!(kubeconfig.caller, "fixture-user");
+                assert_eq!(kubeconfig.user, "target-user");
+            }
+            requests => panic!("unexpected k8s requests: {requests:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_commands_do_not_resolve_a_caller() {
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        let controller = format!("http://{addr}");
+        let resolutions = std::cell::Cell::new(0);
+        let unresolved = || {
+            resolutions.set(resolutions.get() + 1);
+            Err(anyhow::anyhow!("failed to determine current username"))
+        };
+
+        main_with_args_and_user_resolver(
+            vec![
+                "k8s".into(),
+                "--controller".into(),
+                controller,
+                "status".into(),
+            ],
+            &unresolved,
+        )
+        .await
+        .unwrap();
+
+        let temp = tempfile::tempdir().unwrap();
+        let existing_k0s = temp.path().join("k0s");
+        std::fs::write(&existing_k0s, b"fixture").unwrap();
+        main_with_args_and_user_resolver(
+            vec![
+                "k8s".into(),
+                "install-k0s".into(),
+                "--path".into(),
+                existing_k0s.to_string_lossy().into_owned(),
+            ],
+            &unresolved,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resolutions.get(), 0);
+        assert_eq!(
+            capture.k8s_requests(),
+            vec![crate::mock_controller::K8sRequest::Status]
         );
     }
 }

--- a/crates/spur-cli/src/k8s.rs
+++ b/crates/spur-cli/src/k8s.rs
@@ -137,6 +137,7 @@ async fn main_with_args_and_user_resolver(
             partition,
             selector,
         } => {
+            let selector = selector_map(selector)?;
             let caller = current_user()?;
             cmd_up(
                 &controller,
@@ -231,9 +232,8 @@ async fn cmd_up(
     control_plane_nodes: Vec<String>,
     nodes: Option<String>,
     partition: Option<String>,
-    selector: Vec<(String, String)>,
+    selector: std::collections::HashMap<String, String>,
 ) -> Result<()> {
-    let selector = selector_map(selector)?;
     let mut client = SlurmControllerClient::new(crate::authclient::connect(controller).await?);
     let resp = client
         .cluster_up(ClusterUpRequest {
@@ -590,6 +590,35 @@ mod tests {
             assert_eq!(error.to_string(), "failed to determine current username");
         }
 
+        assert!(capture.k8s_requests().is_empty());
+    }
+
+    #[tokio::test]
+    async fn duplicate_selectors_fail_before_user_resolution_and_dispatch() {
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        let resolutions = std::cell::Cell::new(0);
+
+        let error = main_with_args_and_user_resolver(
+            vec![
+                "k8s".into(),
+                "--controller".into(),
+                format!("http://{addr}"),
+                "up".into(),
+                "--selector".into(),
+                "zone=z1".into(),
+                "--selector".into(),
+                "zone=z2".into(),
+            ],
+            || {
+                resolutions.set(resolutions.get() + 1);
+                Ok("fixture-user".into())
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "duplicate --selector key zone");
+        assert_eq!(resolutions.get(), 0);
         assert!(capture.k8s_requests().is_empty());
     }
 

--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -7,10 +7,8 @@
 //! Follows the same shape as the `MockAgent` harness in `spurctld`: bind an
 //! ephemeral localhost port, serve a hand-written service on it, and hand the
 //! caller back the address plus a shared record of what the server observed.
-//! Only a handful of RPCs are implemented (`CreateJobStep`, `RunStep`,
-//! `GetNode`, `GetNodes`, `UpdateNode`, `DrainNode`, `DeregisterNode`); every
-//! other RPC reports `unimplemented` so an unexpected call fails loudly instead
-//! of silently returning a default.
+//! Only the RPCs exercised by CLI tests are implemented; every other RPC
+//! reports `unimplemented` so an unexpected call fails loudly instead of silently returning a default.
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -28,6 +26,14 @@ pub(crate) const MOCK_STEP_ID: u32 = 4242;
 /// Exit code the mock reports from `RunStep`.
 pub(crate) const MOCK_EXIT_CODE: i32 = 7;
 
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum K8sRequest {
+    Up(proto::ClusterUpRequest),
+    Down(proto::ClusterDownRequest),
+    Status,
+    Kubeconfig(proto::ClusterKubeconfigRequest),
+}
+
 /// What the mock controller actually received, shared with the test body.
 #[derive(Clone, Default)]
 pub(crate) struct StepCapture {
@@ -41,6 +47,7 @@ pub(crate) struct StepCapture {
     deregister_node_calls: Arc<Mutex<Vec<(String, bool)>>>,
     /// Node names that `update_node` should reject with `NotFound`.
     update_node_fail_names: Arc<Mutex<HashSet<String>>>,
+    k8s_requests: Arc<Mutex<Vec<K8sRequest>>>,
 }
 
 impl StepCapture {
@@ -82,6 +89,10 @@ impl StepCapture {
 
     pub(crate) fn set_update_node_fail_names(&self, names: HashSet<String>) {
         *self.update_node_fail_names.lock().unwrap() = names;
+    }
+
+    pub(crate) fn k8s_requests(&self) -> Vec<K8sRequest> {
+        self.k8s_requests.lock().unwrap().clone()
     }
 }
 
@@ -210,6 +221,65 @@ mock_controller_impl! {
                 .push((request.name, request.force));
             Ok(tonic::Response::new(proto::DeregisterNodeResponse::default()))
         }
+
+        async fn cluster_up(
+            &self,
+            request: tonic::Request<proto::ClusterUpRequest>,
+        ) -> Result<tonic::Response<proto::ClusterUpResponse>, tonic::Status> {
+            self.capture
+                .k8s_requests
+                .lock()
+                .unwrap()
+                .push(K8sRequest::Up(request.into_inner()));
+            Ok(tonic::Response::new(proto::ClusterUpResponse {
+                accepted: true,
+                ..Default::default()
+            }))
+        }
+
+        async fn cluster_down(
+            &self,
+            request: tonic::Request<proto::ClusterDownRequest>,
+        ) -> Result<tonic::Response<proto::ClusterDownResponse>, tonic::Status> {
+            self.capture
+                .k8s_requests
+                .lock()
+                .unwrap()
+                .push(K8sRequest::Down(request.into_inner()));
+            Ok(tonic::Response::new(proto::ClusterDownResponse {
+                accepted: true,
+                ..Default::default()
+            }))
+        }
+
+        async fn cluster_status(
+            &self,
+            _request: tonic::Request<proto::ClusterStatusRequest>,
+        ) -> Result<tonic::Response<proto::ClusterStatusResponse>, tonic::Status> {
+            self.capture
+                .k8s_requests
+                .lock()
+                .unwrap()
+                .push(K8sRequest::Status);
+            Ok(tonic::Response::new(proto::ClusterStatusResponse {
+                phase: "down".into(),
+                ..Default::default()
+            }))
+        }
+
+        async fn cluster_kubeconfig(
+            &self,
+            request: tonic::Request<proto::ClusterKubeconfigRequest>,
+        ) -> Result<tonic::Response<proto::ClusterKubeconfigResponse>, tonic::Status> {
+            self.capture
+                .k8s_requests
+                .lock()
+                .unwrap()
+                .push(K8sRequest::Kubeconfig(request.into_inner()));
+            Ok(tonic::Response::new(proto::ClusterKubeconfigResponse {
+                kubeconfig: "fixture".into(),
+            }))
+        }
     }
     unimplemented {
         submit_job(proto::SubmitJobRequest) -> proto::SubmitJobResponse;
@@ -246,10 +316,6 @@ mock_controller_impl! {
         delete_reservation(proto::DeleteReservationRequest) -> ();
         list_reservations(proto::ListReservationsRequest) -> proto::ListReservationsResponse;
         exec_in_job(proto::ExecInJobRequest) -> proto::ExecInJobResponse;
-        cluster_up(proto::ClusterUpRequest) -> proto::ClusterUpResponse;
-        cluster_down(proto::ClusterDownRequest) -> proto::ClusterDownResponse;
-        cluster_status(proto::ClusterStatusRequest) -> proto::ClusterStatusResponse;
-        cluster_kubeconfig(proto::ClusterKubeconfigRequest) -> proto::ClusterKubeconfigResponse;
         cluster_add_nodes(proto::ClusterAddNodesRequest) -> proto::ClusterAddNodesResponse;
         cluster_remove_nodes(proto::ClusterRemoveNodesRequest) -> proto::ClusterRemoveNodesResponse;
     }


### PR DESCRIPTION
Closes #603.

`spur k8s up`, `down`, and `kubeconfig` used `unknown` when the local username could not be resolved. The controller rejects that caller, but the CLI still sent an ambiguous identity.

These commands now reuse the existing fail-closed username resolver and return its error before dispatching an RPC. `status` and the local `install-k0s` command do not perform a username lookup.

## Testing

- 14 focused k8s command tests, including controller-backed caller and no-dispatch checks
- full `spur-cli` test suite: 360 unit tests and 1 integration test
- `cargo clippy -p spur-cli --all-targets --locked -- -D warnings`
- formatting, SPDX, and diff checks

The `spur-cli` checks required a temporary macOS-only compile shim for the pre-existing `nix::unistd::getgroups` failure on Apple targets. The shim was reverted and is not part of this PR. The repository-wide run then reached the existing Linux-only `spur-mpi-pmix` linker boundary.
