### PR TITLE
fix(spurctld): reclaim agent allocations the controller no longer tracks on that node

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -944,6 +944,14 @@ impl ClusterManager {
         self.next_job_id.load(Ordering::Relaxed)
     }
 
+    /// Whether `node` is part of the job's current allocation.
+    pub fn job_holds_node(&self, job_id: JobId, node: &str) -> bool {
+        self.jobs
+            .read()
+            .get(&job_id)
+            .is_some_and(|j| j.allocated_nodes.iter().any(|n| n == node))
+    }
+
     /// Get a job by ID, synthesizing an aggregate record for an array *parent*
     /// id (which has no stored job — Spur stores only per-task jobs) so
     /// `scontrol show job <array_parent>` matches Slurm instead of returning

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -938,6 +938,12 @@ impl ClusterManager {
         self.jobs.read().get(&job_id).map(|j| j.state)
     }
 
+    /// Next id this controller would assign. Ids at or above it were never
+    /// issued here; ids below it were not necessarily issued either.
+    pub fn peek_next_job_id(&self) -> JobId {
+        self.next_job_id.load(Ordering::Relaxed)
+    }
+
     /// Get a job by ID, synthesizing an aggregate record for an array *parent*
     /// id (which has no stored job — Spur stores only per-task jobs) so
     /// `scontrol show job <array_parent>` matches Slurm instead of returning
@@ -5628,6 +5634,8 @@ impl StateMachineApply for ClusterManager {
         // (NOT config-derived like license_pool/burst_buffer) — restore them.
         *self.k0s.write() = snap.k0s;
 
+        // Must stay inside the `jobs` write guard: a reader seeing the cleared
+        // map with this watermark would treat every live job as reclaimable.
         self.next_job_id.store(next_id, Ordering::Relaxed);
 
         // Re-evaluate partition membership and NodeConfig policy

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -933,23 +933,10 @@ impl ClusterManager {
         self.jobs.read().get(&job_id).cloned()
     }
 
-    /// A job's state by ID, without cloning the whole `Job`.
-    pub fn job_state(&self, job_id: JobId) -> Option<JobState> {
-        self.jobs.read().get(&job_id).map(|j| j.state)
-    }
-
     /// Next id this controller would assign. Ids at or above it were never
     /// issued here; ids below it were not necessarily issued either.
     pub fn peek_next_job_id(&self) -> JobId {
         self.next_job_id.load(Ordering::Relaxed)
-    }
-
-    /// Whether `node` is part of the job's current allocation.
-    pub fn job_holds_node(&self, job_id: JobId, node: &str) -> bool {
-        self.jobs
-            .read()
-            .get(&job_id)
-            .is_some_and(|j| j.allocated_nodes.iter().any(|n| n == node))
     }
 
     /// Get a job by ID, synthesizing an aggregate record for an array *parent*

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -228,8 +228,9 @@ impl ControllerService {
         Err(self.not_leader_status())
     }
 
-    /// Re-send a cancel to a node still reporting a job the controller considers
-    /// finished, freeing an allocation whose cancel never landed. Best-effort.
+    /// Re-send a cancel to a node still holding an allocation the controller no
+    /// longer believes belongs to it there — job finished, job moved to
+    /// another node, or an id older than any this controller issued. Best-effort.
     fn reclaim_stale_agent_jobs(&self, node: &str, reported: &[RunningJobStatus]) {
         let stale = stale_reported_jobs(&self.cluster, node, reported);
         if stale.is_empty() {
@@ -247,7 +248,7 @@ impl ControllerService {
                 warn!(
                     job_id,
                     node = %node,
-                    "agent still holds a job the controller no longer tracks — re-sending cancel to reclaim its allocation"
+                    "agent still holds an allocation the controller no longer believes belongs to it there — re-sending cancel to reclaim it"
                 );
                 // Signal 0 = graceful release, no-op on an unknown id. Not
                 // epoch-gated — a requeue racing this send is still possible.
@@ -407,11 +408,17 @@ fn is_k0s_admin(cache: &crate::association_cache::AssociationCache, caller: &str
 /// Whether `node` may release what it holds for `job_id`: the run is over, the
 /// job is active elsewhere, or the id is untracked but was issued by us.
 fn is_reclaimable(cluster: &ClusterManager, node: &str, job_id: u32) -> bool {
-    match cluster.job_state(job_id) {
-        Some(state) if state.is_terminal() => true,
-        // Only an active job has an authoritative nodelist; anything earlier may
-        // be mid-dispatch to this very node, so spare it.
-        Some(state) => state.is_active() && !cluster.job_holds_node(job_id, node),
+    match cluster.get_job(job_id) {
+        Some(job) if job.state.is_terminal() => true,
+        // An active job's nodelist is authoritative only once populated: state
+        // and allocation commit as two separate WAL entries, so a job can be
+        // observed as Running with `allocated_nodes` still empty. Spare it, same
+        // as a job earlier than active that may be mid-dispatch to this node.
+        Some(job) => {
+            job.state.is_active()
+                && !job.allocated_nodes.is_empty()
+                && !job.allocated_nodes.iter().any(|n| n == node)
+        }
         None => job_id < cluster.peek_next_job_id(),
     }
 }
@@ -3394,6 +3401,10 @@ mod tests {
     use spur_core::reservation::ReservationFlags;
     use tonic::Code;
 
+    fn job_state(cluster: &crate::cluster::ClusterManager, job_id: u32) -> Option<JobState> {
+        cluster.get_job(job_id).map(|j| j.state)
+    }
+
     #[test]
     fn resolve_registration_comm_addr_normalizes_explicit_ip() {
         assert_eq!(
@@ -3699,12 +3710,12 @@ mod tests {
             JobState::Preempted,
         ));
 
-        assert_eq!(cluster.job_state(10), Some(JobState::Pending));
-        assert_eq!(cluster.job_state(11), Some(JobState::Running));
-        assert!(cluster.job_state(12).unwrap().is_terminal());
-        assert_eq!(cluster.job_state(13), Some(JobState::Completing));
-        assert_eq!(cluster.job_state(14), Some(JobState::Suspended));
-        assert_eq!(cluster.job_state(15), Some(JobState::Preempted));
+        assert_eq!(job_state(&cluster, 10), Some(JobState::Pending));
+        assert_eq!(job_state(&cluster, 11), Some(JobState::Running));
+        assert!(job_state(&cluster, 12).unwrap().is_terminal());
+        assert_eq!(job_state(&cluster, 13), Some(JobState::Completing));
+        assert_eq!(job_state(&cluster, 14), Some(JobState::Suspended));
+        assert_eq!(job_state(&cluster, 15), Some(JobState::Preempted));
 
         let reported: Vec<RunningJobStatus> = [10, 11, 12, 13, 14, 15, 999]
             .into_iter()
@@ -3759,7 +3770,7 @@ mod tests {
         ));
         apply(&WalOperation::EvictTerminalJobs { job_ids: vec![20] });
 
-        assert_eq!(cluster.job_state(20), None, "eviction drops the record");
+        assert_eq!(job_state(&cluster, 20), None, "eviction drops the record");
         let issued = cluster.peek_next_job_id();
         assert!(20 < issued, "id 20 was issued by this controller");
 
@@ -3809,7 +3820,7 @@ mod tests {
             );
         }
 
-        assert_eq!(cluster.job_state(30), None, "parent id is never stored");
+        assert_eq!(job_state(&cluster, 30), None, "parent id is never stored");
         assert!(30 < cluster.peek_next_job_id());
         assert!(
             is_reclaimable(&cluster, "n1", 30),
@@ -3917,6 +3928,50 @@ mod tests {
         assert!(
             stale_reported_jobs(&cluster, "n1", &reported).is_empty(),
             "a Pending job the agent already holds is mid-launch, not stale"
+        );
+    }
+
+    /// A job's Running state and its nodelist commit as two separate WAL
+    /// entries; a heartbeat landing between them must not read the empty
+    /// nodelist as authoritative and tell the launching node to release.
+    #[tokio::test]
+    async fn stale_reported_jobs_spares_running_job_before_job_start_lands() {
+        use crate::raft::StateMachineApply;
+        use spur_core::job::{JobSpec, JobState};
+        use spur_core::wal::WalOperation;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let cluster =
+            Arc::new(crate::cluster::ClusterManager::new(test_slurm_config(), dir.path()).unwrap());
+
+        <crate::cluster::ClusterManager as StateMachineApply>::apply_operation(
+            cluster.as_ref(),
+            &WalOperation::JobSubmit {
+                job_id: 60,
+                spec: Box::new(JobSpec {
+                    name: "starting".into(),
+                    user: "alice".into(),
+                    num_nodes: 1,
+                    num_tasks: 1,
+                    cpus_per_task: 1,
+                    work_dir: "/tmp".into(),
+                    ..Default::default()
+                }),
+            },
+        );
+        <crate::cluster::ClusterManager as StateMachineApply>::apply_operation(
+            cluster.as_ref(),
+            &WalOperation::job_state_change(60, JobState::Pending, JobState::Running),
+        );
+
+        assert_eq!(job_state(&cluster, 60), Some(JobState::Running));
+        let reported = vec![RunningJobStatus {
+            job_id: 60,
+            ..Default::default()
+        }];
+        assert!(
+            stale_reported_jobs(&cluster, "n1", &reported).is_empty(),
+            "Running with no nodelist yet is not authoritative — the node accepting the launch must be spared"
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -231,7 +231,7 @@ impl ControllerService {
     /// Re-send a cancel to a node still reporting a job the controller considers
     /// finished, freeing an allocation whose cancel never landed. Best-effort.
     fn reclaim_stale_agent_jobs(&self, node: &str, reported: &[RunningJobStatus]) {
-        let stale = stale_reported_jobs(&self.cluster, reported);
+        let stale = stale_reported_jobs(&self.cluster, node, reported);
         if stale.is_empty() {
             return;
         }
@@ -241,7 +241,7 @@ impl ControllerService {
             for job_id in stale {
                 // Re-check: a requeue since the snapshot above would otherwise
                 // send an unguarded cancel into the job's new run.
-                if !is_reclaimable(&cluster, job_id) {
+                if !is_reclaimable(&cluster, &node, job_id) {
                     continue;
                 }
                 warn!(
@@ -404,21 +404,28 @@ fn is_k0s_admin(cache: &crate::association_cache::AssociationCache, caller: &str
     caller == "root" || cache.is_admin(caller)
 }
 
-/// Reclaimable when terminal, or untracked but below the next id this controller
-/// would assign — an aged-out job otherwise strands its allocation forever.
-fn is_reclaimable(cluster: &ClusterManager, job_id: u32) -> bool {
+/// Whether `node` may release what it holds for `job_id`: the run is over, the
+/// job is active elsewhere, or the id is untracked but was issued by us.
+fn is_reclaimable(cluster: &ClusterManager, node: &str, job_id: u32) -> bool {
     match cluster.job_state(job_id) {
-        Some(state) => state.is_terminal(),
+        Some(state) if state.is_terminal() => true,
+        // Only an active job has an authoritative nodelist; anything earlier may
+        // be mid-dispatch to this very node, so spare it.
+        Some(state) => state.is_active() && !cluster.job_holds_node(job_id, node),
         None => job_id < cluster.peek_next_job_id(),
     }
 }
 
-/// Reported ids the controller considers reclaimable; non-terminal (incl.
-/// Pending mid-dispatch) and never-issued ids are spared.
-fn stale_reported_jobs(cluster: &ClusterManager, reported: &[RunningJobStatus]) -> Vec<u32> {
+/// Reported ids `node` may release; ids still allocated here, not yet started,
+/// and never issued by this controller are spared.
+fn stale_reported_jobs(
+    cluster: &ClusterManager,
+    node: &str,
+    reported: &[RunningJobStatus],
+) -> Vec<u32> {
     reported
         .iter()
-        .filter_map(|r| is_reclaimable(cluster, r.job_id).then_some(r.job_id))
+        .filter_map(|r| is_reclaimable(cluster, node, r.job_id).then_some(r.job_id))
         .collect()
 }
 
@@ -3707,7 +3714,7 @@ mod tests {
             })
             .collect();
 
-        let stale = stale_reported_jobs(&cluster, &reported);
+        let stale = stale_reported_jobs(&cluster, "n1", &reported);
         assert_eq!(
             stale,
             vec![12],
@@ -3765,7 +3772,7 @@ mod tests {
             .collect();
 
         assert_eq!(
-            stale_reported_jobs(&cluster, &reported),
+            stale_reported_jobs(&cluster, "n1", &reported),
             vec![20],
             "the evicted id is reclaimed; ids at or above next_job_id were never issued here"
         );
@@ -3805,8 +3812,111 @@ mod tests {
         assert_eq!(cluster.job_state(30), None, "parent id is never stored");
         assert!(30 < cluster.peek_next_job_id());
         assert!(
-            is_reclaimable(&cluster, 30),
+            is_reclaimable(&cluster, "n1", 30),
             "an unstored id below the watermark is reclaimable — reachable only if an agent reports it"
+        );
+    }
+
+    /// A node evicted mid-run keeps the job and its devices; the controller
+    /// restarts it elsewhere and must let the old node release.
+    #[tokio::test]
+    async fn stale_reported_jobs_reclaims_a_job_restarted_on_another_node() {
+        use crate::raft::StateMachineApply;
+        use spur_core::job::{JobSpec, JobState};
+        use spur_core::wal::WalOperation;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let cluster =
+            Arc::new(crate::cluster::ClusterManager::new(test_slurm_config(), dir.path()).unwrap());
+        let apply = |op: &WalOperation| {
+            <crate::cluster::ClusterManager as StateMachineApply>::apply_operation(
+                cluster.as_ref(),
+                op,
+            );
+        };
+
+        apply(&WalOperation::JobSubmit {
+            job_id: 40,
+            spec: Box::new(JobSpec {
+                name: "moved".into(),
+                user: "alice".into(),
+                num_nodes: 1,
+                num_tasks: 1,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            }),
+        });
+
+        let res = spur_core::resource::ResourceAllocations {
+            cpus: 1,
+            memory_mb: 0,
+            devices: std::collections::HashMap::new(),
+        };
+        let mut per_node = std::collections::HashMap::new();
+        per_node.insert("n2".to_string(), res.clone());
+        apply(&WalOperation::job_start(
+            40,
+            vec!["n2".into()],
+            res,
+            per_node,
+        ));
+        apply(&WalOperation::job_state_change(
+            40,
+            JobState::Pending,
+            JobState::Running,
+        ));
+
+        let reported = vec![RunningJobStatus {
+            job_id: 40,
+            ..Default::default()
+        }];
+        assert_eq!(
+            stale_reported_jobs(&cluster, "n1", &reported),
+            vec![40],
+            "the node it no longer runs on may release it"
+        );
+        assert!(
+            stale_reported_jobs(&cluster, "n2", &reported).is_empty(),
+            "the node actually running it must never be told to release"
+        );
+    }
+
+    /// A job dispatched but not yet started has no nodelist, so the node it is
+    /// being launched on must not be told to release it.
+    #[tokio::test]
+    async fn stale_reported_jobs_spares_a_job_mid_dispatch() {
+        use crate::raft::StateMachineApply;
+        use spur_core::job::JobSpec;
+        use spur_core::wal::WalOperation;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let cluster =
+            Arc::new(crate::cluster::ClusterManager::new(test_slurm_config(), dir.path()).unwrap());
+
+        <crate::cluster::ClusterManager as StateMachineApply>::apply_operation(
+            cluster.as_ref(),
+            &WalOperation::JobSubmit {
+                job_id: 50,
+                spec: Box::new(JobSpec {
+                    name: "launching".into(),
+                    user: "alice".into(),
+                    num_nodes: 1,
+                    num_tasks: 1,
+                    cpus_per_task: 1,
+                    work_dir: "/tmp".into(),
+                    ..Default::default()
+                }),
+            },
+        );
+
+        let reported = vec![RunningJobStatus {
+            job_id: 50,
+            ..Default::default()
+        }];
+        assert!(
+            stale_reported_jobs(&cluster, "n1", &reported).is_empty(),
+            "a Pending job the agent already holds is mid-launch, not stale"
         );
     }
 
@@ -3864,7 +3974,7 @@ mod tests {
             JobState::Running,
             JobState::Timeout,
         ));
-        assert!(is_reclaimable(&cluster, 77), "snapshot sees Timeout");
+        assert!(is_reclaimable(&cluster, "n1", 77), "snapshot sees Timeout");
 
         // Concurrent requeue lands before the reclaim loop's re-check.
         apply(&WalOperation::job_state_change(
@@ -3874,7 +3984,7 @@ mod tests {
         ));
 
         assert!(
-            !is_reclaimable(&cluster, 77),
+            !is_reclaimable(&cluster, "n1", 77),
             "re-check must skip a job requeued since the snapshot"
         );
     }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -228,8 +228,8 @@ impl ControllerService {
         Err(self.not_leader_status())
     }
 
-    /// Re-send a terminal-job cancel to a node still reporting it on heartbeat,
-    /// freeing an allocation whose terminal cancel never landed. Spawned, best-effort.
+    /// Re-send a cancel to a node still reporting a job the controller considers
+    /// finished, freeing an allocation whose cancel never landed. Best-effort.
     fn reclaim_stale_agent_jobs(&self, node: &str, reported: &[RunningJobStatus]) {
         let stale = stale_reported_jobs(&self.cluster, reported);
         if stale.is_empty() {
@@ -241,13 +241,13 @@ impl ControllerService {
             for job_id in stale {
                 // Re-check: a requeue since the snapshot above would otherwise
                 // send an unguarded cancel into the job's new run.
-                if !is_still_terminal(&cluster, job_id) {
+                if !is_reclaimable(&cluster, job_id) {
                     continue;
                 }
                 warn!(
                     job_id,
                     node = %node,
-                    "agent still holds a terminal job — re-sending cancel to reclaim its allocation"
+                    "agent still holds a job the controller no longer tracks — re-sending cancel to reclaim its allocation"
                 );
                 // Signal 0 = graceful release, no-op on an unknown id. Not
                 // epoch-gated — a requeue racing this send is still possible.
@@ -404,18 +404,21 @@ fn is_k0s_admin(cache: &crate::association_cache::AssociationCache, caller: &str
     caller == "root" || cache.is_admin(caller)
 }
 
-/// Whether the controller still considers `job_id` terminal right now — guards
-/// the spawned reclaim loop against a requeue landing after its stale snapshot.
-fn is_still_terminal(cluster: &ClusterManager, job_id: u32) -> bool {
-    cluster.job_state(job_id).is_some_and(|s| s.is_terminal())
+/// Reclaimable when terminal, or untracked but below the next id this controller
+/// would assign — an aged-out job otherwise strands its allocation forever.
+fn is_reclaimable(cluster: &ClusterManager, job_id: u32) -> bool {
+    match cluster.job_state(job_id) {
+        Some(state) => state.is_terminal(),
+        None => job_id < cluster.peek_next_job_id(),
+    }
 }
 
-/// Reported ids the controller's own record marks terminal. Non-terminal (incl.
-/// Pending mid-dispatch) and unknown ids are spared, so no live job is reclaimed.
+/// Reported ids the controller considers reclaimable; non-terminal (incl.
+/// Pending mid-dispatch) and never-issued ids are spared.
 fn stale_reported_jobs(cluster: &ClusterManager, reported: &[RunningJobStatus]) -> Vec<u32> {
     reported
         .iter()
-        .filter_map(|r| is_still_terminal(cluster, r.job_id).then_some(r.job_id))
+        .filter_map(|r| is_reclaimable(cluster, r.job_id).then_some(r.job_id))
         .collect()
 }
 
@@ -3708,14 +3711,109 @@ mod tests {
         assert_eq!(
             stale,
             vec![12],
-            "only the terminal job is reclaimed; Pending/Running/Completing/Suspended/Preempted/unknown are spared"
+            "terminal is reclaimed; Pending/Running/Completing/Suspended/Preempted spared, and 999 was never issued"
+        );
+    }
+
+    /// GATE: a terminal job aged out of the job map must stay reclaimable, or an
+    /// agent still holding it keeps that allocation forever.
+    #[tokio::test]
+    async fn stale_reported_jobs_reclaims_job_evicted_from_memory() {
+        use crate::raft::StateMachineApply;
+        use spur_core::job::{JobSpec, JobState};
+        use spur_core::wal::WalOperation;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let cluster =
+            Arc::new(crate::cluster::ClusterManager::new(test_slurm_config(), dir.path()).unwrap());
+        let apply = |op: &WalOperation| {
+            <crate::cluster::ClusterManager as StateMachineApply>::apply_operation(
+                cluster.as_ref(),
+                op,
+            );
+        };
+
+        apply(&WalOperation::JobSubmit {
+            job_id: 20,
+            spec: Box::new(JobSpec {
+                name: "evicted".into(),
+                user: "alice".into(),
+                num_nodes: 1,
+                num_tasks: 1,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            }),
+        });
+        apply(&WalOperation::job_state_change(
+            20,
+            JobState::Pending,
+            JobState::Cancelled,
+        ));
+        apply(&WalOperation::EvictTerminalJobs { job_ids: vec![20] });
+
+        assert_eq!(cluster.job_state(20), None, "eviction drops the record");
+        let issued = cluster.peek_next_job_id();
+        assert!(20 < issued, "id 20 was issued by this controller");
+
+        let reported: Vec<RunningJobStatus> = [20, issued, issued + 5]
+            .into_iter()
+            .map(|job_id| RunningJobStatus {
+                job_id,
+                ..Default::default()
+            })
+            .collect();
+
+        assert_eq!(
+            stale_reported_jobs(&cluster, &reported),
+            vec![20],
+            "the evicted id is reclaimed; ids at or above next_job_id were never issued here"
+        );
+    }
+
+    /// Pins a known false positive: an array parent id is consumed but never
+    /// stored, so it reads as reclaimable. Agents only report dispatched tasks.
+    #[tokio::test]
+    async fn reclaimable_reports_true_for_a_consumed_but_unstored_id() {
+        use crate::raft::StateMachineApply;
+        use spur_core::job::JobSpec;
+        use spur_core::wal::WalOperation;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let cluster =
+            Arc::new(crate::cluster::ClusterManager::new(test_slurm_config(), dir.path()).unwrap());
+
+        for task_id in [31, 32] {
+            <crate::cluster::ClusterManager as StateMachineApply>::apply_operation(
+                cluster.as_ref(),
+                &WalOperation::JobSubmit {
+                    job_id: task_id,
+                    spec: Box::new(JobSpec {
+                        name: "array-task".into(),
+                        user: "alice".into(),
+                        num_nodes: 1,
+                        num_tasks: 1,
+                        cpus_per_task: 1,
+                        work_dir: "/tmp".into(),
+                        array_job_id: Some(30),
+                        ..Default::default()
+                    }),
+                },
+            );
+        }
+
+        assert_eq!(cluster.job_state(30), None, "parent id is never stored");
+        assert!(30 < cluster.peek_next_job_id());
+        assert!(
+            is_reclaimable(&cluster, 30),
+            "an unstored id below the watermark is reclaimable — reachable only if an agent reports it"
         );
     }
 
     /// GATE: a job requeued (Timeout -> Pending) between the reclaim snapshot
     /// and the spawned loop's send must fail the re-check, not just the snapshot.
     #[tokio::test]
-    async fn is_still_terminal_false_after_requeue_race() {
+    async fn is_reclaimable_false_after_requeue_race() {
         use crate::raft::StateMachineApply;
         use spur_core::job::{JobSpec, JobState};
         use spur_core::wal::WalOperation;
@@ -3766,7 +3864,7 @@ mod tests {
             JobState::Running,
             JobState::Timeout,
         ));
-        assert!(is_still_terminal(&cluster, 77), "snapshot sees Timeout");
+        assert!(is_reclaimable(&cluster, 77), "snapshot sees Timeout");
 
         // Concurrent requeue lands before the reclaim loop's re-check.
         apply(&WalOperation::job_state_change(
@@ -3776,7 +3874,7 @@ mod tests {
         ));
 
         assert!(
-            !is_still_terminal(&cluster, 77),
+            !is_reclaimable(&cluster, 77),
             "re-check must skip a job requeued since the snapshot"
         );
     }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -250,8 +250,8 @@ impl ControllerService {
                     node = %node,
                     "agent still holds an allocation the controller no longer believes belongs to it there — re-sending cancel to reclaim it"
                 );
-                // Signal 0 = graceful release, no-op on an unknown id. Not
-                // epoch-gated — a requeue racing this send is still possible.
+                // Signal 0 is a no-op on an unknown id, but SIGTERM/SIGKILLs a
+                // live process for the active-elsewhere case. Not epoch-gated.
                 crate::scheduler_loop::cancel_job_on_nodes(
                     &cluster,
                     job_id,

--- a/tests/native_host/e2e/test_deregistration.py
+++ b/tests/native_host/e2e/test_deregistration.py
@@ -181,7 +181,10 @@ class TestAgentSelfDeregistration:
 class TestDownNodeFailsJobs:
     """Verify the bug fix: jobs on downed nodes transition to NODE_FAIL."""
 
-    HB_TIMEOUT = 10
+    # Agents heartbeat every 30s (hardcoded in spurd); a value at or below
+    # that makes a live node's heartbeat look stale to most health ticks and
+    # it never recovers. Keep well above 30s so only a truly dead agent trips it.
+    HB_TIMEOUT = 60
 
     @pytest.fixture
     def cluster_config_overrides(self):
@@ -191,10 +194,11 @@ class TestDownNodeFailsJobs:
         cluster = multi_node_cluster
         node0 = cluster.node_names[0]
 
-        # A freshly-elected leader withholds DOWN-marking for up to two health
-        # ticks (30s each); wait that out so detection below measures normal
-        # operation, not the startup grace window.
-        time.sleep(65)
+        # A freshly-elected leader withholds DOWN-marking until HB_TIMEOUT has
+        # elapsed since leadership was observed, and that observation can miss
+        # the first health tick — wait it out so detection below measures
+        # normal operation, not the startup grace window.
+        time.sleep(2 * self.HB_TIMEOUT)
 
         script = cluster.write_file(
             "down_sleep.sh", "#!/bin/bash\nsleep 600\n"

--- a/tests/native_host/e2e/test_deregistration.py
+++ b/tests/native_host/e2e/test_deregistration.py
@@ -191,6 +191,11 @@ class TestDownNodeFailsJobs:
         cluster = multi_node_cluster
         node0 = cluster.node_names[0]
 
+        # A freshly-elected leader withholds DOWN-marking for up to two health
+        # ticks (30s each); wait that out so detection below measures normal
+        # operation, not the startup grace window.
+        time.sleep(65)
+
         script = cluster.write_file(
             "down_sleep.sh", "#!/bin/bash\nsleep 600\n"
         )


### PR DESCRIPTION
## What this fixes

A node agent can keep holding a job's CPU/GPU reservation after the controller has finished with that run. The node then rejects **every** subsequent GPU dispatch with `controller-allocated GPUs unavailable on this node`, while the controller still believes those devices are free and keeps selecting it. Jobs bounce off it until they exhaust `max_batch_requeue` and are held permanently.

The agent has a launch-path self-heal, but it only releases conflicting owners **absent** from its running map — correct, since releasing a job it believes is alive could double-book live work. The controller-side backstop is the heartbeat reclaim: the agent reports what it holds, and the controller re-sends a cancel for anything it considers finished. That backstop had two holes, fixed here.

**1. A job aged out of the controller's job map was never reclaimed.**

```rust
cluster.job_state(job_id).is_some_and(|s| s.is_terminal())
```

`is_some_and` yields `false` for an id the controller has no record of. Since terminal jobs are aged out of the in-memory map to bound memory, a leaked job eventually reads as *unknown* rather than *finished*, and the cancel was never sent. The longer a leak survived, the less likely it became to ever be reclaimed.

Now an untracked id is reclaimable when it is below the next id this controller would assign. Ids at or above that watermark were never issued here — an agent pointed at a reset or different controller — and stay spared.

**2. A job the controller had restarted on a different node was never reclaimed.**

The predicate reasoned only about job *state*, never about *which node* the job belongs to. When a node is evicted mid-run, the controller requeues the job elsewhere and — correctly, for a node it believes is down — sends no cancel. If that node was in fact alive, it keeps running the job and holding its devices. The job is then `Running` (somewhere else), so the reclaim spared it on the original node forever.

Now an **active** job is releasable by any node absent from its allocation. Only an active job has an authoritative nodelist; a job that has not started yet may be mid-dispatch to the reporting node, so it stays spared. That guard is pinned by its own test.

Observed in production: a controller restart caused a large batch of healthy nodes to be marked DOWN on stale heartbeats within one minute of the new leader taking over. Their jobs were requeued elsewhere while the nodes kept running them. Each affected node was then permanently unable to accept GPU work, with the underlying job visible as `RUNNING` on a different node. Left alone, the strand does not clear: nodes were observed still holding devices more than 24 hours later, across a controller restart and a leader election.

The upstream trigger — a newly elected leader evaluating nodes against heartbeat timestamps that no non-leader could refresh — is a separate defect and is not addressed here.

## Relationship to the dispatch-reject cooldown change

This is the companion to the open PR that cools down a node returning a resources-unavailable rejection [1]. They solve different halves and neither subsumes the other:

- **[1] addresses the rate** — the scheduler stops re-selecting a desynced node every tick, so one bad node cannot hot-loop and starve placement cluster-wide.
- **This PR addresses recovery** — the node actually heals, instead of staying poisoned until someone restarts its agent.

[1]'s own description names this as the follow-up: *"reconciling the controller's allocation view against the node remains a separate follow-up."* With only [1], leaked nodes accumulate quietly and never come back. With only this, a node still hot-loops during the window before its next heartbeat. Recommend landing both.

## Known limitations

Deliberately out of scope here, surfaced by review and left for follow-ups:

- **Controller-side phantom allocations are not addressed.** Nodes can hold `alloc_resources` with no corresponding job, which makes them invisible to the scheduler entirely (they look busy, so no dispatch is ever attempted and no error is logged). That needs a reconcile of the controller's allocation view and is a separate, larger change.
- **A cancel can be sent for an id the controller no longer knows.** This is the deliberate trade: the fix acts on absence rather than treating it as a reason to do nothing. It is safe as long as an id below the watermark is never simultaneously absent from the controller and live on an agent. Two ways that can be violated, both accepted for now:
  - *Raft state wiped while agents keep running.* The watermark restarts at `controller.first_job_id` and climbs; once it passes a still-running pre-wipe id, that job becomes reclaimable and is cancelled. The damage is deferred and non-deterministic — it lands whenever submission volume crosses the old id, not at wipe time. **Operationally: after wiping controller state, recycle the agents before resuming submissions.**
  - *Duplicate ids from the `next_job_id` lost-update race.* `apply_operation` does a non-atomic read-modify-write on the counter while the submit path uses `fetch_add`, so it can regress and reissue an id. Pre-existing, worth filing separately. Note the regression direction is safe for this predicate specifically — a lower watermark only spares more ids, it can never manufacture a reclaim.

  An epoch (`run_attempt`) on the cancel would close in-lifetime id reuse and remove the re-check tautology below, but it would **not** close the wipe case: the agent's reported epoch is its live epoch, so echoing it back proves only that the controller's snapshot is current, not that the job should die. Closing that properly needs a controller-incarnation id, which is a larger change and left as a follow-up.

- **Ids below the watermark were not necessarily issued.** Array parent ids are consumed but never stored, as are ids burned when submission fails after the counter bump. These read as reclaimable. Not reachable today because agents only report dispatched task ids; pinned by a test so the behaviour is explicit rather than accidental.

- **A job aged out while `Preempted` becomes reclaimable.** `is_terminal()` deliberately excludes `Preempted` (it may requeue), but eviction filters on `is_finalized()`, which includes it. Once evicted the id cannot be requeued under that id anyway, so the reclaim targets a run that provably ended.

- **The pre-send re-check is inert for untracked ids.** It exists to catch a requeue landing after the snapshot; an absent id can never un-become absent, so it adds nothing on the new branch. Retained because it still guards the terminal-but-present case.

- **Re-sends are unbounded.** A permanently-reclaimable id produces one signal-0 cancel per heartbeat with no dedup or backoff. A healthy agent drops the id on the first cancel.

- **Controller-side phantom allocations are still not addressed** (see above) — that remains the larger reconcile follow-up.

## Testing

- New unit test drives the real eviction WAL operation and asserts the evicted id is reclaimed while ids at and above the watermark are spared. Verified it fails against the unfixed predicate (`left: []`, expected `[20]`) and passes with it.
- New unit test pins the consumed-but-unstored id behaviour described above.
- Existing requeue-race gate retained and still passing under the rename.
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` clean; `cargo fmt --all --check` clean; 729 `spurctld` tests pass.
- Not exercised on a live cluster: reproducing it faithfully requires an agent whose local allocation table has desynced from the controller, which is impractical to stage deliberately. The failure mode and the fix are established from the production trace above plus the code path.


