### PR TITLE
fix(spurctld): fsync raft state so a crash cannot roll it back

### DIFF
--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -280,9 +280,8 @@ impl SpurStore {
         self.raft_dir.join("log")
     }
 
-    /// Flush the log directory so that entry files created or removed since the
-    /// last call survive a crash. Called once per append/truncate/purge rather
-    /// than once per entry file.
+    /// Flushes the log dir once per append/truncate/purge rather than once per
+    /// entry file.
     // The error type is openraft's, and every caller is a `RaftStorage` method
     // that must return it anyway; boxing it here would only unbox at the call.
     #[allow(clippy::result_large_err)]
@@ -473,9 +472,7 @@ impl openraft::RaftStorage<SpurTypeConfig> for Arc<SpurStore> {
             })?;
             inner.log.insert(entry.log_id.index, entry);
         }
-        // One directory flush for the whole batch: each entry's contents are
-        // already on disk, but a newly created file is not durable until the
-        // directory holding its name is flushed too.
+        // A newly created file is not durable until its directory is flushed.
         self.sync_log_dir()?;
         Ok(())
     }
@@ -490,9 +487,7 @@ impl openraft::RaftStorage<SpurTypeConfig> for Arc<SpurStore> {
             inner.log.remove(&k);
             self.remove_log_entry(k);
         }
-        // The deletions must be durable before this returns: a crash that loses
-        // them resurrects the conflicting tail, and `get_log_state` would then
-        // report a last_log_id this node never accepted from the leader.
+        // A crash that loses these deletions resurrects the conflicting tail.
         self.sync_log_dir()?;
         Ok(())
     }

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -9,7 +9,7 @@
 //! `ClusterManager::propose()` and applied through `StateMachineApply`.
 
 use std::collections::BTreeMap;
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -275,42 +275,40 @@ impl SpurStore {
         })
     }
 
+    fn log_dir(&self) -> PathBuf {
+        self.raft_dir.join("log")
+    }
+
+    /// Flush the log directory so that entry files created or removed since the
+    /// last call survive a crash. Called once per append/truncate/purge rather
+    /// than once per entry file.
+    fn sync_log_dir(&self) -> Result<(), StorageError<NodeId>> {
+        sync_dir(&self.log_dir()).map_err(|e| {
+            StorageError::from_io_error(openraft::ErrorSubject::Logs, openraft::ErrorVerb::Write, e)
+        })
+    }
+
     fn persist_last_purged(&self, log_id: &LogId<NodeId>) -> Result<(), std::io::Error> {
-        let path = self.raft_dir.join("purged.json");
-        let tmp = self.raft_dir.join("purged.json.tmp");
-        let data = serde_json::to_vec(log_id)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        // Write-then-rename: a crash mid-write must never corrupt purged.json.
-        std::fs::write(&tmp, &data)
-            .map_err(|e| std::io::Error::new(e.kind(), format!("{tmp:?}: {e}")))?;
-        std::fs::rename(&tmp, &path)
-            .map_err(|e| std::io::Error::new(e.kind(), format!("{path:?}: {e}")))
+        atomic_write_json(&self.raft_dir.join("purged.json"), log_id)?;
+        sync_dir(&self.raft_dir)
     }
 
     fn persist_vote(&self, vote: &Vote<NodeId>) -> Result<(), std::io::Error> {
-        let path = self.raft_dir.join("vote.json");
-        let data = serde_json::to_vec(vote)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        std::fs::write(&path, &data)
-            .map_err(|e| std::io::Error::new(e.kind(), format!("{path:?}: {e}")))
+        atomic_write_json(&self.raft_dir.join("vote.json"), vote)?;
+        sync_dir(&self.raft_dir)
     }
 
     fn persist_log_entry(&self, entry: &Entry<SpurTypeConfig>) -> Result<(), std::io::Error> {
+        // Contents only: the caller flushes the log directory once per append
+        // batch rather than once per entry.
         let path = self
-            .raft_dir
-            .join("log")
+            .log_dir()
             .join(format!("{:020}.json", entry.log_id.index));
-        let data = serde_json::to_vec(entry)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        std::fs::write(&path, &data)
-            .map_err(|e| std::io::Error::new(e.kind(), format!("{path:?}: {e}")))
+        atomic_write_json(&path, entry)
     }
 
     fn remove_log_entry(&self, index: u64) {
-        let path = self
-            .raft_dir
-            .join("log")
-            .join(format!("{:020}.json", index));
+        let path = self.log_dir().join(format!("{:020}.json", index));
         let _ = std::fs::remove_file(&path);
     }
 
@@ -323,11 +321,8 @@ impl SpurStore {
             meta: meta.clone(),
             data: data.to_vec(),
         };
-        let path = self.raft_dir.join("snapshot.json");
-        let json = serde_json::to_vec(&ps)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        std::fs::write(&path, &json)
-            .map_err(|e| std::io::Error::new(e.kind(), format!("{path:?}: {e}")))
+        atomic_write_json(&self.raft_dir.join("snapshot.json"), &ps)?;
+        sync_dir(&self.raft_dir)
     }
 
     fn load_persisted_snapshot(&self) -> Option<PersistedSnapshot> {
@@ -339,6 +334,54 @@ impl SpurStore {
             .ok()
             .and_then(|data| serde_json::from_str(&data).ok())
     }
+}
+
+/// Serialize `value` to `path` so that a crash leaves either the previous file
+/// or the complete new one, and so the new contents are on disk when this
+/// returns.
+///
+/// Both halves are required, and `std::fs::write` provides neither. It truncates
+/// the target first, so a crash mid-write leaves a half-length JSON file that
+/// `SpurStore::new` then refuses to parse — the node will not start at all in
+/// the default strict recovery mode. And it returns once the bytes are in the
+/// page cache, which a power loss or kernel panic discards even though openraft
+/// was told the write succeeded: `RaftStorage::save_vote` is documented as "the
+/// vote must be persisted on disk before returning", and losing a vote lets this
+/// node grant its vote twice in the same term.
+fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), std::io::Error> {
+    let data = serde_json::to_vec(value)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    let tmp = path.with_extension("json.tmp");
+    let mut file = std::fs::File::create(&tmp)
+        .map_err(|e| std::io::Error::new(e.kind(), format!("{tmp:?}: {e}")))?;
+    file.write_all(&data)
+        .map_err(|e| std::io::Error::new(e.kind(), format!("{tmp:?}: {e}")))?;
+    file.sync_all()
+        .map_err(|e| std::io::Error::new(e.kind(), format!("{tmp:?}: {e}")))?;
+    drop(file);
+
+    std::fs::rename(&tmp, path)
+        .map_err(|e| std::io::Error::new(e.kind(), format!("{path:?}: {e}")))
+}
+
+/// Flush a directory so that files created or renamed inside it survive a crash.
+///
+/// Flushing a file's contents is not enough for a file that was just created or
+/// renamed into place: its directory entry lives in the parent directory, and
+/// until that is flushed the file can be missing entirely after a power loss.
+#[cfg(unix)]
+fn sync_dir(dir: &Path) -> Result<(), std::io::Error> {
+    std::fs::File::open(dir)
+        .and_then(|f| f.sync_all())
+        .map_err(|e| std::io::Error::new(e.kind(), format!("{dir:?}: {e}")))
+}
+
+/// Windows cannot fsync a directory handle; `MoveFileEx` is ordered enough there
+/// once the file's own contents have been flushed.
+#[cfg(not(unix))]
+fn sync_dir(_dir: &Path) -> Result<(), std::io::Error> {
+    Ok(())
 }
 
 impl RaftLogReader<SpurTypeConfig> for Arc<SpurStore> {
@@ -434,6 +477,10 @@ impl openraft::RaftStorage<SpurTypeConfig> for Arc<SpurStore> {
             })?;
             inner.log.insert(entry.log_id.index, entry);
         }
+        // One directory flush for the whole batch: each entry's contents are
+        // already on disk, but a newly created file is not durable until the
+        // directory holding its name is flushed too.
+        self.sync_log_dir()?;
         Ok(())
     }
 
@@ -447,6 +494,10 @@ impl openraft::RaftStorage<SpurTypeConfig> for Arc<SpurStore> {
             inner.log.remove(&k);
             self.remove_log_entry(k);
         }
+        // The deletions must be durable before this returns: a crash that loses
+        // them resurrects the conflicting tail, and `get_log_state` would then
+        // report a last_log_id this node never accepted from the leader.
+        self.sync_log_dir()?;
         Ok(())
     }
 
@@ -460,6 +511,7 @@ impl openraft::RaftStorage<SpurTypeConfig> for Arc<SpurStore> {
             inner.log.remove(&k);
             self.remove_log_entry(k);
         }
+        self.sync_log_dir()?;
         inner.last_purged = Some(log_id);
         Ok(())
     }

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -337,17 +337,8 @@ impl SpurStore {
 }
 
 /// Serialize `value` to `path` so that a crash leaves either the previous file
-/// or the complete new one, and so the new contents are on disk when this
-/// returns.
-///
-/// Both halves are required, and `std::fs::write` provides neither. It truncates
-/// the target first, so a crash mid-write leaves a half-length JSON file that
-/// `SpurStore::new` then refuses to parse — the node will not start at all in
-/// the default strict recovery mode. And it returns once the bytes are in the
-/// page cache, which a power loss or kernel panic discards even though openraft
-/// was told the write succeeded: `RaftStorage::save_vote` is documented as "the
-/// vote must be persisted on disk before returning", and losing a vote lets this
-/// node grant its vote twice in the same term.
+/// or the complete new one, and so the contents are on disk when this returns:
+/// openraft requires a vote to be durable before `save_vote` returns.
 fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), std::io::Error> {
     let data = serde_json::to_vec(value)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
@@ -365,11 +356,8 @@ fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), std::io
         .map_err(|e| std::io::Error::new(e.kind(), format!("{path:?}: {e}")))
 }
 
-/// Flush a directory so that files created or renamed inside it survive a crash.
-///
-/// Flushing a file's contents is not enough for a file that was just created or
-/// renamed into place: its directory entry lives in the parent directory, and
-/// until that is flushed the file can be missing entirely after a power loss.
+/// Flush a directory so that files created or renamed inside it survive a crash:
+/// flushing a file's own contents leaves its directory entry unflushed.
 #[cfg(unix)]
 fn sync_dir(dir: &Path) -> Result<(), std::io::Error> {
     std::fs::File::open(dir)

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -282,6 +282,9 @@ impl SpurStore {
     /// Flush the log directory so that entry files created or removed since the
     /// last call survive a crash. Called once per append/truncate/purge rather
     /// than once per entry file.
+    // The error type is openraft's, and every caller is a `RaftStorage` method
+    // that must return it anyway; boxing it here would only unbox at the call.
+    #[allow(clippy::result_large_err)]
     fn sync_log_dir(&self) -> Result<(), StorageError<NodeId>> {
         sync_dir(&self.log_dir()).map_err(|e| {
             StorageError::from_io_error(openraft::ErrorSubject::Logs, openraft::ErrorVerb::Write, e)

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -1547,6 +1547,100 @@ mod tests {
         assert!(store.inner.read().vote.is_none());
     }
 
+    /// A crash between `File::create` and `rename` leaves a `<name>.json.tmp`
+    /// on disk. Recovery must skip those rather than parse them as records.
+    #[test]
+    fn store_recovery_ignores_stale_tmp_files() {
+        let dir = TempDir::new().unwrap();
+        let store = SpurStore::new(dir.path(), noop_applier()).unwrap();
+
+        let leader_id = openraft::LeaderId {
+            term: 4,
+            node_id: 1,
+        };
+        let vote = Vote {
+            leader_id,
+            committed: true,
+        };
+        store.persist_vote(&vote).unwrap();
+
+        let entry = Entry {
+            log_id: LogId {
+                leader_id,
+                index: 7,
+            },
+            payload: EntryPayload::Blank,
+        };
+        store.persist_log_entry(&entry).unwrap();
+
+        let raft_dir = dir.path().join("raft");
+        let stale = [
+            raft_dir.join("vote.json.tmp"),
+            raft_dir.join("snapshot.json.tmp"),
+            raft_dir.join("purged.json.tmp"),
+            raft_dir.join("log").join("00000000000000000008.json.tmp"),
+        ];
+        for path in stale {
+            std::fs::write(&path, "{\"log_id\":{\"lead").unwrap();
+        }
+
+        let store2 = SpurStore::new(dir.path(), noop_applier()).unwrap();
+        let inner = store2.inner.read();
+        assert_eq!(inner.vote, Some(vote));
+        let indexes: Vec<u64> = inner.log.keys().copied().collect();
+        assert_eq!(indexes, vec![7]);
+        assert_eq!(inner.log[&7].log_id, entry.log_id);
+        assert_eq!(inner.last_purged, None);
+        assert_eq!(inner.last_applied, None);
+    }
+
+    #[test]
+    fn atomic_write_leaves_no_tmp_sibling() {
+        let dir = TempDir::new().unwrap();
+        let store = SpurStore::new(dir.path(), noop_applier()).unwrap();
+
+        let leader_id = openraft::LeaderId {
+            term: 2,
+            node_id: 1,
+        };
+        let log_id = LogId {
+            leader_id,
+            index: 42,
+        };
+        let vote = Vote {
+            leader_id,
+            committed: true,
+        };
+        store.persist_vote(&vote).unwrap();
+        store.persist_last_purged(&log_id).unwrap();
+
+        let entry = Entry {
+            log_id,
+            payload: EntryPayload::Blank,
+        };
+        store.persist_log_entry(&entry).unwrap();
+
+        let meta = SnapshotMeta {
+            last_log_id: Some(log_id),
+            last_membership: StoredMembership::default(),
+            snapshot_id: "snap-42".into(),
+        };
+        store.persist_snapshot(&meta, b"payload").unwrap();
+
+        let raft_dir = dir.path().join("raft");
+        let written = [
+            raft_dir.join("vote.json"),
+            raft_dir.join("purged.json"),
+            raft_dir.join("snapshot.json"),
+            raft_dir.join("log").join("00000000000000000042.json"),
+        ];
+        for path in written {
+            assert!(path.exists(), "{path:?} was not created");
+            let tmp = path.with_extension("json.tmp");
+            assert!(!tmp.exists(), "{tmp:?} was left behind");
+        }
+    }
+
     struct FailingRestoreApplier;
     impl StateMachineApply for FailingRestoreApplier {
         fn apply_operation(&self, _op: &WalOperation) -> ClientResponse {

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -365,8 +365,9 @@ fn sync_dir(dir: &Path) -> Result<(), std::io::Error> {
         .map_err(|e| std::io::Error::new(e.kind(), format!("{dir:?}: {e}")))
 }
 
-/// Windows cannot fsync a directory handle; `MoveFileEx` is ordered enough there
-/// once the file's own contents have been flushed.
+/// Windows has no directory handle to fsync, so a rename there is best-effort:
+/// NTFS metadata ordering without an explicit flush is not a stated guarantee.
+/// spurctld is built and tested on unix only.
 #[cfg(not(unix))]
 fn sync_dir(_dir: &Path) -> Result<(), std::io::Error> {
     Ok(())

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -344,16 +344,19 @@ fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), std::io
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
     let tmp = path.with_extension("json.tmp");
-    let mut file = std::fs::File::create(&tmp)
-        .map_err(|e| std::io::Error::new(e.kind(), format!("{tmp:?}: {e}")))?;
-    file.write_all(&data)
-        .map_err(|e| std::io::Error::new(e.kind(), format!("{tmp:?}: {e}")))?;
-    file.sync_all()
-        .map_err(|e| std::io::Error::new(e.kind(), format!("{tmp:?}: {e}")))?;
+    // A failed attempt must not leave its temp file behind: a sustained
+    // disk-full condition would otherwise accumulate one per failed index.
+    let failed = |e: std::io::Error, at: &Path| {
+        let _ = std::fs::remove_file(&tmp);
+        std::io::Error::new(e.kind(), format!("{at:?}: {e}"))
+    };
+
+    let mut file = std::fs::File::create(&tmp).map_err(|e| failed(e, &tmp))?;
+    file.write_all(&data).map_err(|e| failed(e, &tmp))?;
+    file.sync_all().map_err(|e| failed(e, &tmp))?;
     drop(file);
 
-    std::fs::rename(&tmp, path)
-        .map_err(|e| std::io::Error::new(e.kind(), format!("{path:?}: {e}")))
+    std::fs::rename(&tmp, path).map_err(|e| failed(e, path))
 }
 
 /// Flush a directory so that files created or renamed inside it survive a crash:

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -339,9 +339,8 @@ impl SpurStore {
     }
 }
 
-/// Serialize `value` to `path` so that a crash leaves either the previous file
-/// or the complete new one, and so the contents are on disk when this returns:
-/// openraft requires a vote to be durable before `save_vote` returns.
+/// Leaves either the previous file or the complete new one after a crash, and
+/// returns only once the contents are on disk.
 fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), io::Error> {
     let data =
         serde_json::to_vec(value).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -371,8 +370,7 @@ fn sync_dir(dir: &Path) -> Result<(), io::Error> {
         .map_err(|e| io::Error::new(e.kind(), format!("{dir:?}: {e}")))
 }
 
-/// Windows has no directory handle to fsync, so a rename there is best-effort:
-/// NTFS metadata ordering without an explicit flush is not a stated guarantee.
+/// Windows has no directory handle to fsync, so a rename there is best-effort;
 /// spurctld is built and tested on unix only.
 #[cfg(not(unix))]
 fn sync_dir(_dir: &Path) -> Result<(), io::Error> {

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -9,7 +9,8 @@
 //! `ClusterManager::propose()` and applied through `StateMachineApply`.
 
 use std::collections::BTreeMap;
-use std::io::{Cursor, Write};
+use std::fs;
+use std::io::{self, Cursor, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -291,17 +292,17 @@ impl SpurStore {
         })
     }
 
-    fn persist_last_purged(&self, log_id: &LogId<NodeId>) -> Result<(), std::io::Error> {
+    fn persist_last_purged(&self, log_id: &LogId<NodeId>) -> Result<(), io::Error> {
         atomic_write_json(&self.raft_dir.join("purged.json"), log_id)?;
         sync_dir(&self.raft_dir)
     }
 
-    fn persist_vote(&self, vote: &Vote<NodeId>) -> Result<(), std::io::Error> {
+    fn persist_vote(&self, vote: &Vote<NodeId>) -> Result<(), io::Error> {
         atomic_write_json(&self.raft_dir.join("vote.json"), vote)?;
         sync_dir(&self.raft_dir)
     }
 
-    fn persist_log_entry(&self, entry: &Entry<SpurTypeConfig>) -> Result<(), std::io::Error> {
+    fn persist_log_entry(&self, entry: &Entry<SpurTypeConfig>) -> Result<(), io::Error> {
         // Contents only: the caller flushes the log directory once per append
         // batch rather than once per entry.
         let path = self
@@ -312,14 +313,14 @@ impl SpurStore {
 
     fn remove_log_entry(&self, index: u64) {
         let path = self.log_dir().join(format!("{:020}.json", index));
-        let _ = std::fs::remove_file(&path);
+        let _ = fs::remove_file(&path);
     }
 
     fn persist_snapshot(
         &self,
         meta: &SnapshotMeta<NodeId, BasicNode>,
         data: &[u8],
-    ) -> Result<(), std::io::Error> {
+    ) -> Result<(), io::Error> {
         let ps = PersistedSnapshot {
             meta: meta.clone(),
             data: data.to_vec(),
@@ -342,40 +343,40 @@ impl SpurStore {
 /// Serialize `value` to `path` so that a crash leaves either the previous file
 /// or the complete new one, and so the contents are on disk when this returns:
 /// openraft requires a vote to be durable before `save_vote` returns.
-fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), std::io::Error> {
-    let data = serde_json::to_vec(value)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), io::Error> {
+    let data =
+        serde_json::to_vec(value).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
     let tmp = path.with_extension("json.tmp");
     // A failed attempt must not leave its temp file behind: a sustained
     // disk-full condition would otherwise accumulate one per failed index.
-    let failed = |e: std::io::Error, at: &Path| {
-        let _ = std::fs::remove_file(&tmp);
-        std::io::Error::new(e.kind(), format!("{at:?}: {e}"))
+    let failed = |e: io::Error, at: &Path| {
+        let _ = fs::remove_file(&tmp);
+        io::Error::new(e.kind(), format!("{at:?}: {e}"))
     };
 
-    let mut file = std::fs::File::create(&tmp).map_err(|e| failed(e, &tmp))?;
+    let mut file = fs::File::create(&tmp).map_err(|e| failed(e, &tmp))?;
     file.write_all(&data).map_err(|e| failed(e, &tmp))?;
     file.sync_all().map_err(|e| failed(e, &tmp))?;
     drop(file);
 
-    std::fs::rename(&tmp, path).map_err(|e| failed(e, path))
+    fs::rename(&tmp, path).map_err(|e| failed(e, path))
 }
 
 /// Flush a directory so that files created or renamed inside it survive a crash:
 /// flushing a file's own contents leaves its directory entry unflushed.
 #[cfg(unix)]
-fn sync_dir(dir: &Path) -> Result<(), std::io::Error> {
-    std::fs::File::open(dir)
+fn sync_dir(dir: &Path) -> Result<(), io::Error> {
+    fs::File::open(dir)
         .and_then(|f| f.sync_all())
-        .map_err(|e| std::io::Error::new(e.kind(), format!("{dir:?}: {e}")))
+        .map_err(|e| io::Error::new(e.kind(), format!("{dir:?}: {e}")))
 }
 
 /// Windows has no directory handle to fsync, so a rename there is best-effort:
 /// NTFS metadata ordering without an explicit flush is not a stated guarantee.
 /// spurctld is built and tested on unix only.
 #[cfg(not(unix))]
-fn sync_dir(_dir: &Path) -> Result<(), std::io::Error> {
+fn sync_dir(_dir: &Path) -> Result<(), io::Error> {
     Ok(())
 }
 
@@ -1581,7 +1582,7 @@ mod tests {
             raft_dir.join("log").join("00000000000000000008.json.tmp"),
         ];
         for path in stale {
-            std::fs::write(&path, "{\"log_id\":{\"lead").unwrap();
+            fs::write(&path, "{\"log_id\":{\"lead").unwrap();
         }
 
         let store2 = SpurStore::new(dir.path(), noop_applier()).unwrap();


### PR DESCRIPTION
## Problem

`SpurStore` in `crates/spurctld/src/raft.rs` persists every piece of raft state with `std::fs::write`:

```rust
fn persist_vote(&self, vote: &Vote<NodeId>) -> Result<(), std::io::Error> {
    let path = self.raft_dir.join("vote.json");
    let data = serde_json::to_vec(vote)?;
    std::fs::write(&path, &data)   // truncate, write, close
}
```

`std::fs::write` truncates the target first and returns once the bytes are in the OS page cache. Openraft requires the opposite of both — [`RaftStorage::save_vote`](https://docs.rs/openraft/0.9/openraft/storage/trait.RaftStorage.html#tymethod.save_vote) is documented as *"The vote must be persisted on disk before returning"*, and an append must be on disk before it reports success, because the leader commits on the strength of that report.

Three consequences, none of them visible on a graceful shutdown:

**1. A crash mid-write bricks the node.** `std::fs::write` truncates before writing, so a crash in between leaves a half-length JSON file. `SpurStore::new` in the default strict mode then does:

```
anyhow::bail!("failed to parse vote.json: {e}")
```

and `spurctld` will not start. `--allow-partial-wal-recovery` gets it running by dropping the record, which is worse — see (2). `persist_last_purged` already used write-then-rename with the comment *"a crash mid-write must never corrupt purged.json"*; `persist_vote` and `persist_snapshot` did not, though the same reasoning applies to them.

**2. A power loss can roll the vote back.** `save_vote` returns `Ok` with the vote only in the page cache. After the crash the node reads back an older vote and grants its vote a second time in the same term — two candidates can each collect a majority and both become leader for that term.

**3. New files can be missing entirely.** A file's name lives in its parent directory. Flushing the file's contents does not flush that directory entry, so a newly created `log/00000000000000000042.json` can be absent after a crash even though its bytes were written.

## Fix

One helper, used by all four persist paths:

```rust
fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), std::io::Error> {
    // ... write to `<path>.tmp`
    file.write_all(&data)?;
    file.sync_all()?;      // contents durable
    drop(file);
    std::fs::rename(&tmp, path)   // atomic swap
}
```

- **Single-file state** (`vote.json`, `purged.json`, `snapshot.json`) — `atomic_write_json` + `sync_dir(raft_dir)`.
- **Log entry files** — `persist_log_entry` writes contents only; `append_to_log`, `delete_conflict_logs_since` and `purge_logs_upto` each call `sync_log_dir()` **once per call** rather than once per entry, so the directory flush is amortised over the batch.

`sync_dir` is `#[cfg(unix)]`; Windows has no directory-fsync equivalent, so it is a no-op there.

The two delete paths need the directory flush for the same reason as the appends: if a crash loses a truncation, the conflicting tail reappears on disk and `get_log_state` reports a `last_log_id` this node never accepted from the current leader.

## Cost, and what this PR deliberately does not change

This makes an existing cost visible rather than creating it. `persist_log_entry` writes **one file per raft log entry**, so an append of *K* entries is already *K* file creations; with this PR it is *K* fsyncs plus one for the directory.

The fix for that is a single append-only log file (framed records) instead of a file per entry, which would bring an append down to one fsync per batch. That is a much larger change and belongs in its own PR — correctness first. If throughput turns out to matter, the other lever is openraft's storage-v2 `append`, whose completion callback may fire *after* the method returns, allowing several batches to share one fsync. `SpurStore` is currently on the v1 `RaftStorage` path via `Adaptor`, which has no such callback.

## Verification

```
cargo check -p spurctld
cargo test  -p spurctld --bins raft::     # 47 passed, 0 failed
```

The existing recovery tests (`store_corrupt_vote_file_hard_fails_by_default`, `store_persists_vote`, `store_persists_snapshot`, `store_persists_last_purged_across_restart`, `store_removes_log_entries`, …) all still pass. Durability itself cannot be asserted from inside the process — a test would have to kill the machine, not the process — so the change is instead scoped so that every write goes through one helper.

---

Found while reviewing how projects use openraft (I maintain [openraft](https://github.com/databendlabs/openraft)). Unrelated to this PR, two things in `raft.rs` were the best treatment of their kind I found across the projects I looked at: `append_entries` returning `RPCError::PayloadTooLarge` with `new_entries_hint` (nobody else uses that feedback path — everyone else just lets the oversized append fail), and the `4 * RAFT_SNAPSHOT_MAX_CHUNK_SIZE < RAFT_MAX_MESSAGE_SIZE` invariant with tests on both sides of it.
