### PR TITLE
fix(spurd): stop warning when no spur.conf exists at the default path

### DIFF
--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -16,11 +16,12 @@ mod seccomp;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use clap::Parser;
+use clap::parser::ValueSource;
+use clap::{CommandFactory, FromArgMatches, Parser};
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
-use spur_core::config::SlurmConfig;
+use spur_core::config::{ConfigError, SlurmConfig};
 use spur_devices::cdi::cache::CdiCache;
 use spur_devices::DeviceRegistry;
 
@@ -52,6 +53,16 @@ fn log_memlock_status(memlock: spur_core::config::MemlockLimit) {
              jobs will get at most the hard limit unless spurd runs as root"
         );
     }
+}
+
+/// Whether a best-effort config load failed only because no file exists at the default
+/// path, which is the expected shape for an agent configured entirely by flags.
+///
+/// Anything else — an explicitly requested path, or a file that is present but malformed,
+/// invalid, or unreadable — means settings the operator intended are being ignored, and
+/// has to stay visible.
+fn absent_optional_config(explicit_path: bool, err: &ConfigError) -> bool {
+    !explicit_path && matches!(err, ConfigError::Io(e) if e.kind() == std::io::ErrorKind::NotFound)
 }
 
 /// Parse a "key=value" string into a validated label.
@@ -119,7 +130,10 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let args = Args::parse();
+    let matches = Args::command().get_matches();
+    // Any source but the built-in default means the operator named this path themselves.
+    let explicit_config = matches.value_source("config") != Some(ValueSource::DefaultValue);
+    let args = Args::from_arg_matches(&matches)?;
 
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -155,6 +169,10 @@ async fn main() -> anyhow::Result<()> {
         Ok(config) => {
             info!(path = %args.config.display(), "loaded spur.conf");
             Some(config)
+        }
+        Err(e) if absent_optional_config(explicit_config, &e) => {
+            info!(path = %args.config.display(), "no spur.conf found, using default config");
+            None
         }
         Err(e) => {
             warn!(
@@ -421,5 +439,38 @@ mod tests {
     #[test]
     fn parse_label_just_equals() {
         assert!(parse_label("=").is_err());
+    }
+
+    #[test]
+    fn absent_config_at_default_path_is_expected() {
+        let err = ConfigError::Io(std::io::Error::from(std::io::ErrorKind::NotFound));
+        assert!(absent_optional_config(false, &err));
+    }
+
+    #[test]
+    fn absent_config_at_explicit_path_is_reported() {
+        // A typo'd --config must not be silently ignored.
+        let err = ConfigError::Io(std::io::Error::from(std::io::ErrorKind::NotFound));
+        assert!(!absent_optional_config(true, &err));
+    }
+
+    #[test]
+    fn unreadable_config_is_reported_even_at_default_path() {
+        // Present but unreadable is a misconfiguration, not an absent file.
+        let err = ConfigError::Io(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+        assert!(!absent_optional_config(false, &err));
+    }
+
+    #[test]
+    fn malformed_config_is_reported_even_at_default_path() {
+        let err = SlurmConfig::load_from_str("this is not toml").expect_err("must not parse");
+        assert!(!absent_optional_config(false, &err));
+    }
+
+    #[test]
+    fn invalid_config_is_reported_even_at_default_path() {
+        // Parses, then fails validation — settings the operator wrote are ignored.
+        let err = SlurmConfig::load_from_str("cluster_name = \"\"").expect_err("must not validate");
+        assert!(!absent_optional_config(false, &err));
     }
 }


### PR DESCRIPTION
## Summary

`spurd` reads `spur.conf` best-effort — it supplies local agent settings (`[hooks]`,
`[devices]`, `rlimits.memlock`, `[cluster]`, `[mpi]`) and the agent runs on defaults
without it. An agent configured entirely by flags therefore has no such file, yet every
startup logged:

```
WARN spurd: failed to load spur.conf, using default config path=/etc/spur/spur.conf
  error=failed to read config file: No such file or directory (os error 2)
```

A warning that fires when nothing is wrong is how operators learn to skip warnings, which
costs them the ones that matter.

Fixes #586.

## Approach

Failures are now classified rather than reported uniformly:

| `--config` | failure | level |
|---|---|---|
| default path | file absent | `info` — expected shape, the fix |
| default path | malformed, invalid, or unreadable | `warn` |
| named explicitly | any failure | `warn` |

`spurctld` already draws this line (`info!("no config file found, using defaults")`), so
the two daemons now agree on what an absent config means.

## Design notes

**A malformed file at the default path still warns.** The issue asks for a narrower rule —
*"only an explicitly-passed `--config` path that fails to load warrants a warning"* — but
read literally that also silences a broken file at the default path, which is worse than
the noise being removed: the file exists, its settings are being ignored, and nothing says
so. A missing file is a deployment shape; a malformed, invalid, or unreadable one is a
misconfiguration. Flagging this as a deliberate deviation from the issue text.

**Classify the error, don't stat the path.** `Path::exists()` would be the shorter test but
cannot separate "absent" from "present and unreadable", so a permission-denied config would
take the quiet path. Matching `io::ErrorKind::NotFound` on the error `load_from_file`
already returns distinguishes the two exactly and costs no extra syscall.

**Explicitness is read as "not the default value", not "came from the command line".** The
field has no `env`, so `ValueSource::CommandLine` would work today, but it would silently
misclassify an env-supplied path as a default if one were ever added — the surrounding code
already treats `EnvVariable` as user intent (`spur-cli/src/sbatch.rs`). Testing against
`DefaultValue` stays correct through that change.

**`ValueSource` over `config: Option<PathBuf>`.** Dropping `default_value` to detect an
explicit path is less code, but `--help` would lose its `[default: /etc/spur/spur.conf]`
line. Reading the value's source leaves the `Args` declaration and the help output
untouched; a test in the smoke table below pins that.

The predicate is a free function so the rule is unit-tested directly rather than through
`main()`.

## Compatibility

No change to persisted state, the Raft log, proto, the config schema, or any CLI flag,
default, or help text. The load remains best-effort: `spurd` still starts on defaults in
every failure case.

The one visible change is the log line itself — anything grepping `spurd` output for
`failed to load spur.conf` on a host with no config file will stop matching, which is the
point of the fix.

## Testing

`cargo test --locked` → **2853 passed, 0 failed, 25 ignored** (ignored tests need
PostgreSQL). Five new unit tests cover the matrix above, including a validation failure and
a permission-denied read, and build their `ConfigError` values through
`SlurmConfig::load_from_str` rather than hand-rolling stand-ins.

Gates green: `cargo fmt --all --check`; `cargo clippy --workspace --exclude spur-ffi
--all-targets --locked` with `RUSTFLAGS="-D warnings"`; `cargo test --locked`;
`cargo deny check` (`advisories ok, bans ok, licenses ok, sources ok`).

Verified against a built binary on a host with no `/etc/spur/spur.conf`:

| Invocation | Result |
|---|---|
| `spurd -D` (no config present) | `INFO no spur.conf found, using default config` — no warning |
| `spurd -D --config <absent>` | `WARN failed to load spur.conf … No such file or directory` |
| `spurd -D -f <absent>` (short form) | `WARN …` — short and long forms agree |
| `spurd -D --config <invalid TOML>` | `WARN … failed to parse TOML` |
| `spurd -D --config <valid>` | `INFO loaded spur.conf` |
| `spurd --help` | `-f, --config <CONFIG>  … [default: /etc/spur/spur.conf]` intact |

## Note for reviewers

`main()` is not unit-testable, so the wiring — that each branch reaches the intended macro
— rests on the smoke runs above rather than on a test. Keeping the rule in a pure predicate
confines that gap to a single `match`.
