### PR TITLE
feat(spurctld): implement scontrol requeue and requeuehold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1328,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2787,7 +2787,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3094,7 +3094,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3152,7 +3152,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4194,7 +4194,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5058,7 +5058,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -144,7 +144,7 @@ mock_controller_impl! {
         suspend_job(proto::SuspendJobRequest) -> ();
         resume_job(proto::ResumeJobRequest) -> ();
         update_job(proto::UpdateJobRequest) -> ();
-        requeue_job(proto::RequeueJobRequest) -> ();
+        requeue_job(proto::RequeueJobRequest) -> proto::RequeueJobResponse;
         get_nodes(proto::GetNodesRequest) -> proto::GetNodesResponse;
         get_node(proto::GetNodeRequest) -> proto::NodeInfo;
         drain_node(proto::DrainNodeRequest) -> proto::DrainNodeResponse;

--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -144,6 +144,7 @@ mock_controller_impl! {
         suspend_job(proto::SuspendJobRequest) -> ();
         resume_job(proto::ResumeJobRequest) -> ();
         update_job(proto::UpdateJobRequest) -> ();
+        requeue_job(proto::RequeueJobRequest) -> ();
         get_nodes(proto::GetNodesRequest) -> proto::GetNodesResponse;
         get_node(proto::GetNodeRequest) -> proto::NodeInfo;
         drain_node(proto::DrainNodeRequest) -> proto::DrainNodeResponse;

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -75,8 +75,14 @@ pub enum ScontrolCommand {
         /// Job ID
         job_id: u32,
     },
-    /// Requeue a job
+    /// Requeue a job (return it to PENDING with the same spec)
     Requeue {
+        /// Job ID
+        job_id: u32,
+    },
+    /// Requeue a job and leave it in a held state
+    #[command(name = "requeuehold", alias = "requeue-hold")]
+    RequeueHold {
         /// Job ID
         job_id: u32,
     },
@@ -329,23 +335,8 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             )
             .await
         }
-        ScontrolCommand::Requeue { job_id } => {
-            // Requeue = cancel + resubmit, simplified for now
-            let channel = crate::authclient::connect(&args.controller)
-                .await
-                .context("failed to connect to spurctld")?;
-            let mut client = spur_proto::controller_client(channel);
-            client
-                .cancel_job(spur_proto::proto::CancelJobRequest {
-                    job_id,
-                    signal: 0,
-                    user: crate::interactive::current_user()?,
-                })
-                .await
-                .context("requeue failed")?;
-            println!("job {} requeued (cancelled for resubmission)", job_id);
-            Ok(())
-        }
+        ScontrolCommand::Requeue { job_id } => requeue(&args.controller, job_id, false).await,
+        ScontrolCommand::RequeueHold { job_id } => requeue(&args.controller, job_id, true).await,
         ScontrolCommand::Suspend { job_id } => {
             let channel = crate::authclient::connect(&args.controller)
                 .await
@@ -883,6 +874,27 @@ fn format_ts(ts: Option<&prost_types::Timestamp>) -> String {
         }
         _ => "N/A".into(),
     }
+}
+
+async fn requeue(controller: &str, job_id: u32, hold: bool) -> Result<()> {
+    let channel = spur_client::connect_channel(controller)
+        .await
+        .context("failed to connect to spurctld")?;
+    let mut client = spur_proto::controller_client(channel);
+    client
+        .requeue_job(spur_proto::proto::RequeueJobRequest {
+            job_id,
+            user: crate::interactive::current_user()?,
+            hold,
+        })
+        .await
+        .context("requeue failed")?;
+    if hold {
+        println!("job {} requeued and held", job_id);
+    } else {
+        println!("job {} requeued", job_id);
+    }
+    Ok(())
 }
 
 async fn send_job_update(controller: &str, req: spur_proto::proto::UpdateJobRequest) -> Result<()> {

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -881,18 +881,25 @@ async fn requeue(controller: &str, job_id: u32, hold: bool) -> Result<()> {
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);
-    client
+    let resp = client
         .requeue_job(spur_proto::proto::RequeueJobRequest {
             job_id,
             user: crate::interactive::current_user()?,
             hold,
         })
         .await
-        .context("requeue failed")?;
-    if hold {
-        println!("job {} requeued and held", job_id);
+        .context("requeue failed")?
+        .into_inner();
+    let held = if hold { " and held" } else { "" };
+    // A single job (or non-array) requeues exactly one record; only an array
+    // fan-out reports a count and any skipped tasks.
+    if resp.requeued <= 1 && resp.skipped.is_empty() {
+        println!("job {} requeued{}", job_id, held);
     } else {
-        println!("job {} requeued", job_id);
+        println!("requeued {} task(s){}", resp.requeued, held);
+        for skipped in &resp.skipped {
+            eprintln!("scontrol: skipped {}", skipped);
+        }
     }
     Ok(())
 }

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -504,6 +504,7 @@ mod tests {
         suspend_job(pb::SuspendJobRequest) -> ();
         resume_job(pb::ResumeJobRequest) -> ();
         update_job(pb::UpdateJobRequest) -> ();
+        requeue_job(pb::RequeueJobRequest) -> ();
         get_node(pb::GetNodeRequest) -> pb::NodeInfo;
         update_node(pb::UpdateNodeRequest) -> ();
         drain_node(pb::DrainNodeRequest) -> pb::DrainNodeResponse;

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -504,7 +504,7 @@ mod tests {
         suspend_job(pb::SuspendJobRequest) -> ();
         resume_job(pb::ResumeJobRequest) -> ();
         update_job(pb::UpdateJobRequest) -> ();
-        requeue_job(pb::RequeueJobRequest) -> ();
+        requeue_job(pb::RequeueJobRequest) -> pb::RequeueJobResponse;
         get_node(pb::GetNodeRequest) -> pb::NodeInfo;
         update_node(pb::UpdateNodeRequest) -> ();
         drain_node(pb::DrainNodeRequest) -> pb::DrainNodeResponse;

--- a/crates/spur-core/src/array.rs
+++ b/crates/spur-core/src/array.rs
@@ -46,7 +46,8 @@ pub fn aggregate_array_state(task_states: &[JobState]) -> Option<JobState> {
         | JobState::Running
         | JobState::Completing
         | JobState::Suspended
-        | JobState::Preempted => 0,
+        | JobState::Preempted
+        | JobState::Requeued => 0,
     };
     task_states
         .iter()

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -33,6 +33,9 @@ pub enum JobState {
     Suspended,
     Deadline,
     OutOfMemory,
+    /// Finalized end-of-run for an admin requeue; like `Preempted`, the run is
+    /// over but the job returns to `Pending` rather than staying terminal.
+    Requeued,
 }
 
 /// Sentinel bit spurd OR's into a completion `signal` for an OOM kill, so the
@@ -55,6 +58,7 @@ impl JobState {
             Self::Suspended => "S",
             Self::Deadline => "DL",
             Self::OutOfMemory => "OOM",
+            Self::Requeued => "RQ",
         }
     }
 
@@ -73,6 +77,7 @@ impl JobState {
             Self::Suspended => "SUSPENDED",
             Self::Deadline => "DEADLINE",
             Self::OutOfMemory => "OUT_OF_MEMORY",
+            Self::Requeued => "REQUEUED",
         }
     }
 
@@ -92,6 +97,7 @@ impl JobState {
             Self::Preempted => 9,
             Self::Deadline => 10,
             Self::OutOfMemory => 11,
+            Self::Requeued => 12,
         }
     }
 
@@ -112,10 +118,11 @@ impl JobState {
         matches!(self, Self::Running | Self::Completing | Self::Suspended)
     }
 
-    /// End of a run: `is_terminal()` plus `Preempted` (which may still requeue).
+    /// End of a run: `is_terminal()` plus `Preempted` and `Requeued`, which
+    /// finalize the current run but return the job to `Pending`.
     /// Distinct from `is_terminal()`, whose semantics must not shift.
     pub fn is_finalized(&self) -> bool {
-        self.is_terminal() || matches!(self, Self::Preempted)
+        self.is_terminal() || matches!(self, Self::Preempted | Self::Requeued)
     }
 
     /// Per-node completion state implied by one exit code.
@@ -152,7 +159,7 @@ impl JobState {
     }
 
     /// Every core variant, in proto discriminant order for iteration only.
-    pub const ALL: [JobState; 12] = [
+    pub const ALL: [JobState; 13] = [
         Self::Pending,
         Self::Running,
         Self::Completing,
@@ -165,6 +172,7 @@ impl JobState {
         Self::Suspended,
         Self::Deadline,
         Self::OutOfMemory,
+        Self::Requeued,
     ];
 
     pub const COUNT: usize = Self::ALL.len();
@@ -184,6 +192,7 @@ impl JobState {
             spur_proto::proto::JobState::JobSuspended => Self::Suspended,
             spur_proto::proto::JobState::JobDeadline => Self::Deadline,
             spur_proto::proto::JobState::JobOutOfMemory => Self::OutOfMemory,
+            spur_proto::proto::JobState::JobRequeued => Self::Requeued,
         }
     }
 
@@ -202,6 +211,7 @@ impl JobState {
             Self::Suspended => spur_proto::proto::JobState::JobSuspended,
             Self::Deadline => spur_proto::proto::JobState::JobDeadline,
             Self::OutOfMemory => spur_proto::proto::JobState::JobOutOfMemory,
+            Self::Requeued => spur_proto::proto::JobState::JobRequeued,
         }
     }
 
@@ -725,6 +735,11 @@ pub struct Job {
     /// separately since it isn't a failure signal and never counts toward `max_batch_requeue`.
     #[serde(default)]
     pub preempt_requeue_count: u32,
+    /// Number of times an admin requeued this job (`scontrol requeue`); tracked
+    /// separately as it is an operator action, never a failure, and never counts
+    /// toward `max_batch_requeue`.
+    #[serde(default)]
+    pub user_requeue_count: u32,
 
     /// Monotonic run epoch, bumped on each dispatch (first dispatch = 1). Lets
     /// the controller drop a completion report from a superseded run.
@@ -818,6 +833,7 @@ impl Job {
             derived_exit_code: 0,
             requeue_count: 0,
             preempt_requeue_count: 0,
+            user_requeue_count: 0,
             run_attempt: 0,
             het_job_id: None,
             het_group: None,
@@ -1197,6 +1213,7 @@ impl Job {
             (JobState::Running, JobState::Preempted) => true,
             (JobState::Running, JobState::Suspended) => true,
             (JobState::Running, JobState::OutOfMemory) => true,
+            (JobState::Running, JobState::Requeued) => true,
             (JobState::Completing, JobState::Completed) => true,
             (JobState::Completing, JobState::Failed) => true,
             (JobState::Completing, JobState::Cancelled) => true,
@@ -1218,12 +1235,21 @@ impl Job {
             (JobState::Suspended, JobState::Timeout) => true,
             (JobState::Suspended, JobState::NodeFail) => true,
             (JobState::Suspended, JobState::OutOfMemory) => true,
+            (JobState::Suspended, JobState::Requeued) => true,
             // Requeue transitions: terminal → Pending (for --requeue jobs)
             (JobState::Timeout, JobState::Pending) => true,
             (JobState::Preempted, JobState::Pending) => true,
             (JobState::Preempted, JobState::Cancelled) => true,
             (JobState::NodeFail, JobState::Pending) => true,
             (JobState::Failed, JobState::Pending) => true,
+            // Admin requeue (`scontrol requeue`): the killed run is finalized as
+            // Requeued and returns to Pending; any terminal batch job can be put
+            // back into the queue with the same spec.
+            (JobState::Requeued, JobState::Pending) => true,
+            (JobState::Completed, JobState::Pending) => true,
+            (JobState::Cancelled, JobState::Pending) => true,
+            (JobState::Deadline, JobState::Pending) => true,
+            (JobState::OutOfMemory, JobState::Pending) => true,
             _ => false,
         };
 
@@ -1905,6 +1931,58 @@ mod tests {
     }
 
     #[test]
+    fn requeued_is_finalized_but_not_terminal() {
+        // Like Preempted, Requeued ends a run for accounting but returns the
+        // job to Pending, so it must not be treated as terminal.
+        assert!(JobState::Requeued.is_finalized());
+        assert!(!JobState::Requeued.is_terminal());
+        assert!(!JobState::Requeued.is_active());
+        assert_eq!(JobState::Requeued.display(), "REQUEUED");
+        assert_eq!(JobState::Requeued.code(), "RQ");
+        assert_eq!(
+            JobState::from_proto(JobState::Requeued.to_proto()),
+            JobState::Requeued
+        );
+    }
+
+    #[test]
+    fn admin_requeue_transitions_are_allowed() {
+        // Live job finalized as Requeued, then re-pended.
+        let mut job = make_job();
+        job.transition(JobState::Running).unwrap();
+        job.transition(JobState::Requeued).unwrap();
+        job.transition(JobState::Pending).unwrap();
+        assert_eq!(job.state, JobState::Pending);
+        assert!(job.end_time.is_none(), "re-pend clears end_time");
+
+        // A completed job can be put back into the queue.
+        let mut done = make_job();
+        done.transition(JobState::Running).unwrap();
+        done.transition(JobState::Completed).unwrap();
+        done.transition(JobState::Pending).unwrap();
+        assert_eq!(done.state, JobState::Pending);
+
+        // As can a cancelled one.
+        let mut cancelled = make_job();
+        cancelled.transition(JobState::Cancelled).unwrap();
+        cancelled.transition(JobState::Pending).unwrap();
+        assert_eq!(cancelled.state, JobState::Pending);
+
+        // Every other terminal batch state is requeue-able too, so the leader's
+        // acceptance and the state machine never disagree (no false success).
+        let mut oom = make_job();
+        oom.transition(JobState::Running).unwrap();
+        oom.transition(JobState::OutOfMemory).unwrap();
+        oom.transition(JobState::Pending).unwrap();
+        assert_eq!(oom.state, JobState::Pending);
+
+        let mut deadline = make_job();
+        deadline.transition(JobState::Deadline).unwrap();
+        deadline.transition(JobState::Pending).unwrap();
+        assert_eq!(deadline.state, JobState::Pending);
+    }
+
+    #[test]
     fn apply_transition_noop_on_non_terminal_repeat() {
         let mut job = make_job();
         job.transition(JobState::Running).unwrap();
@@ -2257,6 +2335,7 @@ mod tests {
             (P::JobSuspended, JobState::Suspended),
             (P::JobDeadline, JobState::Deadline),
             (P::JobOutOfMemory, JobState::OutOfMemory),
+            (P::JobRequeued, JobState::Requeued),
         ];
 
         assert_eq!(TABLE.len(), JobState::COUNT);

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -1213,7 +1213,6 @@ impl Job {
             (JobState::Running, JobState::Preempted) => true,
             (JobState::Running, JobState::Suspended) => true,
             (JobState::Running, JobState::OutOfMemory) => true,
-            (JobState::Running, JobState::Requeued) => true,
             (JobState::Completing, JobState::Completed) => true,
             (JobState::Completing, JobState::Failed) => true,
             (JobState::Completing, JobState::Cancelled) => true,
@@ -1235,21 +1234,14 @@ impl Job {
             (JobState::Suspended, JobState::Timeout) => true,
             (JobState::Suspended, JobState::NodeFail) => true,
             (JobState::Suspended, JobState::OutOfMemory) => true,
-            (JobState::Suspended, JobState::Requeued) => true,
-            // Requeue transitions: terminal → Pending (for --requeue jobs)
+            // Only failure/preempt states auto-requeue here; a finished or live
+            // run re-pends only via the admin `requeue_to_pending`, so nothing
+            // else can resurrect a finished job.
             (JobState::Timeout, JobState::Pending) => true,
             (JobState::Preempted, JobState::Pending) => true,
             (JobState::Preempted, JobState::Cancelled) => true,
             (JobState::NodeFail, JobState::Pending) => true,
             (JobState::Failed, JobState::Pending) => true,
-            // Admin requeue (`scontrol requeue`): the killed run is finalized as
-            // Requeued and returns to Pending; any terminal batch job can be put
-            // back into the queue with the same spec.
-            (JobState::Requeued, JobState::Pending) => true,
-            (JobState::Completed, JobState::Pending) => true,
-            (JobState::Cancelled, JobState::Pending) => true,
-            (JobState::Deadline, JobState::Pending) => true,
-            (JobState::OutOfMemory, JobState::Pending) => true,
             _ => false,
         };
 
@@ -1269,6 +1261,23 @@ impl Job {
                 to,
             })
         }
+    }
+
+    /// Admin requeue (`scontrol requeue`): return a live or terminal job to
+    /// Pending. Kept off the general `transition()` machine so nothing else can
+    /// resurrect a finished run.
+    pub fn requeue_to_pending(&mut self) -> Result<(), JobTransitionError> {
+        let ok = self.state.is_terminal()
+            || matches!(self.state, JobState::Running | JobState::Suspended);
+        if !ok {
+            return Err(JobTransitionError::Invalid {
+                from: self.state,
+                to: JobState::Pending,
+            });
+        }
+        self.state = JobState::Pending;
+        self.end_time = None;
+        Ok(())
     }
 
     /// WAL-apply transition: a move to the current state is a `NoOp` (replay /
@@ -1946,40 +1955,52 @@ mod tests {
     }
 
     #[test]
-    fn admin_requeue_transitions_are_allowed() {
-        // Live job finalized as Requeued, then re-pended.
+    fn requeue_to_pending_covers_live_and_terminal_states() {
+        // A live run finalizes through Requeued to Pending.
         let mut job = make_job();
         job.transition(JobState::Running).unwrap();
-        job.transition(JobState::Requeued).unwrap();
-        job.transition(JobState::Pending).unwrap();
+        job.requeue_to_pending().unwrap();
         assert_eq!(job.state, JobState::Pending);
         assert!(job.end_time.is_none(), "re-pend clears end_time");
 
-        // A completed job can be put back into the queue.
-        let mut done = make_job();
-        done.transition(JobState::Running).unwrap();
-        done.transition(JobState::Completed).unwrap();
-        done.transition(JobState::Pending).unwrap();
-        assert_eq!(done.state, JobState::Pending);
+        // Every terminal batch state can be put back in the queue.
+        for terminal in [
+            JobState::Completed,
+            JobState::Cancelled,
+            JobState::Failed,
+            JobState::Timeout,
+            JobState::NodeFail,
+            JobState::OutOfMemory,
+            JobState::Deadline,
+        ] {
+            let mut j = make_job();
+            j.state = terminal;
+            j.requeue_to_pending()
+                .unwrap_or_else(|e| panic!("{terminal:?} must be requeue-able: {e}"));
+            assert_eq!(j.state, JobState::Pending);
+        }
+    }
 
-        // As can a cancelled one.
-        let mut cancelled = make_job();
-        cancelled.transition(JobState::Cancelled).unwrap();
-        cancelled.transition(JobState::Pending).unwrap();
-        assert_eq!(cancelled.state, JobState::Pending);
-
-        // Every other terminal batch state is requeue-able too, so the leader's
-        // acceptance and the state machine never disagree (no false success).
-        let mut oom = make_job();
-        oom.transition(JobState::Running).unwrap();
-        oom.transition(JobState::OutOfMemory).unwrap();
-        oom.transition(JobState::Pending).unwrap();
-        assert_eq!(oom.state, JobState::Pending);
-
-        let mut deadline = make_job();
-        deadline.transition(JobState::Deadline).unwrap();
-        deadline.transition(JobState::Pending).unwrap();
-        assert_eq!(deadline.state, JobState::Pending);
+    #[test]
+    fn general_transition_never_resurrects_a_finished_job() {
+        // The invariant the guarded requeue path preserves: no ordinary
+        // `transition()` caller can move a finished run back to Pending.
+        for terminal in [
+            JobState::Completed,
+            JobState::Cancelled,
+            JobState::OutOfMemory,
+            JobState::Deadline,
+        ] {
+            let mut j = make_job();
+            j.state = terminal;
+            assert!(
+                j.transition(JobState::Pending).is_err(),
+                "{terminal:?} -> Pending must not be a general transition"
+            );
+        }
+        // Requeuing a Pending or Completing job is likewise rejected.
+        let mut pending = make_job();
+        assert!(pending.requeue_to_pending().is_err());
     }
 
     #[test]

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -135,6 +135,19 @@ pub enum WalOperation {
     JobPreemptCancel {
         job_id: JobId,
     },
+    /// Admin requeue (`scontrol requeue` / `requeuehold`): return a job to
+    /// Pending with the same spec in one atomic step. A running/suspended job is
+    /// finalized once (steps, allocations, accounting-end as REQUEUED) before
+    /// re-pending; an already-terminal job re-pends with no re-finalization.
+    /// `hold` parks it held; `begin_time` defers eligibility (leader-computed).
+    /// NoOp on replay once Pending.
+    JobUserRequeue {
+        job_id: JobId,
+        #[serde(default)]
+        hold: bool,
+        #[serde(default)]
+        begin_time: Option<chrono::DateTime<chrono::Utc>>,
+    },
     JobSuspend {
         job_id: JobId,
         /// Controller-stamped instant of suspension (for replay-deterministic accounting).
@@ -1011,6 +1024,52 @@ mod suspend_wal_tests {
             } => {
                 assert_eq!(job_id, 42);
                 assert_eq!(b, begin_time);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn user_requeue_op_round_trips() {
+        let begin = chrono::Utc::now();
+        for (hold, begin_time) in [(false, Some(begin)), (true, None), (false, None)] {
+            let op = WalOperation::JobUserRequeue {
+                job_id: 42,
+                hold,
+                begin_time,
+            };
+            let json = serde_json::to_string(&op).unwrap();
+            let back: WalOperation = serde_json::from_str(&json).unwrap();
+            match back {
+                WalOperation::JobUserRequeue {
+                    job_id,
+                    hold: got_hold,
+                    begin_time: got_begin,
+                } => {
+                    assert_eq!(job_id, 42);
+                    assert_eq!(got_hold, hold);
+                    assert_eq!(got_begin, begin_time);
+                }
+                _ => panic!("wrong variant"),
+            }
+        }
+    }
+
+    /// The optional fields default when absent, so a minimal/older-encoded
+    /// entry still replays.
+    #[test]
+    fn user_requeue_op_defaults_missing_fields() {
+        let json = r#"{"JobUserRequeue":{"job_id":7}}"#;
+        let back: WalOperation = serde_json::from_str(json).unwrap();
+        match back {
+            WalOperation::JobUserRequeue {
+                job_id,
+                hold,
+                begin_time,
+            } => {
+                assert_eq!(job_id, 7);
+                assert!(!hold);
+                assert_eq!(begin_time, None);
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/spur-metrics/src/export/jobs.rs
+++ b/crates/spur-metrics/src/export/jobs.rs
@@ -25,6 +25,7 @@ pub fn job_state_metric_suffix(state: JobState) -> &'static str {
         JobState::Suspended => "suspended",
         JobState::Deadline => "deadline",
         JobState::OutOfMemory => "out_of_memory",
+        JobState::Requeued => "requeued",
     }
 }
 

--- a/crates/spur-metrics/tests/fixtures/jobs.prom
+++ b/crates/spur-metrics/tests/fixtures/jobs.prom
@@ -37,6 +37,9 @@ spur_jobs_deadline 0
 # HELP spur_jobs_out_of_memory Number of jobs in OUT_OF_MEMORY state.
 # TYPE spur_jobs_out_of_memory gauge
 spur_jobs_out_of_memory 0
+# HELP spur_jobs_requeued Number of jobs in REQUEUED state.
+# TYPE spur_jobs_requeued gauge
+spur_jobs_requeued 0
 # HELP spur_jobs_hold Number of jobs in Pending state with a hold set.
 # TYPE spur_jobs_hold gauge
 spur_jobs_hold 1

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -375,13 +375,16 @@ mod tests {
     }
 
     #[test]
-    fn t50_37_requeue_from_completed_succeeds() {
+    fn t50_37_requeue_from_completed_is_guarded() {
         let mut job = make_job("requeue-completed");
         assert_transition_ok(&mut job, JobState::Running);
         assert_transition_ok(&mut job, JobState::Completed);
-        // Admin requeue (`scontrol requeue`) puts a finished job back in the
-        // queue: Completed → Pending is a legal transition.
-        assert_transition_ok(&mut job, JobState::Pending);
+        // The general state machine must NOT resurrect a finished job; only the
+        // guarded admin path (`Job::requeue_to_pending`) may.
+        assert_transition_err(&mut job, JobState::Pending);
+        assert_job_state(&job, JobState::Completed);
+        job.requeue_to_pending()
+            .expect("admin requeue re-pends a completed job");
         assert_job_state(&job, JobState::Pending);
     }
 
@@ -452,15 +455,17 @@ mod tests {
         assert_eq!(node.state, NodeState::Error);
     }
 
-    // ── T50.42–43: Admin requeue can reset from Cancelled ──────
+    // ── T50.42–43: Cancelled re-pend is admin-guarded ─────────
 
     #[test]
-    fn t50_42_requeue_from_cancelled_succeeds() {
+    fn t50_42_requeue_from_cancelled_is_guarded() {
         let mut job = make_job("requeue-cancelled");
         assert_transition_ok(&mut job, JobState::Cancelled);
-        // Admin requeue (`scontrol requeue`) can put a cancelled job back into
-        // the queue: Cancelled → Pending is a legal transition.
-        assert_transition_ok(&mut job, JobState::Pending);
+        // The general machine rejects Cancelled → Pending; only the guarded
+        // admin requeue path re-pends it.
+        assert_transition_err(&mut job, JobState::Pending);
+        job.requeue_to_pending()
+            .expect("admin requeue re-pends a cancelled job");
         assert_job_state(&job, JobState::Pending);
     }
 

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -375,13 +375,14 @@ mod tests {
     }
 
     #[test]
-    fn t50_37_requeue_from_completed_fails() {
+    fn t50_37_requeue_from_completed_succeeds() {
         let mut job = make_job("requeue-completed");
         assert_transition_ok(&mut job, JobState::Running);
         assert_transition_ok(&mut job, JobState::Completed);
-        // Completed → Pending should fail (Completed is not retriable)
-        assert_transition_err(&mut job, JobState::Pending);
-        assert_job_state(&job, JobState::Completed);
+        // Admin requeue (`scontrol requeue`) puts a finished job back in the
+        // queue: Completed → Pending is a legal transition.
+        assert_transition_ok(&mut job, JobState::Pending);
+        assert_job_state(&job, JobState::Pending);
     }
 
     // ── T50.38–40: Drain / Draining node behavior ──────────────
@@ -451,14 +452,16 @@ mod tests {
         assert_eq!(node.state, NodeState::Error);
     }
 
-    // ── T50.42–43: Requeue does not reset from Cancelled ───────
+    // ── T50.42–43: Admin requeue can reset from Cancelled ──────
 
     #[test]
-    fn t50_42_requeue_from_cancelled_fails() {
+    fn t50_42_requeue_from_cancelled_succeeds() {
         let mut job = make_job("requeue-cancelled");
         assert_transition_ok(&mut job, JobState::Cancelled);
-        // Cancelled → Pending should fail
-        assert_transition_err(&mut job, JobState::Pending);
+        // Admin requeue (`scontrol requeue`) can put a cancelled job back into
+        // the queue: Cancelled → Pending is a legal transition.
+        assert_transition_ok(&mut job, JobState::Pending);
+        assert_job_state(&job, JobState::Pending);
     }
 
     #[test]

--- a/crates/spur-tests/src/t55_format.rs
+++ b/crates/spur-tests/src/t55_format.rs
@@ -65,6 +65,7 @@ mod tests {
             ("S", "SUSPENDED"),
             ("DL", "DEADLINE"),
             ("OOM", "OUT_OF_MEMORY"),
+            ("RQ", "REQUEUED"),
         ];
         assert_eq!(JobState::ALL.len(), expected.len());
         for (i, state) in JobState::ALL.iter().enumerate() {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1185,6 +1185,135 @@ impl ClusterManager {
         Ok(())
     }
 
+    /// Admin requeue (`scontrol requeue` / `requeuehold`), keeping the `job_id`.
+    /// A bare array-parent id (no job record of its own) fans out to every task.
+    /// Returns snapshots of the jobs that were Running/Suspended so the caller
+    /// can kill their old processes.
+    pub fn requeue_job_by_user(
+        &self,
+        job_id: JobId,
+        user: &str,
+        hold: bool,
+    ) -> anyhow::Result<Vec<Job>> {
+        let (targets, is_array) = {
+            let jobs = self.jobs.read();
+            if jobs.contains_key(&job_id) {
+                (vec![job_id], false)
+            } else {
+                let mut tasks: Vec<JobId> = jobs
+                    .values()
+                    .filter(|j| j.spec.array_job_id == Some(job_id))
+                    .map(|j| j.job_id)
+                    .collect();
+                tasks.sort_unstable();
+                (tasks, true)
+            }
+        };
+        if targets.is_empty() {
+            anyhow::bail!("job {} not found", job_id);
+        }
+
+        // A single, explicitly named job propagates its error verbatim so the
+        // user sees exactly why (not owner, interactive, already pending, ...).
+        if !is_array {
+            return Ok(self
+                .requeue_one_job(targets[0], user, hold)?
+                .into_iter()
+                .collect());
+        }
+
+        // Array fan-out: requeue every task that can be, collecting per-task
+        // failures. Only fail outright if no task could be requeued at all.
+        let total = targets.len();
+        let mut killed = Vec::new();
+        let mut errors = Vec::new();
+        for id in targets {
+            match self.requeue_one_job(id, user, hold) {
+                Ok(Some(job)) => killed.push(job),
+                Ok(None) => {}
+                Err(e) => errors.push(format!("task {id}: {e}")),
+            }
+        }
+        if killed.is_empty() && errors.len() == total {
+            anyhow::bail!(
+                "no tasks of array {} could be requeued: {}",
+                job_id,
+                errors.join("; ")
+            );
+        }
+        // Partial success is reported as success (some tasks requeued), so make
+        // the skipped tasks visible rather than swallowing them silently.
+        if !errors.is_empty() {
+            warn!(
+                array_job_id = job_id,
+                "some array tasks were not requeued: {}",
+                errors.join("; ")
+            );
+        }
+        Ok(killed)
+    }
+
+    /// Requeue exactly one job/task. Returns its pre-requeue snapshot when the
+    /// job was Running/Suspended (so its processes must be killed on the nodes).
+    fn requeue_one_job(
+        &self,
+        job_id: JobId,
+        user: &str,
+        hold: bool,
+    ) -> anyhow::Result<Option<Job>> {
+        let snapshot = {
+            let jobs = self.jobs.read();
+            let job = jobs
+                .get(&job_id)
+                .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
+            Self::check_job_owner(user, &job.spec.user, "requeue")?;
+            // Interactive/srun allocations have no batch script to re-run.
+            if job.spec.interactive || job.spec.srun_job || job.spec.pty {
+                anyhow::bail!("job {} is interactive and cannot be requeued", job_id);
+            }
+            match job.state {
+                JobState::Pending => anyhow::bail!("job {} is already pending", job_id),
+                JobState::Completing => {
+                    anyhow::bail!("job {} is completing; cannot requeue", job_id)
+                }
+                JobState::Preempted | JobState::Requeued => {
+                    anyhow::bail!("job {} is already being requeued", job_id)
+                }
+                _ => {}
+            }
+            matches!(job.state, JobState::Running | JobState::Suspended).then(|| job.clone())
+        };
+
+        // Defer a live, non-held requeue's eligibility so the scheduler can't
+        // re-dispatch it into its own in-flight cancel (same guard as preemption
+        // requeue). Held/terminal requeues can't hit that race. Computed on the
+        // leader so every replica applies one instant.
+        let begin_time = match (&snapshot, hold) {
+            (Some(job), false) => {
+                let hold_secs = (self.scheduler_interval_secs as i64 * 2 + 3).max(5);
+                let deferred = Utc::now() + chrono::Duration::seconds(hold_secs);
+                Some(
+                    job.spec
+                        .begin_time
+                        .map_or(deferred, |user| user.max(deferred)),
+                )
+            }
+            _ => None,
+        };
+
+        let resp = self.propose(WalOperation::JobUserRequeue {
+            job_id,
+            hold,
+            begin_time,
+        })?;
+        // Fires accounting-end + epilog for the finalized run (live path only;
+        // an already-terminal job emits no finalized entry here).
+        self.run_all_finalized_side_effects(&resp);
+        self.scheduler_notify.notify_one();
+        info!(job_id, hold, "job requeued by admin");
+        Ok(snapshot)
+    }
+
     /// Complete a standalone srun allocation after its step finishes.
     pub fn finish_srun_job(
         &self,
@@ -4371,6 +4500,14 @@ impl ClusterManager {
         Self::clear_run_state_for_requeue(job);
     }
 
+    /// Requeue by admin action (`scontrol requeue`): tracked separately since it
+    /// is an operator decision, never a failure, and must never contribute to
+    /// the `max_batch_requeue` hold.
+    fn reset_job_for_user_requeue(job: &mut Job) {
+        job.user_requeue_count += 1;
+        Self::clear_run_state_for_requeue(job);
+    }
+
     /// Evict a single job by ID: transition to NodeFail, then free its
     /// allocations on every node it spans. Transition is validated first
     /// so allocations are never freed for a job that can't be evicted.
@@ -4621,6 +4758,109 @@ impl ClusterManager {
                     }],
                     ..Default::default()
                 };
+            }
+            WalOperation::JobUserRequeue {
+                job_id,
+                hold,
+                begin_time,
+            } => {
+                // A live job is finalized once (routed through Requeued so
+                // accounting/steps see a finished run) then re-pended; an
+                // already-terminal job re-pends with no second finalization to
+                // avoid double-counting. NoOp on replay / non-requeuable states.
+                let was_live;
+                let freed_nodes;
+                let allocated_resources;
+                let per_node_map;
+                {
+                    let Some(job) = jobs.get_mut(job_id) else {
+                        return ClientResponse::default();
+                    };
+                    match job.state {
+                        JobState::Running | JobState::Suspended => {
+                            was_live = true;
+                            if let Some(since) = job.suspended_at.take() {
+                                job.suspended_secs += (timestamp - since).num_seconds().max(0);
+                            }
+                            if let Err(e) = job.transition(JobState::Requeued) {
+                                warn!(job_id = *job_id, error = %e, "invalid requeue finalize transition in WAL apply");
+                                return ClientResponse::default();
+                            }
+                            job.exit_code = Some(-1);
+                            job.end_time = Some(timestamp);
+                        }
+                        s if s.is_terminal() => {
+                            was_live = false;
+                        }
+                        _ => {
+                            // Pending, Completing, or an in-flight finalized
+                            // state: nothing to requeue.
+                            return ClientResponse::default();
+                        }
+                    }
+                    freed_nodes = job.allocated_nodes.clone();
+                    allocated_resources = job.allocated_resources.clone();
+                    per_node_map = job.per_node_alloc.clone();
+                    job.node_completions.clear();
+
+                    if let Err(e) = job.transition(JobState::Pending) {
+                        warn!(job_id = *job_id, error = %e, "invalid requeue transition in WAL apply");
+                        return ClientResponse::default();
+                    }
+                    Self::reset_job_for_user_requeue(job);
+                    if *hold {
+                        job.priority = 0;
+                        job.set_pending_reason(PendingReason::Held);
+                    } else if let Some(bt) = begin_time {
+                        // Leader-computed hold against re-dispatch into the cancel.
+                        job.spec.begin_time = Some(*bt);
+                        job.set_pending_reason(PendingReason::BeginTime);
+                    } else {
+                        job.set_pending_reason(PendingReason::None);
+                    }
+                }
+                // Only the live path has allocations to free; for a terminal job
+                // `allocated_resources` is already None and this is skipped.
+                if let Some(ref total) = allocated_resources {
+                    let node_count = freed_nodes.len().max(1) as u32;
+                    for name in &freed_nodes {
+                        if let Some(node) = nodes.get_mut(name) {
+                            let slice = per_node_map.get(name).cloned().unwrap_or_else(|| {
+                                warn!(job_id = *job_id, node = %name, "per_node_alloc missing at requeue deallocation, using scalar fallback");
+                                ResourceAllocations::with_scalar(
+                                    total.cpus / node_count,
+                                    total.memory_mb / node_count as u64,
+                                )
+                            });
+                            node.alloc_resources.subtract(&slice);
+                            node.update_state_from_alloc();
+                            if node.state == NodeState::Draining
+                                && node.alloc_resources.cpus == 0
+                                && !node.alloc_resources.has_devices()
+                            {
+                                node.state = NodeState::Drain;
+                            }
+                        }
+                    }
+                }
+                drop(jobs);
+                drop(nodes);
+                self.next_job_id.store(next_id, Ordering::Relaxed);
+                if was_live {
+                    // Complete steps and fire accounting-end for the terminated
+                    // run as REQUEUED; the terminal path already did this at its
+                    // real completion, so it emits nothing here (no double-count).
+                    self.complete_job_steps(job_id, -1, timestamp);
+                    return ClientResponse {
+                        jobs_finalized: vec![JobFinalized {
+                            job_id: *job_id,
+                            state: JobState::Requeued,
+                            exit_code: -1,
+                        }],
+                        ..Default::default()
+                    };
+                }
+                return ClientResponse::default();
             }
             WalOperation::JobPreemptCancel { job_id } => {
                 let freed_nodes;
@@ -9590,6 +9830,325 @@ mod tests {
         .unwrap();
         settle(cm, job_id, JobState::Running);
         job_id
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_running_job_frees_nodes_and_repends() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "requeue-me", "worker1");
+        assert_eq!(cm.node_metrics().alloc_cpus, 2);
+
+        let killed = cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        assert_eq!(
+            killed.len(),
+            1,
+            "a running job must be reported for agent kill"
+        );
+        settle(&cm, job_id, JobState::Pending);
+
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.state, JobState::Pending);
+        assert!(job.allocated_nodes.is_empty());
+        assert_eq!(cm.node_metrics().alloc_cpus, 0, "nodes must be freed");
+        assert_eq!(job.user_requeue_count, 1);
+        assert_eq!(
+            job.requeue_count, 0,
+            "manual requeue must not touch the batch cap"
+        );
+        // A live job carries a short begin_time hold so the scheduler cannot
+        // re-dispatch it into its own in-flight cancel.
+        assert_eq!(job.pending_reason, PendingReason::BeginTime);
+        let begin = job
+            .spec
+            .begin_time
+            .expect("live requeue sets a begin_time hold");
+        assert!(begin > Utc::now(), "begin_time hold must be in the future");
+        assert!(
+            !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "held-by-begin-time job must not be eligible yet"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_suspended_job_repends() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "suspend-requeue", "worker1");
+        cm.suspend_job(job_id, "testuser").unwrap();
+        settle(&cm, job_id, JobState::Suspended);
+
+        let killed = cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        assert_eq!(killed.len(), 1);
+        settle(&cm, job_id, JobState::Pending);
+
+        let job = cm.get_job(job_id).unwrap();
+        assert!(job.allocated_nodes.is_empty());
+        assert_eq!(cm.node_metrics().alloc_cpus, 0, "nodes must be freed");
+        assert_eq!(job.user_requeue_count, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_completed_job_repends_without_extra_finalize() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "completed-requeue", "worker1");
+        cm.complete_job(job_id, 0, JobState::Completed).unwrap();
+        settle(&cm, job_id, JobState::Completed);
+
+        // An already-terminal job has no live processes to kill.
+        let killed = cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        assert!(killed.is_empty(), "terminal job needs no agent kill");
+        settle(&cm, job_id, JobState::Pending);
+
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.state, JobState::Pending);
+        assert_eq!(job.user_requeue_count, 1);
+        assert!(job.end_time.is_none(), "re-pended job clears end_time");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_all_terminal_states_repend() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 32, 64000);
+
+        // Every terminal state must re-pend, so the leader's acceptance and the
+        // apply-side transition never disagree (no "requeued" print without effect).
+        for state in [
+            JobState::Failed,
+            JobState::Timeout,
+            JobState::NodeFail,
+            JobState::OutOfMemory,
+        ] {
+            let job_id = run_job_on(&cm, &format!("term-{state:?}"), "worker1");
+            cm.complete_job(job_id, -1, state).unwrap();
+            settle(&cm, job_id, state);
+
+            cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+            settle(&cm, job_id, JobState::Pending);
+            assert_eq!(cm.get_job(job_id).unwrap().user_requeue_count, 1);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_finalizes_only_live_jobs() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        // Live path finalizes once (REQUEUED); the terminal path emits none, so
+        // a completed job is never accounted twice.
+        let live = run_job_on(&cm, "finalize-live", "worker1");
+        let resp = cm.apply_operation(&WalOperation::JobUserRequeue {
+            job_id: live,
+            hold: false,
+            begin_time: None,
+        });
+        assert_eq!(resp.jobs_finalized.len(), 1);
+        assert_eq!(resp.jobs_finalized[0].state, JobState::Requeued);
+
+        let done = run_job_on(&cm, "finalize-done", "worker1");
+        cm.complete_job(done, 0, JobState::Completed).unwrap();
+        settle(&cm, done, JobState::Completed);
+        let resp = cm.apply_operation(&WalOperation::JobUserRequeue {
+            job_id: done,
+            hold: false,
+            begin_time: None,
+        });
+        assert!(
+            resp.jobs_finalized.is_empty(),
+            "an already-terminal job must not be finalized again"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_hold_parks_job_held() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "requeue-hold", "worker1");
+        cm.requeue_job_by_user(job_id, "testuser", true).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.priority, 0, "held job sits at priority 0");
+        assert_eq!(job.pending_reason, PendingReason::Held);
+        assert!(job.pending_reason.is_scheduling_hold());
+        assert!(
+            !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "held job must not be eligible for dispatch"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_rejects_interactive_job() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = submit_and_wait(&cm, srun_spec("interactive"));
+        let resources = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec!["worker1".into()],
+            resources.clone(),
+            per_node_for(&["worker1"], resources),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
+
+        let err = cm
+            .requeue_job_by_user(job_id, "testuser", false)
+            .expect_err("interactive jobs cannot be requeued");
+        assert!(err.to_string().contains("interactive"), "got: {err}");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_rejects_already_pending() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let job_id = submit_and_wait(&cm, basic_spec("pending"));
+
+        let err = cm
+            .requeue_job_by_user(job_id, "testuser", false)
+            .expect_err("a pending job cannot be requeued");
+        assert!(err.to_string().contains("already pending"), "got: {err}");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_rejects_wrong_user() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+        let job_id = run_job_on(&cm, "owned-by-testuser", "worker1");
+
+        let err = cm
+            .requeue_job_by_user(job_id, "bob", false)
+            .expect_err("a non-owner non-root user must be denied");
+        assert!(
+            err.downcast_ref::<spur_core::auth::AuthError>().is_some(),
+            "got: {err}"
+        );
+        // root may requeue any job.
+        cm.requeue_job_by_user(job_id, "root", false).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_array_parent_fans_out_to_all_tasks() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let mut spec = basic_spec("array-requeue");
+        spec.array_spec = Some("0-1".into());
+        let parent = cm.submit_job(spec).unwrap().job_id;
+
+        // Collect the task ids and run each to completion so they are requeue-able.
+        wait_for("array tasks applied", || {
+            cm.get_jobs(&JobFilter::default())
+                .iter()
+                .filter(|j| j.spec.array_job_id == Some(parent))
+                .count()
+                == 2
+        });
+        let task_ids: Vec<JobId> = cm
+            .get_jobs(&JobFilter::default())
+            .iter()
+            .filter(|j| j.spec.array_job_id == Some(parent))
+            .map(|j| j.job_id)
+            .collect();
+        for &id in &task_ids {
+            let resources = scalar_alloc(2, 4000);
+            cm.start_job(
+                id,
+                vec!["worker1".into()],
+                resources.clone(),
+                per_node_for(&["worker1"], resources),
+            )
+            .unwrap();
+            settle(&cm, id, JobState::Running);
+            cm.complete_job(id, 0, JobState::Completed).unwrap();
+            settle(&cm, id, JobState::Completed);
+        }
+
+        // Requeuing the bare array-parent id fans out to every task.
+        cm.requeue_job_by_user(parent, "testuser", false).unwrap();
+        for &id in &task_ids {
+            settle(&cm, id, JobState::Pending);
+            assert_eq!(cm.get_job(id).unwrap().user_requeue_count, 1);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_apply_is_idempotent_on_replay() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+        let job_id = run_job_on(&cm, "replay", "worker1");
+
+        cm.apply_operation(&WalOperation::JobUserRequeue {
+            job_id,
+            hold: false,
+            begin_time: None,
+        });
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Pending);
+        assert_eq!(cm.get_job(job_id).unwrap().user_requeue_count, 1);
+
+        // Re-applying the same entry (follower catch-up / replay) is a NoOp:
+        // the job is already Pending, so the counter must not double-bump.
+        cm.apply_operation(&WalOperation::JobUserRequeue {
+            job_id,
+            hold: false,
+            begin_time: None,
+        });
+        assert_eq!(
+            cm.get_job(job_id).unwrap().user_requeue_count,
+            1,
+            "replay must not double-count a requeue"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_never_holds_at_max_batch_requeue() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+        let job_id = run_job_on(&cm, "repeat-requeue", "worker1");
+
+        let max = cm.config().controller.max_batch_requeue;
+        for n in 0..(max + 2) {
+            // Re-dispatch then requeue again; the batch cap must never trigger.
+            if cm.get_job(job_id).unwrap().state == JobState::Pending {
+                let resources = scalar_alloc(2, 4000);
+                cm.start_job(
+                    job_id,
+                    vec!["worker1".into()],
+                    resources.clone(),
+                    per_node_for(&["worker1"], resources),
+                )
+                .unwrap();
+                settle(&cm, job_id, JobState::Running);
+            }
+            cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+            settle(&cm, job_id, JobState::Pending);
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.user_requeue_count, n + 1);
+            assert_eq!(job.requeue_count, 0);
+            assert_ne!(
+                job.pending_reason,
+                PendingReason::JobHoldMaxRequeue,
+                "manual requeue must never trip the batch-requeue hold"
+            );
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -439,6 +439,15 @@ pub struct JobFilter<'a> {
     pub nodes: &'a [String],
 }
 
+/// Result of an admin requeue: `killed` are Running/Suspended snapshots whose
+/// old processes must be cancelled; `skipped` lists array tasks not requeued.
+#[derive(Debug, Default)]
+pub struct RequeueOutcome {
+    pub requeued: u32,
+    pub killed: Vec<Job>,
+    pub skipped: Vec<String>,
+}
+
 impl ClusterManager {
     #[cfg(test)]
     pub fn new(config: SlurmConfig, state_dir: &Path) -> anyhow::Result<Self> {
@@ -1187,14 +1196,12 @@ impl ClusterManager {
 
     /// Admin requeue (`scontrol requeue` / `requeuehold`), keeping the `job_id`.
     /// A bare array-parent id (no job record of its own) fans out to every task.
-    /// Returns snapshots of the jobs that were Running/Suspended so the caller
-    /// can kill their old processes.
     pub fn requeue_job_by_user(
         &self,
         job_id: JobId,
         user: &str,
         hold: bool,
-    ) -> anyhow::Result<Vec<Job>> {
+    ) -> anyhow::Result<RequeueOutcome> {
         let (targets, is_array) = {
             let jobs = self.jobs.read();
             if jobs.contains_key(&job_id) {
@@ -1216,41 +1223,39 @@ impl ClusterManager {
         // A single, explicitly named job propagates its error verbatim so the
         // user sees exactly why (not owner, interactive, already pending, ...).
         if !is_array {
-            return Ok(self
+            let killed: Vec<Job> = self
                 .requeue_one_job(targets[0], user, hold)?
                 .into_iter()
-                .collect());
+                .collect();
+            return Ok(RequeueOutcome {
+                requeued: 1,
+                killed,
+                skipped: Vec::new(),
+            });
         }
 
         // Array fan-out: requeue every task that can be, collecting per-task
         // failures. Only fail outright if no task could be requeued at all.
         let total = targets.len();
-        let mut killed = Vec::new();
-        let mut errors = Vec::new();
+        let mut outcome = RequeueOutcome::default();
         for id in targets {
             match self.requeue_one_job(id, user, hold) {
-                Ok(Some(job)) => killed.push(job),
-                Ok(None) => {}
-                Err(e) => errors.push(format!("task {id}: {e}")),
+                Ok(Some(job)) => {
+                    outcome.requeued += 1;
+                    outcome.killed.push(job);
+                }
+                Ok(None) => outcome.requeued += 1,
+                Err(e) => outcome.skipped.push(format!("job {id}: {e}")),
             }
         }
-        if killed.is_empty() && errors.len() == total {
+        if outcome.requeued == 0 && outcome.skipped.len() == total {
             anyhow::bail!(
                 "no tasks of array {} could be requeued: {}",
                 job_id,
-                errors.join("; ")
+                outcome.skipped.join("; ")
             );
         }
-        // Partial success is reported as success (some tasks requeued), so make
-        // the skipped tasks visible rather than swallowing them silently.
-        if !errors.is_empty() {
-            warn!(
-                array_job_id = job_id,
-                "some array tasks were not requeued: {}",
-                errors.join("; ")
-            );
-        }
-        Ok(killed)
+        Ok(outcome)
     }
 
     /// Requeue exactly one job/task. Returns its pre-requeue snapshot when the
@@ -1295,7 +1300,7 @@ impl ClusterManager {
                 Some(
                     job.spec
                         .begin_time
-                        .map_or(deferred, |user| user.max(deferred)),
+                        .map_or(deferred, |user_begin| user_begin.max(deferred)),
                 )
             }
             _ => None,
@@ -4461,6 +4466,45 @@ impl ClusterManager {
         .map_err(|e| anyhow::anyhow!("raft propose failed: {}", e))
     }
 
+    /// Return a finished job's per-node slice to each node it held, skipping any
+    /// in `already_deallocated`; pass `allocated_resources = None` if freed already.
+    fn deallocate_job_slices(
+        nodes: &mut HashMap<String, Node>,
+        freed_nodes: &[String],
+        allocated_resources: Option<&ResourceAllocations>,
+        per_node_alloc: &HashMap<String, ResourceAllocations>,
+        already_deallocated: &[String],
+        job_id: JobId,
+    ) {
+        let Some(total) = allocated_resources else {
+            return;
+        };
+        let node_count = freed_nodes.len().max(1) as u32;
+        for name in freed_nodes {
+            if already_deallocated.iter().any(|n| n == name) {
+                continue;
+            }
+            let Some(node) = nodes.get_mut(name) else {
+                continue;
+            };
+            let slice = per_node_alloc.get(name).cloned().unwrap_or_else(|| {
+                warn!(job_id, node = %name, "per_node_alloc missing at deallocation, using scalar fallback");
+                ResourceAllocations::with_scalar(
+                    total.cpus / node_count,
+                    total.memory_mb / node_count as u64,
+                )
+            });
+            node.alloc_resources.subtract(&slice);
+            node.update_state_from_alloc();
+            if node.state == NodeState::Draining
+                && node.alloc_resources.cpus == 0
+                && !node.alloc_resources.has_devices()
+            {
+                node.state = NodeState::Drain;
+            }
+        }
+    }
+
     /// Clear a job's run-state fields so it's schedulable again after requeue.
     /// Does not bump either counter; callers do that based on why they're requeuing.
     fn clear_run_state_for_requeue(job: &mut Job) {
@@ -4536,35 +4580,14 @@ impl ClusterManager {
         let already_deallocated: Vec<String> = job.node_completions.keys().cloned().collect();
         job.node_completions.clear();
 
-        let alloc_nodes = job.allocated_nodes.clone();
-        if let Some(ref total) = job.allocated_resources {
-            let node_count = alloc_nodes.len().max(1) as u32;
-            for alloc_node in &alloc_nodes {
-                if already_deallocated.iter().any(|n| n == alloc_node) {
-                    continue;
-                }
-                if let Some(node) = nodes.get_mut(alloc_node) {
-                    let slice = job
-                        .per_node_alloc
-                        .get(alloc_node)
-                        .cloned()
-                        .unwrap_or_else(|| {
-                            ResourceAllocations::with_scalar(
-                                total.cpus / node_count,
-                                total.memory_mb / node_count as u64,
-                            )
-                        });
-                    node.alloc_resources.subtract(&slice);
-                    node.update_state_from_alloc();
-                    if node.state == NodeState::Draining
-                        && node.alloc_resources.cpus == 0
-                        && !node.alloc_resources.has_devices()
-                    {
-                        node.state = NodeState::Drain;
-                    }
-                }
-            }
-        }
+        Self::deallocate_job_slices(
+            nodes,
+            &job.allocated_nodes,
+            job.allocated_resources.as_ref(),
+            &job.per_node_alloc,
+            &already_deallocated,
+            job_id,
+        );
 
         Some(JobFinalized {
             job_id,
@@ -4722,32 +4745,18 @@ impl ClusterManager {
                     job.spec.begin_time = Some(*begin_time);
                     job.set_pending_reason(PendingReason::BeginTime);
                 }
-                if let Some(ref total) = allocated_resources {
-                    let node_count = freed_nodes.len().max(1) as u32;
-                    for name in &freed_nodes {
-                        if let Some(node) = nodes.get_mut(name) {
-                            let slice = per_node_map.get(name).cloned().unwrap_or_else(|| {
-                                warn!(job_id = *job_id, node = %name, "per_node_alloc missing at preempt deallocation, using scalar fallback");
-                                ResourceAllocations::with_scalar(
-                                    total.cpus / node_count,
-                                    total.memory_mb / node_count as u64,
-                                )
-                            });
-                            node.alloc_resources.subtract(&slice);
-                            node.update_state_from_alloc();
-                            if node.state == NodeState::Draining
-                                && node.alloc_resources.cpus == 0
-                                && !node.alloc_resources.has_devices()
-                            {
-                                node.state = NodeState::Drain;
-                            }
-                        }
-                    }
-                }
+                Self::deallocate_job_slices(
+                    &mut nodes,
+                    &freed_nodes,
+                    allocated_resources.as_ref(),
+                    &per_node_map,
+                    &[],
+                    *job_id,
+                );
                 drop(jobs);
                 drop(nodes);
-                // Complete steps and fire accounting for the terminated run as
-                // PREEMPTED, even though the job itself is now Pending-with-hold.
+                // Fire accounting for the terminated run as PREEMPTED, even
+                // though the job itself is now Pending-with-hold.
                 self.complete_job_steps(job_id, -1, timestamp);
                 self.next_job_id.store(next_id, Ordering::Relaxed);
                 return ClientResponse {
@@ -4788,9 +4797,20 @@ impl ClusterManager {
                             }
                             job.exit_code = Some(-1);
                             job.end_time = Some(timestamp);
+                            // The live run still holds its allocation; capture it
+                            // to free below.
+                            freed_nodes = job.allocated_nodes.clone();
+                            allocated_resources = job.allocated_resources.clone();
+                            per_node_map = job.per_node_alloc.clone();
+                            job.node_completions.clear();
                         }
                         s if s.is_terminal() => {
+                            // The slice was already freed at completion; freeing
+                            // again would double-subtract on any shared node.
                             was_live = false;
+                            freed_nodes = Vec::new();
+                            allocated_resources = None;
+                            per_node_map = HashMap::new();
                         }
                         _ => {
                             // Pending, Completing, or an in-flight finalized
@@ -4798,10 +4818,6 @@ impl ClusterManager {
                             return ClientResponse::default();
                         }
                     }
-                    freed_nodes = job.allocated_nodes.clone();
-                    allocated_resources = job.allocated_resources.clone();
-                    per_node_map = job.per_node_alloc.clone();
-                    job.node_completions.clear();
 
                     if let Err(e) = job.transition(JobState::Pending) {
                         warn!(job_id = *job_id, error = %e, "invalid requeue transition in WAL apply");
@@ -4819,30 +4835,16 @@ impl ClusterManager {
                         job.set_pending_reason(PendingReason::None);
                     }
                 }
-                // Only the live path has allocations to free; for a terminal job
-                // `allocated_resources` is already None and this is skipped.
-                if let Some(ref total) = allocated_resources {
-                    let node_count = freed_nodes.len().max(1) as u32;
-                    for name in &freed_nodes {
-                        if let Some(node) = nodes.get_mut(name) {
-                            let slice = per_node_map.get(name).cloned().unwrap_or_else(|| {
-                                warn!(job_id = *job_id, node = %name, "per_node_alloc missing at requeue deallocation, using scalar fallback");
-                                ResourceAllocations::with_scalar(
-                                    total.cpus / node_count,
-                                    total.memory_mb / node_count as u64,
-                                )
-                            });
-                            node.alloc_resources.subtract(&slice);
-                            node.update_state_from_alloc();
-                            if node.state == NodeState::Draining
-                                && node.alloc_resources.cpus == 0
-                                && !node.alloc_resources.has_devices()
-                            {
-                                node.state = NodeState::Drain;
-                            }
-                        }
-                    }
-                }
+                // Live path only; the terminal path passes an empty allocation so
+                // this is a no-op (its slice was already freed at completion).
+                Self::deallocate_job_slices(
+                    &mut nodes,
+                    &freed_nodes,
+                    allocated_resources.as_ref(),
+                    &per_node_map,
+                    &[],
+                    *job_id,
+                );
                 drop(jobs);
                 drop(nodes);
                 self.next_job_id.store(next_id, Ordering::Relaxed);
@@ -5189,36 +5191,19 @@ impl ClusterManager {
                 } else {
                     return ClientResponse::default();
                 }
-                // Deallocate node resources not already freed during COMPLETING
+                // Deallocate node resources not already freed during COMPLETING.
                 let per_node_map = jobs
                     .get(job_id)
                     .map(|j| j.per_node_alloc.clone())
                     .unwrap_or_default();
-                if let Some(ref total) = allocated_resources {
-                    let node_count = freed_nodes.len().max(1) as u32;
-                    for name in &freed_nodes {
-                        if already_deallocated.iter().any(|n| n == name) {
-                            continue;
-                        }
-                        if let Some(node) = nodes.get_mut(name) {
-                            let slice = per_node_map.get(name).cloned().unwrap_or_else(|| {
-                                warn!(job_id = *job_id, node = %name, "per_node_alloc missing at deallocation, using scalar fallback");
-                                ResourceAllocations::with_scalar(
-                                    total.cpus / node_count,
-                                    total.memory_mb / node_count as u64,
-                                )
-                            });
-                            node.alloc_resources.subtract(&slice);
-                            node.update_state_from_alloc();
-                            if node.state == NodeState::Draining
-                                && node.alloc_resources.cpus == 0
-                                && !node.alloc_resources.has_devices()
-                            {
-                                node.state = NodeState::Drain;
-                            }
-                        }
-                    }
-                }
+                Self::deallocate_job_slices(
+                    &mut nodes,
+                    &freed_nodes,
+                    allocated_resources.as_ref(),
+                    &per_node_map,
+                    &already_deallocated,
+                    *job_id,
+                );
                 drop(jobs);
                 drop(nodes);
                 self.complete_job_steps(job_id, *exit_code, timestamp);
@@ -9841,9 +9826,9 @@ mod tests {
         let job_id = run_job_on(&cm, "requeue-me", "worker1");
         assert_eq!(cm.node_metrics().alloc_cpus, 2);
 
-        let killed = cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        let outcome = cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
         assert_eq!(
-            killed.len(),
+            outcome.killed.len(),
             1,
             "a running job must be reported for agent kill"
         );
@@ -9882,8 +9867,8 @@ mod tests {
         cm.suspend_job(job_id, "testuser").unwrap();
         settle(&cm, job_id, JobState::Suspended);
 
-        let killed = cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
-        assert_eq!(killed.len(), 1);
+        let outcome = cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        assert_eq!(outcome.killed.len(), 1);
         settle(&cm, job_id, JobState::Pending);
 
         let job = cm.get_job(job_id).unwrap();
@@ -9903,8 +9888,12 @@ mod tests {
         settle(&cm, job_id, JobState::Completed);
 
         // An already-terminal job has no live processes to kill.
-        let killed = cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
-        assert!(killed.is_empty(), "terminal job needs no agent kill");
+        let outcome = cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        assert!(
+            outcome.killed.is_empty(),
+            "terminal job needs no agent kill"
+        );
+        assert_eq!(outcome.requeued, 1);
         settle(&cm, job_id, JobState::Pending);
 
         let job = cm.get_job(job_id).unwrap();
@@ -9926,6 +9915,7 @@ mod tests {
             JobState::Timeout,
             JobState::NodeFail,
             JobState::OutOfMemory,
+            JobState::Cancelled,
         ] {
             let job_id = run_job_on(&cm, &format!("term-{state:?}"), "worker1");
             cm.complete_job(job_id, -1, state).unwrap();
@@ -9935,6 +9925,35 @@ mod tests {
             settle(&cm, job_id, JobState::Pending);
             assert_eq!(cm.get_job(job_id).unwrap().user_requeue_count, 1);
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_terminal_job_does_not_double_free_shared_node() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let a = run_job_on(&cm, "share-a", "worker1");
+        let _b = run_job_on(&cm, "share-b", "worker1");
+        assert_eq!(cm.node_metrics().alloc_cpus, 4);
+
+        cm.complete_job(a, 0, JobState::Completed).unwrap();
+        settle(&cm, a, JobState::Completed);
+        assert_eq!(
+            cm.node_metrics().alloc_cpus,
+            2,
+            "A's slice freed once at completion"
+        );
+
+        // Requeuing already-terminal A must not free its slice a second time, or
+        // B's accounting on the shared node would be corrupted.
+        cm.requeue_job_by_user(a, "testuser", false).unwrap();
+        settle(&cm, a, JobState::Pending);
+        assert_eq!(
+            cm.node_metrics().alloc_cpus,
+            2,
+            "terminal requeue must not double-free the shared node"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -9989,12 +10008,69 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn user_requeue_rejects_interactive_job() {
+    async fn user_requeue_rejects_interactive_jobs() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        // Each of the three non-batch markers must be rejected (the check runs
+        // before the state match, so a Pending allocation is enough to exercise
+        // it). srun/salloc/--pty have no batch script to re-run.
+        for (name, apply) in [
+            (
+                "srun",
+                (|s: &mut JobSpec| s.srun_job = true) as fn(&mut JobSpec),
+            ),
+            ("interactive", |s: &mut JobSpec| s.interactive = true),
+            ("pty", |s: &mut JobSpec| s.pty = true),
+        ] {
+            let mut spec = basic_spec(name);
+            apply(&mut spec);
+            let job_id = submit_and_wait(&cm, spec);
+            let err = cm
+                .requeue_job_by_user(job_id, "testuser", false)
+                .expect_err("interactive jobs cannot be requeued");
+            assert!(err.to_string().contains("interactive"), "{name}: {err}");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_hold_then_release_reschedules() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "worker1", 8, 16000);
 
-        let job_id = submit_and_wait(&cm, srun_spec("interactive"));
+        let job_id = run_job_on(&cm, "hold-release", "worker1");
+        cm.requeue_job_by_user(job_id, "testuser", true).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+        assert!(cm
+            .get_job(job_id)
+            .unwrap()
+            .pending_reason
+            .is_scheduling_hold());
+
+        // Releasing the held requeue makes it schedulable again.
+        cm.release_job(job_id).unwrap();
+        wait_for("released", || {
+            cm.get_job(job_id)
+                .is_some_and(|j| !j.pending_reason.is_scheduling_hold())
+        });
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.priority, DEFAULT_PRIORITY);
+        assert!(cm.pending_jobs().iter().any(|j| j.job_id == job_id));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_preserves_later_user_begin() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        // A user --begin further out than the requeue's own hold must win, so
+        // the requeue never shortens the operator's constraint.
+        let user_begin = Utc::now() + chrono::Duration::hours(1);
+        let mut spec = basic_spec("user-begin-requeue");
+        spec.begin_time = Some(user_begin);
+        let job_id = submit_and_wait(&cm, spec);
         let resources = scalar_alloc(2, 4000);
         cm.start_job(
             job_id,
@@ -10005,10 +10081,45 @@ mod tests {
         .unwrap();
         settle(&cm, job_id, JobState::Running);
 
-        let err = cm
-            .requeue_job_by_user(job_id, "testuser", false)
-            .expect_err("interactive jobs cannot be requeued");
-        assert!(err.to_string().contains("interactive"), "got: {err}");
+        cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+        assert_eq!(
+            cm.get_job(job_id).unwrap().spec.begin_time,
+            Some(user_begin),
+            "user --begin beyond the requeue hold must be preserved"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_preserves_run_attempt_fencing() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        // First run is epoch 1.
+        let job_id = run_job_on(&cm, "epoch", "worker1");
+        assert_eq!(cm.get_job(job_id).unwrap().run_attempt, 1);
+
+        cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+
+        // Re-dispatch bumps the epoch to 2 (requeue must not have reset it).
+        let alloc = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec!["worker1".into()],
+            alloc.clone(),
+            per_node_for(&["worker1"], alloc),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
+        assert_eq!(cm.get_job(job_id).unwrap().run_attempt, 2);
+
+        // A late completion from the killed run (epoch 1) must be dropped so the
+        // old cancel can never finalize the fresh run.
+        let res = cm.node_complete(job_id, "worker1", 0, 9, 1).unwrap();
+        assert!(matches!(res, NodeCompleteResult::StaleReport));
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Running);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -10081,11 +10192,63 @@ mod tests {
         }
 
         // Requeuing the bare array-parent id fans out to every task.
-        cm.requeue_job_by_user(parent, "testuser", false).unwrap();
+        let outcome = cm.requeue_job_by_user(parent, "testuser", false).unwrap();
+        assert_eq!(outcome.requeued, task_ids.len() as u32);
+        assert!(outcome.skipped.is_empty());
         for &id in &task_ids {
             settle(&cm, id, JobState::Pending);
             assert_eq!(cm.get_job(id).unwrap().user_requeue_count, 1);
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_array_partial_reports_skipped_tasks() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let mut spec = basic_spec("array-partial");
+        spec.array_spec = Some("0-1".into());
+        let parent = cm.submit_job(spec).unwrap().job_id;
+        wait_for("array tasks applied", || {
+            cm.get_jobs(&JobFilter::default())
+                .iter()
+                .filter(|j| j.spec.array_job_id == Some(parent))
+                .count()
+                == 2
+        });
+        let mut task_ids: Vec<JobId> = cm
+            .get_jobs(&JobFilter::default())
+            .iter()
+            .filter(|j| j.spec.array_job_id == Some(parent))
+            .map(|j| j.job_id)
+            .collect();
+        task_ids.sort_unstable();
+
+        // Run only the first task; leave the second Pending so the fan-out
+        // requeues one and skips the other ("already pending").
+        let resources = scalar_alloc(2, 4000);
+        cm.start_job(
+            task_ids[0],
+            vec!["worker1".into()],
+            resources.clone(),
+            per_node_for(&["worker1"], resources),
+        )
+        .unwrap();
+        settle(&cm, task_ids[0], JobState::Running);
+
+        let outcome = cm.requeue_job_by_user(parent, "testuser", false).unwrap();
+        assert_eq!(outcome.requeued, 1, "only the running task is requeued");
+        assert_eq!(
+            outcome.skipped.len(),
+            1,
+            "the pending task is surfaced as skipped"
+        );
+        assert!(
+            outcome.skipped[0].contains("already pending"),
+            "got: {:?}",
+            outcome.skipped
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1223,14 +1223,22 @@ impl ClusterManager {
         // A single, explicitly named job propagates its error verbatim so the
         // user sees exactly why (not owner, interactive, already pending, ...).
         if !is_array {
-            let killed: Vec<Job> = self
-                .requeue_one_job(targets[0], user, hold)?
-                .into_iter()
-                .collect();
-            return Ok(RequeueOutcome {
-                requeued: 1,
-                killed,
-                skipped: Vec::new(),
+            let id = targets[0];
+            let (requeued, killed) = self.requeue_one_job(id, user, hold)?;
+            return Ok(if requeued {
+                RequeueOutcome {
+                    requeued: 1,
+                    killed: killed.into_iter().collect(),
+                    skipped: Vec::new(),
+                }
+            } else {
+                // Raced to a non-requeuable state after the pre-check; report it
+                // honestly rather than claiming success.
+                RequeueOutcome {
+                    requeued: 0,
+                    killed: Vec::new(),
+                    skipped: vec![format!("job {id}: state changed before requeue")],
+                }
             });
         }
 
@@ -1240,11 +1248,13 @@ impl ClusterManager {
         let mut outcome = RequeueOutcome::default();
         for id in targets {
             match self.requeue_one_job(id, user, hold) {
-                Ok(Some(job)) => {
+                Ok((true, killed)) => {
                     outcome.requeued += 1;
-                    outcome.killed.push(job);
+                    outcome.killed.extend(killed);
                 }
-                Ok(None) => outcome.requeued += 1,
+                Ok((false, _)) => outcome
+                    .skipped
+                    .push(format!("job {id}: state changed before requeue")),
                 Err(e) => outcome.skipped.push(format!("job {id}: {e}")),
             }
         }
@@ -1258,14 +1268,16 @@ impl ClusterManager {
         Ok(outcome)
     }
 
-    /// Requeue exactly one job/task. Returns its pre-requeue snapshot when the
-    /// job was Running/Suspended (so its processes must be killed on the nodes).
+    /// Requeue exactly one job/task. Returns `(requeued, killed)`: `requeued` is
+    /// false if the job raced to a non-requeuable state between the pre-check and
+    /// the apply (nothing changed); `killed` is the pre-requeue snapshot when it
+    /// was live and its processes must be cancelled on the nodes.
     fn requeue_one_job(
         &self,
         job_id: JobId,
         user: &str,
         hold: bool,
-    ) -> anyhow::Result<Option<Job>> {
+    ) -> anyhow::Result<(bool, Option<Job>)> {
         let snapshot = {
             let jobs = self.jobs.read();
             let job = jobs
@@ -1314,9 +1326,22 @@ impl ClusterManager {
         // Fires accounting-end + epilog for the finalized run (live path only;
         // an already-terminal job emits no finalized entry here).
         self.run_all_finalized_side_effects(&resp);
+
+        // The apply arm NoOps if the job raced out of a requeuable state (e.g. to
+        // Completing) in the propose window; confirm it really re-pended before
+        // reporting success or cancelling. Read before notify so no re-dispatch yet.
+        let repended = self
+            .jobs
+            .read()
+            .get(&job_id)
+            .is_some_and(|j| j.state == JobState::Pending);
+        if !repended {
+            debug!(job_id, "requeue raced a concurrent state change; no-op");
+            return Ok((false, None));
+        }
         self.scheduler_notify.notify_one();
         info!(job_id, hold, "job requeued by admin");
-        Ok(snapshot)
+        Ok((true, snapshot))
     }
 
     /// Complete a standalone srun allocation after its step finishes.
@@ -4513,6 +4538,7 @@ impl ClusterManager {
         job.allocated_nodes.clear();
         job.allocated_resources = None;
         job.per_node_alloc.clear();
+        job.node_completions.clear();
         job.time_limit_signaled_at = None;
         job.pending_reason = PendingReason::None;
         job.pending_reason_desc = None;
@@ -4791,18 +4817,11 @@ impl ClusterManager {
                             if let Some(since) = job.suspended_at.take() {
                                 job.suspended_secs += (timestamp - since).num_seconds().max(0);
                             }
-                            if let Err(e) = job.transition(JobState::Requeued) {
-                                warn!(job_id = *job_id, error = %e, "invalid requeue finalize transition in WAL apply");
-                                return ClientResponse::default();
-                            }
-                            job.exit_code = Some(-1);
-                            job.end_time = Some(timestamp);
                             // The live run still holds its allocation; capture it
-                            // to free below.
+                            // to free below (reset clears node_completions).
                             freed_nodes = job.allocated_nodes.clone();
                             allocated_resources = job.allocated_resources.clone();
                             per_node_map = job.per_node_alloc.clone();
-                            job.node_completions.clear();
                         }
                         s if s.is_terminal() => {
                             // The slice was already freed at completion; freeing
@@ -4819,7 +4838,9 @@ impl ClusterManager {
                         }
                     }
 
-                    if let Err(e) = job.transition(JobState::Pending) {
+                    // Guarded re-pend: a live run finalizes as Requeued first,
+                    // then returns to Pending (terminal jobs go straight back).
+                    if let Err(e) = job.requeue_to_pending() {
                         warn!(job_id = *job_id, error = %e, "invalid requeue transition in WAL apply");
                         return ClientResponse::default();
                     }
@@ -10199,6 +10220,50 @@ mod tests {
             settle(&cm, id, JobState::Pending);
             assert_eq!(cm.get_job(id).unwrap().user_requeue_count, 1);
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_array_all_pending_errors() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        // No node registered, so both tasks stay Pending; requeuing them is
+        // rejected per task, and with none requeue-able the whole call errors.
+        let mut spec = basic_spec("array-all-pending");
+        spec.array_spec = Some("0-1".into());
+        let parent = cm.submit_job(spec).unwrap().job_id;
+        wait_for("array tasks applied", || {
+            cm.get_jobs(&JobFilter::default())
+                .iter()
+                .filter(|j| j.spec.array_job_id == Some(parent))
+                .count()
+                == 2
+        });
+
+        let err = cm
+            .requeue_job_by_user(parent, "testuser", false)
+            .expect_err("all-pending array requeue must error");
+        assert!(err.to_string().contains("no tasks of array"), "got: {err}");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_requeue_rejects_completing_job() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "completing", "worker1");
+        cm.apply_operation(&WalOperation::job_state_change(
+            job_id,
+            JobState::Running,
+            JobState::Completing,
+        ));
+        settle(&cm, job_id, JobState::Completing);
+
+        let err = cm
+            .requeue_job_by_user(job_id, "testuser", false)
+            .expect_err("a completing job cannot be requeued");
+        assert!(err.to_string().contains("completing"), "got: {err}");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -917,7 +917,7 @@ impl SlurmController for ControllerService {
     async fn requeue_job(
         &self,
         request: Request<RequeueJobRequest>,
-    ) -> Result<Response<()>, Status> {
+    ) -> Result<Response<RequeueJobResponse>, Status> {
         if let Err(status) = self.check_leader(&request) {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
@@ -934,21 +934,24 @@ impl SlurmController for ControllerService {
         }
 
         let req = request.into_inner();
-        let killed = self
+        let outcome = self
             .cluster
             .requeue_job_by_user(req.job_id, &req.user, req.hold)
             .map_err(cluster_err_to_precondition_status)?;
 
         // Kill the old processes for jobs that were Running/Suspended; the
         // requeue already freed their allocations and re-pended them.
-        for job in killed {
+        for job in outcome.killed {
             let cluster = self.cluster.clone();
             tokio::spawn(async move {
                 crate::scheduler_loop::send_cancel_to_agents(&cluster, &job, 0).await;
             });
         }
 
-        Ok(Response::new(()))
+        Ok(Response::new(RequeueJobResponse {
+            requeued: outcome.requeued,
+            skipped: outcome.skipped,
+        }))
     }
 
     async fn get_nodes(
@@ -4561,6 +4564,112 @@ mod tests {
             control_plane_replicas: 1,
             jwt_key: String::new(),
         }
+    }
+
+    // Exercises the requeue RPC boundary: gRPC status mapping (auth vs. state
+    // precondition) and the requeued-count response the CLI relies on.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn requeue_job_rpc_reports_count_and_maps_errors() {
+        use spur_core::resource::{ResourceAllocations, ResourceSet};
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        svc.cluster
+            .register_node(
+                "n1".into(),
+                "n1".into(),
+                ResourceSet {
+                    cpus: 8,
+                    memory_mb: 16000,
+                    ..Default::default()
+                },
+                "127.0.0.1".into(),
+                6818,
+                String::new(),
+                String::new(),
+                spur_core::node::NodeSource::NativeHost,
+                std::collections::HashMap::new(),
+            )
+            .unwrap();
+        for _ in 0..200 {
+            if svc.cluster.get_node("n1").is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        let spec = spur_core::job::JobSpec {
+            name: "rq".into(),
+            user: "alice".into(),
+            num_nodes: 1,
+            num_tasks: 1,
+            cpus_per_task: 1,
+            work_dir: "/tmp".into(),
+            ..Default::default()
+        };
+        let job_id = svc.cluster.submit_job(spec).unwrap().job_id;
+        for _ in 0..200 {
+            if svc.cluster.get_job(job_id).is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        // Unknown job -> FailedPrecondition (non-auth cluster error).
+        let err = svc
+            .requeue_job(Request::new(RequeueJobRequest {
+                job_id: 999_999,
+                user: "alice".into(),
+                hold: false,
+            }))
+            .await
+            .expect_err("unknown job must error");
+        assert_eq!(err.code(), Code::FailedPrecondition);
+
+        // Wrong user -> PermissionDenied (auth precedes the state checks).
+        let err = svc
+            .requeue_job(Request::new(RequeueJobRequest {
+                job_id,
+                user: "mallory".into(),
+                hold: false,
+            }))
+            .await
+            .expect_err("non-owner must be denied");
+        assert_eq!(err.code(), Code::PermissionDenied);
+
+        // Drive to terminal, then a valid owner requeue succeeds and reports the count.
+        let res = ResourceAllocations::with_scalar(1, 1000);
+        let per_node: std::collections::HashMap<_, _> =
+            [("n1".to_string(), res.clone())].into_iter().collect();
+        svc.cluster
+            .start_job(job_id, vec!["n1".into()], res, per_node)
+            .unwrap();
+        for _ in 0..200 {
+            if svc.cluster.get_job(job_id).map(|j| j.state) == Some(JobState::Running) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        svc.cluster
+            .complete_job(job_id, 0, JobState::Completed)
+            .unwrap();
+        for _ in 0..200 {
+            if svc.cluster.get_job(job_id).map(|j| j.state) == Some(JobState::Completed) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        let resp = svc
+            .requeue_job(Request::new(RequeueJobRequest {
+                job_id,
+                user: "alice".into(),
+                hold: false,
+            }))
+            .await
+            .expect("owner requeue must succeed")
+            .into_inner();
+        assert_eq!(resp.requeued, 1);
+        assert!(resp.skipped.is_empty());
     }
 
     // A step must NOT be created when the target node is allocated but unregistered: address

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -914,6 +914,43 @@ impl SlurmController for ControllerService {
         Ok(Response::new(()))
     }
 
+    async fn requeue_job(
+        &self,
+        request: Request<RequeueJobRequest>,
+    ) -> Result<Response<()>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            match proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut fwd = Request::new(request.into_inner());
+                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    return client.requeue_job(fwd).await;
+                }
+                Err(e) => {
+                    warn!("failed to forward requeue_job to leader: {e}");
+                    return Err(status);
+                }
+            }
+        }
+
+        let req = request.into_inner();
+        let killed = self
+            .cluster
+            .requeue_job_by_user(req.job_id, &req.user, req.hold)
+            .map_err(cluster_err_to_precondition_status)?;
+
+        // Kill the old processes for jobs that were Running/Suspended; the
+        // requeue already freed their allocations and re-pended them.
+        for job in killed {
+            let cluster = self.cluster.clone();
+            tokio::spawn(async move {
+                crate::scheduler_loop::send_cancel_to_agents(&cluster, &job, 0).await;
+            });
+        }
+
+        Ok(Response::new(()))
+    }
+
     async fn get_nodes(
         &self,
         request: Request<GetNodesRequest>,

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -319,7 +319,7 @@ service SlurmController {
   rpc UpdateJob(UpdateJobRequest) returns (google.protobuf.Empty);
   // Requeue a running/suspended or finished batch job back to PENDING,
   // keeping the same job_id and spec. `hold` parks it in a held state.
-  rpc RequeueJob(RequeueJobRequest) returns (google.protobuf.Empty);
+  rpc RequeueJob(RequeueJobRequest) returns (RequeueJobResponse);
 
   // Node management
   rpc GetNodes(GetNodesRequest) returns (GetNodesResponse);
@@ -548,6 +548,11 @@ message RequeueJobRequest {
   uint32 job_id = 1;   // Array parent id fans out to every task.
   string user = 2;     // For authorization (owner or root).
   bool hold = 3;       // Requeue into a held state (requeuehold).
+}
+
+message RequeueJobResponse {
+  uint32 requeued = 1;         // Jobs/array tasks returned to the queue.
+  repeated string skipped = 2; // "job N: reason" for tasks that could not be requeued (array fan-out).
 }
 
 message GetNodesRequest {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -62,6 +62,8 @@ enum JobState {
   JOB_SUSPENDED = 9;
   JOB_DEADLINE = 10;
   JOB_OUT_OF_MEMORY = 11;
+  // Finalized end-of-run for an admin requeue; the job returns to PENDING.
+  JOB_REQUEUED = 12;
 }
 
 enum NodeState {
@@ -315,6 +317,9 @@ service SlurmController {
   rpc SuspendJob(SuspendJobRequest) returns (google.protobuf.Empty);
   rpc ResumeJob(ResumeJobRequest) returns (google.protobuf.Empty);
   rpc UpdateJob(UpdateJobRequest) returns (google.protobuf.Empty);
+  // Requeue a running/suspended or finished batch job back to PENDING,
+  // keeping the same job_id and spec. `hold` parks it in a held state.
+  rpc RequeueJob(RequeueJobRequest) returns (google.protobuf.Empty);
 
   // Node management
   rpc GetNodes(GetNodesRequest) returns (GetNodesResponse);
@@ -537,6 +542,12 @@ message UpdateJobRequest {
   optional bool hold = 6;
   optional string comment = 7;
   optional string qos = 8;
+}
+
+message RequeueJobRequest {
+  uint32 job_id = 1;   // Array parent id fans out to every task.
+  string user = 2;     // For authorization (owner or root).
+  bool hold = 3;       // Requeue into a held state (requeuehold).
 }
 
 message GetNodesRequest {

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -1146,7 +1146,7 @@ def parse_job_id(sbatch_output: str) -> int | None:
 
 def job_state(squeue_output: str, job_id: int) -> str | None:
     """Parse job state from squeue -t all output."""
-    valid_states = {"PD", "R", "CD", "CG", "F", "CA", "TO", "NF", "PR", "S"}
+    valid_states = {"PD", "R", "CD", "CG", "F", "CA", "TO", "NF", "PR", "S", "RQ"}
     id_str = str(job_id)
     for line in squeue_output.splitlines()[1:]:
         fields = line.split()

--- a/tests/native_host/e2e/test_requeue.py
+++ b/tests/native_host/e2e/test_requeue.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for `scontrol requeue` / `requeuehold`.
+
+Covers returning a running job to the queue (kill + re-pend, same job_id),
+requeuing a finished job, the held variant, whole-array fan-out, and CLI
+guards. Each test cancels its job in a finally block.
+"""
+
+import time
+
+from cluster import parse_job_id, job_state
+
+
+def _cleanup(cluster, job_id):
+    """Best-effort cancel. No-op when submission never produced an id."""
+    if job_id is None:
+        return
+    cluster.cli_allow_fail(["scancel", str(job_id)])
+
+
+def _wait_state(cluster, job_id, want, timeout=60):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if job_state(cluster.squeue_all(), job_id) == want:
+            return True
+        time.sleep(1)
+    return False
+
+
+def _show_field(cluster, job_id, key):
+    """Return the value of `key=` from `scontrol show job` (or None)."""
+    show = cluster.scontrol("show", "job", str(job_id))
+    for token in show.split():
+        if token.startswith(f"{key}="):
+            return token.split("=", 1)[1]
+    return None
+
+
+def _wait_finished(cluster, job_id, timeout=60):
+    """Poll until the job is finished: either shown COMPLETED or gone from the
+    active queue. Avoids racing on the RUNNING window for very short jobs."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        state = job_state(cluster.squeue_all(), job_id)
+        if state in ("CD", None):
+            return True
+        time.sleep(1)
+    return False
+
+
+def _submit_sleep(cluster, name, sleep_secs=600, extra=None, wait_running=True):
+    body = f"#!/bin/bash\necho STARTED\nsleep {sleep_secs}\n"
+    script = cluster.write_file(f"{name}.sh", body)
+    args = ["-J", name, "-N", "1"]
+    if extra:
+        args += extra
+    args.append(script)
+    job_id = parse_job_id(cluster.sbatch(args))
+    assert job_id is not None, "submit failed"
+    # Callers that want to observe RUNNING must use a long-enough sleep; a short
+    # job can finish before squeue ever reports R, so `wait_running=False` skips
+    # that (racy) assertion.
+    if wait_running:
+        assert _wait_state(cluster, job_id, "R"), "job never reached RUNNING"
+    return job_id
+
+
+class TestRequeueRunning:
+    def test_requeue_running_job_returns_to_queue(self, cluster):
+        """`scontrol requeue` on a RUNNING job kills it and re-pends it under
+        the same job_id, and the scheduler re-dispatches it."""
+        job_id = None
+        try:
+            job_id = _submit_sleep(cluster, "rq-running")
+            cluster.scontrol("requeue", str(job_id))
+            # The job leaves RUNNING and comes back on its own (same id).
+            assert _wait_state(cluster, job_id, "R", timeout=90), (
+                "requeued job never returned to RUNNING"
+            )
+            # Same spec: the batch script path is unchanged.
+            assert _show_field(cluster, job_id, "JobId") == str(job_id)
+        finally:
+            _cleanup(cluster, job_id)
+
+    def test_requeue_finished_job_reschedules(self, cluster):
+        """A finished job can be put back into the queue with `scontrol
+        requeue`, keeping its job_id."""
+        job_id = None
+        try:
+            # Short job so it completes quickly; don't require observing R (a
+            # 2s job may finish before squeue reports RUNNING).
+            job_id = _submit_sleep(
+                cluster, "rq-finished", sleep_secs=2, wait_running=False
+            )
+            assert _wait_finished(cluster, job_id), "job did not finish"
+
+            cluster.scontrol("requeue", str(job_id))
+            # It should reappear as PENDING or RUNNING with the same id.
+            back = _wait_state(cluster, job_id, "R", timeout=90) or _wait_state(
+                cluster, job_id, "PD", timeout=1
+            )
+            assert back, "requeued finished job did not return to the queue"
+        finally:
+            _cleanup(cluster, job_id)
+
+
+class TestRequeueHold:
+    def test_requeuehold_parks_job_held_until_released(self, cluster):
+        """`scontrol requeuehold` returns the job to PENDING and holds it; a
+        subsequent `scontrol release` lets it run again."""
+        job_id = None
+        try:
+            job_id = _submit_sleep(cluster, "rq-hold")
+            cluster.scontrol("requeuehold", str(job_id))
+            assert _wait_state(cluster, job_id, "PD", timeout=60), (
+                "requeuehold did not return the job to PENDING"
+            )
+            # It must stay held (not get dispatched) without a release.
+            time.sleep(5)
+            assert job_state(cluster.squeue_all(), job_id) == "PD", (
+                "held job must not be dispatched until released"
+            )
+            assert _show_field(cluster, job_id, "JobState") == "PENDING"
+
+            cluster.scontrol("release", str(job_id))
+            assert _wait_state(cluster, job_id, "R", timeout=90), (
+                "released job did not run"
+            )
+        finally:
+            _cleanup(cluster, job_id)
+
+
+class TestRequeueArray:
+    def test_requeue_array_parent_fans_out(self, cluster):
+        """Requeuing the array parent id returns every task to the queue."""
+        parent = None
+        try:
+            body = "#!/bin/bash\necho STARTED\nsleep 600\n"
+            script = cluster.write_file("rq-array.sh", body)
+            parent = parse_job_id(
+                cluster.sbatch(["-J", "rq-array", "-N", "1", "-a", "0-1", script])
+            )
+            assert parent is not None
+            # At least one task should reach RUNNING before we requeue the array.
+            assert _wait_state(cluster, parent, "R", timeout=90) or _wait_state(
+                cluster, parent, "PD", timeout=1
+            ), "no array task became active"
+
+            out = cluster.scontrol("requeue", str(parent))
+            # The command must be accepted (fan-out) rather than "not found".
+            assert "not found" not in out.lower(), out
+        finally:
+            _cleanup(cluster, parent)
+
+
+class TestRequeueCliGuards:
+    def test_requeue_unknown_job_errors(self, cluster):
+        out = cluster.cli_allow_fail(["scontrol", "requeue", "999999"])
+        assert out.strip(), "expected an error message for unknown job id"
+
+    def test_requeue_pending_job_rejected(self, cluster):
+        """Requeuing an already-PENDING (held) job is rejected."""
+        job_id = None
+        try:
+            script = cluster.write_file("rq-pending.sh", "#!/bin/bash\necho PD\n")
+            job_id = parse_job_id(
+                cluster.sbatch(["-J", "rq-pending", "-N", "1", "-H", script])
+            )
+            assert job_id is not None
+            assert _wait_state(cluster, job_id, "PD", timeout=30)
+            out = cluster.cli_allow_fail(["scontrol", "requeue", str(job_id)])
+            assert job_state(cluster.squeue_all(), job_id) == "PD", (
+                f"job should still be PENDING; cli said:\n{out}"
+            )
+        finally:
+            _cleanup(cluster, job_id)

--- a/tests/native_host/e2e/test_requeue.py
+++ b/tests/native_host/e2e/test_requeue.py
@@ -132,27 +132,46 @@ class TestRequeueHold:
             _cleanup(cluster, job_id)
 
 
+def _wait_named_running(cluster, name, want=1, timeout=90):
+    """Poll until at least `want` tasks named `name` are RUNNING; return their
+    ids. Array tasks carry their own job ids (the parent id is not a stored
+    job), so observe them by name rather than by the parent id."""
+    deadline = time.time() + timeout
+    ids = []
+    while time.time() < deadline:
+        ids = cluster.running_job_ids_by_name(name)
+        if len(ids) >= want:
+            return ids
+        time.sleep(1)
+    return ids
+
+
 class TestRequeueArray:
     def test_requeue_array_parent_fans_out(self, cluster):
-        """Requeuing the array parent id returns every task to the queue."""
-        parent = None
+        """Requeuing the bare array-parent id returns every task to the queue."""
+        name = "rqarr"
         try:
             body = "#!/bin/bash\necho STARTED\nsleep 600\n"
             script = cluster.write_file("rq-array.sh", body)
             parent = parse_job_id(
-                cluster.sbatch(["-J", "rq-array", "-N", "1", "-a", "0-1", script])
+                cluster.sbatch(["-J", name, "-N", "1", "-a", "0-1", script])
             )
             assert parent is not None
-            # At least one task should reach RUNNING before we requeue the array.
-            assert _wait_state(cluster, parent, "R", timeout=90) or _wait_state(
-                cluster, parent, "PD", timeout=1
-            ), "no array task became active"
+            assert _wait_named_running(cluster, name), "no array task reached RUNNING"
 
+            # The bare parent id (not a stored job) must fan out to the tasks,
+            # not be rejected as unknown.
             out = cluster.scontrol("requeue", str(parent))
-            # The command must be accepted (fan-out) rather than "not found".
             assert "not found" not in out.lower(), out
+
+            # Tasks re-pend and run again under their own ids.
+            assert _wait_named_running(cluster, name), (
+                "array tasks did not return to RUNNING after requeue"
+            )
         finally:
-            _cleanup(cluster, parent)
+            # The parent id is not a stored job, so scancel <parent> would error
+            # and leak the tasks; cancel by name instead.
+            cluster.cli_allow_fail(["scancel", "-n", name])
 
 
 class TestRequeueCliGuards:

--- a/tests/native_host/e2e/test_requeue.py
+++ b/tests/native_host/e2e/test_requeue.py
@@ -39,12 +39,12 @@ def _show_field(cluster, job_id, key):
 
 
 def _wait_finished(cluster, job_id, timeout=60):
-    """Poll until the job is finished: either shown COMPLETED or gone from the
-    active queue. Avoids racing on the RUNNING window for very short jobs."""
+    """Poll until the job is shown COMPLETED. Waits for CD specifically (not
+    absence) so a purged job doesn't masquerade as finished and then fail the
+    subsequent requeue with a spurious 'not found'."""
     deadline = time.time() + timeout
     while time.time() < deadline:
-        state = job_state(cluster.squeue_all(), job_id)
-        if state in ("CD", None):
+        if job_state(cluster.squeue_all(), job_id) == "CD":
             return True
         time.sleep(1)
     return False
@@ -177,7 +177,7 @@ class TestRequeueArray:
 class TestRequeueCliGuards:
     def test_requeue_unknown_job_errors(self, cluster):
         out = cluster.cli_allow_fail(["scontrol", "requeue", "999999"])
-        assert out.strip(), "expected an error message for unknown job id"
+        assert "not found" in out.lower(), f"expected a not-found error, got:\n{out}"
 
     def test_requeue_pending_job_rejected(self, cluster):
         """Requeuing an already-PENDING (held) job is rejected."""
@@ -190,6 +190,9 @@ class TestRequeueCliGuards:
             assert job_id is not None
             assert _wait_state(cluster, job_id, "PD", timeout=30)
             out = cluster.cli_allow_fail(["scontrol", "requeue", str(job_id)])
+            assert "already pending" in out.lower(), (
+                f"expected an already-pending rejection, got:\n{out}"
+            )
             assert job_state(cluster.squeue_all(), job_id) == "PD", (
                 f"job should still be PENDING; cli said:\n{out}"
             )


### PR DESCRIPTION
Fixes [SPUR-159](https://amd.atlassian.net/browse/SPUR-159).

### What this fixes
`scontrol requeue $JOBID` was a cancel-only stub — it killed the job and left it gone, despite printing "requeued". It now returns a job to `PENDING` with the same `job_id` and spec, matching Slurm. Adds `scontrol requeuehold`, which re-pends the job into a held state.

### Scope
- Works on running/suspended jobs (kill + re-pend) and on any terminal job (completed, failed, timeout, node_fail, cancelled, deadline, OOM).
- Manual requeue is owner-or-root, uncapped (tracked via a separate `user_requeue_count` that never trips `max_batch_requeue`), rejects interactive/`srun` allocations and already-pending jobs.
- A bare array-parent id fans out to every task.

### Approach
A new additive `RequeueJob` RPC drives a `JobUserRequeue` WAL op that reuses the atomic machinery behind `JobPreemptRequeue`. A live job is finalized exactly once — routed through a new first-class `JobState::Requeued` so steps/accounting see a finished run, allocations and GPUs are freed, epilog fires — then re-pended. An already-terminal job re-pends with **no** second finalization, avoiding double-counted accounting/epilog. The server kills the old processes via `send_cancel_to_agents`, and a leader-computed `begin_time` hold on the live path prevents the scheduler from re-dispatching a job into its own in-flight cancel (same guard as preemption requeue).

### Compatibility
All changes are additive (new RPC/message, appended `JOB_REQUEUED` enum value, new WAL variant and `Job` field with serde defaults, widened state transitions), so a forward rolling upgrade is safe. Note: like any new WAL op, a `scontrol requeue` issued mid-upgrade can't be applied by a not-yet-upgraded follower — finish the rolling upgrade before using it.

### Known limitations / follow-ups
- Accounting keeps one row per `job_id` (the `REQUEUED` end record is overwritten by the next run), same as the existing preempt-requeue path — Slurm keeps per-run history. Follow-up: expose restart count in `scontrol show job` and consider per-run accounting rows.
- Requeuing a completed job does not re-trigger `afterok` dependents that already ran (same behavior as Slurm).

### Testing
`cargo clippy --workspace --exclude spur-ffi --all-targets` and `cargo test --locked` pass. Added unit tests (running/suspended/all terminal states/array fan-out/hold/authz/non-batch/replay-idempotency/batch-cap guard/live-vs-terminal finalization), a WAL round-trip test, and an e2e suite (`tests/native_host/e2e/test_requeue.py`).