### PR TITLE
fix(spurctld): keep admission mode restart-only

### DIFF
--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -224,8 +224,8 @@ pub enum ScontrolCommand {
     },
     /// Re-read spur.conf and apply it live on the leader (partitions, nodes,
     /// licenses, controller hooks, complete_wait_secs/resv_overrun_minutes, etc.).
-    /// Ports/DB/raft/jwt_key, the scheduler loop cadence, and node-side settings
-    /// need a restart; followers converge on restart.
+    /// Ports/DB/Raft, admission.mode/auth.jwt_key, the scheduler loop cadence,
+    /// and node-side settings need a restart; followers converge on restart.
     Reconfigure,
     /// Create a reservation
     #[command(name = "create-reservation")]
@@ -1511,7 +1511,7 @@ async fn reconfigure(controller: &str) -> Result<()> {
     client.reconfigure(()).await.context("reconfigure failed")?;
 
     println!(
-        "Reconfiguration complete on the leader (followers converge on restart; listen ports, accounting DB, raft peers, and jwt_key still require a controller restart)"
+        "Reconfiguration complete on the leader (followers converge on restart; listen ports, accounting DB, Raft peers, admission.mode, and auth.jwt_key still require a controller restart)"
     );
     Ok(())
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3410,22 +3410,22 @@ impl ClusterManager {
     /// `config()`): `[[partitions]]`, `[[nodes]]` features/weight, `licenses`,
     /// `burst_buffer`, `scheduler` tunables (`complete_wait`, `resv_overrun`),
     /// `controller.max_batch_requeue`, `hooks`, `notifications`, `federation`,
-    /// `power` suspend/resume commands, `admission.mode`, and
-    /// `metrics.high_cardinality`.
+    /// `power` suspend/resume commands, and `metrics.high_cardinality`.
     ///
     /// Restart-only (baked in at startup — mirrors Slurm's restart-required set
     /// of ports/plugins/StateSaveLocation/AuthType): bind addresses and ports
     /// (`controller.listen_addr`, `metrics`/`rest_api` listeners), the
     /// accounting database pool (`accounting.database_url`), Raft identity/peers,
-    /// `controller.first_job_id`, `auth.jwt_key` (swapping it live would
-    /// instantly invalidate every outstanding node token), and the scheduler
-    /// loop cadence (`scheduler.interval_secs`, `max_jobs_per_cycle`,
-    /// `topology`).
+    /// `controller.first_job_id`, node admission state (`admission.mode`,
+    /// `auth.jwt_key`), and the scheduler loop cadence
+    /// (`scheduler.interval_secs`, `max_jobs_per_cycle`, `topology`).
     pub fn reconfigure(&self) -> Result<(), anyhow::Error> {
         let Some(ref path) = self.config_path else {
             anyhow::bail!("reconfigure requires a config file path, but none is configured");
         };
-        let new_config = spur_core::config::SlurmConfig::load_from_file(path)?;
+        let mut new_config = spur_core::config::SlurmConfig::load_from_file(path)?;
+        // Admission policy and the node-token signing key must change together at restart.
+        new_config.admission.mode = self.config().admission.mode.clone();
         // Reject a broken submit hook before it goes live, so reconfigure can't
         // silently swap in a hook that fails every subsequent submission.
         crate::hooks::validate_submit_hooks(&new_config.hooks)?;
@@ -3528,7 +3528,7 @@ impl ClusterManager {
             self.reconcile_partitions(&mut nodes);
         }
 
-        info!("reconfigure: applied spur.conf on this leader (followers converge on restart); restart-only sections (listen ports, accounting DB, raft peers, jwt_key, scheduler cadence) unchanged until controller restart");
+        info!("reconfigure: applied spur.conf on this leader (followers converge on restart); restart-only sections (listen ports, accounting DB, raft peers, admission mode/jwt_key, scheduler cadence) unchanged until controller restart");
         Ok(())
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3424,7 +3424,7 @@ impl ClusterManager {
             anyhow::bail!("reconfigure requires a config file path, but none is configured");
         };
         let mut new_config = spur_core::config::SlurmConfig::load_from_file(path)?;
-        // Admission policy and the node-token signing key must change together at restart.
+        // Admission mode is restart-only; keep the startup value across reconfigure to avoid stranding existing agents.
         new_config.admission.mode = self.config().admission.mode.clone();
         // Reject a broken submit hook before it goes live, so reconfigure can't
         // silently swap in a hook that fails every subsequent submission.

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -3752,27 +3752,13 @@ mod tests {
         );
     }
 
-    /// GATE: `auth.jwt_key` is captured at startup and must NOT change on
-    /// `reconfigure`. Swapping it live would instantly invalidate every
-    /// outstanding node token. This drives the real capture path
-    /// (`resolve_startup_jwt_key`) and the real `reconfigure`, then proves the
-    /// running controller still verifies a token minted with the startup key.
-    #[tokio::test]
-    async fn reconfigure_does_not_adopt_new_jwt_key() {
-        use spur_core::admission::{generate_node_token, verify_node_token};
-
-        let dir = tempfile::TempDir::new().unwrap();
-        let conf_path = dir.path().join("spur.conf");
-        std::fs::write(
-            &conf_path,
-            "cluster_name = \"test\"\n[auth]\nplugin = \"jwt\"\njwt_key = \"old-secret\"\n",
-        )
-        .unwrap();
-
-        let config = spur_core::config::SlurmConfig::load_from_file(&conf_path).unwrap();
+    async fn test_service_from_config(
+        dir: &tempfile::TempDir,
+        config: spur_core::config::SlurmConfig,
+        config_path: Option<std::path::PathBuf>,
+    ) -> ControllerService {
         let cluster = Arc::new(
-            ClusterManager::new_with_config_path(config, dir.path(), Some(conf_path.clone()))
-                .unwrap(),
+            ClusterManager::new_with_config_path(config, dir.path(), config_path).unwrap(),
         );
         let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cluster.clone())
             .await
@@ -3783,40 +3769,140 @@ mod tests {
             .metrics(|m| m.current_leader == Some(1), "leader elected")
             .await
             .unwrap();
-        cluster.set_raft(handle.raft);
+        cluster.set_raft(handle.raft.clone());
+        let raft = Arc::new(handle);
+        let jwt_key = resolve_startup_jwt_key(&cluster.config());
+        ControllerService {
+            cluster,
+            raft: raft.clone(),
+            leader_proxy: LeaderProxy::new(raft, BTreeMap::new()),
+            client_addrs: BTreeMap::new(),
+            rpc_stats: Arc::new(RpcStatsCollector::new()),
+            sched_stats: Arc::new(SchedStatsCollector::new("backfill")),
+            control_plane_replicas: 1,
+            jwt_key,
+        }
+    }
 
-        // The controller captures the signing key exactly here, at startup.
-        let startup_key = resolve_startup_jwt_key(&cluster.config());
-        assert_eq!(startup_key, "old-secret");
-        let token = generate_node_token("node-1", startup_key.as_bytes()).unwrap();
+    async fn test_service_with_conf_file(
+        dir: &tempfile::TempDir,
+        contents: &str,
+    ) -> (ControllerService, std::path::PathBuf) {
+        let conf_path = dir.path().join("spur.conf");
+        std::fs::write(&conf_path, contents).unwrap();
+        let config = spur_core::config::SlurmConfig::load_from_file(&conf_path).unwrap();
+        let service = test_service_from_config(dir, config, Some(conf_path.clone())).await;
+        (service, conf_path)
+    }
 
-        // Operator edits jwt_key and reconfigures.
+    /// Node tokens outlive a config reload, so the service must retain its startup key.
+    #[tokio::test]
+    async fn reconfigure_does_not_adopt_new_jwt_key() {
+        use spur_core::admission::{generate_node_token, verify_node_token};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let (service, conf_path) = test_service_with_conf_file(
+            &dir,
+            "cluster_name = \"test\"\n[auth]\nplugin = \"jwt\"\njwt_key = \"old-secret\"\n",
+        )
+        .await;
+        let token = generate_node_token("node-1", service.jwt_key.as_bytes()).unwrap();
+
         std::fs::write(
             &conf_path,
             "cluster_name = \"test\"\n[auth]\nplugin = \"jwt\"\njwt_key = \"new-secret\"\n",
         )
         .unwrap();
-        cluster.reconfigure().unwrap();
+        service.cluster.reconfigure().unwrap();
 
-        // The live config reflects the new key (proving reconfigure did swap
-        // config)...
         assert_eq!(
-            cluster.config().auth.jwt_key.as_deref(),
+            service.cluster.config().auth.jwt_key.as_deref(),
             Some("new-secret"),
             "reconfigure must swap the live config"
         );
-        // ...but the controller's captured key is unchanged, so tokens minted
-        // with the startup key still verify. A live-reloaded key would reject
-        // this token.
-        assert_eq!(startup_key, "old-secret", "captured key must not change");
+        assert_eq!(service.jwt_key, "old-secret");
         assert!(
-            verify_node_token(&token, startup_key.as_bytes()).is_ok(),
+            verify_node_token(&token, service.jwt_key.as_bytes()).is_ok(),
             "outstanding node token must still verify against the startup key"
         );
         assert!(
             verify_node_token(&token, b"new-secret").is_err(),
             "sanity: the token would fail under the new key (proving the key matters)"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reconfigure_does_not_enable_token_admission() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let (service, conf_path) = test_service_with_conf_file(
+            &dir,
+            "cluster_name = \"test\"\n[scheduler]\ncomplete_wait_secs = 30\n[admission]\nmode = \"open\"\n",
+        )
+        .await;
+
+        std::fs::write(
+            &conf_path,
+            "cluster_name = \"test\"\n[scheduler]\ncomplete_wait_secs = 90\n[auth]\nplugin = \"jwt\"\njwt_key = \"new-secret\"\n[admission]\nmode = \"token\"\n",
+        )
+        .unwrap();
+        service.cluster.reconfigure().unwrap();
+
+        let registration = service
+            .register_agent(Request::new(RegisterAgentRequest {
+                hostname: "node-1".into(),
+                address: "127.0.0.1".into(),
+                port: 6818,
+                ..Default::default()
+            }))
+            .await
+            .expect("the startup open policy must still accept a tokenless agent")
+            .into_inner();
+        assert!(registration.node_token.is_empty());
+        service
+            .heartbeat(Request::new(HeartbeatRequest {
+                hostname: "node-1".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect("the startup open policy must still accept a tokenless heartbeat");
+        assert_eq!(service.cluster.config().scheduler.complete_wait_secs, 90);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reconfigure_does_not_disable_token_admission() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let (service, conf_path) = test_service_with_conf_file(
+            &dir,
+            "cluster_name = \"test\"\n[scheduler]\ncomplete_wait_secs = 30\n[auth]\nplugin = \"jwt\"\njwt_key = \"old-secret\"\n[admission]\nmode = \"token\"\n",
+        )
+        .await;
+
+        std::fs::write(
+            &conf_path,
+            "cluster_name = \"test\"\n[scheduler]\ncomplete_wait_secs = 90\n[admission]\nmode = \"open\"\n",
+        )
+        .unwrap();
+        service.cluster.reconfigure().unwrap();
+
+        let registration_error = service
+            .register_agent(Request::new(RegisterAgentRequest {
+                hostname: "node-1".into(),
+                address: "127.0.0.1".into(),
+                port: 6818,
+                ..Default::default()
+            }))
+            .await
+            .expect_err("the startup token policy must still reject a tokenless agent");
+        assert_eq!(registration_error.code(), Code::Unauthenticated);
+        let heartbeat_error = service
+            .heartbeat(Request::new(HeartbeatRequest {
+                hostname: "node-1".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("the startup token policy must still reject a tokenless heartbeat");
+        assert_eq!(heartbeat_error.code(), Code::Unauthenticated);
+        assert_eq!(service.cluster.config().scheduler.complete_wait_secs, 90);
     }
 
     #[test]
@@ -3837,30 +3923,7 @@ mod tests {
     }
 
     async fn test_service(dir: &tempfile::TempDir) -> ControllerService {
-        use crate::cluster::ClusterManager;
-        let cluster =
-            std::sync::Arc::new(ClusterManager::new(step_test_config(), dir.path()).unwrap());
-        let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cluster.clone())
-            .await
-            .unwrap();
-        handle
-            .raft
-            .wait(Some(std::time::Duration::from_secs(5)))
-            .metrics(|m| m.current_leader == Some(1), "leader elected")
-            .await
-            .unwrap();
-        cluster.set_raft(handle.raft.clone());
-        let raft = std::sync::Arc::new(handle);
-        ControllerService {
-            cluster,
-            raft: raft.clone(),
-            leader_proxy: LeaderProxy::new(raft, BTreeMap::new()),
-            client_addrs: BTreeMap::new(),
-            rpc_stats: std::sync::Arc::new(RpcStatsCollector::new()),
-            sched_stats: std::sync::Arc::new(SchedStatsCollector::new("backfill")),
-            control_plane_replicas: 1,
-            jwt_key: String::new(),
-        }
+        test_service_from_config(dir, step_test_config(), None).await
     }
 
     // A step must NOT be created when the target node is allocated but unregistered: address

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -595,7 +595,9 @@ Controls which nodes may register with the controller.
      - string
      - ``"open"``
      - Node admission mode. ``open`` lets any node register; ``token`` requires a
-       registering ``spurd`` to present a valid admission token.
+       registering ``spurd`` to present a valid admission token. Changing this
+       field requires restarting every controller; ``scontrol reconfigure``
+       keeps the mode selected at startup.
 
 See :doc:`accounting` for managing admission tokens with ``spur token``.
 

--- a/docs/deployment/kubernetes.rst
+++ b/docs/deployment/kubernetes.rst
@@ -87,12 +87,12 @@ one), the controller fails fast at startup rather than joining with a wrong ID.
 Adjust partition definitions and node resources to match your cluster hardware.
 Once the controller is running, ``scontrol reconfigure`` applies most section
 changes (partitions, nodes, licenses, hooks, scheduler tunables) without a
-restart; listen ports, the accounting database, Raft peers, and ``jwt_key``
-still require restarting the controller. ``reconfigure`` runs on the Raft
-leader only — followers keep their startup config until restarted, at which
-point they re-read this same ConfigMap and converge. To roll all controllers
-onto an updated ConfigMap, restart the StatefulSet pods. See
-:doc:`partitioning` for the full breakdown.
+restart; listen ports, the accounting database, Raft peers,
+``admission.mode``, and ``auth.jwt_key`` still require restarting every
+controller. ``reconfigure`` runs on the Raft leader only — followers keep their
+startup config until restarted. At that point they re-read this same ConfigMap
+and converge. To roll all controllers onto an updated ConfigMap, restart the
+StatefulSet pods. See :doc:`partitioning` for the full breakdown.
 
 Submitting Jobs
 ---------------

--- a/docs/deployment/partitioning.rst
+++ b/docs/deployment/partitioning.rst
@@ -99,8 +99,8 @@ runtime-only changes not reflected in the file are overwritten.
 to match the file), ``[[nodes]]`` features and weight, ``licenses``,
 ``burst_buffer``, controller-side ``[hooks]`` (``prolog_slurmctld``,
 ``epilog_slurmctld``), ``[notifications]``, ``[federation]``,
-``[power]`` suspend/resume commands, ``[admission]`` mode, and the
-``[scheduler]`` tunables ``complete_wait_secs`` and ``resv_overrun_minutes``.
+``[power]`` suspend/resume commands, and the ``[scheduler]`` tunables
+``complete_wait_secs`` and ``resv_overrun_minutes``.
 Node-side hooks (the per-node prolog/epilog run by ``spurd``), the device
 registry, and memlock are read by the node agent at its own startup;
 ``reconfigure`` does not reach compute nodes, so those need a ``spurd`` restart.
@@ -108,8 +108,8 @@ registry, and memlock are read by the node agent at its own startup;
 **Restart-only**: settings baked in when the daemon starts — listen addresses
 and ports (``[controller]``, ``[metrics]``, ``[rest_api]``), the accounting
 database (``[accounting]``), Raft identity and peers, ``first_job_id``,
-``auth.jwt_key`` (swapping the node-token signing key live would immediately
-invalidate every outstanding node token), and the scheduler loop cadence
+``admission.mode`` and ``auth.jwt_key`` (the node admission policy and token
+signing key change together at restart), and the scheduler loop cadence
 (``interval_secs``, ``max_jobs_per_cycle``, topology). ``reconfigure`` reads
 these but does not apply them; a full controller restart is required. This
 mirrors Slurm, where a documented subset of parameters (ports,


### PR DESCRIPTION
`admission.mode` and `auth.jwt_key` did not follow the same reload rules. `scontrol reconfigure` changed the mode immediately, while the signing key stayed fixed until the controller restarted.

That made changing a live cluster from `open` to `token` unsafe. Existing agents had no token, so their heartbeats began failing. The controller could also keep using its startup fallback key instead of the key from the updated config.

This makes `admission.mode` restart-only, just like `auth.jwt_key`. Everything else that was already safe to reload still reloads normally. The CLI message and docs now make the restart requirement clear.

Fixes #573

## Testing

I added tests for both directions:

- `open` to `token` keeps accepting tokenless registrations and heartbeats until restart
- `token` to `open` keeps rejecting tokenless registrations and heartbeats until restart

Locally, 727 `spurctld` tests passed. `spurctld` Clippy, formatting, license checks, the portable workspace tests, and the warning-as-error docs build also passed. Twenty PostgreSQL tests are ignored by default. Eleven `/proc`-based hook tests, the CLI/agent/PMIx workspace gates, and the native-host/Kubernetes E2E suites need Linux, so CI will cover those.
