### PR TITLE
fix(spur-cli): accept slurm-format reservation durations

### DIFF
--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -236,9 +236,9 @@ pub enum ScontrolCommand {
         /// Start time (ISO 8601 or "now")
         #[arg(long, default_value = "now")]
         start_time: String,
-        /// Duration in minutes
+        /// Duration: whole minutes, Slurm time (H:MM, H:MM:SS, D-HH:MM:SS), or suffixed (90m, 1h30m, 30s)
         #[arg(long)]
-        duration: u32,
+        duration: String,
         /// Comma-separated node names
         #[arg(long)]
         nodes: String,
@@ -258,9 +258,9 @@ pub enum ScontrolCommand {
         /// Reservation name
         #[arg(long)]
         name: String,
-        /// New duration in minutes (0 = no change)
+        /// New duration: whole minutes, Slurm time (01:00:00, 30-00:00:00), or suffixed (90m, 1h30m); any zero-length value (e.g. 0, 00:00:00) leaves it unchanged
         #[arg(long, default_value = "0")]
-        duration: u32,
+        duration: String,
         /// Comma-separated nodes to add
         #[arg(long, default_value = "")]
         add_nodes: String,
@@ -488,6 +488,8 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             users,
             flags,
         } => {
+            crate::privilege::require_privileged("manage reservations")?;
+            let duration = parse_reservation_duration(&duration)?;
             create_reservation(
                 &args.controller,
                 &name,
@@ -512,6 +514,10 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         } => {
             crate::privilege::require_privileged("manage reservations")?;
 
+            // Any zero-length value (default "0", or an explicit "00:00:00" etc.)
+            // resolves to 0, which the controller treats as "leave duration
+            // unchanged"; there is no zero-length reservation to set.
+            let duration = parse_reservation_duration(&duration)?;
             let channel = spur_client::connect_channel(&args.controller)
                 .await
                 .context("failed to connect to spurctld")?;
@@ -1018,11 +1024,24 @@ async fn parse_and_create_partition(controller: &str, params: &[String]) -> Resu
     Ok(())
 }
 
-/// Parse Slurm key=value pairs and call create_reservation.
-async fn parse_and_create_reservation(controller: &str, params: &[String]) -> Result<()> {
+/// Parsed inputs for a Slurm-inline `scontrol create ReservationName=...`.
+#[derive(Debug)]
+struct ReservationCreateParams {
+    name: String,
+    start_time: String,
+    duration_minutes: u32,
+    nodes: String,
+    accounts: String,
+    users: String,
+    flags: String,
+}
+
+/// Pure parse+validate of Slurm key=value pairs, split from the privileged
+/// network call so the required-field and duration rules are unit-testable.
+fn parse_reservation_create_params(params: &[String]) -> Result<ReservationCreateParams> {
     let mut name = String::new();
     let mut start_time = "now".to_string();
-    let mut duration: u32 = 0;
+    let mut duration: Option<String> = None;
     let mut nodes = String::new();
     let mut accounts = String::new();
     let mut users = String::new();
@@ -1033,7 +1052,7 @@ async fn parse_and_create_reservation(controller: &str, params: &[String]) -> Re
             match key.to_lowercase().as_str() {
                 "reservationname" => name = value.into(),
                 "starttime" => start_time = value.into(),
-                "duration" => duration = value.parse().unwrap_or(0),
+                "duration" => duration = Some(value.into()),
                 "nodes" => nodes = value.into(),
                 "accounts" => accounts = value.into(),
                 "users" => users = value.into(),
@@ -1047,15 +1066,36 @@ async fn parse_and_create_reservation(controller: &str, params: &[String]) -> Re
         anyhow::bail!("scontrol create: ReservationName= is required");
     }
 
+    let duration_minutes = match duration {
+        Some(d) => parse_reservation_duration(&d)?,
+        None => anyhow::bail!("scontrol create: Duration= is required"),
+    };
+
+    Ok(ReservationCreateParams {
+        name,
+        start_time,
+        duration_minutes,
+        nodes,
+        accounts,
+        users,
+        flags,
+    })
+}
+
+/// Parse Slurm key=value pairs and call create_reservation.
+async fn parse_and_create_reservation(controller: &str, params: &[String]) -> Result<()> {
+    crate::privilege::require_privileged("manage reservations")?;
+
+    let p = parse_reservation_create_params(params)?;
     create_reservation(
         controller,
-        &name,
-        &start_time,
-        duration,
-        &nodes,
-        &accounts,
-        &users,
-        &flags,
+        &p.name,
+        &p.start_time,
+        p.duration_minutes,
+        &p.nodes,
+        &p.accounts,
+        &p.users,
+        &p.flags,
     )
     .await
 }
@@ -1476,6 +1516,18 @@ async fn reconfigure(controller: &str) -> Result<()> {
     Ok(())
 }
 
+/// Parse a reservation duration into minutes via the shared `--time` grammar
+/// (whole minutes, `HH:MM:SS`, `D-HH:MM:SS`, `90m`); rejects INFINITE. Quirk of
+/// that grammar: a bare `MM:SS` is read as `HH:MM` and bare `days-hours` is
+/// rejected, so prefer the unambiguous colon forms.
+fn parse_reservation_duration(s: &str) -> Result<u32> {
+    spur_core::config::parse_time_minutes(s).ok_or_else(|| {
+        anyhow::anyhow!(
+            "invalid reservation duration '{s}'; use whole minutes, Slurm time (01:00:00, 30-00:00:00), or suffixed (90m, 1h30m)"
+        )
+    })
+}
+
 /// Create a reservation via the controller.
 #[allow(clippy::too_many_arguments)]
 async fn create_reservation(
@@ -1488,7 +1540,11 @@ async fn create_reservation(
     users: &str,
     flags: &str,
 ) -> Result<()> {
-    crate::privilege::require_privileged("manage reservations")?;
+    // Callers gate privilege before parsing so format/privilege errors are
+    // reported in a consistent order; this stays as the last input guard.
+    if duration == 0 {
+        bail!("reservation duration must be positive; e.g. --duration=01:00:00 or Duration=30-00:00:00");
+    }
 
     let channel = spur_client::connect_channel(controller)
         .await
@@ -1726,5 +1782,65 @@ mod tests {
         .await;
         assert!(result.is_err());
         assert!(capture.update_node_names().is_empty());
+    }
+
+    #[test]
+    fn parse_reservation_duration_accepts_minutes_and_slurm_formats() {
+        assert_eq!(parse_reservation_duration("60").unwrap(), 60);
+        assert_eq!(parse_reservation_duration("01:00:00").unwrap(), 60);
+        assert_eq!(
+            parse_reservation_duration("30-00:00:00").unwrap(),
+            30 * 24 * 60
+        );
+        assert_eq!(parse_reservation_duration("90m").unwrap(), 90);
+        // Zero (and any zero-length encoding) is update-reservation's "no
+        // change" sentinel; the create path rejects it via its own guard.
+        assert_eq!(parse_reservation_duration("0").unwrap(), 0);
+        assert_eq!(parse_reservation_duration("00:00:00").unwrap(), 0);
+    }
+
+    #[test]
+    fn parse_reservation_duration_rejects_unparseable() {
+        assert!(parse_reservation_duration("notatime").is_err());
+        assert!(parse_reservation_duration("").is_err());
+        assert!(parse_reservation_duration("1.5h").is_err());
+    }
+
+    #[test]
+    fn parse_reservation_create_params_rejects_bad_duration() {
+        let params = p(&[
+            "ReservationName=r1",
+            "StartTime=now",
+            "Duration=notatime",
+            "Nodes=n1",
+        ]);
+        let err = parse_reservation_create_params(&params).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid reservation duration"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_reservation_create_params_requires_duration() {
+        let params = p(&["ReservationName=r1", "StartTime=now", "Nodes=n1"]);
+        let err = parse_reservation_create_params(&params).unwrap_err();
+        assert!(
+            err.to_string().contains("Duration= is required"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_reservation_create_params_accepts_slurm_duration() {
+        let params = p(&[
+            "ReservationName=r1",
+            "StartTime=now",
+            "Duration=30-00:00:00",
+            "Nodes=n1",
+        ]);
+        let parsed = parse_reservation_create_params(&params).unwrap();
+        assert_eq!(parsed.name, "r1");
+        assert_eq!(parsed.duration_minutes, 30 * 24 * 60);
     }
 }

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -236,7 +236,7 @@ pub enum ScontrolCommand {
         /// Start time (ISO 8601 or "now")
         #[arg(long, default_value = "now")]
         start_time: String,
-        /// Duration: whole minutes, Slurm time (H:MM, H:MM:SS, D-HH:MM:SS), or suffixed (90m, 1h30m, 30s)
+        /// Duration: whole minutes, Slurm time (H:MM, H:MM:SS, D-HH:MM:SS), or suffixed (90m, 1h30m, 30s); UNLIMITED/INFINITE not supported
         #[arg(long)]
         duration: String,
         /// Comma-separated node names
@@ -258,7 +258,7 @@ pub enum ScontrolCommand {
         /// Reservation name
         #[arg(long)]
         name: String,
-        /// New duration: whole minutes, Slurm time (01:00:00, 30-00:00:00), or suffixed (90m, 1h30m); any zero-length value (e.g. 0, 00:00:00) leaves it unchanged
+        /// New duration: whole minutes, Slurm time (01:00:00, 30-00:00:00), or suffixed (90m, 1h30m); any zero-length value (e.g. 0, 00:00:00) leaves it unchanged; UNLIMITED/INFINITE not supported
         #[arg(long, default_value = "0")]
         duration: String,
         /// Comma-separated nodes to add
@@ -1523,7 +1523,7 @@ async fn reconfigure(controller: &str) -> Result<()> {
 fn parse_reservation_duration(s: &str) -> Result<u32> {
     spur_core::config::parse_time_minutes(s).ok_or_else(|| {
         anyhow::anyhow!(
-            "invalid reservation duration '{s}'; use whole minutes, Slurm time (01:00:00, 30-00:00:00), or suffixed (90m, 1h30m)"
+            "invalid reservation duration '{s}'; use whole minutes, Slurm time (01:00:00, 30-00:00:00), or suffixed (90m, 1h30m); UNLIMITED/INFINITE not supported"
         )
     })
 }
@@ -1540,8 +1540,7 @@ async fn create_reservation(
     users: &str,
     flags: &str,
 ) -> Result<()> {
-    // Callers gate privilege before parsing so format/privilege errors are
-    // reported in a consistent order; this stays as the last input guard.
+    // Privilege is gated by callers; this is the last input guard.
     if duration == 0 {
         bail!("reservation duration must be positive; e.g. --duration=01:00:00 or Duration=30-00:00:00");
     }
@@ -1804,6 +1803,14 @@ mod tests {
         assert!(parse_reservation_duration("notatime").is_err());
         assert!(parse_reservation_duration("").is_err());
         assert!(parse_reservation_duration("1.5h").is_err());
+    }
+
+    #[test]
+    fn parse_reservation_duration_rejects_unbounded() {
+        // Reservations store a concrete end_time, so there is no unbounded
+        // representation; UNLIMITED/INFINITE are rejected, not silently mapped.
+        assert!(parse_reservation_duration("UNLIMITED").is_err());
+        assert!(parse_reservation_duration("INFINITE").is_err());
     }
 
     #[test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3519,6 +3519,11 @@ impl ClusterManager {
 
     /// Create a new reservation (validated, persisted via Raft).
     pub fn create_reservation(&self, mut res: Reservation) -> Result<(), ReservationError> {
+        if res.end_time <= res.start_time {
+            return Err(ReservationError::invalid(
+                "reservation duration must be positive",
+            ));
+        }
         if self.reservations.read().iter().any(|r| r.name == res.name) {
             return Err(ReservationError::already_exists(format!(
                 "reservation '{}' already exists",
@@ -3581,6 +3586,14 @@ impl ClusterManager {
         if duration_minutes > 0 {
             preview.end_time =
                 preview.start_time + chrono::Duration::minutes(duration_minutes as i64);
+        }
+        // Unreachable today (start_time is immutable and create rejects zero
+        // spans), but guard explicitly so a future editable start_time can't
+        // silently reintroduce a zero-length, instantly-purged reservation.
+        if preview.end_time <= preview.start_time {
+            return Err(ReservationError::invalid(
+                "reservation duration must be positive",
+            ));
         }
         let known: std::collections::HashSet<String> = self.nodes.read().keys().cloned().collect();
         let mut add_expanded = Vec::new();
@@ -11755,6 +11768,38 @@ mod tests {
         assert!(
             cm.get_reservations().is_empty(),
             "owner delete must succeed"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_reservation_rejects_non_positive_span() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let now = chrono::Utc::now();
+
+        // A zero-length span (duration 0) would be created but is immediately
+        // expired, so the scheduler purge loop would drop it before it is ever
+        // visible. Reject it up front instead.
+        let err = cm
+            .create_reservation(Reservation {
+                name: "zero".into(),
+                start_time: now,
+                end_time: now,
+                nodes: vec!["n1".into()],
+                accounts: Vec::new(),
+                users: Vec::new(),
+                flags: Default::default(),
+                owner: "root".into(),
+            })
+            .unwrap_err();
+        assert!(
+            matches!(err, ReservationError::InvalidArgument(_)),
+            "zero-length reservation must be rejected, got {err:?}"
+        );
+        assert!(
+            cm.get_reservations().is_empty(),
+            "rejected reservation must not persist"
         );
     }
 

--- a/tests/native_host/e2e/test_reservations.py
+++ b/tests/native_host/e2e/test_reservations.py
@@ -358,6 +358,134 @@ class TestReservations:
             # A leaked reservation fences a node for an hour; best-effort cleanup.
             cluster.cli_as_user("root", ["scontrol", "delete-reservation", res_name])
 
+    def test_reservation_duration_formats(self, cluster):
+        """Duration accepts whole minutes and Slurm time (HH:MM:SS, D-HH:MM:SS)
+        via both the subcommand and inline syntax. A positive duration must
+        survive the scheduler's expired-reservation purge; an unparseable, zero,
+        or omitted duration is rejected up front, not silently created then
+        purged (SPUR-182)."""
+        node = cluster.node_names[0]
+
+        def create(name, kind, duration):
+            if kind == "subcommand":
+                args = [
+                    "scontrol",
+                    "create-reservation",
+                    f"--name={name}",
+                    "--start-time=now",
+                    f"--duration={duration}",
+                    f"--nodes={node}",
+                    "--flags=ignore_jobs",
+                ]
+            else:
+                args = [
+                    "scontrol",
+                    "create",
+                    f"ReservationName={name}",
+                    "StartTime=now",
+                    f"Duration={duration}",
+                    f"Nodes={node}",
+                    "Flags=IGNORE_JOBS",
+                ]
+            return cluster.cli_as_user("root", args)
+
+        def classify(name):
+            # Exit code alone can't tell a definitive "not found" from a
+            # transient error (both non-zero), so match the message; that lets
+            # callers retry hiccups instead of misreading them as a purge.
+            out = cluster.cli_allow_fail(["scontrol", "show", "reservation", name])
+            if f"ReservationName={name}" in out:
+                return "present"
+            if f"Reservation {name} not found" in out:
+                return "absent"
+            return "error"
+
+        def assert_survives_purge(name, window=5.0, step=0.5):
+            # Must stay listed across a purge cycle (~1s): fail on a definitive
+            # "not found", tolerate transient errors, and require one real
+            # sighting so a run of errors can't pass vacuously.
+            deadline = time.time() + window
+            seen = False
+            while time.time() < deadline:
+                state = classify(name)
+                if state == "present":
+                    seen = True
+                elif state == "absent":
+                    raise AssertionError(f"reservation {name} was purged unexpectedly")
+                time.sleep(step)
+            assert seen, f"reservation {name} was never observed present within {window}s"
+
+        def assert_never_created(name, window=3.0, step=0.5):
+            # A rejected create must leave nothing: require a definitive "not
+            # found", retrying past transient errors; fail if it ever appears.
+            deadline = time.time() + window
+            confirmed_absent = False
+            while time.time() < deadline:
+                state = classify(name)
+                if state == "present":
+                    raise AssertionError(f"reservation {name} must not have been created")
+                if state == "absent":
+                    confirmed_absent = True
+                    break
+                time.sleep(step)
+            assert confirmed_absent, f"could not confirm reservation {name} absent within {window}s"
+
+        # Positive durations across both entry points and all accepted formats.
+        # 30-00:00:00 is the exact reported case (30 days).
+        valid_cases = [
+            ("subcommand", "30-00:00:00"),
+            ("inline", "30-00:00:00"),
+            ("inline", "01:00:00"),
+            ("subcommand", "60"),
+        ]
+        for idx, (kind, duration) in enumerate(valid_cases):
+            name = f"res-dur-{idx}-{int(time.time())}"
+            try:
+                out = create(name, kind, duration)
+                assert "created" in out.lower(), f"{kind} {duration} create failed: {out}"
+                assert_survives_purge(name)
+            finally:
+                cluster.cli_as_user("root", ["scontrol", "delete-reservation", name])
+
+        # Unique names keep an unexpectedly-successful case isolated (no
+        # cascading "already exists") and cleaned up on its own.
+        rejection_cases = [
+            ("subcommand", "notatime"),
+            ("inline", "notatime"),
+            ("subcommand", "0"),
+            ("inline", "0"),
+        ]
+        for idx, (kind, duration) in enumerate(rejection_cases):
+            name = f"res-dur-rej-{idx}-{int(time.time())}"
+            try:
+                out = create(name, kind, duration)
+                assert "created" not in out.lower(), f"{kind} {duration} should be rejected: {out}"
+                assert_never_created(name)
+            finally:
+                # Defensive cleanup if a bug let the create through; a leaked
+                # reservation fences a node.
+                cluster.cli_as_user("root", ["scontrol", "delete-reservation", name])
+
+        # Omitting Duration in the inline path is rejected too.
+        omit_name = f"res-dur-omit-{int(time.time())}"
+        try:
+            omit_out = cluster.cli_as_user(
+                "root",
+                [
+                    "scontrol",
+                    "create",
+                    f"ReservationName={omit_name}",
+                    "StartTime=now",
+                    f"Nodes={node}",
+                ],
+            )
+            assert "created" not in omit_out.lower(), (
+                f"omitted duration should be rejected: {omit_out}"
+            )
+            assert_never_created(omit_name)
+        finally:
+            cluster.cli_as_user("root", ["scontrol", "delete-reservation", omit_name])
+
     def test_non_owner_cannot_delete_or_update_reservation(self, cluster):
         """A reservation is owned by its creator; a different user must not be
         able to delete or update it, but the owner still can. Exercises the


### PR DESCRIPTION
Reservation duration was parsed as a raw integer with a silent `unwrap_or(0)` fallback (and `--duration` was a `u32`), so a Slurm-style value like `Duration=30-00:00:00`, or an omitted duration, became 0 minutes. That yields `end_time == start_time`, so the reservation was created but immediately expired and purged by the scheduler within a cycle -- invisible in `scontrol show reservation` and `sinfo` (SPUR-182).

Parse reservation duration through the shared `parse_time_minutes` grammar (whole minutes, HH:MM:SS, D-HH:MM:SS, 90m), matching the `--time` flag on sbatch/srun/salloc; `--duration` becomes a String (backward compatible: `60` still means 60 minutes). Reject a non-positive span in the controller's create/update reservation paths as defense-in-depth for CLI/REST/FFI.

Tested with cargo clippy (no warnings), cargo test (new cluster + CLI unit tests), and a new e2e case covering both entry points, all accepted formats, purge survival, and invalid/zero/omitted rejection.