### PR TITLE
fix(spurd): restore supplementary groups on nsenter exec/overlap paths

### DIFF
--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -753,6 +753,45 @@ fn build_nsenter_argv(
     args
 }
 
+/// How to launch `command` for a job: the program to spawn, its arguments, and
+/// whether the privilege drop must still be applied in the spawned child.
+struct LaunchPlan {
+    program: String,
+    args: Vec<String>,
+    /// True only for the direct-spawn path, where the caller must run
+    /// `PrivDrop::apply()` in a `pre_exec` hook. On the nsenter path the drop
+    /// happens inside the entered namespace via `setpriv`, so the child hook is
+    /// skipped.
+    apply_priv_in_child: bool,
+}
+
+/// Decide how to enter a job and run `command`, shared by `exec_in_job` and
+/// `spawn_pty_in_job`.
+///
+/// When the job has live namespaces, enter them with `nsenter` and drop
+/// privilege inside via `setpriv` (see [`build_nsenter_argv`]); the child hook
+/// is not used. Otherwise spawn the command directly and let the caller drop
+/// privilege in a `pre_exec` hook.
+fn build_launch_plan(
+    entry: &crate::job_entry::JobEntry,
+    priv_drop: Option<&crate::privdrop::PrivDrop>,
+    command: &[String],
+) -> LaunchPlan {
+    if entry.has_namespaces() && entry.pid > 0 {
+        LaunchPlan {
+            program: "nsenter".to_string(),
+            args: build_nsenter_argv(entry, priv_drop, command),
+            apply_priv_in_child: false,
+        }
+    } else {
+        LaunchPlan {
+            program: command[0].clone(),
+            args: command[1..].to_vec(),
+            apply_priv_in_child: true,
+        }
+    }
+}
+
 fn cleanup_step_scripts(dir: &std::path::Path, paths: &[&std::path::Path]) {
     for path in paths {
         let _ = std::fs::remove_file(path);
@@ -1700,27 +1739,23 @@ impl SlurmAgent for AgentService {
 
         let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(entry.uid, entry.gid);
 
-        let mut cmd = if entry.has_namespaces() && entry.pid > 0 {
-            let mut c = tokio::process::Command::new("nsenter");
-            c.args(build_nsenter_argv(&entry, priv_drop.as_ref(), &req.command));
-            c
-        } else {
-            let mut c = tokio::process::Command::new(&req.command[0]);
-            for arg in &req.command[1..] {
-                c.arg(arg);
-            }
-            c.current_dir(&entry.work_dir);
+        let plan = build_launch_plan(&entry, priv_drop.as_ref(), &req.command);
+        let mut cmd = tokio::process::Command::new(&plan.program);
+        cmd.args(&plan.args);
+        // Direct-spawn path drops privilege in the child; the nsenter path
+        // already does it inside the namespace via setpriv.
+        if plan.apply_priv_in_child {
+            cmd.current_dir(&entry.work_dir);
             if let Some(pd) = priv_drop {
                 unsafe {
-                    c.pre_exec(move || {
+                    cmd.pre_exec(move || {
                         pd.apply()
                             .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
                         Ok(())
                     });
                 }
             }
-            c
-        };
+        }
 
         let output = cmd
             .output()
@@ -2971,13 +3006,10 @@ impl AgentService {
 
         let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(entry.uid, entry.gid);
 
-        let use_nsenter = entry.has_namespaces() && entry.pid > 0;
-        let (launch_cmd, launch_args, apply_priv_in_child) = if use_nsenter {
-            let args = build_nsenter_argv(entry, priv_drop.as_ref(), &shell);
-            ("nsenter".to_string(), args, false)
-        } else {
-            (shell[0].clone(), shell[1..].to_vec(), true)
-        };
+        let plan = build_launch_plan(entry, priv_drop.as_ref(), &shell);
+        let launch_cmd = plan.program;
+        let launch_args = plan.args;
+        let apply_priv_in_child = plan.apply_priv_in_child;
 
         let mut cmd = tokio::process::Command::new(&launch_cmd);
         let work_dir = if entry.work_dir.is_empty() {
@@ -3247,6 +3279,87 @@ mod tests {
         );
         let sep = argv.iter().position(|a| a == "--").expect("missing --");
         assert_eq!(&argv[sep..], &["--", "id"]);
+    }
+
+    #[test]
+    fn build_launch_plan_namespaced_job_uses_nsenter_no_child_drop() {
+        let entry = nsenter_job_entry(1000, 1000);
+        let pd = crate::privdrop::PrivDrop::for_test(1000, 1000);
+        let plan = build_launch_plan(&entry, Some(&pd), &["id".to_string()]);
+
+        assert_eq!(plan.program, "nsenter");
+        // Privilege is dropped inside the namespace via setpriv, so the child
+        // pre_exec hook must be skipped.
+        assert!(!plan.apply_priv_in_child);
+        assert_eq!(
+            plan.args,
+            build_nsenter_argv(&entry, Some(&pd), &["id".to_string()])
+        );
+    }
+
+    #[test]
+    fn build_launch_plan_no_namespaces_spawns_directly_with_child_drop() {
+        let entry = crate::job_entry::JobEntry {
+            pid: 0,
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
+            uid: 1000,
+            gid: 1000,
+            work_dir: "/home/user".into(),
+        };
+        let pd = crate::privdrop::PrivDrop::for_test(1000, 1000);
+        let plan = build_launch_plan(&entry, Some(&pd), &["echo".to_string(), "hi".to_string()]);
+
+        // No namespaces → spawn the command directly and drop privilege in the
+        // child via pre_exec.
+        assert_eq!(plan.program, "echo");
+        assert_eq!(plan.args, vec!["hi".to_string()]);
+        assert!(plan.apply_priv_in_child);
+    }
+
+    #[tokio::test]
+    async fn spawn_pty_in_job_direct_spawn_runs_command() {
+        // Drives the real spawn_pty_in_job handler (not just the pure planner)
+        // on the direct-spawn path: no namespaces, uid 0 so no privilege drop.
+        // This exercises the build_launch_plan call site inside the handler.
+        let entry = crate::job_entry::JobEntry {
+            pid: 0,
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
+            uid: 0,
+            gid: 0,
+            work_dir: "/tmp".into(),
+        };
+        let (master, mut child, pid) =
+            AgentService::spawn_pty_in_job(&entry, &["true".to_string()], 7, None)
+                .expect("spawn_pty_in_job should succeed for a direct /usr/bin/true");
+        assert!(pid > 0);
+        let status = child.wait().await.expect("child should be reapable");
+        assert!(status.success(), "`true` should exit 0");
+        drop(master);
+    }
+
+    #[test]
+    fn build_launch_plan_namespaced_but_no_pid_spawns_directly() {
+        // has_namespaces() is true but pid is 0 (no live process to enter):
+        // fall back to a direct spawn rather than a broken nsenter.
+        let entry = crate::job_entry::JobEntry {
+            pid: 0,
+            has_pid_namespace: true,
+            has_user_namespace: false,
+            has_mount_namespace: true,
+            uid: 1000,
+            gid: 1000,
+            work_dir: "/home/user".into(),
+        };
+        let pd = crate::privdrop::PrivDrop::for_test(1000, 1000);
+        let plan = build_launch_plan(&entry, Some(&pd), &["id".to_string()]);
+
+        assert_eq!(plan.program, "id");
+        assert!(plan.args.is_empty());
+        assert!(plan.apply_priv_in_child);
     }
 
     #[test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -731,6 +731,28 @@ fn build_one_shot_command_script(command: &[String]) -> Result<String, Status> {
     Ok(format!("#!/bin/bash\nexec {joined}\n"))
 }
 
+/// Build the argument vector passed to `nsenter` (everything after the
+/// `nsenter` program name) for entering a running job and executing `command`.
+///
+/// The namespace is entered as root; privilege is dropped *inside* the target
+/// via `setpriv --init-groups` when `priv_drop` is set, which is the only way
+/// to initialise supplementary groups after nsenter (nsenter's own
+/// --setuid/--setgid skip setgroups). Root jobs pass `priv_drop = None` and run
+/// the command directly.
+fn build_nsenter_argv(
+    entry: &crate::job_entry::JobEntry,
+    priv_drop: Option<&crate::privdrop::PrivDrop>,
+    command: &[String],
+) -> Vec<String> {
+    let mut args = entry.nsenter_args();
+    args.push("--".into());
+    if let Some(pd) = priv_drop {
+        args.extend(pd.setpriv_prefix());
+    }
+    args.extend(command.iter().cloned());
+    args
+}
+
 fn cleanup_step_scripts(dir: &std::path::Path, paths: &[&std::path::Path]) {
     for path in paths {
         let _ = std::fs::remove_file(path);
@@ -1680,19 +1702,7 @@ impl SlurmAgent for AgentService {
 
         let mut cmd = if entry.has_namespaces() && entry.pid > 0 {
             let mut c = tokio::process::Command::new("nsenter");
-            for arg in entry.nsenter_args() {
-                c.arg(arg);
-            }
-            if let Some(ref pd) = priv_drop {
-                for arg in pd.nsenter_args() {
-                    c.arg(arg);
-                }
-            }
-            c.arg("--");
-            c.arg(&req.command[0]);
-            for arg in &req.command[1..] {
-                c.arg(arg);
-            }
+            c.args(build_nsenter_argv(&entry, priv_drop.as_ref(), &req.command));
             c
         } else {
             let mut c = tokio::process::Command::new(&req.command[0]);
@@ -2963,12 +2973,7 @@ impl AgentService {
 
         let use_nsenter = entry.has_namespaces() && entry.pid > 0;
         let (launch_cmd, launch_args, apply_priv_in_child) = if use_nsenter {
-            let mut args = entry.nsenter_args();
-            if let Some(ref pd) = priv_drop {
-                args.extend(pd.nsenter_args());
-            }
-            args.push("--".into());
-            args.extend(shell);
+            let args = build_nsenter_argv(entry, priv_drop.as_ref(), &shell);
             ("nsenter".to_string(), args, false)
         } else {
             (shell[0].clone(), shell[1..].to_vec(), true)
@@ -3153,6 +3158,96 @@ mod tests {
     use super::*;
     use spur_core::resource::ResourceSet;
     use tonic::Request;
+
+    fn nsenter_job_entry(uid: u32, gid: u32) -> crate::job_entry::JobEntry {
+        crate::job_entry::JobEntry {
+            pid: 1234,
+            has_pid_namespace: true,
+            has_user_namespace: false,
+            has_mount_namespace: true,
+            uid,
+            gid,
+            work_dir: "/home/user".into(),
+        }
+    }
+
+    #[test]
+    fn build_nsenter_argv_non_root_wraps_with_setpriv_init_groups() {
+        let entry = nsenter_job_entry(1000, 1000);
+        let pd = crate::privdrop::PrivDrop::for_test(1000, 1000);
+        let argv = build_nsenter_argv(&entry, Some(&pd), &["id".to_string()]);
+
+        // nsenter itself must not carry uid/gid: it enters as root so it can
+        // read /proc/<pid>/ns/*; priv drop happens inside via setpriv.
+        assert!(
+            !argv.iter().any(|a| a.starts_with("--setuid=")),
+            "nsenter portion must not use --setuid: {argv:?}"
+        );
+        assert!(
+            !argv.iter().any(|a| a.starts_with("--setgid=")),
+            "nsenter portion must not use --setgid: {argv:?}"
+        );
+
+        let sep = argv.iter().position(|a| a == "--").expect("missing --");
+        assert_eq!(
+            &argv[sep..],
+            &[
+                "--",
+                "setpriv",
+                "--reuid=1000",
+                "--regid=1000",
+                "--init-groups",
+                "--",
+                "id"
+            ]
+        );
+    }
+
+    #[test]
+    fn build_nsenter_argv_pty_shell_wraps_with_setpriv_init_groups() {
+        // spawn_pty_in_job passes the resolved shell as the command.
+        let entry = nsenter_job_entry(1000, 1000);
+        let pd = crate::privdrop::PrivDrop::for_test(1000, 1000);
+        let argv = build_nsenter_argv(&entry, Some(&pd), &["/bin/bash".to_string()]);
+
+        assert!(
+            !argv.iter().any(|a| a.starts_with("--setuid=")),
+            "PTY nsenter portion must not use --setuid: {argv:?}"
+        );
+        assert!(
+            !argv.iter().any(|a| a.starts_with("--setgid=")),
+            "PTY nsenter portion must not use --setgid: {argv:?}"
+        );
+        let sep = argv.iter().position(|a| a == "--").expect("missing --");
+        assert_eq!(
+            &argv[sep..],
+            &[
+                "--",
+                "setpriv",
+                "--reuid=1000",
+                "--regid=1000",
+                "--init-groups",
+                "--",
+                "/bin/bash"
+            ]
+        );
+    }
+
+    #[test]
+    fn build_nsenter_argv_root_job_runs_command_directly() {
+        let entry = nsenter_job_entry(0, 0);
+        // Root job: resolve_if_needed returns None → no setpriv prefix.
+        let pd = crate::privdrop::PrivDrop::resolve_if_needed(0, 0);
+        assert!(pd.is_none());
+        let argv = build_nsenter_argv(&entry, pd.as_ref(), &["id".to_string()]);
+
+        assert!(
+            !argv.iter().any(|a| a == "setpriv"),
+            "root job must not invoke setpriv: {argv:?}"
+        );
+        let sep = argv.iter().position(|a| a == "--").expect("missing --");
+        assert_eq!(&argv[sep..], &["--", "id"]);
+    }
 
     #[test]
     fn build_job_script_uses_explicit_script_verbatim() {

--- a/crates/spurd/src/job_entry.rs
+++ b/crates/spurd/src/job_entry.rs
@@ -19,6 +19,17 @@ impl JobEntry {
     ///
     /// Returns the arguments to pass between `nsenter` and `--`.
     /// The caller prepends `nsenter` and appends `-- <command>`.
+    ///
+    /// `self.pid` is the process that called `unshare(CLONE_NEWPID)` (the batch
+    /// wrapper or container parent). That process stays in its *original* pid
+    /// namespace — only its children, and the `/proc` mounted inside the job,
+    /// live in the new pid namespace. Entering via `/proc/<pid>/ns/pid` would
+    /// therefore land in the wrong (host) pid namespace, where `/proc` does not
+    /// match: any tool that reads `/proc/self/*` (e.g. `setpriv` activating
+    /// capabilities) then fails with ENOENT. Enter through `pid_for_children`,
+    /// which points at the job's real pid namespace. (For a process already
+    /// settled inside a namespace, `pid_for_children` equals its own pid ns, so
+    /// this is correct in every case.)
     pub fn nsenter_args(&self) -> Vec<String> {
         let mut args = vec!["--target".to_string(), self.pid.to_string()];
 
@@ -29,7 +40,7 @@ impl JobEntry {
             args.push("--mount".to_string());
         }
         if self.has_pid_namespace {
-            args.push("--pid".to_string());
+            args.push(format!("--pid=/proc/{}/ns/pid_for_children", self.pid));
         }
 
         args
@@ -65,7 +76,15 @@ mod tests {
             work_dir: "/home/user".into(),
         };
         let args = entry.nsenter_args();
-        assert_eq!(args, vec!["--target", "1234", "--mount", "--pid"]);
+        assert_eq!(
+            args,
+            vec![
+                "--target",
+                "1234",
+                "--mount",
+                "--pid=/proc/1234/ns/pid_for_children"
+            ]
+        );
     }
 
     #[test]
@@ -80,7 +99,16 @@ mod tests {
             work_dir: "/".into(),
         };
         let args = entry.nsenter_args();
-        assert_eq!(args, vec!["--target", "5678", "--user", "--mount", "--pid"]);
+        assert_eq!(
+            args,
+            vec![
+                "--target",
+                "5678",
+                "--user",
+                "--mount",
+                "--pid=/proc/5678/ns/pid_for_children"
+            ]
+        );
     }
 
     #[test]
@@ -111,7 +139,16 @@ mod tests {
             work_dir: "/".into(),
         };
         let args = entry.nsenter_args();
-        assert_eq!(args, vec!["--target", "4444", "--user", "--mount", "--pid"]);
+        assert_eq!(
+            args,
+            vec![
+                "--target",
+                "4444",
+                "--user",
+                "--mount",
+                "--pid=/proc/4444/ns/pid_for_children"
+            ]
+        );
         assert!(entry.has_namespaces());
     }
 }

--- a/crates/spurd/src/privdrop.rs
+++ b/crates/spurd/src/privdrop.rs
@@ -86,12 +86,32 @@ impl PrivDrop {
         Ok(())
     }
 
-    /// Return nsenter --setuid/--setgid args for the namespace path.
-    pub fn nsenter_args(&self) -> Vec<String> {
+    /// Args to drop privilege *after* namespace entry, initialising the full
+    /// supplementary group set. nsenter's --setuid/--setgid call only
+    /// setuid/setgid (never setgroups), so groups gated on /dev/kfd (render,
+    /// video) are lost; `setpriv --init-groups` resolves them via NSS inside
+    /// the target namespace, mirroring the batch wrapper.
+    pub fn setpriv_prefix(&self) -> Vec<String> {
         vec![
-            format!("--setuid={}", self.uid),
-            format!("--setgid={}", self.gid),
+            "setpriv".into(),
+            format!("--reuid={}", self.uid),
+            format!("--regid={}", self.gid),
+            "--init-groups".into(),
+            "--".into(),
         ]
+    }
+}
+
+#[cfg(test)]
+impl PrivDrop {
+    /// Construct with explicit credentials, bypassing the root/NSS resolution
+    /// in `resolve_if_needed` so arg-construction can be tested off-host.
+    pub(crate) fn for_test(uid: u32, gid: u32) -> Self {
+        Self {
+            uid: Uid::from_raw(uid),
+            gid: Gid::from_raw(gid),
+            groups: vec![Gid::from_raw(gid)],
+        }
     }
 }
 
@@ -135,5 +155,25 @@ mod root_execution_tests {
                 assert!(check_root_execution_allowed(1000, allow, is_root).is_ok());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setpriv_prefix_emits_init_groups() {
+        let pd = PrivDrop::for_test(1000, 1000);
+        assert_eq!(
+            pd.setpriv_prefix(),
+            vec![
+                "setpriv",
+                "--reuid=1000",
+                "--regid=1000",
+                "--init-groups",
+                "--"
+            ]
+        );
     }
 }

--- a/tests/native_host/e2e/test_devices.py
+++ b/tests/native_host/e2e/test_devices.py
@@ -79,10 +79,10 @@ def _render_video_user(cluster: SpurCluster) -> str | None:
     """Return a non-root user that is a member of both the render and video
     groups on node 0, or None if none exists.
 
-    SPUR-172 only manifests when the job runs as a non-root user with
-    supplementary GPU groups (so PrivDrop engages and the nsenter paths must
-    reinitialise the group set). Root jobs bypass PrivDrop entirely, so they
-    cannot exercise the regression.
+    The supplementary-group loss on nsenter entry only manifests when the job
+    runs as a non-root user with GPU groups, so PrivDrop engages and the
+    nsenter paths must reinitialise the group set. Root jobs bypass PrivDrop
+    entirely, so they cannot exercise this path.
     """
     script = (
         "for g in render video; do getent group \"$g\"; done | "
@@ -650,15 +650,14 @@ def _parse_groups(id_output: str) -> set[str]:
 
 
 class TestNsenterSupplementaryGroups:
-    """SPUR-172: commands entering a running job via nsenter (`spur exec`,
+    """Commands entering a running job via nsenter (`spur exec`,
     `spur run --overlap`) must carry the job user's full supplementary group
     set, matching the batch path. Without it, GPU device nodes gated on the
     render/video groups (e.g. /dev/kfd, root:render) are unopenable.
 
     Unit tests in spurd cover the nsenter argv construction; only an end-to-end
     run against a real namespaced job exercises the runtime priv-drop
-    (`setpriv --init-groups`) inside the entered pid/mount namespace, which is
-    where the two defects behind SPUR-172 actually surfaced.
+    (`setpriv --init-groups`) inside the entered pid/mount namespace.
     """
 
     @pytest.mark.rootful
@@ -696,7 +695,7 @@ class TestNsenterSupplementaryGroups:
             exec_id = cluster.cli_as_user(user, ["spur", "exec", str(job_id), "id"])
             exec_groups = _parse_groups(exec_id)
             assert {"render", "video"} <= exec_groups, (
-                f"spur exec lost supplementary groups (SPUR-172): "
+                f"spur exec lost supplementary groups: "
                 f"groups={sorted(exec_groups)}\nraw: {exec_id}"
             )
 
@@ -713,7 +712,7 @@ class TestNsenterSupplementaryGroups:
                 ],
             )
             assert "KFD_READABLE" in exec_kfd, (
-                f"/dev/kfd not readable via spur exec (SPUR-172):\n{exec_kfd}"
+                f"/dev/kfd not readable via spur exec:\n{exec_kfd}"
             )
 
             # Control: the plain-step path was never broken; assert it still

--- a/tests/native_host/e2e/test_devices.py
+++ b/tests/native_host/e2e/test_devices.py
@@ -10,12 +10,19 @@ Complements test_gpu.py (HIP smoke without --gres) and test_container.py
 from __future__ import annotations
 
 import re
+import shlex
 import time
 from pathlib import Path
 
 import pytest
 
-from cluster import SpurCluster, job_state, parse_job_id, wait_job
+from cluster import (
+    SpurCluster,
+    job_state,
+    parse_job_id,
+    wait_job,
+    wait_job_state,
+)
 
 _FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
@@ -66,6 +73,38 @@ def _gpu_type_on_node(cluster: SpurCluster, node_index: int = 0) -> str | None:
 
 def _max_gpus_per_node(cluster: SpurCluster) -> int:
     return max(cluster.node_gpu_count(name) for name in cluster.node_names)
+
+
+def _render_video_user(cluster: SpurCluster) -> str | None:
+    """Return a non-root user that is a member of both the render and video
+    groups on node 0, or None if none exists.
+
+    SPUR-172 only manifests when the job runs as a non-root user with
+    supplementary GPU groups (so PrivDrop engages and the nsenter paths must
+    reinitialise the group set). Root jobs bypass PrivDrop entirely, so they
+    cannot exercise the regression.
+    """
+    script = (
+        "for g in render video; do getent group \"$g\"; done | "
+        "awk -F: '{n=split($4,m,\",\"); for(i=1;i<=n;i++) if(m[i]!=\"\") "
+        "print $1, m[i]}'"
+    )
+    out = cluster.nodes[0].exec_allow_fail(f"bash -c {shlex.quote(script)}")
+    render_members: set[str] = set()
+    video_members: set[str] = set()
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        grp, user = parts
+        if user == "root":
+            continue
+        if grp == "render":
+            render_members.add(user)
+        elif grp == "video":
+            video_members.add(user)
+    both = sorted(render_members & video_members)
+    return both[0] if both else None
 
 
 
@@ -595,3 +634,97 @@ class TestConfigModes:
         )
         cluster.assert_spurd_registry(0, min_gpus=1)
         assert cluster.node_gpu_count(cluster.node_names[0]) >= 1
+
+
+def _parse_groups(id_output: str) -> set[str]:
+    """Extract group names from `id` output: uid=..(..) gid=..(..) groups=.."""
+    match = re.search(r"groups=(\S+)", id_output)
+    if not match:
+        return set()
+    names: set[str] = set()
+    for token in match.group(1).split(","):
+        name = re.search(r"\(([^)]+)\)", token)
+        if name:
+            names.add(name.group(1))
+    return names
+
+
+class TestNsenterSupplementaryGroups:
+    """SPUR-172: commands entering a running job via nsenter (`spur exec`,
+    `spur run --overlap`) must carry the job user's full supplementary group
+    set, matching the batch path. Without it, GPU device nodes gated on the
+    render/video groups (e.g. /dev/kfd, root:render) are unopenable.
+
+    Unit tests in spurd cover the nsenter argv construction; only an end-to-end
+    run against a real namespaced job exercises the runtime priv-drop
+    (`setpriv --init-groups`) inside the entered pid/mount namespace, which is
+    where the two defects behind SPUR-172 actually surfaced.
+    """
+
+    @pytest.mark.rootful
+    def test_exec_into_job_preserves_supplementary_groups(self, gpu_cluster):
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        assert cluster.spurd_agent_user(0) == "root", (
+            f"expected rootful spurd, got user {cluster.spurd_agent_user(0)!r}"
+        )
+
+        user = _render_video_user(cluster)
+        if user is None:
+            pytest.skip(
+                "no non-root user in both render and video groups on the node"
+            )
+
+        kfd_perm = cluster.nodes[0].exec_allow_fail(
+            "stat -c '%U %G %A' /dev/kfd 2>/dev/null"
+        ).strip()
+        if not kfd_perm:
+            pytest.skip("no /dev/kfd on node")
+
+        hold = cluster.write_file("spur172-hold.sh", "#!/bin/bash\nsleep 300\n")
+        sb = cluster.cli_as_user(
+            user,
+            ["sbatch", "-J", "spur172", "-N", "1", "--gres=gpu:1", hold],
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch (as {user}) failed: {sb}"
+
+        try:
+            wait_job_state(cluster, job_id, "R", timeout=60)
+
+            # nsenter path: spur exec into the running job.
+            exec_id = cluster.cli_as_user(user, ["spur", "exec", str(job_id), "id"])
+            exec_groups = _parse_groups(exec_id)
+            assert {"render", "video"} <= exec_groups, (
+                f"spur exec lost supplementary groups (SPUR-172): "
+                f"groups={sorted(exec_groups)}\nraw: {exec_id}"
+            )
+
+            # The consequence that matters: /dev/kfd becomes readable.
+            exec_kfd = cluster.cli_as_user(
+                user,
+                [
+                    "spur",
+                    "exec",
+                    str(job_id),
+                    "bash",
+                    "-c",
+                    "test -r /dev/kfd && echo KFD_READABLE || echo KFD_NOT_READABLE",
+                ],
+            )
+            assert "KFD_READABLE" in exec_kfd, (
+                f"/dev/kfd not readable via spur exec (SPUR-172):\n{exec_kfd}"
+            )
+
+            # Control: the plain-step path was never broken; assert it still
+            # carries the groups so a regression here is distinguishable from a
+            # blanket failure.
+            code, step_id = cluster.srun_in_allocation(job_id, ["id"])
+            assert code == 0, f"srun step failed (exit {code}):\n{step_id}"
+            step_groups = _parse_groups(step_id)
+            assert {"render", "video"} <= step_groups, (
+                f"plain step lost groups (unexpected regression): "
+                f"groups={sorted(step_groups)}\nraw: {step_id}"
+            )
+        finally:
+            cluster.scancel(str(job_id))


### PR DESCRIPTION
## What this fixes

`spur exec <job>` and `spur run --jobid <J> --overlap` enter an already-running job via `nsenter` and dropped **all** supplementary groups, leaving only the primary gid. On an AMD GPU node `/dev/kfd` is `root:render`, so it became unopenable and `amd-smi` failed with `User is missing the following required groups: render, video`. GPU work was unusable through both nsenter entry paths.

Fixes SPUR-172 / ROCm/spur#596.

## Approach

Two defects, both required for the fix:

1. **Missing group initialisation.** `nsenter --setuid/--setgid` performs only `setuid(2)`/`setgid(2)`, never `setgroups(2)`, and nsenter has no `--init-groups` flag. Replaced with entering the namespace as root and dropping privilege *inside* the target via `setpriv --reuid --regid --init-groups`, mirroring the batch wrapper (`executor.rs`). This initialises the full supplementary group set via NSS inside the job's mount namespace.

2. **Wrong pid namespace (latent).** The tracked job pid is the process that called `unshare(CLONE_NEWPID)` (batch wrapper / container parent). That process stays in its *original* pid namespace; only its children — and the `/proc` mounted inside the job — live in the new pid namespace. `nsenter --target <pid> --pid` therefore joined the **host** pid namespace, where the job's `/proc` does not match, so `setpriv` failed at capability activation reading `/proc/<self>/status` (`setpriv: activate capabilities: No such file or directory`). Fixed by entering via `/proc/<pid>/ns/pid_for_children`. This was always wrong; the previous raw `setuid/setgid` never read `/proc`, so it went unnoticed until the setgroups fix surfaced it.

The nsenter argv construction is extracted into a pure, unit-testable helper shared by both entry paths (`spur exec` and `spur run --overlap`). Root jobs (PrivDrop `None`) run the command directly with no setpriv prefix — unchanged.

## Testing

- **Unit:** argv construction for both paths (setpriv wrap present, no `--setuid/--setgid` on the nsenter portion, root job runs directly) + `pid_for_children` entry.
- **E2E (new):** rootful GPU test in `test_devices.py` holds a job as a non-root render/video user, enters it with `spur exec`, and asserts render/video groups + `/dev/kfd` readable, with a plain-step control. Runs on the GPU self-hosted e2e runners, so future refactors of these paths are gated in CI.
- **Manual regression (MI355X, real hardware):** reproduced the bug pre-fix (`spur exec`/`--overlap` → primary group only, `/dev/kfd` NOT_READABLE), confirmed post-fix (both paths → render(109)+video(44), `/dev/kfd` READABLE), plain-step control unchanged.
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` clean; `cargo test --locked` passes.