### PR TITLE
test(spurctld): fix/node recovery review

### DIFF
--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -210,14 +210,16 @@ pub async fn main() -> Result<()> {
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let matches = SrunArgs::command().try_get_matches_from(&args)?;
     let mut args = SrunArgs::from_arg_matches(&matches)?;
+
+    if args.jobid.is_some() && !args.overlap {
+        anyhow::bail!("--jobid requires --overlap");
+    }
+
     resolve_srun_env(&matches, &mut args)?;
     args.nodelist = crate::nodelist::resolve(args.nodelist.take(), args.nodefile.take())?;
 
     // --jobid --overlap: exec into a running job (interactive PTY session)
     if let Some(job_id) = args.jobid {
-        if !args.overlap {
-            anyhow::bail!("--jobid requires --overlap");
-        }
         let node = first_node(args.nodelist.as_deref().unwrap_or_default());
         let user = crate::interactive::current_user()?;
         let exit_code =

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2340,11 +2340,15 @@ impl ClusterManager {
                     }
                 }
                 HealthAction::Recover { name, old_state } => {
-                    info!(node = %name, "node recovered (heartbeat resumed)");
+                    let recovered_state = self
+                        .get_node(&name)
+                        .map(|node| recovered_node_state(&node))
+                        .unwrap_or(NodeState::Idle);
+                    info!(node = %name, state = ?recovered_state, "node recovered (heartbeat resumed)");
                     if let Err(e) = self.propose(WalOperation::NodeStateChange {
                         name,
                         old_state,
-                        new_state: NodeState::Idle,
+                        new_state: recovered_state,
                         reason: None,
                         admin_locked: false,
                     }) {
@@ -5830,6 +5834,13 @@ pub(crate) enum HealthAction {
         name: String,
         old_state: NodeState,
     },
+}
+
+pub(crate) fn recovered_node_state(node: &Node) -> NodeState {
+    let mut recovered = node.clone();
+    recovered.state = NodeState::Idle;
+    recovered.update_state_from_alloc();
+    recovered.state
 }
 
 pub(crate) fn evaluate_node_health(
@@ -14387,6 +14398,19 @@ mod tests {
                 admin_locked: false,
             }]
         );
+    }
+
+    #[test]
+    fn recovered_allocated_node_stays_allocated() {
+        let mut node = make_health_node(
+            "n1",
+            NodeState::Down,
+            false,
+            Some(Utc::now() - chrono::Duration::seconds(10)),
+        );
+        node.total_resources.cpus = 8;
+        node.alloc_resources.cpus = 8;
+        assert_eq!(super::recovered_node_state(&node), NodeState::Allocated);
     }
 
     #[test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2340,10 +2340,7 @@ impl ClusterManager {
                     }
                 }
                 HealthAction::Recover { name, old_state } => {
-                    let recovered_state = self
-                        .get_node(&name)
-                        .map(|node| recovered_node_state(&node))
-                        .unwrap_or(NodeState::Idle);
+                    let recovered_state = recovered_node_state(self.get_node(&name).as_ref());
                     info!(node = %name, state = ?recovered_state, "node recovered (heartbeat resumed)");
                     if let Err(e) = self.propose(WalOperation::NodeStateChange {
                         name,
@@ -5836,7 +5833,10 @@ pub(crate) enum HealthAction {
     },
 }
 
-pub(crate) fn recovered_node_state(node: &Node) -> NodeState {
+pub(crate) fn recovered_node_state(node: Option<&Node>) -> NodeState {
+    let Some(node) = node else {
+        return NodeState::Idle;
+    };
     let mut recovered = node.clone();
     recovered.state = NodeState::Idle;
     recovered.update_state_from_alloc();
@@ -14410,7 +14410,15 @@ mod tests {
         );
         node.total_resources.cpus = 8;
         node.alloc_resources.cpus = 8;
-        assert_eq!(super::recovered_node_state(&node), NodeState::Allocated);
+        assert_eq!(
+            super::recovered_node_state(Some(&node)),
+            NodeState::Allocated
+        );
+    }
+
+    #[test]
+    fn recovered_missing_node_is_idle() {
+        assert_eq!(super::recovered_node_state(None), NodeState::Idle);
     }
 
     #[test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -5838,6 +5838,7 @@ pub(crate) fn recovered_node_state(node: Option<&Node>) -> NodeState {
         return NodeState::Idle;
     };
     let mut recovered = node.clone();
+    // Clear the transient failure state so allocation state can be recomputed.
     recovered.state = NodeState::Idle;
     recovered.update_state_from_alloc();
     recovered.state
@@ -14039,6 +14040,39 @@ mod tests {
         });
         let node = cm.get_node("stale").unwrap();
         assert_eq!(node.state, NodeState::Down);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn check_node_health_recovers_allocated_node_as_allocated() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "recovering", 4, 8000);
+
+        let id = submit_and_wait(&cm, basic_spec("running-job"));
+        let alloc = scalar_alloc(4, 8000);
+        cm.start_job(
+            id,
+            vec!["recovering".into()],
+            alloc.clone(),
+            per_node_for(&["recovering"], alloc),
+        )
+        .unwrap();
+        settle(&cm, id, JobState::Running);
+
+        if let Some(node) = cm.nodes.write().get_mut("recovering") {
+            node.state = NodeState::Down;
+            node.last_heartbeat = Some(Utc::now());
+        }
+
+        cm.check_node_health(90);
+        wait_for("node recovery applied", || {
+            cm.get_node("recovering")
+                .is_some_and(|node| node.state == NodeState::Allocated)
+        });
+        assert_eq!(
+            cm.get_node("recovering").unwrap().state,
+            NodeState::Allocated
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Motivation

This is a follow-up to [PR #613](https://github.com/ROCm/spur/pull/613), which fixed heartbeat recovery incorrectly reporting nodes with live allocations as `IDLE`.

During review of [PR #613](https://github.com/ROCm/spur/pull/613), an end-to-end controller test was suggested to cover the complete recovery path. The original fix was merged before that follow-up could be added.

## Technical Details

Adds a regression test covering `check_node_health` through action application and Raft proposal. It verifies that a node with a live allocation recovers from `DOWN` as `ALLOCATED`.

Also documents why recovery temporarily clears the failure state before recomputing the allocation-derived state.

## Test Plan

- Run the new full-path recovery test.
- Run the targeted node-health tests.
- Run workspace formatting checks.

## Test Result

- `cargo test -p spurctld check_node_health --locked`: 2 passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check upstream/main...HEAD`: passed.

## Submission Checklist

- [x] Look over the [ROCm contributing guidelines](https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests).