### PR TITLE
feat(spur-cli): filter squeue by node with -w/--nodelist

### DIFF
--- a/crates/spur-cli/src/scancel.rs
+++ b/crates/spur-cli/src/scancel.rs
@@ -113,6 +113,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 account: args.account.unwrap_or_default(),
                 job_ids: Vec::new(),
                 name: args.name.unwrap_or_default(),
+                nodes: Vec::new(),
             })
             .await
             .context("failed to get jobs")?;

--- a/crates/spur-cli/src/sprio.rs
+++ b/crates/spur-cli/src/sprio.rs
@@ -66,6 +66,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             account: String::new(),
             job_ids,
             name: String::new(),
+            nodes: Vec::new(),
         })
         .await
         .context("failed to get jobs")?;

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -41,6 +41,10 @@ pub struct SqueueArgs {
     #[arg(short = 'n', long)]
     pub name: Option<String>,
 
+    /// Show only jobs allocated on these nodes (hostlist expression)
+    #[arg(short = 'w', long = "nodelist")]
+    pub nodelist: Option<String>,
+
     /// Output format string
     #[arg(short = 'o', long)]
     pub format: Option<String>,
@@ -112,6 +116,13 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         })
         .unwrap_or_default();
 
+    // Expand the -w node filter before any network I/O so a bad hostlist
+    // surfaces its own error rather than a downstream connect failure.
+    let nodes = match args.nodelist.as_deref() {
+        Some(s) => expand_node_filter(s)?,
+        None => Vec::new(),
+    };
+
     // Connect and fetch
     let channel = spur_client::connect_channel(&args.controller)
         .await
@@ -126,6 +137,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             account: args.account.unwrap_or_default(),
             job_ids,
             name: args.name.unwrap_or_default(),
+            nodes,
         })
         .await
         .context("failed to get jobs")?;
@@ -369,6 +381,23 @@ fn parse_states_arg(s: &str) -> Result<Vec<spur_proto::proto::JobState>> {
     Ok(states)
 }
 
+/// Expand `-w` / `--nodelist` into concrete node names. Accepts every Slurm
+/// hostlist form (`node1,node2`, `node[001-003]`, `node[1,3,5-7]`,
+/// `gpu[01-04],cpu[01-02]`). An empty or whitespace-only value is rejected
+/// rather than sent as a filter that would silently match nothing.
+fn expand_node_filter(s: &str) -> Result<Vec<String>> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("Invalid node name specified: (empty)");
+    }
+    let nodes = spur_core::hostlist::expand(trimmed)
+        .map_err(|e| anyhow::anyhow!("Invalid node name specified: {e}"))?;
+    if nodes.is_empty() {
+        anyhow::bail!("Invalid node name specified: {trimmed}");
+    }
+    Ok(nodes)
+}
+
 fn format_runtime(job: &spur_proto::proto::JobInfo) -> String {
     if let Some(ref rt) = job.run_time {
         format_duration_hms(rt.seconds)
@@ -445,6 +474,41 @@ mod tests {
         assert!(states.contains(&P::JobRunning));
         assert!(states.contains(&P::JobSuspended));
         assert!(states.contains(&P::JobCompleting));
+    }
+
+    #[test]
+    fn expand_node_filter_plain_comma_list() {
+        assert_eq!(
+            expand_node_filter("node1,node2").unwrap(),
+            ["node1", "node2"]
+        );
+    }
+
+    #[test]
+    fn expand_node_filter_compacted_range_preserves_padding() {
+        assert_eq!(
+            expand_node_filter("node[001-003]").unwrap(),
+            ["node001", "node002", "node003"]
+        );
+    }
+
+    #[test]
+    fn expand_node_filter_mixed_and_multi_term() {
+        assert_eq!(
+            expand_node_filter("node[1,3,5-7]").unwrap(),
+            ["node1", "node3", "node5", "node6", "node7"]
+        );
+        assert_eq!(
+            expand_node_filter("gpu[01-04],cpu[01-02]").unwrap(),
+            ["gpu01", "gpu02", "gpu03", "gpu04", "cpu01", "cpu02"]
+        );
+    }
+
+    #[test]
+    fn expand_node_filter_rejects_empty_and_invalid() {
+        assert!(expand_node_filter("").is_err());
+        assert!(expand_node_filter("   ").is_err());
+        assert!(expand_node_filter("node[1-").is_err());
     }
 
     #[test]

--- a/crates/spurctld/src/accounting/reconcile.rs
+++ b/crates/spurctld/src/accounting/reconcile.rs
@@ -11,7 +11,7 @@ use tracing::{error, info, warn};
 
 use spur_core::job::{Job, JobId, JobState};
 
-use crate::cluster::ClusterManager;
+use crate::cluster::{ClusterManager, JobFilter};
 use crate::raft::RaftHandle;
 
 use super::db::{self, AccountingRowState};
@@ -54,7 +54,7 @@ pub fn spawn_loop(
 /// not candidates.
 async fn run_once(pool: &PgPool, cluster: &ClusterManager) {
     let candidates: Vec<Job> = cluster
-        .get_jobs(&[], None, None, None, None, &[])
+        .get_jobs(&JobFilter::default())
         .into_iter()
         .filter(|j| j.start_time.is_some())
         .collect();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1005,15 +1005,20 @@ impl ClusterManager {
 
     /// Get jobs matching filters.
     pub fn get_jobs(&self, filter: &JobFilter) -> Vec<Job> {
+        // Built once per call so the per-job node check is O(allocated_nodes)
+        // rather than O(allocated_nodes * filter.nodes) for large hostlists.
+        let node_set: std::collections::HashSet<&str> =
+            filter.nodes.iter().map(String::as_str).collect();
+
         let matches = |j: &Job| -> bool {
             if !filter.states.is_empty() && !filter.states.contains(&j.state) {
                 return false;
             }
-            if !filter.nodes.is_empty()
+            if !node_set.is_empty()
                 && !j
                     .allocated_nodes
                     .iter()
-                    .any(|n| filter.nodes.iter().any(|f| f == n))
+                    .any(|n| node_set.contains(n.as_str()))
             {
                 return false;
             }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -420,6 +420,22 @@ struct PendingJobCandidate {
     tag_reason: bool,
 }
 
+/// Filters for [`ClusterManager::get_jobs`]. Every field is optional: an empty
+/// slice or `None` disables that dimension, so `JobFilter::default()` returns
+/// all jobs.
+#[derive(Debug, Default, Clone)]
+pub struct JobFilter<'a> {
+    pub states: &'a [JobState],
+    pub user: Option<&'a str>,
+    pub partition: Option<&'a str>,
+    pub account: Option<&'a str>,
+    pub name: Option<&'a str>,
+    pub job_ids: &'a [JobId],
+    /// Concrete node names (already hostlist-expanded); keeps only jobs
+    /// allocated on at least one of them.
+    pub nodes: &'a [String],
+}
+
 impl ClusterManager {
     #[cfg(test)]
     pub fn new(config: SlurmConfig, state_dir: &Path) -> anyhow::Result<Self> {
@@ -988,35 +1004,35 @@ impl ClusterManager {
     }
 
     /// Get jobs matching filters.
-    pub fn get_jobs(
-        &self,
-        states: &[JobState],
-        user: Option<&str>,
-        partition: Option<&str>,
-        account: Option<&str>,
-        name: Option<&str>,
-        job_ids: &[JobId],
-    ) -> Vec<Job> {
+    pub fn get_jobs(&self, filter: &JobFilter) -> Vec<Job> {
         let matches = |j: &Job| -> bool {
-            if !states.is_empty() && !states.contains(&j.state) {
+            if !filter.states.is_empty() && !filter.states.contains(&j.state) {
                 return false;
             }
-            if let Some(u) = user {
+            if !filter.nodes.is_empty()
+                && !j
+                    .allocated_nodes
+                    .iter()
+                    .any(|n| filter.nodes.iter().any(|f| f == n))
+            {
+                return false;
+            }
+            if let Some(u) = filter.user {
                 if !u.is_empty() && j.spec.user != u {
                     return false;
                 }
             }
-            if let Some(p) = partition {
+            if let Some(p) = filter.partition {
                 if !p.is_empty() && j.spec.partition.as_deref() != Some(p) {
                     return false;
                 }
             }
-            if let Some(a) = account {
+            if let Some(a) = filter.account {
                 if !a.is_empty() && j.spec.account.as_deref() != Some(a) {
                     return false;
                 }
             }
-            if let Some(n) = name {
+            if let Some(n) = filter.name {
                 if !n.is_empty() && !n.split(',').any(|pat| pat.trim() == j.spec.name) {
                     return false;
                 }
@@ -1028,7 +1044,7 @@ impl ClusterManager {
             let jobs = self.jobs.read();
             jobs.values()
                 .filter(|j| {
-                    if !job_ids.is_empty() && !job_ids.contains(&j.job_id) {
+                    if !filter.job_ids.is_empty() && !filter.job_ids.contains(&j.job_id) {
                         return false;
                     }
                     matches(j)
@@ -1039,8 +1055,8 @@ impl ClusterManager {
 
         // Requested ids with no stored job may be array parents — synthesize
         // their aggregate. Read lock above is released before get_job_for_display.
-        if !job_ids.is_empty() {
-            for &id in job_ids {
+        if !filter.job_ids.is_empty() {
+            for &id in filter.job_ids {
                 if result.iter().any(|j| j.job_id == id) {
                     continue;
                 }
@@ -7955,14 +7971,10 @@ mod tests {
         cm.suspend_job(id, "testuser").unwrap();
         settle(&cm, id, JobState::Suspended);
 
-        let scanned = cm.get_jobs(
-            &[JobState::Running, JobState::Completing],
-            None,
-            None,
-            None,
-            None,
-            &[],
-        );
+        let scanned = cm.get_jobs(&JobFilter {
+            states: &[JobState::Running, JobState::Completing],
+            ..Default::default()
+        });
         assert!(
             !scanned.iter().any(|j| j.job_id == id),
             "suspended job must not appear in the enforcer's Running/Completing scan"
@@ -9176,8 +9188,7 @@ mod tests {
         assert_eq!(m.running_cpus, 0);
 
         // Snapshot matches a full scan of the job map.
-        let expected =
-            JobMetricsSnapshot::collect(cm.get_jobs(&[], None, None, None, None, &[]).iter());
+        let expected = JobMetricsSnapshot::collect(cm.get_jobs(&JobFilter::default()).iter());
         assert_eq!(cm.job_metrics(), expected);
     }
 
@@ -16622,19 +16633,30 @@ mod tests {
         submit_array_task(&cm, 12, 10, 1);
 
         // Query the parent id explicitly.
-        let got = cm.get_jobs(&[], None, None, None, None, &[10]);
+        let got = cm.get_jobs(&JobFilter {
+            job_ids: &[10],
+            ..Default::default()
+        });
         assert_eq!(got.len(), 1, "parent id should synthesize one record");
         assert_eq!(got[0].job_id, 10);
         assert_eq!(got[0].state, JobState::Pending);
         assert_eq!(got[0].spec.array_job_id, Some(10));
 
         // Querying a real task id still returns that task, not the parent.
-        let got_task = cm.get_jobs(&[], None, None, None, None, &[11]);
+        let got_task = cm.get_jobs(&JobFilter {
+            job_ids: &[11],
+            ..Default::default()
+        });
         assert_eq!(got_task.len(), 1);
         assert_eq!(got_task[0].job_id, 11);
 
         // Unknown id → empty.
-        assert!(cm.get_jobs(&[], None, None, None, None, &[999]).is_empty());
+        assert!(cm
+            .get_jobs(&JobFilter {
+                job_ids: &[999],
+                ..Default::default()
+            })
+            .is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -16646,24 +16668,90 @@ mod tests {
         submit_and_wait(&cm, basic_spec("beta"));
         submit_and_wait(&cm, basic_spec("alpha"));
 
-        let all = cm.get_jobs(&[], None, None, None, None, &[]);
+        let by_name = |name: Option<&str>| {
+            cm.get_jobs(&JobFilter {
+                name,
+                ..Default::default()
+            })
+        };
+
+        let all = by_name(None);
         assert_eq!(all.len(), 3);
 
-        let alphas = cm.get_jobs(&[], None, None, None, Some("alpha"), &[]);
+        let alphas = by_name(Some("alpha"));
         assert_eq!(alphas.len(), 2);
         assert!(alphas.iter().all(|j| j.spec.name == "alpha"));
 
-        let betas = cm.get_jobs(&[], None, None, None, Some("beta"), &[]);
+        let betas = by_name(Some("beta"));
         assert_eq!(betas.len(), 1);
 
-        let multi = cm.get_jobs(&[], None, None, None, Some("alpha,beta"), &[]);
+        let multi = by_name(Some("alpha,beta"));
         assert_eq!(multi.len(), 3);
 
-        let none = cm.get_jobs(&[], None, None, None, Some("nonexistent"), &[]);
+        let none = by_name(Some("nonexistent"));
         assert!(none.is_empty());
 
-        let empty = cm.get_jobs(&[], None, None, None, Some(""), &[]);
+        let empty = by_name(Some(""));
         assert_eq!(empty.len(), 3);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_jobs_filters_by_node() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        register_node(&cm, "n2", 8, 16000);
+        let res = scalar_alloc(2, 4000);
+
+        let id1 = submit_and_wait(&cm, basic_spec("on-n1"));
+        cm.start_job(
+            id1,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res.clone()),
+        )
+        .unwrap();
+        settle(&cm, id1, JobState::Running);
+
+        let id2 = submit_and_wait(&cm, basic_spec("on-n2"));
+        cm.start_job(
+            id2,
+            vec!["n2".into()],
+            res.clone(),
+            per_node_for(&["n2"], res.clone()),
+        )
+        .unwrap();
+        settle(&cm, id2, JobState::Running);
+
+        // Pending job has no allocated nodes and must never match a node filter.
+        let id3 = submit_and_wait(&cm, basic_spec("pending"));
+
+        let by_nodes = |nodes: &[String]| {
+            cm.get_jobs(&JobFilter {
+                nodes,
+                ..Default::default()
+            })
+        };
+
+        // Empty node filter is a no-op.
+        assert_eq!(cm.get_jobs(&JobFilter::default()).len(), 3);
+
+        let on_n1 = by_nodes(&["n1".to_string()]);
+        assert_eq!(on_n1.len(), 1);
+        assert_eq!(on_n1[0].job_id, id1);
+
+        // Filtering by n2 excludes the running n1 job and the pending job.
+        let on_n2 = by_nodes(&["n2".to_string()]);
+        assert_eq!(on_n2.len(), 1);
+        assert_eq!(on_n2[0].job_id, id2);
+
+        // Union of both nodes returns both running jobs, never the pending one.
+        let both = by_nodes(&["n1".to_string(), "n2".to_string()]);
+        assert_eq!(both.len(), 2);
+        assert!(!both.iter().any(|j| j.job_id == id3));
+
+        // Unknown node matches nothing.
+        assert!(by_nodes(&["n3".to_string()]).is_empty());
     }
 
     // --- Partition matching tests ---

--- a/crates/spurctld/src/rest/handlers.rs
+++ b/crates/spurctld/src/rest/handlers.rs
@@ -46,9 +46,14 @@ pub async fn get_jobs(
     let account = query.account.as_deref();
     let name = query.name.as_deref();
 
-    let jobs = state
-        .cluster
-        .get_jobs(&states, user, partition, account, name, &[]);
+    let jobs = state.cluster.get_jobs(&crate::cluster::JobFilter {
+        states: &states,
+        user,
+        partition,
+        account,
+        name,
+        ..Default::default()
+    });
     let json_jobs: Vec<serde_json::Value> = jobs.iter().map(job_to_json).collect();
 
     Ok(ApiResponse::ok(JobsData { jobs: json_jobs }))

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -20,7 +20,7 @@ use spur_proto::proto::{
 use spur_sched::backfill::{self, BackfillScheduler};
 use spur_sched::traits::{ClusterState, Scheduler};
 
-use crate::cluster::ClusterManager;
+use crate::cluster::{ClusterManager, JobFilter};
 use crate::pmix_dispatch::{self, PmixPrepareNode};
 use crate::raft::RaftHandle;
 
@@ -558,7 +558,10 @@ pub(crate) async fn try_preempt(
     };
 
     let mut running: Vec<spur_core::job::Job> = cluster
-        .get_jobs(&[JobState::Running], None, None, None, None, &[])
+        .get_jobs(&JobFilter {
+            states: &[JobState::Running],
+            ..Default::default()
+        })
         .into_iter()
         .collect();
     // Resolve once, reuse for both the priority recompute and the
@@ -1634,14 +1637,10 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
 
         // Deadline enforcement: mark pending jobs whose deadline has passed
         {
-            let pending = cluster.get_jobs(
-                &[spur_core::job::JobState::Pending],
-                None,
-                None,
-                None,
-                None,
-                &[],
-            );
+            let pending = cluster.get_jobs(&JobFilter {
+                states: &[spur_core::job::JobState::Pending],
+                ..Default::default()
+            });
             for job in &pending {
                 if let Some(deadline) = job.spec.deadline {
                     if now > deadline {
@@ -1653,17 +1652,13 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
             }
         }
 
-        let running = cluster.get_jobs(
-            &[
+        let running = cluster.get_jobs(&JobFilter {
+            states: &[
                 spur_core::job::JobState::Running,
                 spur_core::job::JobState::Completing,
             ],
-            None,
-            None,
-            None,
-            None,
-            &[],
-        );
+            ..Default::default()
+        });
 
         for job in &running {
             if job.state == spur_core::job::JobState::Completing {
@@ -1756,7 +1751,10 @@ async fn enforce_inactive_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHan
         let now = Utc::now();
 
         let running: Vec<_> = cluster
-            .get_jobs(&[JobState::Running], None, None, None, None, &[])
+            .get_jobs(&JobFilter {
+                states: &[JobState::Running],
+                ..Default::default()
+            })
             .into_iter()
             .filter(|j| j.spec.interactive || j.spec.srun_job)
             .collect();
@@ -1837,14 +1835,10 @@ async fn enforce_completing_timeout(cluster: Arc<ClusterManager>, raft: Arc<Raft
         let now = Utc::now();
         let wait = chrono::Duration::seconds(cluster.config().scheduler.complete_wait_secs as i64);
 
-        let completing = cluster.get_jobs(
-            &[spur_core::job::JobState::Completing],
-            None,
-            None,
-            None,
-            None,
-            &[],
-        );
+        let completing = cluster.get_jobs(&JobFilter {
+            states: &[spur_core::job::JobState::Completing],
+            ..Default::default()
+        });
 
         for job in completing {
             let Some(completing_since) = job.end_time else {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -21,7 +21,7 @@ use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::slurm_controller_server::SlurmController;
 use spur_proto::proto::*;
 
-use crate::cluster::{ClusterManager, PartitionError, ReservationError};
+use crate::cluster::{ClusterManager, JobFilter, PartitionError, ReservationError};
 use crate::pmix_dispatch::{self, PmixPrepareNode};
 use crate::raft::RaftHandle;
 use crate::rpc_middleware::RpcStatsLayer;
@@ -491,9 +491,15 @@ impl SlurmController for ControllerService {
             Some(req.name.as_str())
         };
 
-        let jobs = self
-            .cluster
-            .get_jobs(&states, user, partition, account, name, &req.job_ids);
+        let jobs = self.cluster.get_jobs(&JobFilter {
+            states: &states,
+            user,
+            partition,
+            account,
+            name,
+            job_ids: &req.job_ids,
+            nodes: &req.nodes,
+        });
 
         let proto_jobs: Vec<JobInfo> = jobs.iter().map(job_to_proto).collect();
 

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -476,6 +476,8 @@ message GetJobsRequest {
   string account = 4;
   repeated uint32 job_ids = 5;
   string name = 6;
+  // Filter: only jobs allocated on any of these nodes (expanded hostlist).
+  repeated string nodes = 7;
 }
 
 message GetJobsResponse {


### PR DESCRIPTION
## Summary

Adds `squeue -w/--nodelist` to show only jobs allocated on the given nodes, matching Slurm.

- The value is a hostlist expression: plain comma list (`node1,node2`), compacted ranges (`node[001-003]`), mixed (`node[1,3,5-7]`), and multiple bracket terms (`gpu[01-04],cpu[01-02]`). It is expanded CLI-side via `spur_core::hostlist::expand`, so an invalid or empty value fails with a clear error before any RPC.
- Expanded node names travel over a new appended `GetJobsRequest.nodes` field (proto tag 7, backward compatible). The controller keeps a job only when its `allocated_nodes` intersect the filter, so pending jobs (no allocation) are excluded, as in Slurm.

## Design notes

- Collapsed the `ClusterManager::get_jobs` filter parameters into a `JobFilter` struct. Adding the node dimension would have pushed the positional signature past the `too_many_arguments` lint; the struct also reads clearly at call sites (`JobFilter { nodes, ..Default::default() }`). All existing callers (server, REST, scheduler loop, accounting, tests) were migrated.
- Known limitation (left intentionally): combining `-w` with `-j <array_parent_id>` matches against the synthesized parent's `allocated_nodes`, which reflect only the lowest task. This mirrors how the aggregate already presents its nodelist and is out of scope here.

## Testing

- Unit tests: hostlist expansion parity (comma list, ranges, mixed, invalid/empty) in `squeue.rs`; `get_jobs` node-filter behavior (intersection, empty-filter no-op, pending excluded, union, unknown node) in `cluster.rs`.
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`: clean.
- `cargo test --locked`: full suite passes.
- Live bare-metal cluster (4 nodes): pinned jobs to node1/node2/node3, verified `-w` for single node, empty node, compacted ranges, comma lists, full range, and clean nonzero-exit errors for invalid/empty input.