### PR TITLE
chore: resolve semantic merge conflict due to #593 and #565

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -574,7 +574,7 @@ impl ClusterManager {
         // bounded whitelist fields, so this still measures what gets persisted.
         check_submission_size(&spec)?;
 
-        self.run_job_submit_hook(&mut spec)?;
+        self.run_job_submit_hook(&mut spec, &partitions)?;
 
         // Reject unknown/malformed dependency types up front so users get a
         // clear error instead of a silently-deadlocked job (e.g. `expand:N`).
@@ -658,7 +658,11 @@ impl ClusterManager {
     /// maps to an invalid-argument error; modify applies whitelisted changes.
     /// The shell hook runs first, then the Lua hook, each on the evolving spec
     /// (mirroring Slurm's config-ordered plugin chain).
-    fn run_job_submit_hook(&self, spec: &mut JobSpec) -> Result<(), SubmitError> {
+    fn run_job_submit_hook(
+        &self,
+        spec: &mut JobSpec,
+        partitions: &[Partition],
+    ) -> Result<(), SubmitError> {
         let config = self.config();
         let shell = config.hooks.job_submit.as_deref();
         let lua = config.hooks.job_submit_lua.as_deref();
@@ -673,7 +677,7 @@ impl ClusterManager {
                     .block_on(async { spur_core::hooks::run_submit_hook(script, &ctx).await })
             })
             .map_err(|e| SubmitError::internal(format!("job_submit hook failed: {e}")))?;
-            self.apply_submit_outcome(spec, "job_submit", outcome)?;
+            self.apply_submit_outcome(spec, "job_submit", outcome, partitions)?;
         }
 
         if let Some(script) = lua {
@@ -685,7 +689,7 @@ impl ClusterManager {
                     .map_err(|e| {
                         SubmitError::internal(format!("job_submit lua hook failed: {e}"))
                     })?;
-            self.apply_submit_outcome(spec, "job_submit_lua", outcome)?;
+            self.apply_submit_outcome(spec, "job_submit_lua", outcome, partitions)?;
         }
 
         Ok(())
@@ -716,6 +720,7 @@ impl ClusterManager {
         spec: &mut JobSpec,
         hook: &str,
         outcome: spur_core::hooks::SubmitHookOutcome,
+        partitions: &[Partition],
     ) -> Result<(), SubmitError> {
         match outcome {
             spur_core::hooks::SubmitHookOutcome::Accept => {
@@ -748,7 +753,7 @@ impl ClusterManager {
                 );
                 if changes.partition.is_some() || changes.account.is_some() {
                     validate_user_account(spec, &self.association_cache)?;
-                    self.validate_partition_node_bounds(spec)?;
+                    self.validate_partition_node_bounds(spec, partitions)?;
                 }
                 // Existence is enforced first: an unknown QOS silently resolves
                 // to the limitless default, which would bypass QOS limits.
@@ -764,7 +769,7 @@ impl ClusterManager {
                 // the three re-checks both against the already-applied spec.
                 if changes.partition.is_some() || changes.account.is_some() || changes.qos.is_some()
                 {
-                    self.validate_partition(spec)?;
+                    self.validate_partition(spec, partitions)?;
                     if let Some(qos) = spec.qos.as_deref().filter(|q| !q.is_empty()) {
                         if let Some(account) = spec.account.as_deref().filter(|a| !a.is_empty()) {
                             self.association_cache


### PR DESCRIPTION
## What

Fixes a build break on `main` from a semantic merge conflict between two independently-merged PRs.

- #593 changed `validate_partition` and `validate_partition_node_bounds` to take a `partitions: &[Partition]` snapshot argument.
- #565 added new call sites for both methods in `apply_submit_outcome` (the job-submit hook re-validation path), still calling them with only `spec`.

Both merged without a textual conflict, so `main` failed to compile:

```
error[E0061]: this method takes 2 arguments but 1 argument was supplied
  --> crates/spurctld/src/cluster.rs  self.validate_partition_node_bounds(spec)?
  --> crates/spurctld/src/cluster.rs  self.validate_partition(spec)?
```

## Approach

`submit_job` already takes one `partitions` snapshot at the top of the submit path so defaulting and enforcement can't observe a concurrent `reconfigure()` mid-submit. Thread that same snapshot down through `run_job_submit_hook` into `apply_submit_outcome`, rather than re-reading the lock. Hook re-validation now runs against the same snapshot as the rest of the submit path.

## Testing

- `cargo build --workspace`
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` (no warnings)
- `cargo test -p spurctld --locked` (727 passed, 0 failed), including the hook re-validation tests