### PR TITLE
test(spur-cli): cover the hostlist first-host path srun depends on

### DIFF
--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -8,9 +8,9 @@
 //! ephemeral localhost port, serve a hand-written service on it, and hand the
 //! caller back the address plus a shared record of what the server observed.
 //! Only a handful of RPCs are implemented (`CreateJobStep`, `RunStep`,
-//! `GetNodes`, `UpdateNode`, `DrainNode`, `DeregisterNode`); every other RPC
-//! reports `unimplemented` so an unexpected call fails loudly instead of
-//! silently returning a default.
+//! `GetNode`, `GetNodes`, `UpdateNode`, `DrainNode`, `DeregisterNode`); every
+//! other RPC reports `unimplemented` so an unexpected call fails loudly instead
+//! of silently returning a default.
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -35,6 +35,7 @@ pub(crate) struct StepCapture {
     run_step_step_id: Arc<AtomicU32>,
     run_step_calls: Arc<AtomicU32>,
     get_node_names: Arc<Mutex<Vec<String>>>,
+    get_node_requests: Arc<Mutex<Vec<String>>>,
     update_node_names: Arc<Mutex<Vec<String>>>,
     drain_node_names: Arc<Mutex<Vec<String>>>,
     deregister_node_calls: Arc<Mutex<Vec<(String, bool)>>>,
@@ -60,6 +61,11 @@ impl StepCapture {
 
     pub(crate) fn set_get_node_names(&self, names: Vec<String>) {
         *self.get_node_names.lock().unwrap() = names;
+    }
+
+    /// Node names asked for by `GetNode`, in call order.
+    pub(crate) fn get_node_requests(&self) -> Vec<String> {
+        self.get_node_requests.lock().unwrap().clone()
     }
 
     pub(crate) fn update_node_names(&self) -> Vec<String> {
@@ -150,6 +156,18 @@ mock_controller_impl! {
             Ok(tonic::Response::new(()))
         }
 
+        /// Records the name, then reports `NotFound`. A caller treats a failed
+        /// lookup as "node unreachable" and stops there, which keeps tests off
+        /// the network instead of dialling an agent that is not running.
+        async fn get_node(
+            &self,
+            request: tonic::Request<proto::GetNodeRequest>,
+        ) -> Result<tonic::Response<proto::NodeInfo>, tonic::Status> {
+            let name = request.into_inner().name;
+            self.capture.get_node_requests.lock().unwrap().push(name.clone());
+            Err(tonic::Status::not_found(format!("node {name} not found")))
+        }
+
         async fn get_nodes(
             &self,
             _request: tonic::Request<proto::GetNodesRequest>,
@@ -204,7 +222,6 @@ mock_controller_impl! {
         resume_job(proto::ResumeJobRequest) -> ();
         update_job(proto::UpdateJobRequest) -> ();
         requeue_job(proto::RequeueJobRequest) -> proto::RequeueJobResponse;
-        get_node(proto::GetNodeRequest) -> proto::NodeInfo;
         deregister_agent(proto::DeregisterAgentRequest) -> ();
         get_partitions(proto::GetPartitionsRequest) -> proto::GetPartitionsResponse;
         create_partition(proto::CreatePartitionRequest) -> ();

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -2230,4 +2230,21 @@ mod tests {
             "expected --overlap error, got: {msg}"
         );
     }
+
+    /// The controller reports `nodelist` as a compressed hostlist, so streaming
+    /// has to expand it. Splitting `node[001-002]` on commas yields the whole
+    /// bracket literal, which is not a host, and the stream then goes nowhere.
+    #[tokio::test]
+    async fn try_stream_output_asks_the_controller_for_an_expanded_hostname() {
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        let mut client = crate::mock_controller::client(addr).await;
+
+        let streamed = try_stream_output(&mut client, "node[001-002]", 42, "tester").await;
+
+        assert!(
+            !streamed,
+            "the mock reports every node missing, so streaming is unavailable"
+        );
+        assert_eq!(capture.get_node_requests(), vec!["node001".to_string()]);
+    }
 }

--- a/crates/spur-tests/src/t51_hostlist.rs
+++ b/crates/spur-tests/src/t51_hostlist.rs
@@ -141,4 +141,70 @@ mod tests {
     fn t51_19_invalid_closing_before_opening_bracket() {
         assert!(hostlist::expand("a]b[1-2]").is_err());
     }
+
+    // ── T51.20: First host ───────────────────────────────────────
+
+    #[test]
+    fn t51_20_first_host_of_range() {
+        assert_eq!(
+            hostlist::expand_first("node[001-003]").unwrap(),
+            Some("node001".to_string())
+        );
+    }
+
+    #[test]
+    fn t51_21_first_host_of_comma_inside_brackets() {
+        assert_eq!(
+            hostlist::expand_first("node[7,1,3]").unwrap(),
+            Some("node7".to_string())
+        );
+    }
+
+    #[test]
+    fn t51_22_first_host_of_multiple_prefixes() {
+        assert_eq!(
+            hostlist::expand_first("gpu[01-02],cpu[01-02]").unwrap(),
+            Some("gpu01".to_string())
+        );
+    }
+
+    #[test]
+    fn t51_23_first_host_of_plain_list_and_single() {
+        assert_eq!(
+            hostlist::expand_first("node1,node2").unwrap(),
+            Some("node1".to_string())
+        );
+        assert_eq!(
+            hostlist::expand_first("login01").unwrap(),
+            Some("login01".to_string())
+        );
+    }
+
+    #[test]
+    fn t51_24_first_host_of_empty_pattern_is_none() {
+        assert_eq!(hostlist::expand_first("").unwrap(), None);
+    }
+
+    #[test]
+    fn t51_25_first_host_agrees_with_full_expansion() {
+        for pattern in [
+            "node[001-003]",
+            "node[9,010-011]",
+            "gpu[01-02],cpu[01-02]",
+            "node1,node2,node3",
+            "login01",
+        ] {
+            assert_eq!(
+                hostlist::expand_first(pattern).unwrap(),
+                hostlist::expand(pattern).unwrap().into_iter().next(),
+                "first host of {pattern} must match full expansion"
+            );
+        }
+    }
+
+    #[test]
+    fn t51_26_first_host_of_invalid_pattern_is_an_error() {
+        assert!(hostlist::expand_first("node[001-003").is_err());
+        assert!(hostlist::expand_first("node[5-1]").is_err());
+    }
 }


### PR DESCRIPTION
This PR originally carried the `srun`/`sattach` compressed-nodelist fix for #575. That fix landed in #589, so everything overlapping it is dropped, including this branch's `hostlist` rewrite, which covered the same ground as the `parse_range_bounds` refactor that merged with it. What is left is the coverage that #589 did not bring, and the branch is rebased onto main so it applies against `expand_first` rather than this branch's old helper.

## What this adds

**A test through the `srun` call path.** Main tests `nodelist::first_allocated_node` directly, but nothing asserts that `try_stream_output` actually calls it. Reintroducing a comma split at that call site would pass every test in the tree while streaming to `node[001-002]`, which is not a host and is exactly the original bug. This drives `try_stream_output` against the mock controller and asserts the name it asks `GetNode` about is `node001`.

That needs the mock to record the request, so `GetNode` moves out of its unimplemented list into a handler that records the name and returns `NotFound`. Returning `NotFound` matters: the caller treats a failed lookup as "node unreachable" and stops, so the test never dials an agent that is not running.

**T51 coverage for `expand_first`.** The tier suite covers `expand`, `compress` and `count` but stopped before the first-host path. The new cases cover ranges, a comma inside brackets, multiple prefixes, plain lists, a single host, the empty pattern, invalid patterns, and agreement with full expansion, which is the property that keeps the two functions from drifting.

## Testing

The srun test is mutation-checked rather than assumed: swapping `first_allocated_node` back to `nodelist.split(',').next()` fails it on the requested name, `left: ["node[001-002]"]` against `right: ["node001"]`. `cargo fmt --check` and `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` are clean, and `cargo test --locked` is green.

No production code changes here, so there is no upgrade or compatibility surface.
