### PR TITLE
fix: fail rejected k8s jobs and enforce swap, burst-buffer, and scancel semantics

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -5,6 +5,7 @@ backfilling
 CDI
 CIDR
 Cargo
+cgroup
 config
 cron
 crontab

--- a/crates/spur-cli/src/nodelist.rs
+++ b/crates/spur-cli/src/nodelist.rs
@@ -5,25 +5,6 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-/// Resolve the first allocated hostname from a controller-supplied `nodelist`.
-///
-/// The controller reports a job's nodes as a *compressed* Slurm-style hostlist
-/// (e.g. `node[001-002]`), not a raw comma-separated list, so a plain
-/// `split(',')` yields a bracket fragment rather than a hostname. Expanding the
-/// pattern (the inverse of the controller's `compress`) gives the true first
-/// node. Falls back to a comma-split if expansion fails, so a malformed pattern
-/// still yields something connectable instead of no node at all.
-pub fn first_allocated_node(nodelist: &str) -> Option<String> {
-    if let Ok(Some(host)) = spur_core::hostlist::expand_first(nodelist) {
-        return Some(host);
-    }
-    nodelist
-        .split(',')
-        .map(str::trim)
-        .find(|name| !name.is_empty())
-        .map(str::to_string)
-}
-
 pub fn resolve(nodelist: Option<String>, nodefile: Option<String>) -> Result<Option<String>> {
     if let Some(path) = nodefile {
         return read(&path).map(Some);
@@ -59,48 +40,6 @@ mod tests {
         let path = directory.path().join("nodes.txt");
         std::fs::write(&path, contents).expect("write node file fixture");
         (directory, path.to_string_lossy().into_owned())
-    }
-
-    #[test]
-    fn first_allocated_node_expands_compressed_patterns() {
-        assert_eq!(
-            first_allocated_node("node[001-002]").as_deref(),
-            Some("node001")
-        );
-        assert_eq!(
-            first_allocated_node("node[001,003]").as_deref(),
-            Some("node001")
-        );
-        assert_eq!(
-            first_allocated_node("gpu[001-004],cpu[001-002]").as_deref(),
-            Some("gpu001")
-        );
-        assert_eq!(
-            first_allocated_node("node[9,010-011]").as_deref(),
-            Some("node9")
-        );
-    }
-
-    #[test]
-    fn first_allocated_node_handles_plain_and_single() {
-        assert_eq!(
-            first_allocated_node("node001,node002").as_deref(),
-            Some("node001")
-        );
-        assert_eq!(first_allocated_node("node007").as_deref(), Some("node007"));
-    }
-
-    #[test]
-    fn first_allocated_node_empty_is_none() {
-        assert_eq!(first_allocated_node(""), None);
-    }
-
-    #[test]
-    fn first_allocated_node_falls_back_on_malformed_pattern() {
-        assert_eq!(
-            first_allocated_node("node[001-002").as_deref(),
-            Some("node[001-002")
-        );
     }
 
     #[test]

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -72,11 +72,13 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         anyhow::bail!("sattach: job {} has no allocated nodes", job_id);
     }
 
-    // Connect to the first node's agent. The controller reports a compressed
-    // hostlist (e.g. `node[001-002]`), so expand it rather than comma-splitting.
-    let first_node = crate::nodelist::first_allocated_node(nodelist).with_context(|| {
-        format!("sattach: could not resolve a node from allocation '{nodelist}'")
-    })?;
+    // The controller reports a hostlist, so `node[1-3]` has to be expanded
+    // before a name is usable as an address.
+    let nodes = spur_core::hostlist::expand(nodelist)
+        .with_context(|| format!("sattach: job {} has an unreadable nodelist", job_id))?;
+    let first_node = nodes
+        .first()
+        .with_context(|| format!("sattach: job {} has no allocated nodes", job_id))?;
     let agent_addr = format!("http://{}:6818", first_node);
     let mut agent = crate::interactive::connect_agent(&agent_addr).await?;
 

--- a/crates/spur-cli/src/scancel.rs
+++ b/crates/spur-cli/src/scancel.rs
@@ -64,7 +64,7 @@ pub async fn main() -> Result<()> {
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let args = ScancelArgs::try_parse_from(&args)?;
 
-    if args.job_ids.is_empty() && args.user.is_none() && args.name.is_none() {
+    if !has_selection(&args) {
         bail!("scancel: no job IDs or filters specified");
     }
 
@@ -161,6 +161,16 @@ fn is_cancellable(proto_state: i32) -> bool {
     }
 }
 
+/// Whether the caller named anything to cancel. `--state` alone does not
+/// count: it narrows a selection rather than making one.
+fn has_selection(args: &ScancelArgs) -> bool {
+    !args.job_ids.is_empty()
+        || args.user.is_some()
+        || args.name.is_some()
+        || args.partition.is_some()
+        || args.account.is_some()
+}
+
 fn filter_states(state: Option<&str>) -> Result<Vec<i32>> {
     let Some(states) = state else {
         return Ok(cancellable_states());
@@ -223,6 +233,38 @@ fn parse_state(s: &str) -> Option<spur_proto::proto::JobState> {
 mod tests {
     use super::*;
     use spur_proto::proto::JobState;
+
+    fn parse(args: &[&str]) -> ScancelArgs {
+        let mut argv = vec!["scancel"];
+        argv.extend_from_slice(args);
+        ScancelArgs::try_parse_from(argv).expect("args should parse")
+    }
+
+    #[test]
+    fn every_selection_flag_counts_as_a_selection() {
+        for args in [
+            vec!["123"],
+            vec!["-u", "alice"],
+            vec!["-n", "myjob"],
+            vec!["-p", "default"],
+            vec!["-A", "acct"],
+        ] {
+            assert!(
+                has_selection(&parse(&args)),
+                "{args:?} should select jobs to cancel"
+            );
+        }
+    }
+
+    #[test]
+    fn no_arguments_selects_nothing() {
+        assert!(!has_selection(&parse(&[])));
+    }
+
+    #[test]
+    fn state_alone_selects_nothing() {
+        assert!(!has_selection(&parse(&["-t", "RUNNING"])));
+    }
 
     #[test]
     fn active_states_are_cancellable() {

--- a/crates/spur-cli/src/scancel.rs
+++ b/crates/spur-cli/src/scancel.rs
@@ -70,10 +70,13 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     let signal = parse_signal(args.signal.as_deref())?;
 
-    let user = match args.user {
-        Some(user) => user,
+    // Requester identity for authorization on each cancel. The server checks
+    // this against the job owner (root/empty bypass), so it must be the caller.
+    let requester = match &args.user {
+        Some(user) => user.clone(),
         None => crate::interactive::current_user()?,
     };
+    let filter_user = filter_user(&args, &requester);
 
     let channel = crate::authclient::connect(&args.controller)
         .await
@@ -87,7 +90,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 .cancel_job(CancelJobRequest {
                     job_id: *job_id,
                     signal,
-                    user: user.clone(),
+                    user: requester.clone(),
                 })
                 .await
             {
@@ -108,11 +111,11 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         let response = client
             .get_jobs(spur_proto::proto::GetJobsRequest {
                 states,
-                user: user.clone(),
-                partition: args.partition.unwrap_or_default(),
-                account: args.account.unwrap_or_default(),
+                user: filter_user,
+                partition: args.partition.clone().unwrap_or_default(),
+                account: args.account.clone().unwrap_or_default(),
                 job_ids: Vec::new(),
-                name: args.name.unwrap_or_default(),
+                name: args.name.clone().unwrap_or_default(),
                 nodes: Vec::new(),
             })
             .await
@@ -132,7 +135,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 .cancel_job(CancelJobRequest {
                     job_id: job.job_id,
                     signal,
-                    user: user.clone(),
+                    user: requester.clone(),
                 })
                 .await
             {
@@ -169,6 +172,19 @@ fn has_selection(args: &ScancelArgs) -> bool {
         || args.name.is_some()
         || args.partition.is_some()
         || args.account.is_some()
+}
+
+/// The `user` filter for get_jobs. `-u` wins; otherwise scope to the caller only
+/// when no other selector was named, so `scancel -A acct` spans the whole account
+/// instead of silently narrowing to self. The server still authorizes each cancel.
+fn filter_user(args: &ScancelArgs, requester: &str) -> String {
+    match &args.user {
+        Some(user) => user.clone(),
+        None if args.partition.is_some() || args.account.is_some() || args.name.is_some() => {
+            String::new()
+        }
+        None => requester.to_string(),
+    }
 }
 
 fn filter_states(state: Option<&str>) -> Result<Vec<i32>> {
@@ -264,6 +280,29 @@ mod tests {
     #[test]
     fn state_alone_selects_nothing() {
         assert!(!has_selection(&parse(&["-t", "RUNNING"])));
+    }
+
+    #[test]
+    fn explicit_user_is_always_the_filter() {
+        assert_eq!(filter_user(&parse(&["-u", "alice"]), "bob"), "alice");
+        assert_eq!(
+            filter_user(&parse(&["-u", "alice", "-A", "gpu"]), "bob"),
+            "alice"
+        );
+    }
+
+    #[test]
+    fn account_or_partition_without_user_spans_all_users() {
+        assert_eq!(filter_user(&parse(&["-A", "gpu"]), "bob"), "");
+        assert_eq!(filter_user(&parse(&["-p", "batch"]), "bob"), "");
+        assert_eq!(filter_user(&parse(&["-n", "train"]), "bob"), "");
+    }
+
+    #[test]
+    fn no_selector_defaults_to_the_caller() {
+        // Reachable via the job-id path, where the filter user is unused but the
+        // fallback must stay the caller rather than an empty (owner-bypass) value.
+        assert_eq!(filter_user(&parse(&["123"]), "bob"), "bob");
     }
 
     #[test]

--- a/crates/spur-cli/src/spur_config.rs
+++ b/crates/spur-cli/src/spur_config.rs
@@ -34,6 +34,7 @@ pub fn load_spur_config() -> SlurmConfig {
             devices: Default::default(),
             admission: Default::default(),
             rlimits: Default::default(),
+            cgroup: Default::default(),
             mpi: Default::default(),
         },
     }

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -996,7 +996,12 @@ async fn try_stream_output(
     job_id: u32,
     user: &str,
 ) -> bool {
-    let Some(first_node) = crate::nodelist::first_allocated_node(nodelist) else {
+    // The controller reports a hostlist, so `node[1-3]` has to be expanded
+    // before a name is usable as an address.
+    let Ok(nodes) = spur_core::hostlist::expand(nodelist) else {
+        return false;
+    };
+    let Some(first_node) = nodes.first() else {
         return false;
     };
 

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1315,10 +1315,8 @@ impl MpiConfig {
     }
 }
 
-/// cgroup constraints applied to a job's processes (Slurm's `cgroup.conf`).
-///
-/// The limits themselves come from the allocation; this section only sets how
-/// they are enforced.
+/// cgroup enforcement settings for a job's processes (Slurm's `cgroup.conf`).
+/// See `docs/admin-guide/configuration.rst` for the semantics.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CgroupConfig {
     /// Cap a job's swap alongside its memory (Slurm's `ConstrainSwapSpace`).

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -112,6 +112,10 @@ pub struct SlurmConfig {
     #[serde(default)]
     pub rlimits: RlimitsConfig,
 
+    /// cgroup enforcement policy for job processes.
+    #[serde(default)]
+    pub cgroup: CgroupConfig,
+
     /// MPI plugin settings for `--mpi=pmix` job steps.
     #[serde(default)]
     pub mpi: MpiConfig,
@@ -1308,6 +1312,81 @@ impl MpiConfig {
             return std::path::PathBuf::from(&self.pmix_plugin);
         }
         std::path::Path::new(&self.plugin_dir).join("spur_mpi_pmix.so")
+    }
+}
+
+/// cgroup constraints applied to a job's processes (Slurm's `cgroup.conf`).
+///
+/// The limits themselves come from the allocation; this section only sets how
+/// they are enforced.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CgroupConfig {
+    /// Cap a job's swap alongside its memory (Slurm's `ConstrainSwapSpace`).
+    ///
+    /// Off by default, as in Slurm: while off, `memory.max` bounds resident
+    /// memory only and a job that outgrows `--mem` swaps instead of being killed.
+    #[serde(default)]
+    pub constrain_swap_space: bool,
+
+    /// Swap a job may use, as a percentage of its memory allocation (Slurm's
+    /// `AllowedSwapSpace`). Only consulted when `constrain_swap_space` is set.
+    #[serde(default)]
+    pub allowed_swap_space: u32,
+}
+
+/// Swap budget for a job's cgroup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SwapLimit {
+    /// Leave `memory.swap.max` alone; the job may swap without bound.
+    Unconstrained,
+    /// Cap swap at this percentage of the job's memory allocation.
+    Percent(u32),
+}
+
+impl SwapLimit {
+    /// Swap budget in bytes for a job capped at `memory_bytes`, or `None` when
+    /// swap is unconstrained.
+    pub fn bytes_for(&self, memory_bytes: u64) -> Option<u64> {
+        match self {
+            Self::Unconstrained => None,
+            Self::Percent(percent) => Some(memory_bytes.saturating_mul(u64::from(*percent)) / 100),
+        }
+    }
+}
+
+impl CgroupConfig {
+    pub fn swap_limit(&self) -> Result<SwapLimit, ConfigError> {
+        if !self.constrain_swap_space {
+            return Ok(SwapLimit::Unconstrained);
+        }
+        if self.allowed_swap_space > 100 {
+            return Err(ConfigError::InvalidValue {
+                field: "cgroup.allowed_swap_space".into(),
+                value: format!(
+                    "{} (expected a percentage of the memory allocation, 0 to 100)",
+                    self.allowed_swap_space
+                ),
+            });
+        }
+        Ok(SwapLimit::Percent(self.allowed_swap_space))
+    }
+}
+
+/// Resolved limits an agent applies to every job it launches, as opposed to
+/// the per-job sizes that come from the allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JobLimits {
+    /// Applied before exec, while still privileged.
+    pub memlock: MemlockLimit,
+    pub swap: SwapLimit,
+}
+
+impl Default for JobLimits {
+    fn default() -> Self {
+        Self {
+            memlock: MemlockLimit::Unlimited,
+            swap: SwapLimit::Unconstrained,
+        }
     }
 }
 
@@ -2938,6 +3017,76 @@ cluster_name = "test"
         assert_eq!(
             config.rlimits.memlock_limit().unwrap(),
             MemlockLimit::Unlimited
+        );
+    }
+
+    #[test]
+    fn cgroup_swap_is_unconstrained_by_default() {
+        let cfg = CgroupConfig::default();
+        assert_eq!(cfg.swap_limit().unwrap(), SwapLimit::Unconstrained);
+        assert_eq!(SwapLimit::Unconstrained.bytes_for(64 * 1024 * 1024), None);
+    }
+
+    #[test]
+    fn cgroup_constrained_swap_defaults_to_denying_swap() {
+        let cfg = CgroupConfig {
+            constrain_swap_space: true,
+            allowed_swap_space: 0,
+        };
+        let limit = cfg.swap_limit().unwrap();
+        assert_eq!(limit, SwapLimit::Percent(0));
+        assert_eq!(limit.bytes_for(64 * 1024 * 1024), Some(0));
+    }
+
+    #[test]
+    fn cgroup_allowed_swap_is_a_percentage_of_the_allocation() {
+        let cfg = CgroupConfig {
+            constrain_swap_space: true,
+            allowed_swap_space: 50,
+        };
+        assert_eq!(
+            cfg.swap_limit().unwrap().bytes_for(64 * 1024 * 1024),
+            Some(32 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn cgroup_allowed_swap_percentage_above_100_errors() {
+        let cfg = CgroupConfig {
+            constrain_swap_space: true,
+            allowed_swap_space: 101,
+        };
+        assert!(cfg.swap_limit().is_err());
+    }
+
+    #[test]
+    fn cgroup_allowed_swap_is_ignored_while_unconstrained() {
+        let cfg = CgroupConfig {
+            constrain_swap_space: false,
+            allowed_swap_space: 999,
+        };
+        assert_eq!(cfg.swap_limit().unwrap(), SwapLimit::Unconstrained);
+    }
+
+    #[test]
+    fn cgroup_from_toml_explicit() {
+        let toml = r#"
+cluster_name = "test"
+
+[cgroup]
+constrain_swap_space = true
+allowed_swap_space = 25
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        assert_eq!(config.cgroup.swap_limit().unwrap(), SwapLimit::Percent(25));
+    }
+
+    #[test]
+    fn cgroup_from_toml_default() {
+        let config = SlurmConfig::load_from_str("cluster_name = \"test\"\n").unwrap();
+        assert_eq!(
+            config.cgroup.swap_limit().unwrap(),
+            SwapLimit::Unconstrained
         );
     }
 

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -108,22 +108,41 @@ fn should_submit(status: &SpurJobStatus) -> bool {
     status.spur_job_id.is_none()
 }
 
+/// Whether a failed submit is worth another attempt. Only "no controller
+/// answered" codes qualify; anything else faults the spec itself and would be
+/// rejected identically forever. Matches the agent's controller-RPC rule.
+fn submit_is_retryable(status: &tonic::Status) -> bool {
+    use tonic::Code;
+    matches!(
+        status.code(),
+        Code::Unavailable | Code::Internal | Code::DeadlineExceeded | Code::Unknown
+    )
+}
+
+/// Result of the submit phase.
+enum SubmitOutcome {
+    Submitted,
+    /// A prior reconcile already submitted this SpurJob.
+    AlreadySubmitted,
+    /// The controller refused the spec; the SpurJob is now Failed.
+    Rejected,
+}
+
 /// Submit to spurctld, apply job-id label, and patch CRD status.
 /// Re-reads from the API server first to guard against stale informer cache.
-/// Returns `Ok(None)` if a prior reconcile already submitted.
 async fn submit_to_controller(
     api: &Api<SpurJob>,
     ctx: &JobControllerCtx,
     name: &str,
     ns: &str,
     job: &SpurJob,
-) -> Result<Option<u32>, ReconcileError> {
+) -> Result<SubmitOutcome, ReconcileError> {
     // Fresh read from API server — informer cache may be stale after finalizer patch
     let fresh = api.get(name).await.map_err(ReconcileError::Kube)?;
     let fresh_status = fresh.status.clone().unwrap_or_default();
     if !should_submit(&fresh_status) {
         debug!(spurjob = %name, "already submitted by prior reconcile");
-        return Ok(None);
+        return Ok(SubmitOutcome::AlreadySubmitted);
     }
 
     let user = job
@@ -145,9 +164,19 @@ async fn submit_to_controller(
         .await
     {
         Ok(resp) => resp.into_inner().job_id,
-        Err(e) => {
+        Err(e) if submit_is_retryable(&e) => {
             error!(spurjob = %name, error = %e, "failed to submit SpurJob");
             return Err(ReconcileError::Grpc(e));
+        }
+        Err(e) => {
+            error!(spurjob = %name, error = %e, "SpurJob rejected by the controller");
+            let new_status = SpurJobStatus {
+                state: "Failed".into(),
+                message: Some(format!("rejected by spurctld: {}", e.message())),
+                ..fresh_status.clone()
+            };
+            patch_status(api, name, &new_status).await;
+            return Ok(SubmitOutcome::Rejected);
         }
     };
     drop(ctrl);
@@ -166,7 +195,7 @@ async fn submit_to_controller(
     };
     patch_status(api, name, &new_status).await;
 
-    Ok(Some(job_id))
+    Ok(SubmitOutcome::Submitted)
 }
 
 /// State-machine dispatcher: submit if no job_id, otherwise poll spurctld.
@@ -190,8 +219,9 @@ async fn handle_job(
     // Phase 1: Submit (no spur_job_id yet)
     if should_submit(&status) {
         return match submit_to_controller(api, ctx, &name, &ns, &job).await? {
-            Some(_job_id) => Ok(Action::requeue(Duration::from_secs(5))),
-            None => Ok(Action::requeue(Duration::from_secs(2))),
+            SubmitOutcome::Submitted => Ok(Action::requeue(Duration::from_secs(5))),
+            SubmitOutcome::AlreadySubmitted => Ok(Action::requeue(Duration::from_secs(2))),
+            SubmitOutcome::Rejected => Ok(Action::await_change()),
         };
     }
 
@@ -888,6 +918,33 @@ mod tests {
         assert!(!is_terminal("Suspended"));
         assert!(!is_terminal("Unknown"));
         assert!(!is_terminal(""));
+    }
+
+    // --- submit_is_retryable ---
+
+    #[test]
+    fn a_spec_rejection_is_not_retried() {
+        // What spurctld returns for an unknown partition or a denied account.
+        assert!(!submit_is_retryable(&tonic::Status::invalid_argument(
+            "partition 'gpu' not found"
+        )));
+        assert!(!submit_is_retryable(&tonic::Status::permission_denied(
+            "account denied"
+        )));
+    }
+
+    #[test]
+    fn a_controller_that_did_not_answer_is_retried() {
+        // "not the Raft leader" and a failed Raft propose are both transient.
+        assert!(submit_is_retryable(&tonic::Status::unavailable(
+            "not the Raft leader"
+        )));
+        assert!(submit_is_retryable(&tonic::Status::internal(
+            "raft propose failed"
+        )));
+        assert!(submit_is_retryable(&tonic::Status::deadline_exceeded(
+            "timed out"
+        )));
     }
 
     // --- resolve_reporting_node ---

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -29,6 +29,7 @@ const FINALIZER: &str = "spur.amd.com/cleanup";
 const INITIAL_BACKOFF_SECS: u64 = 1;
 const MAX_BACKOFF_SECS: u64 = 60;
 const LABEL_PATCH_BUDGET: Duration = Duration::from_secs(3);
+const STATUS_PATCH_BUDGET: Duration = Duration::from_secs(3);
 
 fn is_transient_kube_error(err: &kube::Error) -> bool {
     match err {
@@ -229,8 +230,9 @@ async fn submit_to_controller(
                 ..fresh_status.clone()
             };
             // Rejected returns await_change(), so a dropped write here can't
-            // self-heal; propagate it and let error_policy retry with backoff.
-            patch_status(api, name, &new_status)
+            // self-heal. Retry the write in place rather than propagating, which
+            // would re-run submit_job on the next pass for an already-doomed spec.
+            patch_terminal_status(api, name, &new_status)
                 .await
                 .map_err(ReconcileError::Kube)?;
             return Ok(SubmitOutcome::Rejected);
@@ -840,6 +842,40 @@ async fn patch_status(
     api.patch_status(name, &pp, &Patch::Merge(&patch))
         .await
         .map(|_| ())
+}
+
+/// Write a terminal status, retrying transient API errors within a budget. The
+/// submit that produced this state is already spent, so a dropped write must not
+/// fall back to re-running submit on the next reconcile.
+async fn patch_terminal_status(
+    api: &Api<SpurJob>,
+    name: &str,
+    status: &SpurJobStatus,
+) -> Result<(), kube::Error> {
+    tokio::time::timeout(
+        STATUS_PATCH_BUDGET,
+        (|| async { patch_status(api, name, status).await })
+            .retry(
+                ExponentialBuilder::default()
+                    .with_min_delay(Duration::from_millis(200))
+                    .with_max_delay(Duration::from_secs(1))
+                    .without_max_times(),
+            )
+            .when(is_transient_kube_error),
+    )
+    .await
+    .unwrap_or_else(|_elapsed| {
+        Err(kube::Error::Api(Box::new(
+            kube::core::Status::failure(
+                "TimedOut",
+                &format!(
+                    "status patch timed out after {}s",
+                    STATUS_PATCH_BUDGET.as_secs()
+                ),
+            )
+            .with_code(504),
+        )))
+    })
 }
 
 fn is_terminal(state: &str) -> bool {

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -54,8 +54,8 @@ pub struct JobControllerCtx {
     pub ctrl_client: Mutex<SlurmControllerClient<Channel>>,
     /// Track multi-pod completion: job_id → (expected_count, completed_count, any_failed)
     pub(crate) pod_tracker: Mutex<HashMap<u32, PodTracker>>,
-    /// Consecutive reconcile failures per SpurJob, driving the retry delay.
-    /// Std mutex because `error_policy` is synchronous.
+    /// Consecutive reconcile failures per SpurJob (keyed by [`failure_key`]),
+    /// driving the retry delay. Std mutex because `error_policy` is synchronous.
     pub(crate) failures: StdMutex<HashMap<String, u32>>,
 }
 
@@ -64,6 +64,16 @@ fn object_key(job: &SpurJob) -> String {
         "{}/{}",
         job.metadata.namespace.as_deref().unwrap_or_default(),
         job.metadata.name.as_deref().unwrap_or_default()
+    )
+}
+
+/// Map key for the failure counter. Includes the UID so a delete+recreate under
+/// the same name starts a fresh backoff sequence instead of inheriting the count.
+fn failure_key(job: &SpurJob) -> String {
+    format!(
+        "{}/{}",
+        object_key(job),
+        job.metadata.uid.as_deref().unwrap_or("")
     )
 }
 
@@ -120,7 +130,7 @@ async fn reconcile(
         .clone()
         .ok_or_else(|| ReconcileError::Other("SpurJob has no namespace".into()))?;
     let api: Api<SpurJob> = Api::namespaced(ctx.client.clone(), &ns);
-    let key = object_key(&job);
+    let key = failure_key(&job);
 
     let result = finalizer(&api, FINALIZER, job, |event| {
         let api = api.clone();
@@ -135,8 +145,8 @@ async fn reconcile(
     .await
     .map_err(map_finalizer_err);
 
-    // A clean pass ends the retry sequence; cleanup also lands here, so the
-    // entry is dropped when the SpurJob goes away.
+    // A clean pass ends the retry sequence; a successful cleanup lands here too,
+    // reaping the entry on delete so it does not outlive the SpurJob.
     if result.is_ok() {
         ctx.clear_backoff(&key);
     }
@@ -161,16 +171,7 @@ fn should_submit(status: &SpurJobStatus) -> bool {
     status.spur_job_id.is_none()
 }
 
-/// Whether a failed submit is worth another attempt. Only "no controller
-/// answered" codes qualify; anything else faults the spec itself and would be
-/// rejected identically forever. Matches the agent's controller-RPC rule.
-fn submit_is_retryable(status: &tonic::Status) -> bool {
-    use tonic::Code;
-    matches!(
-        status.code(),
-        Code::Unavailable | Code::Internal | Code::DeadlineExceeded | Code::Unknown
-    )
-}
+use spur_proto::controller_rpc_retryable;
 
 enum SubmitOutcome {
     Submitted,
@@ -216,7 +217,7 @@ async fn submit_to_controller(
         .await
     {
         Ok(resp) => resp.into_inner().job_id,
-        Err(e) if submit_is_retryable(&e) => {
+        Err(e) if controller_rpc_retryable(&e) => {
             error!(spurjob = %name, error = %e, "failed to submit SpurJob");
             return Err(ReconcileError::Grpc(e));
         }
@@ -372,7 +373,7 @@ async fn handle_deletion(job: &SpurJob, ctx: &JobControllerCtx) -> Result<Action
 }
 
 fn error_policy(job: Arc<SpurJob>, error: &ReconcileError, ctx: Arc<JobControllerCtx>) -> Action {
-    let delay = ctx.next_backoff(&object_key(&job));
+    let delay = ctx.next_backoff(&failure_key(&job));
     error!(
         spurjob = %object_key(&job),
         error = %error,
@@ -981,6 +982,25 @@ mod tests {
     }
 
     #[test]
+    fn failure_key_distinguishes_recreated_objects() {
+        let recreate = |uid: &str| -> SpurJob {
+            serde_json::from_value(serde_json::json!({
+                "apiVersion": "spur.amd.com/v1",
+                "kind": "SpurJob",
+                "metadata": { "namespace": "ns", "name": "job", "uid": uid },
+                "spec": { "name": "job", "image": "img" },
+            }))
+            .unwrap()
+        };
+        let old = recreate("uid-a");
+        let new = recreate("uid-b");
+
+        // Same name, but a recreate gets its own backoff sequence.
+        assert_eq!(object_key(&old), object_key(&new));
+        assert_ne!(failure_key(&old), failure_key(&new));
+    }
+
+    #[test]
     fn test_cleared_object_restarts_backoff() {
         let failures = FailureCounts::default();
         record_failure(&failures, "ns/a");
@@ -1020,33 +1040,6 @@ mod tests {
         assert!(!is_terminal("Suspended"));
         assert!(!is_terminal("Unknown"));
         assert!(!is_terminal(""));
-    }
-
-    // --- submit_is_retryable ---
-
-    #[test]
-    fn a_spec_rejection_is_not_retried() {
-        // What spurctld returns for an unknown partition or a denied account.
-        assert!(!submit_is_retryable(&tonic::Status::invalid_argument(
-            "partition 'gpu' not found"
-        )));
-        assert!(!submit_is_retryable(&tonic::Status::permission_denied(
-            "account denied"
-        )));
-    }
-
-    #[test]
-    fn a_controller_that_did_not_answer_is_retried() {
-        // "not the Raft leader" and a failed Raft propose are both transient.
-        assert!(submit_is_retryable(&tonic::Status::unavailable(
-            "not the Raft leader"
-        )));
-        assert!(submit_is_retryable(&tonic::Status::internal(
-            "raft propose failed"
-        )));
-        assert!(submit_is_retryable(&tonic::Status::deadline_exceeded(
-            "timed out"
-        )));
     }
 
     // --- resolve_reporting_node ---

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 use std::pin::pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use backon::{ExponentialBuilder, Retryable};
@@ -26,6 +26,7 @@ use spur_proto::proto::{
 };
 
 const FINALIZER: &str = "spur.amd.com/cleanup";
+const INITIAL_BACKOFF_SECS: u64 = 1;
 const MAX_BACKOFF_SECS: u64 = 60;
 const LABEL_PATCH_BUDGET: Duration = Duration::from_secs(3);
 
@@ -53,6 +54,50 @@ pub struct JobControllerCtx {
     pub ctrl_client: Mutex<SlurmControllerClient<Channel>>,
     /// Track multi-pod completion: job_id → (expected_count, completed_count, any_failed)
     pub(crate) pod_tracker: Mutex<HashMap<u32, PodTracker>>,
+    /// Consecutive reconcile failures per SpurJob, driving the retry delay.
+    /// Std mutex because `error_policy` is synchronous.
+    pub(crate) failures: StdMutex<HashMap<String, u32>>,
+}
+
+fn object_key(job: &SpurJob) -> String {
+    format!(
+        "{}/{}",
+        job.metadata.namespace.as_deref().unwrap_or_default(),
+        job.metadata.name.as_deref().unwrap_or_default()
+    )
+}
+
+type FailureCounts = StdMutex<HashMap<String, u32>>;
+
+/// Delay before the *attempt*-th retry: doubling from `INITIAL_BACKOFF_SECS`, capped.
+fn backoff_delay(attempt: u32) -> Duration {
+    // Cap the shift before the multiply so the doubling cannot overflow.
+    let shift = attempt.saturating_sub(1).min(u32::BITS - 1);
+    let secs = INITIAL_BACKOFF_SECS
+        .saturating_mul(1u64.checked_shl(shift).unwrap_or(u64::MAX))
+        .min(MAX_BACKOFF_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Counts another consecutive failure for *key* and returns how long to wait.
+fn record_failure(failures: &FailureCounts, key: &str) -> Duration {
+    let mut counts = failures.lock().unwrap_or_else(|e| e.into_inner());
+    let attempt = counts.entry(key.to_string()).or_insert(0);
+    *attempt = attempt.saturating_add(1);
+    backoff_delay(*attempt)
+}
+
+impl JobControllerCtx {
+    fn next_backoff(&self, key: &str) -> Duration {
+        record_failure(&self.failures, key)
+    }
+
+    fn clear_backoff(&self, key: &str) {
+        self.failures
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(key);
+    }
 }
 
 pub(crate) struct PodTracker {
@@ -75,8 +120,9 @@ async fn reconcile(
         .clone()
         .ok_or_else(|| ReconcileError::Other("SpurJob has no namespace".into()))?;
     let api: Api<SpurJob> = Api::namespaced(ctx.client.clone(), &ns);
+    let key = object_key(&job);
 
-    finalizer(&api, FINALIZER, job, |event| {
+    let result = finalizer(&api, FINALIZER, job, |event| {
         let api = api.clone();
         let ctx = ctx.clone();
         async move {
@@ -87,7 +133,14 @@ async fn reconcile(
         }
     })
     .await
-    .map_err(map_finalizer_err)
+    .map_err(map_finalizer_err);
+
+    // A clean pass ends the retry sequence; cleanup also lands here, so the
+    // entry is dropped when the SpurJob goes away.
+    if result.is_ok() {
+        ctx.clear_backoff(&key);
+    }
+    result
 }
 
 fn map_finalizer_err(e: finalizer::Error<ReconcileError>) -> ReconcileError {
@@ -119,7 +172,6 @@ fn submit_is_retryable(status: &tonic::Status) -> bool {
     )
 }
 
-/// Result of the submit phase.
 enum SubmitOutcome {
     Submitted,
     /// A prior reconcile already submitted this SpurJob.
@@ -175,7 +227,11 @@ async fn submit_to_controller(
                 message: Some(format!("rejected by spurctld: {}", e.message())),
                 ..fresh_status.clone()
             };
-            patch_status(api, name, &new_status).await;
+            // Rejected returns await_change(), so a dropped write here can't
+            // self-heal; propagate it and let error_policy retry with backoff.
+            patch_status(api, name, &new_status)
+                .await
+                .map_err(ReconcileError::Kube)?;
             return Ok(SubmitOutcome::Rejected);
         }
     };
@@ -193,7 +249,10 @@ async fn submit_to_controller(
         spur_job_id: Some(job_id),
         ..fresh_status
     };
-    patch_status(api, name, &new_status).await;
+    // Best-effort: the Submitted path requeues in 5s, which retries the write.
+    if let Err(e) = patch_status(api, name, &new_status).await {
+        error!(spurjob = %name, error = %e, "failed to patch SpurJob status");
+    }
 
     Ok(SubmitOutcome::Submitted)
 }
@@ -249,7 +308,9 @@ async fn handle_job(
                         .map(|s| s.trim().to_string())
                         .collect();
                 }
-                patch_status(api, &name, &new_status).await;
+                if let Err(e) = patch_status(api, &name, &new_status).await {
+                    warn!(spurjob = %name, job_id, error = %e, "failed to patch SpurJob status");
+                }
             }
 
             if is_terminal(&spur_state) {
@@ -310,10 +371,15 @@ async fn handle_deletion(job: &SpurJob, ctx: &JobControllerCtx) -> Result<Action
     Ok(Action::await_change())
 }
 
-fn error_policy(_job: Arc<SpurJob>, error: &ReconcileError, _ctx: Arc<JobControllerCtx>) -> Action {
-    error!(error = %error, "SpurJob reconciler error");
-    // Exponential backoff capped at MAX_BACKOFF_SECS
-    Action::requeue(Duration::from_secs(MAX_BACKOFF_SECS))
+fn error_policy(job: Arc<SpurJob>, error: &ReconcileError, ctx: Arc<JobControllerCtx>) -> Action {
+    let delay = ctx.next_backoff(&object_key(&job));
+    error!(
+        spurjob = %object_key(&job),
+        error = %error,
+        retry_in_secs = delay.as_secs(),
+        "SpurJob reconciler error"
+    );
+    Action::requeue(delay)
 }
 
 /// Start the SpurJob controller and Pod watcher.
@@ -336,6 +402,7 @@ pub async fn run(
         client: client.clone(),
         ctrl_client: Mutex::new(ctrl_client),
         pod_tracker: Mutex::new(HashMap::new()),
+        failures: StdMutex::new(HashMap::new()),
     });
 
     let spurjobs: Api<SpurJob> = Api::all(client.clone());
@@ -762,12 +829,16 @@ async fn ensure_job_id_label(
     .inspect_err(|e| warn!(spurjob = %name, job_id, error = %e, "failed to apply job-id label"))
 }
 
-async fn patch_status(api: &Api<SpurJob>, name: &str, status: &SpurJobStatus) {
+async fn patch_status(
+    api: &Api<SpurJob>,
+    name: &str,
+    status: &SpurJobStatus,
+) -> Result<(), kube::Error> {
     let patch = serde_json::json!({ "status": status });
     let pp = PatchParams::apply("spur-k8s-operator");
-    if let Err(e) = api.patch_status(name, &pp, &Patch::Merge(&patch)).await {
-        error!(spurjob = %name, error = %e, "failed to patch SpurJob status");
-    }
+    api.patch_status(name, &pp, &Patch::Merge(&patch))
+        .await
+        .map(|_| ())
 }
 
 fn is_terminal(state: &str) -> bool {
@@ -888,6 +959,37 @@ mod tests {
         }
         assert_eq!(proto_job_state_to_string(-1), "Unknown");
         assert_eq!(proto_job_state_to_string(99), "Unknown");
+    }
+
+    // --- retry backoff ---
+
+    #[test]
+    fn test_backoff_doubles_from_one_second_and_caps() {
+        let seconds: Vec<u64> = (1..=10).map(|n| backoff_delay(n).as_secs()).collect();
+        assert_eq!(seconds, vec![1, 2, 4, 8, 16, 32, 60, 60, 60, 60]);
+        assert_eq!(backoff_delay(u32::MAX).as_secs(), MAX_BACKOFF_SECS);
+    }
+
+    #[test]
+    fn test_record_failure_counts_per_object() {
+        let failures = FailureCounts::default();
+        assert_eq!(record_failure(&failures, "ns/a").as_secs(), 1);
+        assert_eq!(record_failure(&failures, "ns/a").as_secs(), 2);
+        // A different SpurJob starts its own sequence.
+        assert_eq!(record_failure(&failures, "ns/b").as_secs(), 1);
+        assert_eq!(record_failure(&failures, "ns/a").as_secs(), 4);
+    }
+
+    #[test]
+    fn test_cleared_object_restarts_backoff() {
+        let failures = FailureCounts::default();
+        record_failure(&failures, "ns/a");
+        record_failure(&failures, "ns/a");
+        failures
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove("ns/a");
+        assert_eq!(record_failure(&failures, "ns/a").as_secs(), 1);
     }
 
     // --- is_terminal ---

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -29,7 +29,6 @@ const FINALIZER: &str = "spur.amd.com/cleanup";
 const INITIAL_BACKOFF_SECS: u64 = 1;
 const MAX_BACKOFF_SECS: u64 = 60;
 const LABEL_PATCH_BUDGET: Duration = Duration::from_secs(3);
-const STATUS_PATCH_BUDGET: Duration = Duration::from_secs(3);
 
 fn is_transient_kube_error(err: &kube::Error) -> bool {
     match err {
@@ -224,14 +223,16 @@ async fn submit_to_controller(
         }
         Err(e) => {
             error!(spurjob = %name, error = %e, "SpurJob rejected by the controller");
+            // Release the controller lock before the (possibly long) status write
+            // so other reconciles can keep talking to spurctld during an API outage.
+            drop(ctrl);
             let new_status = SpurJobStatus {
                 state: "Failed".into(),
                 message: Some(format!("rejected by spurctld: {}", e.message())),
                 ..fresh_status.clone()
             };
-            // Rejected returns await_change(), so a dropped write here can't
-            // self-heal. Retry the write in place rather than propagating, which
-            // would re-run submit_job on the next pass for an already-doomed spec.
+            // Rejected returns await_change(), so a dropped write can't self-heal; land
+            // it here rather than propagating, which would resubmit the doomed spec.
             patch_terminal_status(api, name, &new_status)
                 .await
                 .map_err(ReconcileError::Kube)?;
@@ -844,38 +845,23 @@ async fn patch_status(
         .map(|_| ())
 }
 
-/// Write a terminal status, retrying transient API errors within a budget. The
-/// submit that produced this state is already spent, so a dropped write must not
-/// fall back to re-running submit on the next reconcile.
+/// Write a terminal status, retrying transient API errors until they clear.
+/// The Rejected path uses await_change(), so a dropped write never self-heals; a
+/// bounded budget would resubmit the doomed spec. Permanent errors stop the retry.
 async fn patch_terminal_status(
     api: &Api<SpurJob>,
     name: &str,
     status: &SpurJobStatus,
 ) -> Result<(), kube::Error> {
-    tokio::time::timeout(
-        STATUS_PATCH_BUDGET,
-        (|| async { patch_status(api, name, status).await })
-            .retry(
-                ExponentialBuilder::default()
-                    .with_min_delay(Duration::from_millis(200))
-                    .with_max_delay(Duration::from_secs(1))
-                    .without_max_times(),
-            )
-            .when(is_transient_kube_error),
-    )
-    .await
-    .unwrap_or_else(|_elapsed| {
-        Err(kube::Error::Api(Box::new(
-            kube::core::Status::failure(
-                "TimedOut",
-                &format!(
-                    "status patch timed out after {}s",
-                    STATUS_PATCH_BUDGET.as_secs()
-                ),
-            )
-            .with_code(504),
-        )))
-    })
+    (|| async { patch_status(api, name, status).await })
+        .retry(
+            ExponentialBuilder::default()
+                .with_min_delay(Duration::from_millis(200))
+                .with_max_delay(Duration::from_secs(5))
+                .without_max_times(),
+        )
+        .when(is_transient_kube_error)
+        .await
 }
 
 fn is_terminal(state: &str) -> bool {

--- a/crates/spur-proto/src/lib.rs
+++ b/crates/spur-proto/src/lib.rs
@@ -22,6 +22,15 @@ pub const MAX_GRPC_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
 /// while allowing large outbound responses.
 pub const MAX_GRPC_REQUEST_SIZE: usize = 8 * 1024 * 1024;
 
+/// Only transient RPC failures are retried; a spec rejection would repeat forever.
+pub fn controller_rpc_retryable(status: &tonic::Status) -> bool {
+    use tonic::Code;
+    matches!(
+        status.code(),
+        Code::Unavailable | Code::Internal | Code::DeadlineExceeded | Code::Unknown
+    )
+}
+
 /// Controller client with asymmetric size limits: requests capped at
 /// `MAX_GRPC_REQUEST_SIZE`, responses up to `MAX_GRPC_MESSAGE_SIZE`.
 pub fn controller_client<T>(channel: T) -> proto::slurm_controller_client::SlurmControllerClient<T>
@@ -81,4 +90,35 @@ pub fn accounting_server<T: proto::slurm_accounting_server::SlurmAccounting>(
     proto::slurm_accounting_server::SlurmAccountingServer::new(service)
         .max_decoding_message_size(MAX_GRPC_REQUEST_SIZE)
         .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::controller_rpc_retryable;
+
+    #[test]
+    fn a_spec_rejection_is_not_retried() {
+        // What spurctld returns for an unknown partition or a denied account.
+        assert!(!controller_rpc_retryable(&tonic::Status::invalid_argument(
+            "partition 'gpu' not found"
+        )));
+        assert!(!controller_rpc_retryable(
+            &tonic::Status::permission_denied("account denied")
+        ));
+        assert!(!controller_rpc_retryable(&tonic::Status::not_found("x")));
+    }
+
+    #[test]
+    fn a_controller_that_did_not_answer_is_retried() {
+        // "not the Raft leader" and a failed Raft propose are both transient.
+        assert!(controller_rpc_retryable(&tonic::Status::unavailable(
+            "not the Raft leader"
+        )));
+        assert!(controller_rpc_retryable(&tonic::Status::internal(
+            "raft propose failed"
+        )));
+        assert!(controller_rpc_retryable(&tonic::Status::deadline_exceeded(
+            "timed out"
+        )));
+    }
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -7620,6 +7620,7 @@ mod tests {
             devices: Default::default(),
             admission: Default::default(),
             rlimits: Default::default(),
+            cgroup: Default::default(),
             mpi: Default::default(),
         }
     }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -106,6 +106,9 @@ impl std::error::Error for ReservationError {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SubmitError {
     InvalidArgument(String),
+    /// A transient condition the client should retry (maps to gRPC `Unavailable`,
+    /// REST 503), e.g. a cold association cache right after controller start.
+    Unavailable(String),
     Internal(String),
 }
 
@@ -166,7 +169,7 @@ impl std::error::Error for SrunCompleteError {}
 impl std::fmt::Display for SubmitError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::InvalidArgument(m) | Self::Internal(m) => f.write_str(m),
+            Self::InvalidArgument(m) | Self::Unavailable(m) | Self::Internal(m) => f.write_str(m),
         }
     }
 }
@@ -176,6 +179,10 @@ impl std::error::Error for SubmitError {}
 impl SubmitError {
     pub fn invalid(msg: impl Into<String>) -> Self {
         Self::InvalidArgument(msg.into())
+    }
+
+    pub fn unavailable(msg: impl Into<String>) -> Self {
+        Self::Unavailable(msg.into())
     }
 
     pub fn internal(msg: impl Into<String>) -> Self {
@@ -7348,6 +7355,16 @@ fn validate_user_account(
 ) -> Result<(), SubmitError> {
     let Some(account) = spec.account.as_deref().filter(|a| !a.is_empty()) else {
         if accounting.require_association {
+            // Cold cache: the user's default account may still resolve once the refresh
+            // loop populates associations, so this is transient (retryable), not permanent.
+            if accounting.enabled() && !assoc_cache.is_loaded() {
+                return Err(SubmitError::unavailable(format!(
+                    "account associations are temporarily unavailable (accounting cache not loaded); \
+                     no default account resolved for user '{}' yet. Try again once the accounting \
+                     database is reachable.",
+                    spec.user
+                )));
+            }
             let hint = if assoc_cache.is_loaded() {
                 ""
             } else {
@@ -7373,7 +7390,9 @@ fn validate_user_account(
                 "association cache not loaded while accounting is enabled — denying account-scoped \
                  submission (fail closed). Check the accounting database is reachable."
             );
-            Err(SubmitError::invalid(format!(
+            // Transient: the refresh loop populates the cache shortly after start, so
+            // this must be retryable (Unavailable), not a permanent rejection.
+            Err(SubmitError::unavailable(format!(
                 "account associations are temporarily unavailable (accounting cache not loaded); \
                  cannot verify user '{}' is associated with account '{account}'. Try again once \
                  the accounting database is reachable.",
@@ -13514,8 +13533,8 @@ mod tests {
         spec.account = Some("tenant-b".into());
         let err = validate_user_account(&spec, &cache, &acct_cfg_enabled(true)).unwrap_err();
         assert!(
-            matches!(&err, SubmitError::InvalidArgument(m) if m.contains("temporarily unavailable")),
-            "cold cache with accounting enabled must fail closed, got {err:?}"
+            matches!(&err, SubmitError::Unavailable(m) if m.contains("temporarily unavailable")),
+            "cold cache with accounting enabled must fail closed (retryable), got {err:?}"
         );
     }
 
@@ -13573,8 +13592,8 @@ mod tests {
         spec.account = Some("tenant-b".into());
         let err = cm.submit_job(spec).unwrap_err();
         assert!(
-            matches!(&err, SubmitError::InvalidArgument(m) if m.contains("temporarily unavailable")),
-            "cold cache must fail closed end-to-end, got {err:?}"
+            matches!(&err, SubmitError::Unavailable(m) if m.contains("temporarily unavailable")),
+            "cold cache must fail closed end-to-end (retryable), got {err:?}"
         );
     }
 
@@ -20453,7 +20472,8 @@ mod tests {
     #[test]
     fn validate_user_account_fails_closed_on_cold_cache_with_explicit_account_and_require_association(
     ) {
-        // require_association=true doesn't bypass the cold-cache fence for an explicit account.
+        // require_association=true doesn't bypass the cold-cache fence for an explicit
+        // account. The fence is transient (cache still loading), so it must be retryable.
         let assoc = AssociationCache::new(); // never loaded
         let mut spec = basic_spec("j");
         spec.account = Some("research".into());
@@ -20464,7 +20484,30 @@ mod tests {
         };
 
         let err = super::validate_user_account(&spec, &assoc, &cfg).unwrap_err();
-        assert!(err.to_string().contains("temporarily unavailable"));
+        assert!(
+            matches!(&err, super::SubmitError::Unavailable(m) if m.contains("temporarily unavailable")),
+            "cold cache must be retryable, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_user_account_cold_cache_no_account_require_association_is_retryable() {
+        // A user's default account may still be loading; rejecting it permanently would
+        // fail a job that would succeed once the refresh loop populates the cache.
+        let assoc = AssociationCache::new(); // never loaded
+        let spec = basic_spec("j");
+        assert!(spec.account.is_none());
+        let cfg = spur_core::config::AccountingConfig {
+            database_url: "postgresql://test".into(),
+            require_association: true,
+            ..Default::default()
+        };
+
+        let err = super::validate_user_account(&spec, &assoc, &cfg).unwrap_err();
+        assert!(
+            matches!(&err, super::SubmitError::Unavailable(m) if m.contains("temporarily unavailable")),
+            "cold cache must be retryable, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -468,6 +468,7 @@ fn default_config() -> spur_core::config::SlurmConfig {
         devices: Default::default(),
         admission: Default::default(),
         rlimits: Default::default(),
+        cgroup: Default::default(),
         mpi: Default::default(),
     }
 }

--- a/crates/spurctld/src/metrics_server.rs
+++ b/crates/spurctld/src/metrics_server.rs
@@ -197,6 +197,7 @@ mod tests {
             admission: Default::default(),
             burst_buffer: Default::default(),
             rlimits: Default::default(),
+            cgroup: Default::default(),
             mpi: Default::default(),
         }
     }

--- a/crates/spurctld/src/rest/handlers.rs
+++ b/crates/spurctld/src/rest/handlers.rs
@@ -155,6 +155,7 @@ fn parse_rest_gpu(
 fn submit_rest_error(err: crate::cluster::SubmitError) -> RestError {
     match err {
         crate::cluster::SubmitError::InvalidArgument(m) => bad_request_response(&m),
+        crate::cluster::SubmitError::Unavailable(m) => unavailable_response(&m),
         crate::cluster::SubmitError::Internal(m) => error_response(&format!("submit failed: {m}")),
     }
 }

--- a/crates/spurctld/src/rpc_middleware.rs
+++ b/crates/spurctld/src/rpc_middleware.rs
@@ -207,6 +207,7 @@ mod tests {
                 admission: Default::default(),
                 burst_buffer: Default::default(),
                 rlimits: Default::default(),
+                cgroup: Default::default(),
                 mpi: Default::default(),
             }
         }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -3306,6 +3306,7 @@ mod tests {
                 devices: Default::default(),
                 admission: Default::default(),
                 rlimits: Default::default(),
+                cgroup: Default::default(),
                 mpi: Default::default(),
             }
         }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -6940,10 +6940,7 @@ mod tests {
             let retry = err.retryable();
             let status = node_complete_to_status(err);
             assert_eq!(status.code(), want_code);
-            let agent_retryable = matches!(
-                status.code(),
-                Code::Unavailable | Code::Internal | Code::DeadlineExceeded | Code::Unknown
-            );
+            let agent_retryable = spur_proto::controller_rpc_retryable(&status);
             assert_eq!(retry, agent_retryable, "{status:?}");
         }
     }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -4172,6 +4172,7 @@ fn reservation_rpc_status(err: ReservationError) -> Status {
 fn submit_rpc_status(err: crate::cluster::SubmitError) -> Status {
     match err {
         crate::cluster::SubmitError::InvalidArgument(m) => Status::invalid_argument(m),
+        crate::cluster::SubmitError::Unavailable(m) => Status::unavailable(m),
         crate::cluster::SubmitError::Internal(m) => Status::internal(m),
     }
 }
@@ -4725,6 +4726,17 @@ mod tests {
         let status = submit_rpc_status(SubmitError::invalid("partition 'gpu' not found"));
         assert_eq!(status.code(), Code::InvalidArgument);
         assert_eq!(status.message(), "partition 'gpu' not found");
+    }
+
+    #[test]
+    fn submit_rpc_status_maps_unavailable_as_retryable() {
+        use crate::cluster::SubmitError;
+
+        // A cold association cache is transient; it must surface as Unavailable so
+        // clients (e.g. the k8s operator) retry instead of failing the job.
+        let status = submit_rpc_status(SubmitError::unavailable("associations unavailable"));
+        assert_eq!(status.code(), Code::Unavailable);
+        assert!(spur_proto::controller_rpc_retryable(&status));
     }
 
     /// Only a controller-terminal job is stale; Pending (mid-dispatch), Running,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -233,7 +233,7 @@ pub struct AgentService {
     spank: Arc<Option<SpankHost>>,
     mpi_host: Arc<MpiPluginHost>,
     hooks: Arc<HooksConfig>,
-    memlock: spur_core::config::MemlockLimit,
+    limits: spur_core::config::JobLimits,
     #[allow(dead_code)]
     device_registry: Arc<Mutex<DeviceRegistry>>,
     /// RPC-driven owner of this node's k0s systemd unit.
@@ -262,7 +262,10 @@ impl AgentService {
             hooks,
             device_registry,
             &spur_core::config::ClusterConfig::default(),
-            memlock,
+            spur_core::config::JobLimits {
+                memlock,
+                ..Default::default()
+            },
             MpiConfig::default(),
             new_running_jobs(),
             spur_core::config::AuthConfig::default().allow_root_jobs,
@@ -280,7 +283,7 @@ impl AgentService {
         hooks: HooksConfig,
         device_registry: Arc<Mutex<DeviceRegistry>>,
         cluster: &spur_core::config::ClusterConfig,
-        memlock: spur_core::config::MemlockLimit,
+        limits: spur_core::config::JobLimits,
         mpi: MpiConfig,
         running: RunningJobs,
         allow_root_jobs: bool,
@@ -343,7 +346,7 @@ impl AgentService {
             spank: Arc::new(spank),
             mpi_host: Arc::new(MpiPluginHost::new(mpi)),
             hooks: Arc::new(hooks),
-            memlock,
+            limits,
             device_registry,
             k0s: Arc::new(crate::cluster::K0sAgent::from_config(cluster)),
             active_steps: Arc::new(Mutex::new(HashMap::new())),
@@ -1492,7 +1495,8 @@ impl SlurmAgent for AgentService {
             partition: spec.partition.clone(),
             nodelist: spec.nodelist.clone(),
             host_device_plan: Some(host_device_plan),
-            memlock: self.memlock,
+            memlock: self.limits.memlock,
+            swap_limit: self.limits.swap,
             io_mode: if spec.pty {
                 executor::LaunchIo::Pty
             } else {
@@ -2200,7 +2204,7 @@ impl SlurmAgent for AgentService {
             cmd.env(k, v);
         }
 
-        let memlock = self.memlock;
+        let memlock = self.limits.memlock;
         let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
         unsafe {
             cmd.pre_exec(move || {
@@ -5141,7 +5145,7 @@ mod tests {
             HooksConfig::default(),
             Arc::new(Mutex::new(DeviceRegistry::new())),
             &spur_core::config::ClusterConfig::default(),
-            spur_core::config::MemlockLimit::Unlimited,
+            spur_core::config::JobLimits::default(),
             MpiConfig::default(),
             running,
             false, // allow_root_jobs

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -586,13 +586,7 @@ impl Drop for LaunchReservationGuard {
     }
 }
 
-fn controller_rpc_retryable(status: &tonic::Status) -> bool {
-    use tonic::Code;
-    matches!(
-        status.code(),
-        Code::Unavailable | Code::Internal | Code::DeadlineExceeded | Code::Unknown
-    )
-}
+use spur_proto::controller_rpc_retryable;
 
 const CONTROLLER_RPC_ATTEMPTS: u32 = 3;
 const CONTROLLER_RPC_RETRY_GAP: std::time::Duration = std::time::Duration::from_secs(1);

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -755,10 +755,9 @@ async fn spawn_job_process(
         });
     }
 
-    // Join the cgroup pre-exec, not from the parent after spawn: the rootful path
-    // runs under `unshare --fork`, whose forked workload only inherits the cgroup
-    // if we join before exec. A parent-side move races that fork and can leave the
-    // job unconstrained. Must precede the privilege drop -- only root writes here.
+    // Join the cgroup pre-exec, not parent-side after spawn: under `unshare
+    // --fork` the workload inherits the cgroup only if we join before exec, and a
+    // parent-side move races that fork. Precedes priv drop -- only root writes here.
     let cgroup_procs = cgroup_path
         .as_ref()
         .and_then(|p| CString::new(p.join("cgroup.procs").as_os_str().as_bytes()).ok());
@@ -1479,6 +1478,11 @@ async fn launch_container_job(
     let container_env = config.container_env.clone();
     let entrypoint = config.entrypoint.clone();
 
+    // Precomputed before fork; the forked child joins the cgroup itself (below).
+    let cgroup_procs = cgroup_path
+        .as_ref()
+        .and_then(|p| CString::new(p.join("cgroup.procs").as_os_str().as_bytes()).ok());
+
     match unsafe { nix::unistd::fork().context("fork for container job")? } {
         nix::unistd::ForkResult::Child => {
             // === CHILD PROCESS ===
@@ -1503,6 +1507,13 @@ async fn launch_container_job(
 
             // RLIMIT_MEMLOCK: raise while still root, before container_init drops privileges.
             apply_memlock(cfg.memlock);
+
+            // Join the cgroup here, before container_init's pivot_root hides the
+            // host cgroupfs and its priv drop revokes write access. A parent-side
+            // write would race this child's execve and leave the job unconstrained.
+            if let Some(ref procs) = cgroup_procs {
+                join_cgroup_self(procs);
+            }
 
             // Run container init: namespaces, mounts, pivot_root, priv drop
             let hook_env = match crate::container::container_init(config, &rootfs) {
@@ -1572,9 +1583,8 @@ async fn launch_container_job(
 
             let child_pid = child.as_raw();
 
-            if let Some(ref cgroup) = cgroup_path {
-                let _ = std::fs::write(cgroup.join("cgroup.procs"), child_pid.to_string());
-            }
+            // Cgroup placement already happened in the child before exec; a
+            // parent-side write here would race the container's execve.
 
             // pidfd prevents PID recycling; falls back gracefully on kernels < 5.3
             let pidfd = pidfd_open(child_pid).ok();

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -761,10 +761,15 @@ async fn spawn_job_process(
     let cgroup_procs = cgroup_path
         .as_ref()
         .and_then(|p| CString::new(p.join("cgroup.procs").as_os_str().as_bytes()).ok());
+    // fd 2 is redirected to the job's stdio before pre_exec runs, so hand the
+    // child a dup of spurd's stderr (CLOEXEC) to report a join failure.
+    let mut cgroup_log_fd: RawFd = -1;
     if let Some(procs) = cgroup_procs {
+        cgroup_log_fd = dup_cloexec(libc::STDERR_FILENO);
+        let log_fd = cgroup_log_fd;
         unsafe {
             cmd.pre_exec(move || {
-                join_cgroup_self(&procs);
+                join_cgroup_self(&procs, log_fd);
                 Ok(())
             });
         }
@@ -838,7 +843,13 @@ async fn spawn_job_process(
         });
     }
 
-    let mut child = cmd.spawn().context("failed to spawn job process")?;
+    let spawn_result = cmd.spawn();
+    if cgroup_log_fd >= 0 {
+        unsafe {
+            libc::close(cgroup_log_fd);
+        }
+    }
+    let mut child = spawn_result.context("failed to spawn job process")?;
 
     if piped_mpi_stdio {
         let shared = stderr_resolved == stdout_resolved;
@@ -983,10 +994,10 @@ fn setup_cgroup(
 }
 
 /// Move the calling process into a cgroup by writing its own pid to
-/// `cgroup.procs`. Runs in the post-fork child before exec, so it must be
-/// async-signal-safe: no heap allocation, only raw syscalls. Best-effort —
-/// on failure the job stays in the parent cgroup rather than aborting launch.
-fn join_cgroup_self(procs_path: &std::ffi::CStr) {
+/// `cgroup.procs`. Runs post-fork before exec, so it must be async-signal-safe:
+/// no heap allocation, only raw syscalls. Best-effort — on failure it warns to
+/// `log_fd` (spurd's log; -1 to stay silent) and the job runs unconstrained.
+fn join_cgroup_self(procs_path: &std::ffi::CStr, log_fd: RawFd) {
     let pid = unsafe { libc::getpid() };
 
     let mut buf = [0u8; 24];
@@ -1005,11 +1016,33 @@ fn join_cgroup_self(procs_path: &std::ffi::CStr) {
     unsafe {
         let fd = libc::open(procs_path.as_ptr(), libc::O_WRONLY);
         if fd < 0 {
+            warn_cgroup_join_failed(log_fd);
             return;
         }
-        libc::write(fd, digits.as_ptr() as *const libc::c_void, digits.len());
+        let written = libc::write(fd, digits.as_ptr() as *const libc::c_void, digits.len());
         libc::close(fd);
+        if written < 0 {
+            warn_cgroup_join_failed(log_fd);
+        }
     }
+}
+
+/// Async-signal-safe warning for a failed cgroup join: a fixed message to
+/// `log_fd`, or a no-op when it is negative.
+fn warn_cgroup_join_failed(log_fd: RawFd) {
+    if log_fd < 0 {
+        return;
+    }
+    const MSG: &[u8] = b"spur: failed to join cgroup; job runs without resource limits\n";
+    unsafe {
+        libc::write(log_fd, MSG.as_ptr() as *const libc::c_void, MSG.len());
+    }
+}
+
+/// Duplicate `fd` with CLOEXEC set, returning the new fd or -1. The copy is
+/// usable in the pre-exec child but closes automatically at exec.
+fn dup_cloexec(fd: RawFd) -> RawFd {
+    unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 3) }
 }
 
 /// Whether the job's cgroup recorded an OOM kill (cgroup-v2 `memory.events`).
@@ -1482,6 +1515,13 @@ async fn launch_container_job(
     let cgroup_procs = cgroup_path
         .as_ref()
         .and_then(|p| CString::new(p.join("cgroup.procs").as_os_str().as_bytes()).ok());
+    // Dup spurd's stderr (CLOEXEC) so the child can report a join failure; its
+    // own stderr is wired to the job before the join runs.
+    let cgroup_log_fd = if cgroup_procs.is_some() {
+        dup_cloexec(libc::STDERR_FILENO)
+    } else {
+        -1
+    };
 
     match unsafe { nix::unistd::fork().context("fork for container job")? } {
         nix::unistd::ForkResult::Child => {
@@ -1503,17 +1543,17 @@ async fn launch_container_job(
                 }
             }
 
+            // Join the cgroup while still root and before container_init's
+            // pivot_root hides the host cgroupfs; do it before close_inherited_fds
+            // reaps the log fd. A parent-side write would race this child's execve.
+            if let Some(ref procs) = cgroup_procs {
+                join_cgroup_self(procs, cgroup_log_fd);
+            }
+
             crate::container::close_inherited_fds(ready_w);
 
             // RLIMIT_MEMLOCK: raise while still root, before container_init drops privileges.
             apply_memlock(cfg.memlock);
-
-            // Join the cgroup here, before container_init's pivot_root hides the
-            // host cgroupfs and its priv drop revokes write access. A parent-side
-            // write would race this child's execve and leave the job unconstrained.
-            if let Some(ref procs) = cgroup_procs {
-                join_cgroup_self(procs);
-            }
 
             // Run container init: namespaces, mounts, pivot_root, priv drop
             let hook_env = match crate::container::container_init(config, &rootfs) {
@@ -1577,6 +1617,12 @@ async fn launch_container_job(
 
         nix::unistd::ForkResult::Parent { child } => {
             drop(pipe_w);
+            unsafe {
+                libc::close(ready_w);
+                if cgroup_log_fd >= 0 {
+                    libc::close(cgroup_log_fd);
+                }
+            }
 
             // Drop the slave fd immediately so the master gets EOF when the child exits.
             let pty_master = job_io.into_master();
@@ -2553,7 +2599,7 @@ mod tests {
         std::fs::write(&path, "").unwrap();
         let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
 
-        join_cgroup_self(&c_path);
+        join_cgroup_self(&c_path, -1);
 
         let written = std::fs::read_to_string(&path).unwrap();
         assert_eq!(written, std::process::id().to_string());
@@ -2564,6 +2610,29 @@ mod tests {
         // Best-effort: a non-existent cgroup.procs must not panic, so a failed
         // placement degrades to an unconstrained job instead of aborting launch.
         let c_path = CString::new("/nonexistent/spur-test/cgroup.procs").unwrap();
-        join_cgroup_self(&c_path);
+        join_cgroup_self(&c_path, -1);
+    }
+
+    #[test]
+    fn join_cgroup_self_warns_to_log_fd_on_failure() {
+        // A failed placement must surface on the log fd so an unenforced limit is
+        // not silent; the child's own stderr points at the job, hence a dup here.
+        let mut fds = [0 as libc::c_int; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let (read_fd, write_fd) = (fds[0], fds[1]);
+        let c_path = CString::new("/nonexistent/spur-test/cgroup.procs").unwrap();
+
+        join_cgroup_self(&c_path, write_fd);
+        unsafe { libc::close(write_fd) };
+
+        let mut buf = [0u8; 128];
+        let n = unsafe { libc::read(read_fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+        unsafe { libc::close(read_fd) };
+        assert!(n > 0, "expected a warning on the log fd");
+        let msg = std::str::from_utf8(&buf[..n as usize]).unwrap();
+        assert!(
+            msg.contains("failed to join cgroup"),
+            "unexpected message: {msg}"
+        );
     }
 }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -14,7 +14,7 @@ use nix::unistd::Pid;
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
-use spur_core::config::MemlockLimit;
+use spur_core::config::{MemlockLimit, SwapLimit};
 use spur_core::job::JobId;
 use spur_spank::{SpankContext, SpankHandle, SpankHost};
 
@@ -161,6 +161,8 @@ pub struct JobLaunchConfig {
     pub host_device_plan: Option<spur_devices::inject::HostInjectionPlan>,
     /// RLIMIT_MEMLOCK to apply before exec (while still privileged).
     pub memlock: MemlockLimit,
+    /// Swap budget for the job's cgroup.
+    pub swap_limit: SwapLimit,
     /// I/O mode for the job.
     pub io_mode: LaunchIo,
     /// Direct multi-rank PMIx launch via a wrapper script (batch `--mpi=pmix`).
@@ -502,7 +504,7 @@ async fn spawn_job_process(
     info!(job_id, work_dir, "launching job");
 
     // Set up cgroup for isolation
-    let cgroup_path = setup_cgroup(job_id, cpus, memory_mb, cpu_ids)?;
+    let cgroup_path = setup_cgroup(job_id, cpus, memory_mb, cpu_ids, cfg.swap_limit)?;
 
     // Ensure work_dir exists on this node (the submitted path may only exist on the submitting
     // node). If creation fails (e.g. path is under another user's home), fall back to /tmp so
@@ -873,6 +875,7 @@ fn setup_cgroup(
     cpus: u32,
     memory_mb: u64,
     cpu_ids: &[u32],
+    swap_limit: SwapLimit,
 ) -> anyhow::Result<Option<PathBuf>> {
     let cgroup_root = PathBuf::from(CGROUP_ROOT);
     let cgroup_path = cgroup_root.join(format!("job_{}", job_id));
@@ -918,6 +921,16 @@ fn setup_cgroup(
         let memory_bytes = memory_mb * 1024 * 1024;
         if let Err(e) = std::fs::write(cgroup_path.join("memory.max"), memory_bytes.to_string()) {
             warn!(job_id, error = %e, "failed to set memory.max");
+        }
+        // memory.max bounds resident memory only: with swap available the
+        // kernel pages the overflow out instead of OOM-killing. Opt-in, since
+        // capping swap starts killing jobs that used to survive.
+        if let Some(swap_bytes) = swap_limit.bytes_for(memory_bytes) {
+            if let Err(e) =
+                std::fs::write(cgroup_path.join("memory.swap.max"), swap_bytes.to_string())
+            {
+                warn!(job_id, error = %e, "failed to set memory.swap.max");
+            }
         }
     }
 
@@ -1407,7 +1420,13 @@ async fn launch_container_job(
     job_io: JobIo,
 ) -> anyhow::Result<(RunningJob, Option<OwnedFd>)> {
     let job_id = cfg.job_id;
-    let cgroup_path = setup_cgroup(job_id, cfg.cpus, cfg.memory_mb, &cfg.cpu_ids)?;
+    let cgroup_path = setup_cgroup(
+        job_id,
+        cfg.cpus,
+        cfg.memory_mb,
+        &cfg.cpu_ids,
+        cfg.swap_limit,
+    )?;
 
     // Sync pipe: child writes status, parent reads.
     let (pipe_r, pipe_w) = nix::unistd::pipe().context("create sync pipe")?;
@@ -2149,6 +2168,7 @@ mod tests {
             nodelist: String::new(),
             host_device_plan: None,
             memlock: MemlockLimit::Unlimited,
+            swap_limit: SwapLimit::Unconstrained,
             io_mode: LaunchIo::File,
             pmix_multi_task: false,
         }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -755,9 +755,8 @@ async fn spawn_job_process(
         });
     }
 
-    // Join the cgroup pre-exec, not parent-side after spawn: under `unshare
-    // --fork` the workload inherits the cgroup only if we join before exec, and a
-    // parent-side move races that fork. Precedes priv drop -- only root writes here.
+    // Join pre-exec, not parent-side after spawn: under `unshare --fork` a
+    // parent-side move races the fork and misses the workload's cgroup.
     let cgroup_procs = cgroup_path
         .as_ref()
         .and_then(|p| CString::new(p.join("cgroup.procs").as_os_str().as_bytes()).ok());
@@ -993,10 +992,8 @@ fn setup_cgroup(
     Ok(Some(cgroup_path))
 }
 
-/// Move the calling process into a cgroup by writing its own pid to
-/// `cgroup.procs`. Runs post-fork before exec, so it must be async-signal-safe:
-/// no heap allocation, only raw syscalls. Best-effort — on failure it warns to
-/// `log_fd` (spurd's log; -1 to stay silent) and the job runs unconstrained.
+/// Join the calling process to a cgroup (its pid → `cgroup.procs`). Runs post-fork
+/// pre-exec so it's async-signal-safe (raw syscalls only); best-effort, warns to `log_fd`.
 fn join_cgroup_self(procs_path: &std::ffi::CStr, log_fd: RawFd) {
     let pid = unsafe { libc::getpid() };
 
@@ -1543,9 +1540,8 @@ async fn launch_container_job(
                 }
             }
 
-            // Join the cgroup while still root and before container_init's
-            // pivot_root hides the host cgroupfs; do it before close_inherited_fds
-            // reaps the log fd. A parent-side write would race this child's execve.
+            // Join while still root, before pivot_root hides the host cgroupfs and
+            // before close_inherited_fds reaps the log fd.
             if let Some(ref procs) = cgroup_procs {
                 join_cgroup_self(procs, cgroup_log_fd);
             }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -754,6 +755,22 @@ async fn spawn_job_process(
         });
     }
 
+    // Join the cgroup pre-exec, not from the parent after spawn: the rootful path
+    // runs under `unshare --fork`, whose forked workload only inherits the cgroup
+    // if we join before exec. A parent-side move races that fork and can leave the
+    // job unconstrained. Must precede the privilege drop -- only root writes here.
+    let cgroup_procs = cgroup_path
+        .as_ref()
+        .and_then(|p| CString::new(p.join("cgroup.procs").as_os_str().as_bytes()).ok());
+    if let Some(procs) = cgroup_procs {
+        unsafe {
+            cmd.pre_exec(move || {
+                join_cgroup_self(&procs);
+                Ok(())
+            });
+        }
+    }
+
     // Issue #99, #107: Run job as the submitting user (not root).
     // Must set supplementary groups (video, render) so the process can
     // access GPU device nodes.
@@ -847,12 +864,8 @@ async fn spawn_job_process(
     // Drop the slave fd immediately so the master gets EOF when the child exits.
     let pty_master = job_io.into_master();
 
-    // Move process into cgroup
-    if let Some(ref cgroup) = cgroup_path {
-        if let Some(pid) = child.id() {
-            move_to_cgroup(cgroup, pid);
-        }
-    }
+    // Cgroup placement already happened pre-exec (join_cgroup_self); a move here
+    // would race the wrapper's fork.
 
     debug!(
         job_id,
@@ -970,18 +983,33 @@ fn setup_cgroup(
     Ok(Some(cgroup_path))
 }
 
-/// Move a process into a cgroup. Returns true if successful.
-fn move_to_cgroup(cgroup_path: &Path, pid: u32) -> bool {
-    let procs_file = cgroup_path.join("cgroup.procs");
-    if let Err(e) = std::fs::write(&procs_file, pid.to_string()) {
-        warn!(
-            pid,
-            error = %e,
-            "failed to move process to cgroup — job runs without isolation"
-        );
-        false
-    } else {
-        true
+/// Move the calling process into a cgroup by writing its own pid to
+/// `cgroup.procs`. Runs in the post-fork child before exec, so it must be
+/// async-signal-safe: no heap allocation, only raw syscalls. Best-effort —
+/// on failure the job stays in the parent cgroup rather than aborting launch.
+fn join_cgroup_self(procs_path: &std::ffi::CStr) {
+    let pid = unsafe { libc::getpid() };
+
+    let mut buf = [0u8; 24];
+    let mut i = buf.len();
+    let mut n = pid.max(0) as u64;
+    loop {
+        i -= 1;
+        buf[i] = b'0' + (n % 10) as u8;
+        n /= 10;
+        if n == 0 {
+            break;
+        }
+    }
+    let digits = &buf[i..];
+
+    unsafe {
+        let fd = libc::open(procs_path.as_ptr(), libc::O_WRONLY);
+        if fd < 0 {
+            return;
+        }
+        libc::write(fd, digits.as_ptr() as *const libc::c_void, digits.len());
+        libc::close(fd);
     }
 }
 
@@ -2502,5 +2530,30 @@ mod tests {
             libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
             "wire() should have returned an error for bad fd"
         );
+    }
+
+    #[test]
+    fn join_cgroup_self_writes_own_pid() {
+        // cgroup.procs is a plain "write my decimal pid" interface, so a regular
+        // file exercises the hand-rolled formatting and write without a cgroup.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cgroup.procs");
+        // The real cgroup.procs is kernel-created; join_cgroup_self opens it
+        // without O_CREAT, so the stand-in must exist first.
+        std::fs::write(&path, "").unwrap();
+        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
+
+        join_cgroup_self(&c_path);
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(written, std::process::id().to_string());
+    }
+
+    #[test]
+    fn join_cgroup_self_is_silent_when_the_path_is_missing() {
+        // Best-effort: a non-existent cgroup.procs must not panic, so a failed
+        // placement degrades to an unconstrained job instead of aborting launch.
+        let c_path = CString::new("/nonexistent/spur-test/cgroup.procs").unwrap();
+        join_cgroup_self(&c_path);
     }
 }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -518,15 +518,11 @@ async fn spawn_job_process(
     };
     let work_dir = effective_work_dir.as_str();
 
-    // Wrap script with burst buffer stage-in/stage-out if configured
-    let script = if let Ok(bb) = std::env::var("SPUR_BURST_BUFFER") {
-        if !bb.is_empty() {
-            wrap_with_burst_buffer(script, &bb)
-        } else {
-            script.to_string()
-        }
-    } else {
-        script.to_string()
+    // The directive is per job, so it comes from the job's environment. Reading
+    // the daemon's own env instead would only ever see a cluster-wide value.
+    let script = match environment.get("SPUR_BURST_BUFFER") {
+        Some(bb) if !bb.is_empty() => wrap_with_burst_buffer(script, bb),
+        _ => script.to_string(),
     };
     let script = script.as_str();
 

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -121,6 +121,19 @@ struct Args {
     log_level: String,
 }
 
+fn log_swap_status(swap: spur_core::config::SwapLimit) {
+    use spur_core::config::SwapLimit;
+    match swap {
+        SwapLimit::Unconstrained => info!(
+            "job swap unconstrained; --mem bounds resident memory only \
+             (see cgroup.constrain_swap_space)"
+        ),
+        SwapLimit::Percent(percent) => {
+            info!(allowed_swap_space = percent, "job swap constrained")
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     if std::env::args_os()
@@ -323,11 +336,15 @@ async fn main() -> anyhow::Result<()> {
 
     // Start agent gRPC server (receives job launches + cluster-component RPCs from spurctld).
     // Pass the [cluster] config so the K0sAgent uses the operator's k0s version + install path.
-    let memlock = match config.as_ref() {
-        Some(c) => c.rlimits.memlock_limit()?,
-        None => spur_core::config::MemlockLimit::Unlimited,
+    let limits = match config.as_ref() {
+        Some(c) => spur_core::config::JobLimits {
+            memlock: c.rlimits.memlock_limit()?,
+            swap: c.cgroup.swap_limit()?,
+        },
+        None => spur_core::config::JobLimits::default(),
     };
-    log_memlock_status(memlock);
+    log_memlock_status(limits.memlock);
+    log_swap_status(limits.swap);
     let cluster_config = config
         .as_ref()
         .map(|c| c.cluster.clone())
@@ -359,7 +376,7 @@ async fn main() -> anyhow::Result<()> {
         hooks_config,
         registry.clone(),
         &cluster_config,
-        memlock,
+        limits,
         mpi_config,
         running_jobs,
         allow_root_jobs,

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -938,9 +938,12 @@ How a job's account is resolved
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 At submit, Spur resolves the job's account in this order, matching Slurm.
-This validation is skipped (fail-open) while the association cache has not
-yet loaded, e.g. at controller startup or while the accounting database is
-unreachable:
+When accounting is enabled but the association cache has not yet loaded
+(e.g. just after controller startup, or while the accounting database is
+unreachable), account validation cannot run yet: an account-scoped submit is
+refused with a *transient* error (gRPC ``Unavailable`` / REST ``503``) rather
+than a permanent rejection, so clients retry once the cache is populated. With
+accounting disabled there are no associations to check:
 
 1. **Explicit** ``--account`` on the job. Once the association cache has
    loaded, it must name an account the user is associated with, or the job
@@ -949,11 +952,12 @@ unreachable:
    if the user has none at all.
 2. Otherwise the **user's default account**, if the user has one on file.
 3. Otherwise, if ``accounting.require_association`` is ``true``, the job is
-   **rejected** (``no account resolved for user 'X'``) — even if the user
-   does have associations, just none flagged as their default. This step is
-   unconditional, unlike step 1: it applies even before the association
-   cache has loaded. If ``require_association`` is ``false`` (the default),
-   the job runs with no account.
+   **rejected** (``no account resolved for user 'X'``) once the cache has
+   loaded and the user has no default on file — even if the user does have
+   associations, just none flagged as their default. Before the cache loads
+   this is transient (as above), since the default may still resolve. If
+   ``require_association`` is ``false`` (the default), the job runs with no
+   account.
 
 TRES
 ----

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -935,7 +935,7 @@ fields mirror ``ConstrainSwapSpace`` and ``AllowedSwapSpace`` in Slurm's
      - ``0``
      - Swap a job may use, as a percentage (0-100) of its memory allocation.
        Only consulted when ``constrain_swap_space`` is set; ``0`` denies swap
-       outright. A value above 100 errors at parse time.
+       outright. A value above 100 is rejected when spurd starts.
 
 .. note::
 

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -908,6 +908,43 @@ POSIX ``RLIMIT_*`` values ``spurd`` applies to job steps at launch.
    ``memlock = "unlimited"`` lets RDMA and NCCL workloads pin memory out of the box.
    Lower it only when a hard cap is required.
 
+``[cgroup]``
+------------
+
+How ``spurd`` enforces a job's cgroup limits. The limits themselves come from the
+allocation (``--mem``, ``--cpus-per-task``); this section only sets policy. The
+fields mirror ``ConstrainSwapSpace`` and ``AllowedSwapSpace`` in Slurm's
+``cgroup.conf``, including their defaults.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 10 12 54
+
+   * - Field
+     - Type
+     - Default
+     - Description
+   * - ``constrain_swap_space``
+     - bool
+     - ``false``
+     - Cap a job's swap along with its memory. While ``false``, ``memory.max``
+       bounds resident memory only: on a node with swap, a job that outgrows
+       ``--mem`` keeps running on swap instead of being killed.
+   * - ``allowed_swap_space``
+     - integer
+     - ``0``
+     - Swap a job may use, as a percentage (0-100) of its memory allocation.
+       Only consulted when ``constrain_swap_space`` is set; ``0`` denies swap
+       outright. A value above 100 errors at parse time.
+
+.. note::
+
+   Enabling ``constrain_swap_space`` is what makes ``--mem`` a hard cap and lets a
+   runaway job be reported as ``OUT_OF_MEMORY`` rather than completing slowly on
+   swap. It is off by default because turning it on starts killing jobs that
+   previously survived by swapping. Both fields are read at ``spurd`` startup, so
+   changing them needs an agent restart.
+
 ``[mpi]``
 ---------
 

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -1023,7 +1023,10 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
     def _start_postgres(self):
         """Bring up Postgres (Docker) on node 0. Accounting runs inside spurctld."""
         node = self.nodes[0]
-        node.exec_allow_fail(f"docker rm -f '{self._pg_container}' 2>/dev/null || true")
+        node.exec_allow_fail(
+            "c=$(docker ps -aq --filter name=spur-e2e-pg-); "
+            "[ -n \"$c\" ] && docker rm -f $c || true"
+        )
         node.exec(
             f"docker run -d --name '{self._pg_container}' "
             f"-e POSTGRES_USER=spur -e POSTGRES_PASSWORD=spur -e POSTGRES_DB=spur "


### PR DESCRIPTION
## Summary

The expanded e2e suite (companion PR #579) ran the daemons, CLI, and operator
against real clusters and turned up a set of genuine product defects. This PR
carries only those fixes and their unit tests; the e2e tests that caught them
live in #579.

## Fixes

- **Burst buffer directives were silently dropped** (`spurd`) — `stage_in:`/
  `stage_out:` were read from the daemon's own environment instead of the job's,
  so they never ran (a job with `stage_in:exit 7` still completed with exit 0).
  Now read from the job config's environment.
- **`scancel --partition` / `--account` never selected anything** (`spur-cli`) —
  both flags were declared and passed through, but the "did the caller name a
  selection?" guard only checked job IDs, `--user`, and `--name`, so they always
  failed with *"no job IDs or filters specified."* Replaced with a
  `has_selection()` predicate (unit-tested); `--state` stays a narrower, not a
  selector.
- **`--mem` overruns were paged to swap instead of OOM-killed** (`spurd`,
  `spur-core`) — `memory.max` was set but swap was uncapped, so a job that
  outgrew its limit kept running on swap and never reached `OutOfMemory`. A new
  `[cgroup]` config section caps swap, mirroring Slurm's `ConstrainSwapSpace` /
  `AllowedSwapSpace`. It defaults **off** so deployed clusters keep today's
  behavior; enforcement is opt-in.
- **Compressed nodelists were mis-parsed** (`spur-cli`) — `sattach`/`srun` took
  the first comma-separated field of the nodelist, yielding `node[1` once the
  controller compresses a multi-node allocation. Both now expand the hostlist
  first.
- **The k8s operator wedged on permanent rejections and retried too slowly**
  (`spur-k8s`) — every failed submit was requeued, so a SpurJob the controller
  permanently rejected (unknown partition, denied account) sat without status
  forever; and reconcile failures backed off a flat 60s despite a comment
  claiming exponential backoff. Permanent rejections are now marked `Failed`
  (only transient RPC codes requeue, matching the agent's rule), and retries
  double from 1s to a 60s cap, counted per SpurJob and reset on a clean pass.

## Compatibility

No breaking changes. `[cgroup]` is additive with serde defaults; there are no
proto, persisted-state, config, or CLI removals/renames/retypes.

## Testing

- Unit tests: `scancel` selection predicate; the `[cgroup]` swap policy;
  `spur-k8s` operator (`cargo test -p spur-k8s`, 152 passing), clippy clean.
- Validated on the 3-node bare-metal cluster: resource limits pass 17/17
  including the OOM cases that depend on the new swap knob.
- End-to-end validation is the companion suite in #579.

## Merge order

Merge this first, then rebase #579 onto `main` so its e2e tests run against the
fixed code (those tests are red without these fixes — that's the point of the
split).