### PR TITLE
fix(spur-core): reject hostlist patterns with ']' before '['

### DIFF
--- a/crates/spur-core/src/hostlist.rs
+++ b/crates/spur-core/src/hostlist.rs
@@ -287,6 +287,13 @@ fn expand_single(pattern: &str, results: &mut Vec<String>) -> Result<(), Hostlis
             .find(']')
             .ok_or_else(|| HostlistError::InvalidPattern("unmatched [".into()))?;
 
+        // ']' before '[' would make the slice below reversed (start > end) and panic.
+        if bracket_end < bracket_start {
+            return Err(HostlistError::InvalidPattern(format!(
+                "']' before '[': {pattern}"
+            )));
+        }
+
         let prefix = &pattern[..bracket_start];
         let range_str = &pattern[bracket_start + 1..bracket_end];
         let suffix = &pattern[bracket_end + 1..];
@@ -588,5 +595,13 @@ mod tests {
         round_tripped.sort();
 
         assert_eq!(round_tripped, expected);
+    }
+
+    #[test]
+    fn test_closing_bracket_before_opening() {
+        assert!(expand("n]ode[1-2]").is_err());
+        assert!(expand("a]b[1-2]").is_err());
+        assert!(expand("][").is_err());
+        assert!(expand("node]1").is_ok()); // ']' with no '[' is a plain hostname
     }
 }

--- a/crates/spur-tests/src/t51_hostlist.rs
+++ b/crates/spur-tests/src/t51_hostlist.rs
@@ -136,4 +136,9 @@ mod tests {
     fn t51_18_invalid_reversed_range() {
         assert!(hostlist::expand("node[5-1]").is_err());
     }
+
+    #[test]
+    fn t51_19_invalid_closing_before_opening_bracket() {
+        assert!(hostlist::expand("a]b[1-2]").is_err());
+    }
 }


### PR DESCRIPTION
Fixes #638

## Summary

`hostlist::expand` panicked (reversed slice, process abort exit 101) on
patterns where `]` appears before `[`. `find(']')` took the first `]` without
checking it comes after `[`, producing a reversed range slice. This adds the
missing ordering guard so the input is rejected as `InvalidPattern`, consistent
with existing handling for unmatched `[` and reversed ranges.

## Approach

- Guard in `expand_single`: return `InvalidPattern` when `bracket_end < bracket_start`.
- Regression tests in `hostlist.rs` and `spur-tests/t51_hostlist.rs`.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked -- -D warnings`
- [x] `cargo test -p spur-core --locked` (hostlist: pass)
- [x] `cargo test -p spur-tests --locked` (366 passed, incl. t51_19)
- [x] `spur squeue -w 'a]b[1-2]'` now exits 1 with a clean error instead of panicking (exit 101)
