### PR TITLE
fix(spur-core): ignore quoted srun tokens in batch step detection

### DIFF
--- a/crates/spur-core/src/task_launch.rs
+++ b/crates/spur-core/src/task_launch.rs
@@ -18,77 +18,69 @@ static STEP_LAUNCH_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?:^|[\s;&|])(?:/.*/)?(srun|mpirun|mpiexec)\b").expect("valid step-launch regex")
 });
 
-/// Split a shell line into spans outside single/double quotes. Stops at an
-/// unquoted `#` (inline comment). Used to avoid treating launcher names inside
-/// string literals as real invocations.
-fn unquoted_shell_segments(line: &str) -> Vec<&str> {
-    let mut segments = Vec::new();
-    let mut segment_start = 0;
-    let mut i = 0;
+/// Placeholder for a quoted span when sanitizing a line for step-launcher detection.
+/// Must not be whitespace or a shell command separator so word adjacency is preserved.
+const QUOTED_SPAN_PLACEHOLDER: char = 'x';
+
+fn hash_starts_shell_comment(line: &str, hash_index: usize) -> bool {
+    if hash_index == 0 {
+        return true;
+    }
+    let prev = line.as_bytes()[hash_index - 1] as char;
+    matches!(prev, ' ' | '\t' | ';' | '&' | '|' | '(' | ')')
+}
+
+/// Build a sanitized copy of a shell line for step-launcher regex matching: quoted
+/// spans collapse to a single placeholder (preserving adjacency with neighbors),
+/// and `#` starts a comment only at a word boundary.
+fn sanitize_shell_line_for_step_launch(line: &str) -> String {
+    let mut sanitized = String::with_capacity(line.len());
     let bytes = line.as_bytes();
+    let mut i = 0;
     let mut in_single = false;
     let mut in_double = false;
     let mut escaped = false;
 
     while i < bytes.len() {
         let c = bytes[i] as char;
-        if escaped {
-            escaped = false;
-            i += 1;
-            continue;
-        }
         if in_single {
             if c == '\'' {
                 in_single = false;
-                segment_start = i + 1;
+                sanitized.push(QUOTED_SPAN_PLACEHOLDER);
             }
             i += 1;
             continue;
         }
         if in_double {
-            if c == '\\' {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
                 escaped = true;
             } else if c == '"' {
                 in_double = false;
-                segment_start = i + 1;
+                sanitized.push(QUOTED_SPAN_PLACEHOLDER);
             }
             i += 1;
             continue;
         }
         if c == '\'' {
-            if segment_start < i {
-                segments.push(&line[segment_start..i]);
-            }
-            segment_start = i + 1;
             in_single = true;
             i += 1;
             continue;
         }
         if c == '"' {
-            if segment_start < i {
-                segments.push(&line[segment_start..i]);
-            }
-            segment_start = i + 1;
             in_double = true;
             i += 1;
             continue;
         }
-        if c == '#' {
-            if segment_start < i {
-                segments.push(&line[segment_start..i]);
-            }
-            return segments;
+        if c == '#' && hash_starts_shell_comment(line, i) {
+            break;
         }
-        if c == '\\' {
-            escaped = true;
-        }
+        sanitized.push(c);
         i += 1;
     }
 
-    if !in_single && !in_double && segment_start < line.len() {
-        segments.push(&line[segment_start..]);
-    }
-    segments
+    sanitized
 }
 
 /// True when a batch script delegates rank fan-out to an inner step launcher.
@@ -98,10 +90,9 @@ pub fn batch_script_uses_step_launch(script: &str) -> bool {
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
-        for segment in unquoted_shell_segments(trimmed) {
-            if STEP_LAUNCH_RE.is_match(segment.trim()) {
-                return true;
-            }
+        let sanitized = sanitize_shell_line_for_step_launch(trimmed);
+        if STEP_LAUNCH_RE.is_match(sanitized.trim()) {
+            return true;
         }
     }
     false
@@ -807,6 +798,17 @@ mod tests {
         ));
         assert!(batch_script_uses_step_launch(
             "srun hostname # real invocation, srun in comment ignored\n",
+        ));
+        assert!(!batch_script_uses_step_launch("echo \"x\"srun\n"));
+        assert!(!batch_script_uses_step_launch("foo|\"x\"srun\n"));
+        assert!(!batch_script_uses_step_launch("\"$VAR\"srun\n"));
+        assert!(batch_script_uses_step_launch(
+            "echo foo#bar; srun -n 2 hostname\n"
+        ));
+        assert!(!batch_script_uses_step_launch("echo ${VAR#prefix}\n"));
+        // Unclosed quotes: remainder of line is treated as quoted; not full shell parsing.
+        assert!(!batch_script_uses_step_launch(
+            "echo \"unclosed; srun -n 2 hostname\n"
         ));
     }
 

--- a/crates/spur-core/src/task_launch.rs
+++ b/crates/spur-core/src/task_launch.rs
@@ -18,6 +18,79 @@ static STEP_LAUNCH_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?:^|[\s;&|])(?:/.*/)?(srun|mpirun|mpiexec)\b").expect("valid step-launch regex")
 });
 
+/// Split a shell line into spans outside single/double quotes. Stops at an
+/// unquoted `#` (inline comment). Used to avoid treating launcher names inside
+/// string literals as real invocations.
+fn unquoted_shell_segments(line: &str) -> Vec<&str> {
+    let mut segments = Vec::new();
+    let mut segment_start = 0;
+    let mut i = 0;
+    let bytes = line.as_bytes();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if escaped {
+            escaped = false;
+            i += 1;
+            continue;
+        }
+        if in_single {
+            if c == '\'' {
+                in_single = false;
+                segment_start = i + 1;
+            }
+            i += 1;
+            continue;
+        }
+        if in_double {
+            if c == '\\' {
+                escaped = true;
+            } else if c == '"' {
+                in_double = false;
+                segment_start = i + 1;
+            }
+            i += 1;
+            continue;
+        }
+        if c == '\'' {
+            if segment_start < i {
+                segments.push(&line[segment_start..i]);
+            }
+            segment_start = i + 1;
+            in_single = true;
+            i += 1;
+            continue;
+        }
+        if c == '"' {
+            if segment_start < i {
+                segments.push(&line[segment_start..i]);
+            }
+            segment_start = i + 1;
+            in_double = true;
+            i += 1;
+            continue;
+        }
+        if c == '#' {
+            if segment_start < i {
+                segments.push(&line[segment_start..i]);
+            }
+            return segments;
+        }
+        if c == '\\' {
+            escaped = true;
+        }
+        i += 1;
+    }
+
+    if !in_single && !in_double && segment_start < line.len() {
+        segments.push(&line[segment_start..]);
+    }
+    segments
+}
+
 /// True when a batch script delegates rank fan-out to an inner step launcher.
 pub fn batch_script_uses_step_launch(script: &str) -> bool {
     for line in script.lines() {
@@ -25,8 +98,10 @@ pub fn batch_script_uses_step_launch(script: &str) -> bool {
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
-        if STEP_LAUNCH_RE.is_match(trimmed) {
-            return true;
+        for segment in unquoted_shell_segments(trimmed) {
+            if STEP_LAUNCH_RE.is_match(segment.trim()) {
+                return true;
+            }
         }
     }
     false
@@ -711,6 +786,28 @@ mod tests {
             "#SBATCH --mpi=pmix\n/tmp/a\n"
         ));
         assert!(!batch_script_uses_step_launch("# srun hidden in comment\n"));
+    }
+
+    #[test]
+    fn batch_script_uses_step_launch_ignores_launchers_in_quotes() {
+        assert!(!batch_script_uses_step_launch(
+            "echo \"this job launches no steps, but the word srun appears in this string\"\n",
+        ));
+        assert!(!batch_script_uses_step_launch(
+            "echo \"token=use srun here\"\n"
+        ));
+        assert!(!batch_script_uses_step_launch(
+            "echo \"token=prefixsrunsuffix\"\n"
+        ));
+        assert!(!batch_script_uses_step_launch(
+            "echo 'srun is only in single quotes'\n"
+        ));
+        assert!(batch_script_uses_step_launch(
+            "echo \"quoted\"; srun -n 2 hostname\n"
+        ));
+        assert!(batch_script_uses_step_launch(
+            "srun hostname # real invocation, srun in comment ignored\n",
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #625

## Summary

Multi-node `sbatch` jobs could run the user script on the primary node only when the batch script contained the standalone word `srun` inside a quoted string (e.g. `echo "token=use srun here"`). Secondary nodes were replaced with the companion hold loop from the inner-`srun` PMIx path (#561), then SIGTERM'd when the primary finished.

`batch_script_uses_step_launch()` matched launcher tokens with a line-level regex and did not respect shell quoting. This change scans only **unquoted** segments of each script line before applying the existing `(srun|mpirun|mpiexec)` pattern.

## Approach

- Add `unquoted_shell_segments()` — tracks single/double quotes, `\` escapes in doubles, and stops at unquoted `#` comments.
- Run `STEP_LAUNCH_RE` on each unquoted segment instead of the full line.
- Add unit tests, substring tokens (`prefixsrunsuffix`), and real `srun` invocations still detected.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`
- [x] `cargo test --locked`
- [x] Manual repro on Crusoe (v0.8.0 bisect): quoted `srun` triggers bug; real `srun -n 2` still works as intended