### PR TITLE
fix(spurctld): tag in-pass-blocked jobs so pending reason is never None

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2854,15 +2854,15 @@ impl ClusterManager {
                 if let Some(reason) =
                     account_block_with(job, &self.association_cache, &jobs, &reserved)
                 {
-                    return Some(reason);
+                    return GateOutcome::Block(reason);
                 }
                 if let Some(reason) =
                     qos_block_with(job, &qos_by_job[&job.job_id], &jobs, &reserved)
                 {
-                    return Some(reason);
+                    return GateOutcome::Block(reason);
                 }
                 reserved.reserve(job);
-                None
+                GateOutcome::Keep
             });
         }
 
@@ -2871,7 +2871,7 @@ impl ClusterManager {
             let mut remaining = available.clone();
             retain_eligible(&mut candidates, &mut blocked, |job| {
                 if let Some(reason) = license_block(job, &available) {
-                    return Some(reason);
+                    return GateOutcome::Block(reason);
                 }
                 let req = extract_license_requirements(&job.spec);
                 // In-pass contention counts as a license wait, same as a shortage.
@@ -2879,14 +2879,14 @@ impl ClusterManager {
                     .iter()
                     .any(|(lic, n)| remaining.get(lic).copied().unwrap_or(0) < *n)
                 {
-                    return Some(PendingReason::Licenses);
+                    return GateOutcome::Block(PendingReason::Licenses);
                 }
                 for (lic, n) in &req {
                     if let Some(avail) = remaining.get_mut(lic) {
                         *avail = avail.saturating_sub(*n);
                     }
                 }
-                None
+                GateOutcome::Keep
             });
         }
 
@@ -2894,36 +2894,29 @@ impl ClusterManager {
         {
             let available = self.available_bb_with(&jobs);
             let mut remaining = available;
-            candidates.retain(|candidate| {
-                if !candidate.scheduling_eligible {
-                    return true;
-                }
-                let job = &candidate.job;
+            retain_eligible(&mut candidates, &mut blocked, |job| {
                 if job.bb_stage_state == BbStageState::Staging {
-                    record_blocked(&mut blocked, candidate, PendingReason::BurstBufferStageIn);
-                    return false;
+                    return GateOutcome::Block(PendingReason::BurstBufferStageIn);
                 }
                 if let Some(reason) = burst_buffer_block(job, available) {
-                    record_blocked(&mut blocked, candidate, reason);
-                    return false;
+                    return GateOutcome::Block(reason);
                 }
                 let req = extract_bb_requirement(&job.spec);
                 if req == 0 {
-                    return true;
+                    return GateOutcome::Keep;
                 }
                 if job.bb_stage_state == BbStageState::Ready {
-                    return true;
+                    return GateOutcome::Keep;
                 }
                 // In-pass contention counts as a BB wait, same as a shortage.
                 if req > remaining {
-                    record_blocked(&mut blocked, candidate, PendingReason::BurstBufferResources);
-                    return false;
+                    return GateOutcome::Block(PendingReason::BurstBufferResources);
                 }
-                // Not a block: capacity is reserved and stage-in scheduled, so the
-                // job leaves the schedulable set and shows BurstBufferStageIn next.
+                // Capacity reserved and stage-in scheduled, so the job leaves the
+                // schedulable set and shows BurstBufferStageIn next cycle.
                 remaining = remaining.saturating_sub(req);
                 bb_stage_candidates.push(job.job_id);
-                false
+                GateOutcome::DropUntagged
             });
         }
 
@@ -5609,23 +5602,41 @@ fn retain_unblocked(
     });
 }
 
+/// Outcome of an eligibility gate for one candidate. Exhaustive so every gate
+/// branch must name an outcome: a silent drop is a compile error.
+enum GateOutcome {
+    /// Keep the candidate in the schedulable set.
+    Keep,
+    /// Drop and record `reason` (a no-op tag for already-tagged candidates).
+    Block(PendingReason),
+    /// Drop without recording a reason. Only the burst-buffer stage-in handoff
+    /// uses this: the gate reserved capacity and enqueued the job for staging,
+    /// so it is tagged `BurstBufferStageIn` on the next cycle. Do not use this
+    /// to bypass tagging in any other gate.
+    DropUntagged,
+}
+
 /// Like [`retain_unblocked`], but skips not-yet-eligible candidates and lets
-/// `block` reserve in-pass headroom on the keep path. Eligible drops are
-/// recorded via `record_blocked` (a no-op for already-tagged candidates).
+/// `gate` reserve in-pass headroom on the keep path. A [`GateOutcome::Block`]
+/// drop is recorded via `record_blocked` (a no-op for already-tagged
+/// candidates); [`GateOutcome::DropUntagged`] drops without a reason.
 fn retain_eligible(
     candidates: &mut Vec<PendingJobCandidate>,
     blocked: &mut Vec<(JobId, PendingReason)>,
-    mut block: impl FnMut(&Job) -> Option<PendingReason>,
+    mut gate: impl FnMut(&Job) -> GateOutcome,
 ) {
     candidates.retain(|candidate| {
         if !candidate.scheduling_eligible {
             return true;
         }
-        let Some(reason) = block(&candidate.job) else {
-            return true;
-        };
-        record_blocked(blocked, candidate, reason);
-        false
+        match gate(&candidate.job) {
+            GateOutcome::Keep => true,
+            GateOutcome::Block(reason) => {
+                record_blocked(blocked, candidate, reason);
+                false
+            }
+            GateOutcome::DropUntagged => false,
+        }
     });
 }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4027,30 +4027,6 @@ impl ClusterManager {
         }
     }
 
-    /// Logs (never rewrites, which would mask the gap) any pending job stuck at
-    /// `Reason=None`. Holds, deadlines, begin-time holds, and array-throttled
-    /// tasks are legitimately None and skipped.
-    pub(crate) fn warn_untagged_pending(&self) -> Vec<JobId> {
-        let now = Utc::now();
-        let jobs = self.jobs.read();
-        let mut untagged = Vec::new();
-        for job in jobs.values() {
-            if job.state != JobState::Pending
-                || job.pending_reason != PendingReason::None
-                || job.is_begin_held(now)
-                || job.spec.array_max_concurrent.is_some()
-            {
-                continue;
-            }
-            warn!(
-                job_id = job.job_id,
-                "pending job left with Reason=None after classification (classifier gap)"
-            );
-            untagged.push(job.job_id);
-        }
-        untagged
-    }
-
     /// Send a job event notification via webhook (if configured).
     ///
     /// Uses `curl` as a subprocess to avoid pulling in an HTTP client dependency.
@@ -5634,7 +5610,8 @@ fn retain_unblocked(
 }
 
 /// Like [`retain_unblocked`], but skips not-yet-eligible candidates and lets
-/// `block` reserve in-pass headroom on the keep path. Drops are always recorded.
+/// `block` reserve in-pass headroom on the keep path. Eligible drops are
+/// recorded via `record_blocked` (a no-op for already-tagged candidates).
 fn retain_eligible(
     candidates: &mut Vec<PendingJobCandidate>,
     blocked: &mut Vec<(JobId, PendingReason)>,
@@ -12861,63 +12838,6 @@ mod tests {
         assert_eq!(
             cm.get_job(j2).unwrap().pending_reason,
             PendingReason::BurstBufferResources
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn warn_untagged_pending_detects_leak_without_rewriting_reason() {
-        // A leaked-None pending job is detected and returned, but its reason is
-        // left None, not rewritten. No node registered, so nothing tags it first.
-        let dir = TempDir::new().unwrap();
-        let cm = test_cluster(&dir).await;
-        let id = submit_and_wait(&cm, basic_spec("leak"));
-        assert_eq!(cm.get_job(id).unwrap().pending_reason, PendingReason::None);
-
-        let untagged = cm.warn_untagged_pending();
-        assert_eq!(untagged, vec![id]);
-        assert_eq!(
-            cm.get_job(id).unwrap().pending_reason,
-            PendingReason::None,
-            "the reason must stay the honest None, not be rewritten"
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn warn_untagged_pending_ignores_begin_held() {
-        // A begin-time hold at None is legitimate, not a gap: must not be flagged.
-        let dir = TempDir::new().unwrap();
-        let cm = test_cluster(&dir).await;
-        let mut spec = basic_spec("held");
-        spec.begin_time = Some(Utc::now() + chrono::Duration::hours(1));
-        let id = submit_and_wait(&cm, spec);
-
-        let untagged = cm.warn_untagged_pending();
-        assert!(untagged.is_empty(), "begin-held job must not be flagged");
-        assert_eq!(cm.get_job(id).unwrap().pending_reason, PendingReason::None);
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn warn_untagged_pending_ignores_array_throttled() {
-        // A task held back by array_max_concurrent sits at None by design (its
-        // reason is tracked separately); the check must not flag it as a gap.
-        let dir = TempDir::new().unwrap();
-        let cm = test_cluster(&dir).await;
-        register_node(&cm, "n1", 8, 16000);
-        let mut spec = basic_spec("arr");
-        spec.array_spec = Some("0-1%1".into());
-        let parent_id = cm.submit_job(spec).unwrap().job_id;
-        let t1 = parent_id + 1;
-        let t2 = parent_id + 2;
-        wait_for("array tasks", || {
-            cm.get_job(t1).is_some() && cm.get_job(t2).is_some()
-        });
-        start_job_on(&cm, t1, "n1");
-        settle(&cm, t1, JobState::Running);
-
-        assert_eq!(cm.get_job(t2).unwrap().pending_reason, PendingReason::None);
-        assert!(
-            !cm.warn_untagged_pending().contains(&t2),
-            "throttled array task must not be flagged as a classifier gap"
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4027,30 +4027,32 @@ impl ClusterManager {
         }
     }
 
-    /// Safety net for a classifier gap: a pending job that is not a hold,
-    /// deadline, or begin-time hold should never be left at `None`. Any that is
-    /// gets logged and defaulted to `Priority` so the gap is visible in logs
-    /// rather than surfacing as a bare `Reason=None`. Returns the patched ids.
-    pub(crate) fn backstop_untagged_pending(&self) -> Vec<JobId> {
+    /// Detects the classifier-invariant violation where a pending job that is
+    /// not a hold, deadline, or begin-time hold is left at `Reason=None`. This
+    /// should never happen; if it does, it is a classifier gap. Log it loudly
+    /// with the job id so operators can find and fix it, but deliberately do
+    /// NOT rewrite the reason: inventing a plausible cause (e.g. `Priority`)
+    /// would assert something false and mask the very gap we want surfaced. The
+    /// honest `None` stands until the classifier is fixed. Returns the offending
+    /// ids for tests and metrics.
+    pub(crate) fn warn_untagged_pending(&self) -> Vec<JobId> {
         let now = Utc::now();
-        let mut jobs = self.jobs.write();
-        let mut patched = Vec::new();
-        for job in jobs.values_mut() {
+        let jobs = self.jobs.read();
+        let mut untagged = Vec::new();
+        for job in jobs.values() {
             if job.state != JobState::Pending
                 || job.pending_reason != PendingReason::None
-                || job.pending_reason.is_scheduling_hold()
                 || job.is_begin_held(now)
             {
                 continue;
             }
             warn!(
                 job_id = job.job_id,
-                "pending job left with Reason=None after classification; defaulting to Priority (classifier gap)"
+                "pending job left with Reason=None after classification (classifier gap)"
             );
-            job.set_pending_reason(PendingReason::Priority);
-            patched.push(job.job_id);
+            untagged.push(job.job_id);
         }
-        patched
+        untagged
     }
 
     /// Send a job event notification via webhook (if configured).
@@ -12881,35 +12883,37 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn backstop_defaults_leaked_none_pending_job_to_priority() {
-        // Safety net: a pending job that reaches the backstop still at None (a
-        // classifier gap) is defaulted to Priority so the CLI never shows a bare
-        // None. No node is registered, so no scheduler cycle tags it first.
+    async fn warn_untagged_pending_detects_leak_without_rewriting_reason() {
+        // A pending job left at None (a classifier gap) is detected and returned
+        // so it gets logged, but the reason is not overwritten: fabricating a
+        // cause would assert something false and hide the gap. No node is
+        // registered, so no scheduler cycle tags it first.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         let id = submit_and_wait(&cm, basic_spec("leak"));
         assert_eq!(cm.get_job(id).unwrap().pending_reason, PendingReason::None);
 
-        let patched = cm.backstop_untagged_pending();
-        assert_eq!(patched, vec![id]);
+        let untagged = cm.warn_untagged_pending();
+        assert_eq!(untagged, vec![id]);
         assert_eq!(
             cm.get_job(id).unwrap().pending_reason,
-            PendingReason::Priority
+            PendingReason::None,
+            "the reason must stay the honest None, not be rewritten"
         );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn backstop_leaves_begin_held_none_alone() {
-        // A begin-time hold with reason None is a separate, tracked case. The
-        // backstop must not mislabel it as Priority (that would hide the hold).
+    async fn warn_untagged_pending_ignores_begin_held() {
+        // A begin-time hold with reason None is a separate, tracked case, not a
+        // classifier gap: it must not be flagged.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         let mut spec = basic_spec("held");
         spec.begin_time = Some(Utc::now() + chrono::Duration::hours(1));
         let id = submit_and_wait(&cm, spec);
 
-        let patched = cm.backstop_untagged_pending();
-        assert!(patched.is_empty(), "begin-held job must be left alone");
+        let untagged = cm.warn_untagged_pending();
+        assert!(untagged.is_empty(), "begin-held job must not be flagged");
         assert_eq!(cm.get_job(id).unwrap().pending_reason, PendingReason::None);
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4027,14 +4027,8 @@ impl ClusterManager {
         }
     }
 
-    /// Detects the classifier-invariant violation where a pending job that is
-    /// not a hold, deadline, or begin-time hold is left at `Reason=None`. This
-    /// should never happen; if it does, it is a classifier gap. Log it loudly
-    /// with the job id so operators can find and fix it, but deliberately do
-    /// NOT rewrite the reason: inventing a plausible cause (e.g. `Priority`)
-    /// would assert something false and mask the very gap we want surfaced. The
-    /// honest `None` stands until the classifier is fixed. Returns the offending
-    /// ids for tests and metrics.
+    /// Logs (never rewrites, which would mask the gap) any pending job stuck at
+    /// `Reason=None`; holds/deadlines/begin-time holds are legitimately None.
     pub(crate) fn warn_untagged_pending(&self) -> Vec<JobId> {
         let now = Utc::now();
         let jobs = self.jobs.read();
@@ -5637,11 +5631,8 @@ fn retain_unblocked(
     });
 }
 
-/// Like [`retain_unblocked`], but for the consumable gates that reserve
-/// aggregate headroom within a pass. Not-yet-`scheduling_eligible` candidates
-/// are kept untouched for a later gate to classify; `block` may reserve headroom
-/// on the keep path. Every eligible candidate it rejects is dropped *and*
-/// recorded, so a job removed from the schedulable set always carries a reason.
+/// Like [`retain_unblocked`], but skips not-yet-eligible candidates and lets
+/// `block` reserve in-pass headroom on the keep path. Drops are always recorded.
 fn retain_eligible(
     candidates: &mut Vec<PendingJobCandidate>,
     blocked: &mut Vec<(JobId, PendingReason)>,
@@ -5724,9 +5715,7 @@ fn license_block(job: &Job, pool: &HashMap<String, u64>) -> Option<spur_core::jo
 }
 
 /// `Some(reason)` if the job would exceed a QOS group/per-user cap. `reserved`
-/// folds in headroom already claimed by higher-priority jobs earlier in the
-/// same scheduling pass, so a single pass can't over-subscribe a cap. Caller
-/// resolves the `Qos`.
+/// folds in headroom claimed earlier this pass so it can't over-subscribe.
 fn qos_block_with(
     job: &Job,
     qos: &Qos,
@@ -5782,12 +5771,8 @@ fn qos_block_with(
     }
 }
 
-/// `Some(reason)` if the job would exceed an account group/association cap.
-/// Looks up the job's (user, account) association limits from
-/// `AssociationCache`; a job with no account (or an association the cache has no
-/// limits for) is unconstrained. `reserved` folds in headroom already claimed
-/// by higher-priority jobs earlier in the same scheduling pass, so a single
-/// pass can't over-subscribe an account group cap.
+/// `Some(reason)` if the job would exceed its (user, account) association cap (no
+/// account means unconstrained). `reserved` folds in this pass's claimed headroom.
 fn account_block_with(
     job: &Job,
     assoc_cache: &AssociationCache,
@@ -12790,10 +12775,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn in_pass_qos_grp_node_block_tags_reason_not_none() {
-        // Two pending 1-node jobs, QOS capped at grp_tres node=1, nothing
-        // running. The first reserves the slot in-pass; the second is blocked
-        // only by that in-pass reservation and must surface QosGrpNodeLimit, not
-        // the bare None this drop used to leave.
+        // Two 1-node jobs, QOS grp_tres node=1, nothing running: the second is
+        // blocked only by the first's in-pass reservation. Expect QosGrpNodeLimit.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "n1", 8, 16000);
@@ -12825,9 +12808,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn in_pass_account_grp_node_block_tags_reason_not_none() {
-        // Same in-pass reservation drop, one layer up: two pending 1-node jobs
-        // in an account capped at grp_tres node=1. The second is blocked only by
-        // the first's in-pass reservation and must surface AssocGrpNodeLimit.
+        // Account grp_tres node=1: the second job is blocked only by the first's
+        // in-pass reservation. Expect AssocGrpNodeLimit, not None.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "n1", 8, 16000);
@@ -12859,10 +12841,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn in_pass_bb_exhaustion_tags_reason_not_none() {
-        // Two pending jobs each want 60GB from a 100GB burst-buffer pool. In a
-        // single pass the first reserves capacity and is selected for stage-in;
-        // the second, blocked only by that in-pass reservation, must surface
-        // BurstBufferResources instead of None.
+        // Two jobs want 60GB from a 100GB BB pool: the second, blocked only by
+        // the first's in-pass reservation, must surface BurstBufferResources.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "n1", 8, 16000);
@@ -12884,10 +12864,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn warn_untagged_pending_detects_leak_without_rewriting_reason() {
-        // A pending job left at None (a classifier gap) is detected and returned
-        // so it gets logged, but the reason is not overwritten: fabricating a
-        // cause would assert something false and hide the gap. No node is
-        // registered, so no scheduler cycle tags it first.
+        // A leaked-None pending job is detected and returned, but its reason is
+        // left None, not rewritten. No node registered, so nothing tags it first.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         let id = submit_and_wait(&cm, basic_spec("leak"));
@@ -12904,8 +12882,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn warn_untagged_pending_ignores_begin_held() {
-        // A begin-time hold with reason None is a separate, tracked case, not a
-        // classifier gap: it must not be flagged.
+        // A begin-time hold at None is legitimate, not a gap: must not be flagged.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         let mut spec = basic_spec("held");
@@ -13223,9 +13200,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn pending_jobs_does_not_overallocate_licenses_within_one_pass() {
-        // Two pending jobs each request fluent:1 from a pool of 1. One is
-        // admitted; the loser waits on Licenses (not None), since from its view
-        // it is waiting for a license regardless of contention vs shortage.
+        // Two jobs each request fluent:1 from a pool of 1: the loser waits on
+        // Licenses (not None), the same as an outright shortage.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "n1", 8, 16000);

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2850,57 +2850,43 @@ impl ClusterManager {
 
         {
             let mut reserved = PassReservations::default();
-            candidates.retain(|candidate| {
-                if !candidate.scheduling_eligible {
-                    return true;
-                }
-                let job = &candidate.job;
+            retain_eligible(&mut candidates, &mut blocked, |job| {
                 if let Some(reason) =
                     account_block_with(job, &self.association_cache, &jobs, &reserved)
                 {
-                    if account_block_for(job, &self.association_cache, &jobs).is_some() {
-                        record_blocked(&mut blocked, candidate, reason);
-                    }
-                    return false;
+                    return Some(reason);
                 }
                 if let Some(reason) =
                     qos_block_with(job, &qos_by_job[&job.job_id], &jobs, &reserved)
                 {
-                    if qos_block_for(job, &qos_by_job[&job.job_id], &jobs).is_some() {
-                        record_blocked(&mut blocked, candidate, reason);
-                    }
-                    return false;
+                    return Some(reason);
                 }
                 reserved.reserve(job);
-                true
+                None
             });
         }
 
         {
             let available = self.available_licenses_with(&jobs);
             let mut remaining = available.clone();
-            candidates.retain(|candidate| {
-                if !candidate.scheduling_eligible {
-                    return true;
-                }
-                let job = &candidate.job;
+            retain_eligible(&mut candidates, &mut blocked, |job| {
                 if let Some(reason) = license_block(job, &available) {
-                    record_blocked(&mut blocked, candidate, reason);
-                    return false;
+                    return Some(reason);
                 }
                 let req = extract_license_requirements(&job.spec);
+                // In-pass contention counts as a license wait, same as a shortage.
                 if req
                     .iter()
                     .any(|(lic, n)| remaining.get(lic).copied().unwrap_or(0) < *n)
                 {
-                    return false;
+                    return Some(PendingReason::Licenses);
                 }
                 for (lic, n) in &req {
                     if let Some(avail) = remaining.get_mut(lic) {
                         *avail = avail.saturating_sub(*n);
                     }
                 }
-                true
+                None
             });
         }
 
@@ -2928,9 +2914,13 @@ impl ClusterManager {
                 if job.bb_stage_state == BbStageState::Ready {
                     return true;
                 }
+                // In-pass contention counts as a BB wait, same as a shortage.
                 if req > remaining {
+                    record_blocked(&mut blocked, candidate, PendingReason::BurstBufferResources);
                     return false;
                 }
+                // Not a block: capacity is reserved and stage-in scheduled, so the
+                // job leaves the schedulable set and shows BurstBufferStageIn next.
                 remaining = remaining.saturating_sub(req);
                 bb_stage_candidates.push(job.job_id);
                 false
@@ -4035,6 +4025,32 @@ impl ClusterManager {
             };
             job_entry.set_pending_reason(reason);
         }
+    }
+
+    /// Safety net for a classifier gap: a pending job that is not a hold,
+    /// deadline, or begin-time hold should never be left at `None`. Any that is
+    /// gets logged and defaulted to `Priority` so the gap is visible in logs
+    /// rather than surfacing as a bare `Reason=None`. Returns the patched ids.
+    pub(crate) fn backstop_untagged_pending(&self) -> Vec<JobId> {
+        let now = Utc::now();
+        let mut jobs = self.jobs.write();
+        let mut patched = Vec::new();
+        for job in jobs.values_mut() {
+            if job.state != JobState::Pending
+                || job.pending_reason != PendingReason::None
+                || job.pending_reason.is_scheduling_hold()
+                || job.is_begin_held(now)
+            {
+                continue;
+            }
+            warn!(
+                job_id = job.job_id,
+                "pending job left with Reason=None after classification; defaulting to Priority (classifier gap)"
+            );
+            job.set_pending_reason(PendingReason::Priority);
+            patched.push(job.job_id);
+        }
+        patched
     }
 
     /// Send a job event notification via webhook (if configured).
@@ -5619,6 +5635,28 @@ fn retain_unblocked(
     });
 }
 
+/// Like [`retain_unblocked`], but for the consumable gates that reserve
+/// aggregate headroom within a pass. Not-yet-`scheduling_eligible` candidates
+/// are kept untouched for a later gate to classify; `block` may reserve headroom
+/// on the keep path. Every eligible candidate it rejects is dropped *and*
+/// recorded, so a job removed from the schedulable set always carries a reason.
+fn retain_eligible(
+    candidates: &mut Vec<PendingJobCandidate>,
+    blocked: &mut Vec<(JobId, PendingReason)>,
+    mut block: impl FnMut(&Job) -> Option<PendingReason>,
+) {
+    candidates.retain(|candidate| {
+        if !candidate.scheduling_eligible {
+            return true;
+        }
+        let Some(reason) = block(&candidate.job) else {
+            return true;
+        };
+        record_blocked(blocked, candidate, reason);
+        false
+    });
+}
+
 fn record_blocked(
     blocked: &mut Vec<(JobId, PendingReason)>,
     candidate: &PendingJobCandidate,
@@ -5683,18 +5721,10 @@ fn license_block(job: &Job, pool: &HashMap<String, u64>) -> Option<spur_core::jo
     None
 }
 
-/// Caller resolves the `Qos`.
-fn qos_block_for(
-    job: &Job,
-    qos: &Qos,
-    jobs: &HashMap<JobId, Job>,
-) -> Option<spur_core::job::PendingReason> {
-    qos_block_with(job, qos, jobs, &PassReservations::default())
-}
-
-/// Like [`qos_block_for`] but folds `reserved` (headroom already claimed by
-/// higher-priority jobs earlier in the same scheduling pass) into the running
-/// aggregates, so a single pass can't over-subscribe a QOS group/per-user cap.
+/// `Some(reason)` if the job would exceed a QOS group/per-user cap. `reserved`
+/// folds in headroom already claimed by higher-priority jobs earlier in the
+/// same scheduling pass, so a single pass can't over-subscribe a cap. Caller
+/// resolves the `Qos`.
 fn qos_block_with(
     job: &Job,
     qos: &Qos,
@@ -5750,20 +5780,12 @@ fn qos_block_with(
     }
 }
 
+/// `Some(reason)` if the job would exceed an account group/association cap.
 /// Looks up the job's (user, account) association limits from
-/// `AssociationCache`; a job with no account (or an association the cache has
-/// no limits for) is unconstrained.
-fn account_block_for(
-    job: &Job,
-    assoc_cache: &AssociationCache,
-    jobs: &HashMap<JobId, Job>,
-) -> Option<spur_core::job::PendingReason> {
-    account_block_with(job, assoc_cache, jobs, &PassReservations::default())
-}
-
-/// Like [`account_block_for`] but folds `reserved` (headroom already claimed by
-/// higher-priority jobs earlier in the same scheduling pass) into the running
-/// aggregates, so a single pass can't over-subscribe an account group cap.
+/// `AssociationCache`; a job with no account (or an association the cache has no
+/// limits for) is unconstrained. `reserved` folds in headroom already claimed
+/// by higher-priority jobs earlier in the same scheduling pass, so a single
+/// pass can't over-subscribe an account group cap.
 fn account_block_with(
     job: &Job,
     assoc_cache: &AssociationCache,
@@ -12445,7 +12467,7 @@ mod tests {
         let cm = test_cluster(&dir).await;
         // Seed the cache with a QoS that caps wall time at 1 min, then submit a
         // job to that QoS asking for more — the specific QOS reason must surface
-        // through resolve_qos -> qos_block_for (not the old limitless default).
+        // through resolve_qos -> qos_block_with (not the old limitless default).
         cm.qos_cache().insert(Qos {
             name: "short".into(),
             limits: spur_core::accounting::QosLimits {
@@ -12765,6 +12787,133 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn in_pass_qos_grp_node_block_tags_reason_not_none() {
+        // Two pending 1-node jobs, QOS capped at grp_tres node=1, nothing
+        // running. The first reserves the slot in-pass; the second is blocked
+        // only by that in-pass reservation and must surface QosGrpNodeLimit, not
+        // the bare None this drop used to leave.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Node, 1);
+        cm.qos_cache().insert(Qos {
+            name: "capped".into(),
+            limits: spur_core::accounting::QosLimits {
+                grp_tres: Some(grp),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut s1 = basic_spec("q1");
+        s1.qos = Some("capped".into());
+        let j1 = submit_and_wait(&cm, s1);
+        let mut s2 = basic_spec("q2");
+        s2.qos = Some("capped".into());
+        let j2 = submit_and_wait(&cm, s2);
+
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(cm.get_job(j1).unwrap().pending_reason, PendingReason::None);
+        assert_eq!(
+            cm.get_job(j2).unwrap().pending_reason,
+            PendingReason::QosGrpNodeLimit
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn in_pass_account_grp_node_block_tags_reason_not_none() {
+        // Same in-pass reservation drop, one layer up: two pending 1-node jobs
+        // in an account capped at grp_tres node=1. The second is blocked only by
+        // the first's in-pass reservation and must surface AssocGrpNodeLimit.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Node, 1);
+        cm.association_cache().insert_limits(
+            "testuser",
+            "research",
+            spur_core::accounting::AccountLimits {
+                grp_tres: Some(grp),
+                ..Default::default()
+            },
+        );
+
+        let mut s1 = basic_spec("a1");
+        s1.account = Some("research".into());
+        let j1 = submit_and_wait(&cm, s1);
+        let mut s2 = basic_spec("a2");
+        s2.account = Some("research".into());
+        let j2 = submit_and_wait(&cm, s2);
+
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(cm.get_job(j1).unwrap().pending_reason, PendingReason::None);
+        assert_eq!(
+            cm.get_job(j2).unwrap().pending_reason,
+            PendingReason::AssocGrpNodeLimit
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn in_pass_bb_exhaustion_tags_reason_not_none() {
+        // Two pending jobs each want 60GB from a 100GB burst-buffer pool. In a
+        // single pass the first reserves capacity and is selected for stage-in;
+        // the second, blocked only by that in-pass reservation, must surface
+        // BurstBufferResources instead of None.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        *cm.burst_buffer_total_gb.write() = 100;
+
+        let mut s1 = basic_spec("bb1");
+        s1.burst_buffer = Some("capacity=60".into());
+        let _j1 = submit_and_wait(&cm, s1);
+        let mut s2 = basic_spec("bb2");
+        s2.burst_buffer = Some("capacity=60".into());
+        let j2 = submit_and_wait(&cm, s2);
+
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(j2).unwrap().pending_reason,
+            PendingReason::BurstBufferResources
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn backstop_defaults_leaked_none_pending_job_to_priority() {
+        // Safety net: a pending job that reaches the backstop still at None (a
+        // classifier gap) is defaulted to Priority so the CLI never shows a bare
+        // None. No node is registered, so no scheduler cycle tags it first.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let id = submit_and_wait(&cm, basic_spec("leak"));
+        assert_eq!(cm.get_job(id).unwrap().pending_reason, PendingReason::None);
+
+        let patched = cm.backstop_untagged_pending();
+        assert_eq!(patched, vec![id]);
+        assert_eq!(
+            cm.get_job(id).unwrap().pending_reason,
+            PendingReason::Priority
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn backstop_leaves_begin_held_none_alone() {
+        // A begin-time hold with reason None is a separate, tracked case. The
+        // backstop must not mislabel it as Priority (that would hide the hold).
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let mut spec = basic_spec("held");
+        spec.begin_time = Some(Utc::now() + chrono::Duration::hours(1));
+        let id = submit_and_wait(&cm, spec);
+
+        let patched = cm.backstop_untagged_pending();
+        assert!(patched.is_empty(), "begin-held job must be left alone");
+        assert_eq!(cm.get_job(id).unwrap().pending_reason, PendingReason::None);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn account_limits_do_not_block_jobs_without_an_account() {
         // A job with no account can't be constrained by an association it
         // doesn't belong to.
@@ -13070,9 +13219,9 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn pending_jobs_does_not_overallocate_licenses_within_one_pass() {
-        // Two pending jobs each request fluent:1 but the pool holds only 1.
-        // A single classification must not return both or label the greedy
-        // contention drop as an absolute license shortage.
+        // Two pending jobs each request fluent:1 from a pool of 1. One is
+        // admitted; the loser waits on Licenses (not None), since from its view
+        // it is waiting for a license regardless of contention vs shortage.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "n1", 8, 16000);
@@ -13095,12 +13244,12 @@ mod tests {
             granted, 1,
             "pending_jobs() returned {granted} fluent jobs but the pool holds only 1"
         );
-        for id in [a, b] {
-            assert_ne!(
-                cm.get_job(id).unwrap().pending_reason,
-                PendingReason::Licenses
-            );
-        }
+        let loser = [a, b].into_iter().find(|id| !pending.contains(id)).unwrap();
+        assert_eq!(
+            cm.get_job(loser).unwrap().pending_reason,
+            PendingReason::Licenses,
+            "the job that lost the single license must wait on Licenses, not None"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4028,7 +4028,8 @@ impl ClusterManager {
     }
 
     /// Logs (never rewrites, which would mask the gap) any pending job stuck at
-    /// `Reason=None`; holds/deadlines/begin-time holds are legitimately None.
+    /// `Reason=None`. Holds, deadlines, begin-time holds, and array-throttled
+    /// tasks are legitimately None and skipped.
     pub(crate) fn warn_untagged_pending(&self) -> Vec<JobId> {
         let now = Utc::now();
         let jobs = self.jobs.read();
@@ -4037,6 +4038,7 @@ impl ClusterManager {
             if job.state != JobState::Pending
                 || job.pending_reason != PendingReason::None
                 || job.is_begin_held(now)
+                || job.spec.array_max_concurrent.is_some()
             {
                 continue;
             }
@@ -12892,6 +12894,31 @@ mod tests {
         let untagged = cm.warn_untagged_pending();
         assert!(untagged.is_empty(), "begin-held job must not be flagged");
         assert_eq!(cm.get_job(id).unwrap().pending_reason, PendingReason::None);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn warn_untagged_pending_ignores_array_throttled() {
+        // A task held back by array_max_concurrent sits at None by design (its
+        // reason is tracked separately); the check must not flag it as a gap.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let mut spec = basic_spec("arr");
+        spec.array_spec = Some("0-1%1".into());
+        let parent_id = cm.submit_job(spec).unwrap().job_id;
+        let t1 = parent_id + 1;
+        let t2 = parent_id + 2;
+        wait_for("array tasks", || {
+            cm.get_job(t1).is_some() && cm.get_job(t2).is_some()
+        });
+        start_job_on(&cm, t1, "n1");
+        settle(&cm, t1, JobState::Running);
+
+        assert_eq!(cm.get_job(t2).unwrap().pending_reason, PendingReason::None);
+        assert!(
+            !cm.warn_untagged_pending().contains(&t2),
+            "throttled array task must not be flagged as a classifier gap"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -4,7 +4,7 @@
 //! Controller-side cache of QoS definitions loaded from the accounting database.
 //!
 //! Mirrors `fairshare_cache`: an `RwLock<HashMap>` refreshed on a background
-//! loop that retains stale data on error. The scheduler's `qos_block_for` reads
+//! loop that retains stale data on error. The scheduler's `qos_block_with` reads
 //! this cache so the dormant `QOS*` pending-reasons fire against real limits.
 
 use std::collections::HashMap;

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -225,6 +225,10 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             }
         }
 
+        // Safety net for any pending job the passes above left at Reason=None:
+        // log it and apply a fallback so the gap is visible, not silent.
+        cluster.backstop_untagged_pending();
+
         let cycle_time_us = cycle_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
         cluster.record_sched_cycle(
             cycle_time_us,

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -225,10 +225,6 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             }
         }
 
-        // Invariant check: warn loudly if any pending job the passes above left
-        // at Reason=None slipped through, so a classifier gap surfaces in logs.
-        cluster.warn_untagged_pending();
-
         let cycle_time_us = cycle_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
         cluster.record_sched_cycle(
             cycle_time_us,

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -225,9 +225,9 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             }
         }
 
-        // Safety net for any pending job the passes above left at Reason=None:
-        // log it and apply a fallback so the gap is visible, not silent.
-        cluster.backstop_untagged_pending();
+        // Invariant check: warn loudly if any pending job the passes above left
+        // at Reason=None slipped through, so a classifier gap surfaces in logs.
+        cluster.warn_untagged_pending();
 
         let cycle_time_us = cycle_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
         cluster.record_sched_cycle(


### PR DESCRIPTION
## What this fixes

Pending jobs could sit indefinitely with `Reason=None` in `squeue`/`scontrol`. Observed on a production cluster: a job blocked purely by a higher-priority sibling reserving QOS group headroom showed no reason at all.

## Root cause

`classify_pending_jobs` filters candidates through four aggregate gates (account, QOS, license, burst-buffer). Each gate dropped a candidate from the schedulable set **without recording a reason** when the block came only from *in-pass* reservation (a higher-priority job earlier in the same pass claimed the headroom), not from the persistent limit. Such a job never reached `update_pending_reasons` and was never added to the blocked set, so it kept the default `PendingReason::None`. It became permanent whenever a higher-priority job perpetually reserved the aggregate headroom in-pass but was itself never placed.

The gates split the drop decision (`*_block_with`, in-pass) from the displayed reason (`*_block_for`, persistent). When `_with` tripped but `_for` did not, the job was dropped and left untagged. This split was introduced by [478], which added the in-pass `*_block_with` checks and `PassReservations` to stop a single pass over-subscribing aggregate caps, but kept `*_block_for` for the displayed reason.

## Approach

Restore the invariant: any candidate removed from the schedulable set carries a reason.

- Add `retain_eligible`, mirroring `retain_unblocked` but for the consumable gates. It keeps not-yet-eligible candidates untouched, lets the gate reserve headroom on the keep path, and records a reason whenever it drops an eligible candidate.
- Route the account+QOS gate through it and drop the `_for` guard, so any in-pass block is tagged.
- Tag the license and burst-buffer in-pass exhaustion (`Licenses` / `BurstBufferResources`).
- Delete the now-dead `account_block_for` / `qos_block_for`. This removes the `_with`/`_for` drift that caused the split, so the bug class cannot recur.

## How it was tested

- New in-pass regression tests per gate (QOS, account, burst-buffer) asserting the specific reason instead of `None`. Updated the existing license single-pass test to assert `Licenses`.
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` clean; `cargo test --locked` green.
- Bare-metal repro on the QOS path: same submission sequence, the in-pass-blocked job flipped from `Reason=None` (before) to `QOSGrpNodeLimit` (after).

## Follow-ups (same bug class, separate scope)

- [1] Array-throttled tasks show `Reason=None`: [618].
- [2] Jobs with a future `--begin` show `Reason=None` on submit: [619].

[478]: https://github.com/ROCm/spur/pull/478
[618]: https://github.com/ROCm/spur/issues/618
[619]: https://github.com/ROCm/spur/issues/619
