### PR TITLE
feat(auth): authenticate control-plane callers (identity spine)

### DIFF
--- a/crates/spur-cli/src/authclient.rs
+++ b/crates/spur-cli/src/authclient.rs
@@ -98,21 +98,26 @@ pub async fn connect(endpoints: &str) -> Result<AuthChannel, tonic::transport::E
 mod tests {
     use super::*;
 
+    /// Both env cases live in ONE test on purpose: the variable is process-global, so two tests
+    /// mutating it run concurrently under the default test harness and race each other.
     #[test]
-    fn env_token_takes_precedence_and_is_trimmed() {
-        // SAFETY: single-threaded test process for this variable.
+    fn env_token_is_trimmed_and_blank_is_not_a_credential() {
+        // SAFETY: this is the only test that touches TOKEN_ENV, so no other thread reads it here.
         unsafe { std::env::set_var(TOKEN_ENV, "  abc123\n") };
-        assert_eq!(load_token().as_deref(), Some("abc123"));
-        unsafe { std::env::remove_var(TOKEN_ENV) };
-    }
+        assert_eq!(
+            load_token().as_deref(),
+            Some("abc123"),
+            "the env credential wins and is trimmed"
+        );
 
-    #[test]
-    fn an_empty_env_token_is_not_a_credential() {
         unsafe { std::env::set_var(TOKEN_ENV, "   ") };
-        // Falls through to the file (absent in the test environment) rather than sending "Bearer ".
-        let t = load_token();
+        // Blank falls through to the file rather than sending a literal "Bearer " with no token.
+        let blank = load_token();
         unsafe { std::env::remove_var(TOKEN_ENV) };
-        assert!(t.is_none() || !t.unwrap().is_empty());
+        assert!(
+            blank.as_deref() != Some(""),
+            "a blank env value must not become an empty credential"
+        );
     }
 
     #[test]

--- a/crates/spur-cli/src/authclient.rs
+++ b/crates/spur-cli/src/authclient.rs
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Controller channel that attaches the caller's credential.
+//!
+//! Every CLI subcommand connects through [`connect`], so a token is sent on all RPCs without each
+//! command knowing about authentication. Having no token is not an error: the control plane decides
+//! whether that is acceptable via `[auth] mode`, and the CLI stays usable against a cluster that has
+//! not adopted authentication yet.
+
+use std::path::PathBuf;
+
+use tonic::metadata::MetadataValue;
+use tonic::service::interceptor::InterceptedService;
+use tonic::transport::Channel;
+use tonic::{Request, Status};
+
+/// Environment variable holding a credential, checked before the on-disk token.
+const TOKEN_ENV: &str = "SPUR_AUTH_TOKEN";
+
+/// Credential file, relative to the user's home directory.
+const TOKEN_FILE: &str = ".spur/token";
+
+/// A channel that attaches the caller's credential to every request.
+pub type AuthChannel = InterceptedService<Channel, AuthInterceptor>;
+
+#[derive(Clone, Default)]
+pub struct AuthInterceptor {
+    /// Pre-formatted `Bearer <token>`; `None` when the caller has no credential.
+    header: Option<MetadataValue<tonic::metadata::Ascii>>,
+}
+
+impl tonic::service::Interceptor for AuthInterceptor {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        if let Some(value) = &self.header {
+            request
+                .metadata_mut()
+                .insert("authorization", value.clone());
+        }
+        Ok(request)
+    }
+}
+
+/// Read the caller's credential: `$SPUR_AUTH_TOKEN`, else `~/.spur/token`.
+///
+/// A token file with group/other permissions is ignored with a warning rather than used — a bearer
+/// credential readable by other users on a shared login node is not a credential.
+pub fn load_token() -> Option<String> {
+    if let Ok(t) = std::env::var(TOKEN_ENV) {
+        let t = t.trim().to_string();
+        if !t.is_empty() {
+            return Some(t);
+        }
+    }
+    let path: PathBuf = dirs_home()?.join(TOKEN_FILE);
+    let meta = std::fs::metadata(&path).ok()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = meta.permissions().mode() & 0o077;
+        if mode != 0 {
+            eprintln!(
+                "warning: ignoring {} because it is readable by other users (chmod 600 it)",
+                path.display()
+            );
+            return None;
+        }
+    }
+    let t = std::fs::read_to_string(&path).ok()?.trim().to_string();
+    (!t.is_empty()).then_some(t)
+}
+
+fn dirs_home() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+fn interceptor() -> AuthInterceptor {
+    let header = load_token().and_then(|t| MetadataValue::try_from(format!("Bearer {t}")).ok());
+    AuthInterceptor { header }
+}
+
+/// Wrap an already-established channel, for callers that build one directly (a lazily connected
+/// test channel) instead of going through [`connect`]. Test-only today.
+#[cfg(test)]
+pub fn wrap(channel: Channel) -> AuthChannel {
+    InterceptedService::new(channel, interceptor())
+}
+
+/// Connect to the controller, attaching the caller's credential if one is available.
+pub async fn connect(endpoints: &str) -> Result<AuthChannel, tonic::transport::Error> {
+    // NOTE: the raw transport connect — deliberately the only `spur_client::connect_channel` call
+    // left in the CLI, so every subcommand goes through the credential-attaching wrapper.
+    let channel = spur_client::connect_channel(endpoints).await?;
+    Ok(InterceptedService::new(channel, interceptor()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_token_takes_precedence_and_is_trimmed() {
+        // SAFETY: single-threaded test process for this variable.
+        unsafe { std::env::set_var(TOKEN_ENV, "  abc123\n") };
+        assert_eq!(load_token().as_deref(), Some("abc123"));
+        unsafe { std::env::remove_var(TOKEN_ENV) };
+    }
+
+    #[test]
+    fn an_empty_env_token_is_not_a_credential() {
+        unsafe { std::env::set_var(TOKEN_ENV, "   ") };
+        // Falls through to the file (absent in the test environment) rather than sending "Bearer ".
+        let t = load_token();
+        unsafe { std::env::remove_var(TOKEN_ENV) };
+        assert!(t.is_none() || !t.unwrap().is_empty());
+    }
+
+    #[test]
+    fn no_credential_yields_an_interceptor_that_adds_no_header() {
+        let i = AuthInterceptor::default();
+        assert!(i.header.is_none());
+    }
+}

--- a/crates/spur-cli/src/exec.rs
+++ b/crates/spur-cli/src/exec.rs
@@ -37,7 +37,7 @@ pub async fn main() -> Result<()> {
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let args = ExecArgs::try_parse_from(&args)?;
 
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to controller")?;
     let mut client = spur_proto::controller_client(channel);

--- a/crates/spur-cli/src/interactive.rs
+++ b/crates/spur-cli/src/interactive.rs
@@ -27,7 +27,7 @@ impl Drop for KeepaliveGuard {
 /// traffic, so without these pings the controller's InactiveLimit reaper would
 /// reclaim a live allocation.
 pub fn spawn_keepalive(
-    client: SlurmControllerClient<tonic::transport::Channel>,
+    client: SlurmControllerClient<crate::authclient::AuthChannel>,
     job_id: u32,
     user: String,
     tool: &'static str,
@@ -67,6 +67,8 @@ pub fn spawn_keepalive(
 
 /// Connect to a spurd agent, applying the standard gRPC size limits.
 pub async fn connect_agent(addr: &str) -> Result<SlurmAgentClient<tonic::transport::Channel>> {
+    // Raw channel: the agent does not authenticate its callers yet (tracked separately), so there
+    // is nothing to present a controller credential to.
     let channel = spur_client::connect_channel(addr)
         .await
         .context("cannot connect to agent")?;

--- a/crates/spur-cli/src/k8s.rs
+++ b/crates/spur-cli/src/k8s.rs
@@ -184,7 +184,7 @@ async fn cmd_up(
     selector: Vec<(String, String)>,
 ) -> Result<()> {
     let selector = selector_map(selector)?;
-    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let mut client = SlurmControllerClient::new(crate::authclient::connect(controller).await?);
     let resp = client
         .cluster_up(ClusterUpRequest {
             control_plane_node,
@@ -209,7 +209,7 @@ async fn cmd_up(
 }
 
 async fn cmd_down(controller: &str, reset: bool) -> Result<()> {
-    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let mut client = SlurmControllerClient::new(crate::authclient::connect(controller).await?);
     let resp = client
         .cluster_down(ClusterDownRequest {
             reset,
@@ -226,7 +226,7 @@ async fn cmd_down(controller: &str, reset: bool) -> Result<()> {
 }
 
 async fn cmd_status(controller: &str) -> Result<()> {
-    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let mut client = SlurmControllerClient::new(crate::authclient::connect(controller).await?);
     let resp = client
         .cluster_status(ClusterStatusRequest {})
         .await?
@@ -260,7 +260,7 @@ async fn cmd_status(controller: &str) -> Result<()> {
 }
 
 async fn cmd_kubeconfig(controller: &str, user: Option<String>, admin: bool) -> Result<()> {
-    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let mut client = SlurmControllerClient::new(crate::authclient::connect(controller).await?);
     let resp = client
         .cluster_kubeconfig(ClusterKubeconfigRequest {
             user: user.unwrap_or_default(),

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod authclient;
 mod env_defaults;
 mod exec;
 mod exit_fmt;

--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, Mutex};
 
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{self, slurm_controller_server};
-use tonic::transport::{Channel, Endpoint};
+use tonic::transport::Endpoint;
 
 /// Step id the mock hands back from `CreateJobStep`. Distinctive so tests can
 /// prove it is threaded into the follow-up `RunStep` rather than defaulted.
@@ -199,8 +199,10 @@ pub(crate) async fn spawn() -> (SocketAddr, StepCapture) {
 }
 
 /// Dial the mock through the same helper production code uses.
-pub(crate) async fn client(addr: SocketAddr) -> SlurmControllerClient<Channel> {
-    let channel = spur_client::connect_channel(&format!("http://{addr}"))
+pub(crate) async fn client(
+    addr: SocketAddr,
+) -> SlurmControllerClient<crate::authclient::AuthChannel> {
+    let channel = crate::authclient::connect(&format!("http://{addr}"))
         .await
         .expect("connect to mock controller");
     spur_proto::controller_client(channel)
@@ -208,11 +210,13 @@ pub(crate) async fn client(addr: SocketAddr) -> SlurmControllerClient<Channel> {
 
 /// A client whose channel is created without dialing, so the first RPC is what
 /// fails. Lets tests drive the RPC-failure path without a server.
-pub(crate) fn lazy_client(addr: SocketAddr) -> SlurmControllerClient<Channel> {
+pub(crate) fn lazy_client(
+    addr: SocketAddr,
+) -> SlurmControllerClient<crate::authclient::AuthChannel> {
     let channel = Endpoint::from_shared(format!("http://{addr}"))
         .expect("valid endpoint")
         .connect_lazy();
-    spur_proto::controller_client(channel)
+    spur_proto::controller_client(crate::authclient::wrap(channel))
 }
 
 /// Reserve a localhost port and release it, so connecting to it is refused

--- a/crates/spur-cli/src/node.rs
+++ b/crates/spur-cli/src/node.rs
@@ -105,7 +105,7 @@ fn parse_label_args(label_args: &[String]) -> Result<(HashMap<String, String>, V
 async fn cmd_label(controller: &str, node_pattern: String, label_args: Vec<String>) -> Result<()> {
     let (set_labels, remove_labels) = parse_label_args(&label_args)?;
     let nodes = expand_node_pattern(&node_pattern)?;
-    let mut client = spur_proto::controller_client(spur_client::connect_channel(controller).await?);
+    let mut client = spur_proto::controller_client(crate::authclient::connect(controller).await?);
 
     let mut failed: Vec<String> = Vec::new();
     for node in &nodes {
@@ -147,7 +147,7 @@ async fn cmd_label(controller: &str, node_pattern: String, label_args: Vec<Strin
 
 async fn cmd_drain(controller: &str, node_pattern: String, reason: Option<String>) -> Result<()> {
     let nodes = expand_node_pattern(&node_pattern)?;
-    let mut client = spur_proto::controller_client(spur_client::connect_channel(controller).await?);
+    let mut client = spur_proto::controller_client(crate::authclient::connect(controller).await?);
 
     let mut failed: Vec<String> = Vec::new();
     for node in &nodes {
@@ -197,7 +197,7 @@ async fn cmd_remove(
     reason: Option<String>,
 ) -> Result<()> {
     let nodes = expand_node_pattern(&node_pattern)?;
-    let mut client = spur_proto::controller_client(spur_client::connect_channel(controller).await?);
+    let mut client = spur_proto::controller_client(crate::authclient::connect(controller).await?);
 
     let mut failed: Vec<String> = Vec::new();
     for node in &nodes {

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -152,7 +152,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         })
         .unwrap_or_default();
 
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to controller")?;
     let mut client = spur_proto::accounting_client(channel);

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -177,8 +177,8 @@ fn reject_unknown_keys(
     Ok(())
 }
 
-async fn connect(addr: &str) -> Result<SlurmAccountingClient<tonic::transport::Channel>> {
-    let channel = spur_client::connect_channel(addr)
+async fn connect(addr: &str) -> Result<SlurmAccountingClient<crate::authclient::AuthChannel>> {
+    let channel = crate::authclient::connect(addr)
         .await
         .context("failed to connect to controller")?;
     Ok(spur_proto::accounting_client(channel))

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -121,7 +121,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let job_spec = build_salloc_job_spec(&args, nodelist)?;
     let user = job_spec.user.clone();
 
-    let channel = spur_client::connect_channel(&controller)
+    let channel = crate::authclient::connect(&controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -46,7 +46,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .and_then(|s| s.parse().ok())
         .context("sattach: invalid job ID format (expected JOB_ID or JOB_ID.STEP_ID)")?;
 
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -1021,7 +1021,7 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
     };
 
     // Submit to controller
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);

--- a/crates/spur-cli/src/scancel.rs
+++ b/crates/spur-cli/src/scancel.rs
@@ -75,7 +75,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         None => crate::interactive::current_user()?,
     };
 
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -332,7 +332,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         }
         ScontrolCommand::Requeue { job_id } => {
             // Requeue = cancel + resubmit, simplified for now
-            let channel = spur_client::connect_channel(&args.controller)
+            let channel = crate::authclient::connect(&args.controller)
                 .await
                 .context("failed to connect to spurctld")?;
             let mut client = spur_proto::controller_client(channel);
@@ -348,7 +348,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             Ok(())
         }
         ScontrolCommand::Suspend { job_id } => {
-            let channel = spur_client::connect_channel(&args.controller)
+            let channel = crate::authclient::connect(&args.controller)
                 .await
                 .context("failed to connect to spurctld")?;
             let mut client = spur_proto::controller_client(channel);
@@ -363,7 +363,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             Ok(())
         }
         ScontrolCommand::Resume { job_id } => {
-            let channel = spur_client::connect_channel(&args.controller)
+            let channel = crate::authclient::connect(&args.controller)
                 .await
                 .context("failed to connect to spurctld")?;
             let mut client = spur_proto::controller_client(channel);
@@ -518,7 +518,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             // resolves to 0, which the controller treats as "leave duration
             // unchanged"; there is no zero-length reservation to set.
             let duration = parse_reservation_duration(&duration)?;
-            let channel = spur_client::connect_channel(&args.controller)
+            let channel = crate::authclient::connect(&args.controller)
                 .await
                 .context("failed to connect to spurctld")?;
             let mut client = spur_proto::controller_client(channel);
@@ -546,7 +546,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 }
 
 async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> {
-    let channel = spur_client::connect_channel(controller)
+    let channel = crate::authclient::connect(controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);
@@ -847,7 +847,7 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
 }
 
 async fn ping(controller: &str) -> Result<()> {
-    let channel = spur_client::connect_channel(controller)
+    let channel = crate::authclient::connect(controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);
@@ -889,7 +889,7 @@ fn format_ts(ts: Option<&prost_types::Timestamp>) -> String {
 async fn send_job_update(controller: &str, req: spur_proto::proto::UpdateJobRequest) -> Result<()> {
     let hold = req.hold;
     let job_id = req.job_id;
-    let channel = spur_client::connect_channel(controller)
+    let channel = crate::authclient::connect(controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);
@@ -1169,7 +1169,7 @@ async fn parse_and_update(controller: &str, params: &[String]) -> Result<()> {
     if let Some(node_pattern) = node_name {
         let proto_state = node_state.as_deref().map(parse_node_state).transpose()?;
 
-        let channel = spur_client::connect_channel(controller)
+        let channel = crate::authclient::connect(controller)
             .await
             .context("failed to connect to spurctld")?;
         let mut client = spur_proto::controller_client(channel);
@@ -1225,7 +1225,7 @@ async fn parse_and_update(controller: &str, params: &[String]) -> Result<()> {
 /// Supports Slurm-compatible hostlist expressions (`node[1-3]`),
 /// comma-separated lists (`node1,node2`), and the `ALL` keyword.
 async fn resolve_node_names(
-    client: &mut SlurmControllerClient<tonic::transport::Channel>,
+    client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
     pattern: &str,
 ) -> Result<Vec<String>> {
     if pattern.eq_ignore_ascii_case("ALL") {
@@ -1360,7 +1360,7 @@ async fn parse_and_update_partition(controller: &str, params: &[String]) -> Resu
 
 /// Update a node's state via the controller.
 async fn update_node(
-    client: &mut SlurmControllerClient<tonic::transport::Channel>,
+    client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
     name: &str,
     state: Option<i32>,
     reason: Option<String>,
@@ -1430,7 +1430,7 @@ async fn create_partition(
     priority_tier: u32,
     preempt_mode: &str,
 ) -> Result<()> {
-    let channel = spur_client::connect_channel(controller)
+    let channel = crate::authclient::connect(controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);
@@ -1468,7 +1468,7 @@ async fn update_partition(
     controller: &str,
     req: spur_proto::proto::UpdatePartitionRequest,
 ) -> Result<()> {
-    let channel = spur_client::connect_channel(controller)
+    let channel = crate::authclient::connect(controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);
@@ -1485,7 +1485,7 @@ async fn update_partition(
 
 /// Delete a partition via the controller.
 async fn delete_partition(controller: &str, name: &str) -> Result<()> {
-    let channel = spur_client::connect_channel(controller)
+    let channel = crate::authclient::connect(controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);
@@ -1503,7 +1503,7 @@ async fn delete_partition(controller: &str, name: &str) -> Result<()> {
 
 /// Reload spur.conf and reconcile partition state to match it.
 async fn reconfigure(controller: &str) -> Result<()> {
-    let channel = spur_client::connect_channel(controller)
+    let channel = crate::authclient::connect(controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);
@@ -1545,7 +1545,7 @@ async fn create_reservation(
         bail!("reservation duration must be positive; e.g. --duration=01:00:00 or Duration=30-00:00:00");
     }
 
-    let channel = spur_client::connect_channel(controller)
+    let channel = crate::authclient::connect(controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);
@@ -1593,7 +1593,7 @@ async fn create_reservation(
 async fn delete_reservation(controller: &str, name: &str) -> Result<()> {
     crate::privilege::require_privileged("manage reservations")?;
 
-    let channel = spur_client::connect_channel(controller)
+    let channel = crate::authclient::connect(controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);

--- a/crates/spur-cli/src/sdiag.rs
+++ b/crates/spur-cli/src/sdiag.rs
@@ -35,7 +35,7 @@ pub async fn main() -> Result<()> {
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let args = SdiagArgs::try_parse_from(&args)?;
 
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -80,7 +80,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     // Built before connecting so an invalid `-t` fails without a round-trip.
     let nodes_req = build_get_nodes_request(&args)?;
 
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);

--- a/crates/spur-cli/src/smd.rs
+++ b/crates/spur-cli/src/smd.rs
@@ -41,7 +41,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let args = SmdArgs::try_parse_from(&args)?;
 
     loop {
-        let channel = spur_client::connect_channel(&args.controller)
+        let channel = crate::authclient::connect(&args.controller)
             .await
             .context("failed to connect to spurctld")?;
         let mut client = spur_proto::controller_client(channel);

--- a/crates/spur-cli/src/sprio.rs
+++ b/crates/spur-cli/src/sprio.rs
@@ -52,7 +52,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         })
         .unwrap_or_default();
 
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -124,7 +124,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     };
 
     // Connect and fetch
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);

--- a/crates/spur-cli/src/sreport.rs
+++ b/crates/spur-cli/src/sreport.rs
@@ -66,7 +66,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .and_then(parse_time_arg)
         .map(datetime_to_proto);
 
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to controller")?;
     let mut client = spur_proto::accounting_client(channel);
@@ -103,7 +103,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     }
 }
 
-type AcctClient = SlurmAccountingClient<tonic::transport::Channel>;
+type AcctClient = SlurmAccountingClient<crate::authclient::AuthChannel>;
 
 async fn report_account_utilization_by_user(
     client: &mut AcctClient,

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -611,7 +611,7 @@ fn build_srun_job_spec(
 }
 
 fn install_ctrl_c_cancel(
-    client: SlurmControllerClient<tonic::transport::Channel>,
+    client: SlurmControllerClient<crate::authclient::AuthChannel>,
     job_id: u32,
     user: String,
 ) -> tokio::task::JoinHandle<()> {
@@ -632,7 +632,7 @@ fn install_ctrl_c_cancel(
 }
 
 async fn wait_for_job_running(
-    client: &mut SlurmControllerClient<tonic::transport::Channel>,
+    client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
     job_id: u32,
 ) -> Result<String> {
     let mut poll_interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
@@ -712,7 +712,7 @@ struct StepDispatchParams<'a> {
 }
 
 async fn dispatch_step(
-    client: &mut SlurmControllerClient<tonic::transport::Channel>,
+    client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
     job_id: u32,
     params: &StepDispatchParams<'_>,
 ) -> Result<StepDispatchResult> {
@@ -777,7 +777,7 @@ async fn dispatch_step(
 }
 
 async fn release_srun_allocation(
-    client: &mut SlurmControllerClient<tonic::transport::Channel>,
+    client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
     job_id: u32,
     user: &str,
     exit_code: i32,
@@ -811,7 +811,7 @@ async fn release_srun_allocation(
 }
 
 async fn dispatch_step_cancellable(
-    client: &mut SlurmControllerClient<tonic::transport::Channel>,
+    client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
     job_id: u32,
     params: &StepDispatchParams<'_>,
     cancel_job_on_interrupt: bool,
@@ -835,7 +835,7 @@ async fn run_standalone_srun(
     mpi: &str,
 ) -> Result<()> {
     let io = resolve_io_paths(args);
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = SlurmControllerClient::new(channel);
@@ -990,7 +990,7 @@ fn first_node(nodelist: &str) -> String {
 }
 
 async fn try_stream_output(
-    controller: &mut SlurmControllerClient<tonic::transport::Channel>,
+    controller: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
     nodelist: &str,
     job_id: u32,
     user: &str,
@@ -1047,7 +1047,7 @@ async fn try_stream_output(
 }
 
 async fn poll_for_completion(
-    client: &mut SlurmControllerClient<tonic::transport::Channel>,
+    client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
     job_id: u32,
     work_dir: &str,
     stdout_path: &str,
@@ -1207,7 +1207,7 @@ async fn run_interactive_pty(
     node: String,
     user: &str,
 ) -> Result<i32> {
-    let channel = spur_client::connect_channel(controller)
+    let channel = crate::authclient::connect(controller)
         .await
         .context("cannot connect to controller")?;
     let mut ctrl = SlurmControllerClient::new(channel);
@@ -1309,7 +1309,7 @@ async fn run_as_step(
     work_dir: &str,
     step_mpi: &str,
 ) -> Result<()> {
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);
@@ -2117,7 +2117,7 @@ mod tests {
     }
 
     async fn dispatch_with(
-        client: &mut SlurmControllerClient<tonic::transport::Channel>,
+        client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
         cli: &[&str],
     ) -> Result<StepDispatchResult> {
         let args = SrunArgs::try_parse_from(cli).expect("parse failed");

--- a/crates/spur-cli/src/sshare.rs
+++ b/crates/spur-cli/src/sshare.rs
@@ -41,7 +41,7 @@ pub async fn main() -> Result<()> {
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let args = SshareArgs::try_parse_from(&args)?;
 
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to controller")?;
     let mut client = spur_proto::accounting_client(channel);

--- a/crates/spur-cli/src/sstat.rs
+++ b/crates/spur-cli/src/sstat.rs
@@ -52,7 +52,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         bail!("sstat: no valid job IDs specified");
     }
 
-    let channel = spur_client::connect_channel(&args.controller)
+    let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
     let mut client = spur_proto::controller_client(channel);

--- a/crates/spur-cli/src/token.rs
+++ b/crates/spur-cli/src/token.rs
@@ -133,7 +133,7 @@ fn parse_ttl(s: &str) -> Result<u32> {
 async fn cmd_create(controller: &str, ttl: Option<String>) -> Result<()> {
     let ttl_secs = ttl.map(|t| parse_ttl(&t)).transpose()?;
 
-    let mut client = spur_proto::controller_client(spur_client::connect_channel(controller).await?);
+    let mut client = spur_proto::controller_client(crate::authclient::connect(controller).await?);
     let resp = client.create_token(CreateTokenRequest { ttl_secs }).await?;
 
     let inner = resp.into_inner();
@@ -143,7 +143,7 @@ async fn cmd_create(controller: &str, ttl: Option<String>) -> Result<()> {
 }
 
 async fn cmd_list(controller: &str) -> Result<()> {
-    let mut client = spur_proto::controller_client(spur_client::connect_channel(controller).await?);
+    let mut client = spur_proto::controller_client(crate::authclient::connect(controller).await?);
     let resp = client.list_tokens(ListTokensRequest {}).await?;
     let tokens = resp.into_inner().tokens;
 
@@ -169,7 +169,7 @@ async fn cmd_list(controller: &str) -> Result<()> {
 }
 
 async fn cmd_revoke(controller: &str, token_id: &str) -> Result<()> {
-    let mut client = spur_proto::controller_client(spur_client::connect_channel(controller).await?);
+    let mut client = spur_proto::controller_client(crate::authclient::connect(controller).await?);
     client
         .revoke_token(RevokeTokenRequest {
             token_id: token_id.to_string(),

--- a/crates/spur-cli/src/token.rs
+++ b/crates/spur-cli/src/token.rs
@@ -38,6 +38,28 @@ pub enum TokenCommand {
         /// Token ID to revoke.
         token_id: String,
     },
+    /// Mint a USER credential for authenticating RPCs (distinct from the admission tokens above,
+    /// which admit a node to the cluster).
+    ///
+    /// Signed locally from `[auth] jwt_key` in the config, so it needs read access to that file —
+    /// run it on the controller host. Local signing is deliberate: under `[auth] mode = required`
+    /// an RPC-based mint would need a credential to obtain a credential.
+    ///
+    /// Write the output to `~/.spur/token` (mode 0600) or export it as `SPUR_AUTH_TOKEN`.
+    User {
+        /// Username the token authenticates as.
+        #[arg(long)]
+        user: String,
+        /// Mark the token as a cluster admin.
+        #[arg(long)]
+        admin: bool,
+        /// Token time-to-live (e.g. "24h", "7d", "3600s"). Default 24h.
+        #[arg(long)]
+        ttl: Option<String>,
+        /// Config file to read `[auth] jwt_key` from.
+        #[arg(long, default_value = "/etc/spur/spur.conf")]
+        config: String,
+    },
 }
 
 pub async fn main() -> Result<()> {
@@ -51,7 +73,46 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         TokenCommand::Create { ttl } => cmd_create(&controller, ttl).await,
         TokenCommand::List => cmd_list(&controller).await,
         TokenCommand::Revoke { token_id } => cmd_revoke(&controller, &token_id).await,
+        TokenCommand::User {
+            user,
+            admin,
+            ttl,
+            config,
+        } => cmd_user_token(&user, admin, ttl, &config),
     }
+}
+
+/// Mint a user credential locally from the configured signing key.
+fn cmd_user_token(user: &str, admin: bool, ttl: Option<String>, config_path: &str) -> Result<()> {
+    let ttl_secs = match ttl.as_deref() {
+        Some(t) => parse_ttl(t)? as u64,
+        None => 86_400,
+    };
+    let cfg = spur_core::config::SlurmConfig::load_from_file(std::path::Path::new(config_path))
+        .map_err(|e| anyhow::anyhow!("read {config_path}: {e}"))?;
+    let key = cfg.auth.jwt_key.as_deref().unwrap_or_default();
+    if key.is_empty() {
+        anyhow::bail!(
+            "[auth] jwt_key is not set in {config_path}; a signing key is required to mint user \
+             credentials (the same key is used for node admission)"
+        );
+    }
+    // uid is carried for reference only — the controller re-resolves uid/gid from the username
+    // through NSS, so a stale or wrong uid here cannot influence what a job runs as.
+    let uid = spur_core::auth::resolve_unix_credentials(user)
+        .map(|(uid, _)| uid)
+        .unwrap_or(0);
+    let token = spur_core::auth::generate_token(user, uid, admin, key.as_bytes(), ttl_secs)
+        .map_err(|e| anyhow::anyhow!("mint token: {e}"))?;
+    // stdout = the token alone, so it can be redirected straight into ~/.spur/token.
+    println!("{token}");
+    eprintln!(
+        "minted a {} credential for {user}, valid {}h. Store it as ~/.spur/token (chmod 600) or \
+         export SPUR_AUTH_TOKEN.",
+        if admin { "cluster-admin" } else { "user" },
+        ttl_secs / 3600
+    );
+    Ok(())
 }
 
 fn parse_ttl(s: &str) -> Result<u32> {

--- a/crates/spur-core/src/auth.rs
+++ b/crates/spur-core/src/auth.rs
@@ -25,6 +25,25 @@ pub enum AuthError {
         owner: String,
         action: String,
     },
+    #[error("no such user on this host: {0}")]
+    UnknownUser(String),
+}
+
+/// Resolve a username to its UNIX credentials through NSS.
+///
+/// The controller derives uid/gid from the *authenticated* username rather than accepting them from
+/// the wire: `TokenClaims` carries no gid at all, and a client-supplied uid is what allowed a job to
+/// run as an arbitrary user (see the `allow_root_jobs` guard in spurd). Fails closed — an
+/// unresolvable user is an error, never a fallback to uid 0.
+pub fn resolve_unix_credentials(user: &str) -> Result<(u32, u32), AuthError> {
+    if user.is_empty() {
+        return Err(AuthError::UnknownUser("<empty>".into()));
+    }
+    match nix::unistd::User::from_name(user) {
+        Ok(Some(u)) => Ok((u.uid.as_raw(), u.gid.as_raw())),
+        Ok(None) => Err(AuthError::UnknownUser(user.to_string())),
+        Err(e) => Err(AuthError::UnknownUser(format!("{user}: {e}"))),
+    }
 }
 
 /// Authenticated identity extracted from a token or peer credentials.

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -565,14 +565,43 @@ impl Default for SchedulerConfig {
     }
 }
 
+/// How strictly the control plane authenticates its callers.
+///
+/// Exists so a running cluster can adopt authentication without an outage: bring the control plane
+/// up in `permissive`, roll credentials out to clients (the logs name every caller still
+/// unauthenticated), then flip to `required`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthMode {
+    /// Do not authenticate at all; trust the identity asserted by the client.
+    Disabled,
+    /// Verify a credential when one is presented, and reject it if invalid; fall back to the
+    /// client-asserted identity when none is presented, logging the caller. The default, because
+    /// flipping an existing cluster straight to `required` locks out every client at once.
+    #[default]
+    Permissive,
+    /// Require a valid credential on every request.
+    Required,
+}
+
+impl AuthMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AuthMode::Disabled => "disabled",
+            AuthMode::Permissive => "permissive",
+            AuthMode::Required => "required",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthConfig {
-    /// Auth plugin: "jwt", "munge", "none".
-    ///
-    /// NOTE: this selector is not yet enforced — spurctld does not authenticate the calling user on
-    /// any RPC, and the identity used for authorization is a client-supplied field. Treat the
-    /// control-plane ports as an administrative boundary until that lands.
+    /// Auth plugin: "jwt" (implemented) or "none". "munge" is recognised but not implemented and is
+    /// rejected at startup rather than silently ignored.
     pub plugin: String,
+    /// How strictly callers are authenticated. See [`AuthMode`].
+    #[serde(default)]
+    pub mode: AuthMode,
     /// JWT secret key (file path or inline). Currently used only to sign/verify NODE admission
     /// tokens, not user identity.
     pub jwt_key: Option<String>,
@@ -590,6 +619,7 @@ impl Default for AuthConfig {
     fn default() -> Self {
         Self {
             plugin: "jwt".into(),
+            mode: AuthMode::default(),
             jwt_key: None,
             allow_root_jobs: false,
         }
@@ -1310,6 +1340,33 @@ impl SlurmConfig {
                 ),
             });
         }
+        // `plugin` used to be parsed and never read, so an operator could set "munge" (or a typo)
+        // and get no authentication with no warning — worse than the field not existing. Reject
+        // anything unimplemented instead of silently ignoring it.
+        match self.auth.plugin.as_str() {
+            "jwt" | "none" => {}
+            "munge" => {
+                return Err(ConfigError::InvalidValue {
+                    field: "auth.plugin".into(),
+                    value: "munge (not implemented; use \"jwt\", or \"none\" to disable)".into(),
+                })
+            }
+            other => {
+                return Err(ConfigError::InvalidValue {
+                    field: "auth.plugin".into(),
+                    value: format!("{other} (expected \"jwt\" or \"none\")"),
+                })
+            }
+        }
+        // "none" and a mode that promises enforcement are contradictory; fail rather than pick one.
+        if self.auth.plugin == "none" && self.auth.mode == AuthMode::Required {
+            return Err(ConfigError::InvalidValue {
+                field: "auth.mode".into(),
+                value: "required with auth.plugin = \"none\" (no credential can be verified)"
+                    .into(),
+            });
+        }
+
         if self.cluster.enabled {
             if self.cluster.distro != "k0s" {
                 return Err(ConfigError::InvalidValue {

--- a/crates/spur-proto/src/lib.rs
+++ b/crates/spur-proto/src/lib.rs
@@ -11,8 +11,6 @@ pub mod raft_proto {
 
 pub use proto::*;
 
-use tonic::transport::Channel;
-
 /// Maximum size of a gRPC *response* (server encode / client decode), in bytes.
 /// Large `GetJobs`/`GetNodes` responses can exceed tonic's default 4 MiB on big
 /// clusters. The Raft-internal service uses a separate constant in `raft.rs`.
@@ -26,18 +24,30 @@ pub const MAX_GRPC_REQUEST_SIZE: usize = 8 * 1024 * 1024;
 
 /// Controller client with asymmetric size limits: requests capped at
 /// `MAX_GRPC_REQUEST_SIZE`, responses up to `MAX_GRPC_MESSAGE_SIZE`.
-pub fn controller_client(
-    channel: Channel,
-) -> proto::slurm_controller_client::SlurmControllerClient<Channel> {
+pub fn controller_client<T>(channel: T) -> proto::slurm_controller_client::SlurmControllerClient<T>
+where
+    T: tonic::client::GrpcService<tonic::body::Body>,
+    T::Error: Into<tonic::codegen::StdError>,
+    T::ResponseBody:
+        tonic::codegen::Body<Data = tonic::codegen::Bytes> + std::marker::Send + 'static,
+    <T::ResponseBody as tonic::codegen::Body>::Error:
+        Into<tonic::codegen::StdError> + std::marker::Send,
+{
     proto::slurm_controller_client::SlurmControllerClient::new(channel)
         .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
         .max_encoding_message_size(MAX_GRPC_REQUEST_SIZE)
 }
 
 /// Accounting client with asymmetric size limits.
-pub fn accounting_client(
-    channel: Channel,
-) -> proto::slurm_accounting_client::SlurmAccountingClient<Channel> {
+pub fn accounting_client<T>(channel: T) -> proto::slurm_accounting_client::SlurmAccountingClient<T>
+where
+    T: tonic::client::GrpcService<tonic::body::Body>,
+    T::Error: Into<tonic::codegen::StdError>,
+    T::ResponseBody:
+        tonic::codegen::Body<Data = tonic::codegen::Bytes> + std::marker::Send + 'static,
+    <T::ResponseBody as tonic::codegen::Body>::Error:
+        Into<tonic::codegen::StdError> + std::marker::Send,
+{
     proto::slurm_accounting_client::SlurmAccountingClient::new(channel)
         .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
         .max_encoding_message_size(MAX_GRPC_REQUEST_SIZE)

--- a/crates/spurctld/src/auth_middleware.rs
+++ b/crates/spurctld/src/auth_middleware.rs
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tower middleware that authenticates controller RPC callers.
+//!
+//! This is the single verification point for the control plane. It runs as a Tower layer rather
+//! than a per-service tonic interceptor deliberately: the layer wraps everything served on the port,
+//! so the accounting service — which has no authorization of its own, and whose `add_user` takes an
+//! `admin_level` — is covered by the same gate as the controller.
+//!
+//! On success a verified [`Identity`] is inserted into the request extensions; handlers read it
+//! instead of trusting a client-supplied `user`/`caller` field. Nothing else in the pipeline may
+//! insert an `Identity`, so a handler that finds one knows it was verified here.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use http::{Request, Response};
+use tower::{Layer, Service};
+use tracing::warn;
+
+use spur_core::auth::{verify_token, Identity};
+use spur_core::config::AuthMode;
+
+/// Marker inserted alongside the identity so handlers can tell "verified" from "asserted" without
+/// re-reading config. Absent in `disabled` mode and for unauthenticated calls under `permissive`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Verified;
+
+#[derive(Clone)]
+pub struct AuthLayer {
+    inner: Arc<AuthConfig>,
+}
+
+struct AuthConfig {
+    mode: AuthMode,
+    /// HS256 key. Empty disables verification regardless of mode (startup refuses that combination
+    /// for `required`, so an empty key here can only mean `disabled`/`permissive`).
+    jwt_key: Vec<u8>,
+}
+
+impl AuthLayer {
+    pub fn new(mode: AuthMode, jwt_key: &str) -> Self {
+        Self {
+            inner: Arc::new(AuthConfig {
+                mode,
+                jwt_key: jwt_key.as_bytes().to_vec(),
+            }),
+        }
+    }
+}
+
+impl<S> Layer<S> for AuthLayer {
+    type Service = AuthMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthMiddleware {
+            inner,
+            config: self.inner.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AuthMiddleware<S> {
+    inner: S,
+    config: Arc<AuthConfig>,
+}
+
+/// Outcome of inspecting one request's credential.
+enum Decision {
+    /// Verified; carry this identity to the handler.
+    Authenticated(Box<Identity>),
+    /// No credential presented, and the mode tolerates that.
+    Anonymous,
+    /// Reject with this gRPC status message.
+    Reject(String),
+}
+
+fn decide(config: &AuthConfig, header: Option<&str>) -> Decision {
+    let token = match header {
+        Some(h) => match h
+            .strip_prefix("Bearer ")
+            .or_else(|| h.strip_prefix("bearer "))
+        {
+            Some(t) if !t.trim().is_empty() => t.trim(),
+            // A malformed header is a client bug, not an anonymous call — say so rather than
+            // silently downgrading to unauthenticated.
+            _ => {
+                return Decision::Reject(
+                    "malformed authorization header: expected 'Bearer <token>'".into(),
+                )
+            }
+        },
+        None => {
+            return match config.mode {
+                AuthMode::Required => Decision::Reject(
+                    "authentication required: pass a token (see `spur auth token`)".into(),
+                ),
+                _ => Decision::Anonymous,
+            }
+        }
+    };
+
+    if config.mode == AuthMode::Disabled {
+        // Do not verify what we have declared we do not enforce; treating a token as authoritative
+        // here would make `disabled` quietly stricter than it claims.
+        return Decision::Anonymous;
+    }
+    if config.jwt_key.is_empty() {
+        return Decision::Reject("a token was presented but no auth.jwt_key is configured".into());
+    }
+
+    match verify_token(token, &config.jwt_key) {
+        Ok(identity) => Decision::Authenticated(Box::new(identity)),
+        // An invalid token is always a rejection, even in `permissive`: permissive tolerates the
+        // ABSENCE of a credential, never a bad one. Otherwise a forged token would be strictly
+        // better for an attacker than sending none.
+        Err(e) => Decision::Reject(format!("invalid credential: {e}")),
+    }
+}
+
+impl<S, B> Service<Request<B>> for AuthMiddleware<S>
+where
+    S: Service<Request<B>, Response = Response<tonic::body::Body>> + Clone + Send + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Future: Send + 'static,
+    B: Send + 'static,
+{
+    type Response = Response<tonic::body::Body>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, mut req: Request<B>) -> Self::Future {
+        let config = self.config.clone();
+        let header = req
+            .headers()
+            .get(http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+
+        match decide(&config, header.as_deref()) {
+            Decision::Authenticated(identity) => {
+                req.extensions_mut().insert(*identity);
+                req.extensions_mut().insert(Verified);
+            }
+            Decision::Anonymous => {
+                if config.mode == AuthMode::Permissive {
+                    // Name the caller so an operator rolling out credentials can see exactly who is
+                    // still unauthenticated instead of guessing.
+                    warn!(
+                        path = %req.uri().path(),
+                        "unauthenticated request accepted (auth.mode = permissive); \
+                         the caller's asserted identity is being trusted"
+                    );
+                }
+            }
+            Decision::Reject(msg) => {
+                let resp = tonic::Status::unauthenticated(msg).into_http();
+                return Box::pin(async move { Ok(resp) });
+            }
+        }
+
+        let mut inner = self.inner.clone();
+        Box::pin(async move { inner.call(req).await.map_err(Into::into) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spur_core::auth::generate_token;
+
+    fn cfg(mode: AuthMode, key: &str) -> AuthConfig {
+        AuthConfig {
+            mode,
+            jwt_key: key.as_bytes().to_vec(),
+        }
+    }
+
+    fn token(key: &str) -> String {
+        generate_token("alice", 1000, false, key.as_bytes(), 3600).unwrap()
+    }
+
+    #[test]
+    fn required_rejects_a_missing_credential() {
+        assert!(matches!(
+            decide(&cfg(AuthMode::Required, "k"), None),
+            Decision::Reject(_)
+        ));
+    }
+
+    #[test]
+    fn permissive_allows_a_missing_credential() {
+        assert!(matches!(
+            decide(&cfg(AuthMode::Permissive, "k"), None),
+            Decision::Anonymous
+        ));
+    }
+
+    #[test]
+    fn a_valid_token_authenticates_and_carries_the_subject() {
+        let t = token("k");
+        let header = format!("Bearer {t}");
+        match decide(&cfg(AuthMode::Required, "k"), Some(&header)) {
+            Decision::Authenticated(id) => {
+                assert_eq!(id.user, "alice");
+                assert_eq!(id.uid, 1000);
+                assert!(!id.is_admin);
+            }
+            _ => panic!("valid token must authenticate"),
+        }
+    }
+
+    #[test]
+    fn permissive_still_rejects_an_invalid_token() {
+        // Permissive tolerates the absence of a credential, never a bad one — otherwise forging a
+        // token would be strictly better for an attacker than sending none.
+        let forged = format!("Bearer {}", token("attacker-key"));
+        assert!(matches!(
+            decide(&cfg(AuthMode::Permissive, "real-key"), Some(&forged)),
+            Decision::Reject(_)
+        ));
+    }
+
+    #[test]
+    fn a_malformed_header_is_rejected_not_downgraded() {
+        for h in ["", "Basic abc", "Bearer", "Bearer    "] {
+            assert!(
+                matches!(
+                    decide(&cfg(AuthMode::Permissive, "k"), Some(h)),
+                    Decision::Reject(_)
+                ),
+                "header {h:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn disabled_ignores_even_a_valid_token() {
+        let t = token("k");
+        let header = format!("Bearer {t}");
+        assert!(matches!(
+            decide(&cfg(AuthMode::Disabled, "k"), Some(&header)),
+            Decision::Anonymous
+        ));
+    }
+
+    #[test]
+    fn a_token_without_a_configured_key_is_rejected() {
+        let header = format!("Bearer {}", token("k"));
+        assert!(matches!(
+            decide(&cfg(AuthMode::Permissive, ""), Some(&header)),
+            Decision::Reject(_)
+        ));
+    }
+}

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -3,6 +3,7 @@
 
 mod accounting;
 mod association_cache;
+mod auth_middleware;
 mod cluster;
 mod cluster_k8s;
 mod fairshare_cache;

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -358,15 +358,32 @@ async fn main() -> anyhow::Result<()> {
 
     // Start gRPC server
     let addr: std::net::SocketAddr = listen_addr.parse()?;
-    // Be explicit about the posture rather than letting `plugin = "jwt"` imply a control that does
-    // not run: no RPC authenticates the calling user yet, so the listening port IS the trust
-    // boundary. Warn once at startup when that boundary is the network.
-    if !addr.ip().is_loopback() {
+    // State the authentication posture explicitly at startup: it determines whether the listening
+    // port is the trust boundary or merely the transport.
+    match config.auth.mode {
+        spur_core::config::AuthMode::Required => {
+            info!(
+                mode = "required",
+                "RPC callers must present a valid credential"
+            )
+        }
+        spur_core::config::AuthMode::Permissive => tracing::warn!(
+            mode = "permissive",
+            "RPC callers are authenticated WHEN they present a credential, and trusted on their \
+             own assertion when they do not. Unauthenticated callers are logged — roll credentials \
+             out (`spur token user`), then set [auth] mode = \"required\"."
+        ),
+        spur_core::config::AuthMode::Disabled => tracing::warn!(
+            mode = "disabled",
+            "RPC callers are NOT authenticated: the identity used for authorization is supplied by \
+             the client. Treat this port as an administrative boundary."
+        ),
+    }
+    if !addr.ip().is_loopback() && config.auth.mode != spur_core::config::AuthMode::Required {
         tracing::warn!(
             %addr,
-            "spurctld does not authenticate RPC callers: the user identity used for authorization \
-             is supplied by the client. Treat this port as an administrative boundary — restrict \
-             it to trusted hosts. ([auth] plugin is not enforced yet.)"
+            "listening on a non-loopback address without required authentication — restrict this \
+             port to trusted hosts."
         );
     }
     info!(%addr, "gRPC server listening");

--- a/crates/spurctld/src/rest/mod.rs
+++ b/crates/spurctld/src/rest/mod.rs
@@ -38,17 +38,83 @@ fn routes() -> Router<Arc<RestState>> {
         .route("/partitions/", get(handlers::get_partitions))
 }
 
+/// Authenticate a REST request, mirroring the gRPC policy in [`crate::auth_middleware`].
+///
+/// `/ping` is exempt so health checks keep working without a credential — it exposes no state.
+async fn rest_auth(
+    mode: spur_core::config::AuthMode,
+    jwt_key: Vec<u8>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::http::StatusCode;
+    use spur_core::config::AuthMode;
+
+    if req.uri().path().ends_with("/ping") || mode == AuthMode::Disabled {
+        return next.run(req).await;
+    }
+    let header = req
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
+    let deny = |msg: &str| (StatusCode::UNAUTHORIZED, msg.to_string()).into_response();
+    use axum::response::IntoResponse;
+
+    match header {
+        None => {
+            if mode == AuthMode::Required {
+                return deny("authentication required: pass 'Authorization: Bearer <token>'");
+            }
+        }
+        Some(h) => {
+            let Some(token) = h
+                .strip_prefix("Bearer ")
+                .or_else(|| h.strip_prefix("bearer "))
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+            else {
+                return deny("malformed authorization header: expected 'Bearer <token>'");
+            };
+            if jwt_key.is_empty() {
+                return deny("a token was presented but no auth.jwt_key is configured");
+            }
+            // As on the gRPC side, a bad credential is rejected even in permissive mode.
+            if let Err(e) = spur_core::auth::verify_token(token, &jwt_key) {
+                return deny(&format!("invalid credential: {e}"));
+            }
+        }
+    }
+    next.run(req).await
+}
+
 /// Start the REST API server. Runs until the listener is closed.
 pub async fn serve(
     listen: SocketAddr,
     cluster: Arc<ClusterManager>,
     raft: Arc<RaftHandle>,
 ) -> anyhow::Result<()> {
+    // Same policy as gRPC: verify a presented credential, and under `required` refuse a request
+    // without one. The REST surface has no per-user handling of its own, so this gate is what keeps
+    // it from being a way around the authenticated gRPC path.
+    let auth_mode = cluster.config().auth.mode;
+    let jwt_key = cluster
+        .config()
+        .auth
+        .jwt_key
+        .clone()
+        .unwrap_or_default()
+        .into_bytes();
     let state = Arc::new(RestState { cluster, raft });
 
     let app = Router::new()
         .nest("/api/v1", routes())
         .nest("/slurm/v0.0.42", routes())
+        .layer(axum::middleware::from_fn(move |req, next| {
+            let key = jwt_key.clone();
+            async move { rest_auth(auth_mode, key, req, next).await }
+        }))
         .layer(TraceLayer::new_for_http())
         .with_state(state);
 

--- a/crates/spurctld/src/rest/mod.rs
+++ b/crates/spurctld/src/rest/mod.rs
@@ -164,7 +164,11 @@ mod tests {
                 Request::get("/api/v1/ping").body(Body::empty()).unwrap(),
             )
             .await;
-            assert_eq!(s, StatusCode::OK, "{mode:?}: /ping must not require a token");
+            assert_eq!(
+                s,
+                StatusCode::OK,
+                "{mode:?}: /ping must not require a token"
+            );
         }
     }
 

--- a/crates/spurctld/src/rest/mod.rs
+++ b/crates/spurctld/src/rest/mod.rs
@@ -124,3 +124,128 @@ pub async fn serve(
     axum::serve(listener, app).await?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use spur_core::auth::generate_token;
+    use spur_core::config::AuthMode;
+    use tower::ServiceExt;
+
+    const KEY: &str = "test-signing-key";
+
+    fn valid_token() -> String {
+        generate_token("alice", 1000, false, KEY.as_bytes(), 3600).unwrap()
+    }
+
+    /// Build a minimal Router with rest_auth wired, backed by a trivial handler that always 200s.
+    fn app(mode: AuthMode, key: &str) -> Router {
+        let jwt_key = key.as_bytes().to_vec();
+        Router::new()
+            .route("/api/v1/jobs", axum::routing::get(|| async { "ok" }))
+            .route("/api/v1/ping", axum::routing::get(|| async { "pong" }))
+            .layer(axum::middleware::from_fn(move |req, next| {
+                let k = jwt_key.clone();
+                async move { rest_auth(mode, k, req, next).await }
+            }))
+    }
+
+    async fn status(app: Router, req: Request<Body>) -> StatusCode {
+        app.oneshot(req).await.unwrap().status()
+    }
+
+    #[tokio::test]
+    async fn ping_is_always_exempt() {
+        for mode in [AuthMode::Required, AuthMode::Permissive, AuthMode::Disabled] {
+            let s = status(
+                app(mode, KEY),
+                Request::get("/api/v1/ping").body(Body::empty()).unwrap(),
+            )
+            .await;
+            assert_eq!(s, StatusCode::OK, "{mode:?}: /ping must not require a token");
+        }
+    }
+
+    #[tokio::test]
+    async fn required_rejects_missing_credential() {
+        let s = status(
+            app(AuthMode::Required, KEY),
+            Request::get("/api/v1/jobs").body(Body::empty()).unwrap(),
+        )
+        .await;
+        assert_eq!(s, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn permissive_allows_missing_credential() {
+        let s = status(
+            app(AuthMode::Permissive, KEY),
+            Request::get("/api/v1/jobs").body(Body::empty()).unwrap(),
+        )
+        .await;
+        assert_eq!(s, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn valid_token_passes_in_required_mode() {
+        let s = status(
+            app(AuthMode::Required, KEY),
+            Request::get("/api/v1/jobs")
+                .header("authorization", format!("Bearer {}", valid_token()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(s, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn invalid_token_rejected_even_in_permissive_mode() {
+        let forged = generate_token("eve", 0, true, "wrong-key".as_bytes(), 3600).unwrap();
+        let s = status(
+            app(AuthMode::Permissive, KEY),
+            Request::get("/api/v1/jobs")
+                .header("authorization", format!("Bearer {forged}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(s, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn malformed_header_is_rejected() {
+        for bad in ["Basic abc", "Bearer", "Bearer   "] {
+            let s = status(
+                app(AuthMode::Permissive, KEY),
+                Request::get("/api/v1/jobs")
+                    .header("authorization", bad)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(
+                s,
+                StatusCode::UNAUTHORIZED,
+                "header {bad:?} must be rejected"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_mode_skips_verification_entirely() {
+        // Even a forged token passes when auth is disabled.
+        let forged = generate_token("eve", 0, true, "wrong-key".as_bytes(), 3600).unwrap();
+        let s = status(
+            app(AuthMode::Disabled, KEY),
+            Request::get("/api/v1/jobs")
+                .header("authorization", format!("Bearer {forged}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(s, StatusCode::OK);
+    }
+}

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -301,6 +301,12 @@ impl ControllerService {
         let payload = payload?;
         let client = self.leader_proxy.try_get_leader_client().await?;
         let mut fwd = Request::new(payload);
+        // NOTE: callers consume the request before reaching here, so the original credential is not
+        // available to preserve (unlike `forward_request`). Under `auth.mode = required` the leader
+        // therefore rejects this hop and the error is swallowed below, degrading to a local read —
+        // safe (this helper is documented as best-effort), but it means reads stop being routed to
+        // the leader once auth is enforced. Threading the metadata through these callers is a
+        // follow-up.
         *fwd.metadata_mut() = Self::forwarded_metadata();
         match call(client, fwd).await {
             Ok(resp) => Some(resp),
@@ -327,6 +333,71 @@ impl ControllerService {
         let mut meta = tonic::metadata::MetadataMap::new();
         meta.insert(FORWARDED_HEADER, "true".parse().unwrap());
         meta
+    }
+
+    /// The verified identity for this request, if the auth layer authenticated one.
+    ///
+    /// `None` means the caller was not authenticated — which under `permissive` is allowed and the
+    /// handler falls back to the client-asserted fields. Only [`crate::auth_middleware`] inserts
+    /// this, so its presence always means "verified".
+    fn verified_identity<T>(request: &Request<T>) -> Option<&spur_core::auth::Identity> {
+        request.extensions().get::<spur_core::auth::Identity>()
+    }
+
+    /// Bind a submitted spec to the authenticated caller.
+    ///
+    /// Overwrites `user`/`uid`/`gid` from the verified identity rather than trusting what the client
+    /// sent, and derives uid/gid from the username through NSS (the token carries no gid, and a
+    /// client-chosen uid is what allowed a job to run as an arbitrary user). Unauthenticated callers
+    /// are left as-is so `permissive` keeps working; `required` never reaches here without an
+    /// identity because the auth layer rejects first.
+    fn bind_spec_to_identity(
+        spec: &mut spur_core::job::JobSpec,
+        identity: Option<&spur_core::auth::Identity>,
+    ) -> Result<(), Status> {
+        let Some(id) = identity else { return Ok(()) };
+        let (uid, gid) = spur_core::auth::resolve_unix_credentials(&id.user).map_err(|e| {
+            // Fail closed: never fall back to the wire's uid (or to 0) for a user we cannot resolve.
+            Status::failed_precondition(format!(
+                "cannot resolve UNIX credentials for authenticated user '{}': {e}",
+                id.user
+            ))
+        })?;
+        if spec.user != id.user && !spec.user.is_empty() {
+            warn!(
+                claimed = %spec.user,
+                authenticated = %id.user,
+                "job spec claimed a different user than the credential; using the authenticated one"
+            );
+        }
+        spec.user = id.user.clone();
+        spec.uid = uid;
+        spec.gid = gid;
+        Ok(())
+    }
+
+    /// Forwarding metadata that carries the caller's credential through to the leader.
+    ///
+    /// The leader is what authorizes the request, so it must see the ORIGINAL caller — not the
+    /// forwarding follower. Building a fresh metadata map (as `forwarded_metadata` does) drops the
+    /// `authorization` header, which would make every forwarded call anonymous and break auth the
+    /// moment HA is enabled.
+    fn forwarded_metadata_preserving(
+        orig: &tonic::metadata::MetadataMap,
+    ) -> tonic::metadata::MetadataMap {
+        let mut meta = Self::forwarded_metadata();
+        if let Some(auth) = orig.get(http::header::AUTHORIZATION.as_str()) {
+            meta.insert(http::header::AUTHORIZATION.as_str(), auth.clone());
+        }
+        meta
+    }
+
+    /// Re-wrap a request for forwarding to the leader, preserving the caller's credential.
+    fn forward_request<T>(request: Request<T>) -> Request<T> {
+        let meta = Self::forwarded_metadata_preserving(request.metadata());
+        let mut fwd = Request::new(request.into_inner());
+        *fwd.metadata_mut() = meta;
+        fwd
     }
 
     fn spawn_cancel_for_evicted(&self, evicted: &[crate::raft::JobFinalized]) {
@@ -446,8 +517,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.submit_job(fwd).await;
                 }
                 Err(e) => {
@@ -457,12 +527,16 @@ impl SlurmController for ControllerService {
             }
         }
 
+        // Bind to the authenticated caller BEFORE the spec reaches the cluster, so a stale or
+        // hostile client cannot choose the user/uid the job runs as.
+        let identity = Self::verified_identity(&request).cloned();
         let spec = request
             .into_inner()
             .spec
             .ok_or_else(|| Status::invalid_argument("missing job spec"))?;
 
-        let core_spec = proto_to_job_spec(spec)?;
+        let mut core_spec = proto_to_job_spec(spec)?;
+        Self::bind_spec_to_identity(&mut core_spec, identity.as_ref())?;
         let outcome = self
             .cluster
             .submit_job(core_spec)
@@ -559,8 +633,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.cancel_job(fwd).await;
                 }
                 Err(e) => {
@@ -599,8 +672,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.complete_job(fwd).await;
                 }
                 Err(e) => {
@@ -656,8 +728,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.job_keepalive(fwd).await;
                 }
                 Err(e) => {
@@ -700,8 +771,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.suspend_job(fwd).await;
                 }
                 Err(e) => {
@@ -733,8 +803,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.resume_job(fwd).await;
                 }
                 Err(e) => {
@@ -767,8 +836,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.update_job(fwd).await;
                 }
                 Err(e) => {
@@ -891,8 +959,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.update_node(fwd).await;
                 }
                 Err(e) => {
@@ -926,8 +993,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.drain_node(fwd).await;
                 }
                 Err(e) => {
@@ -963,8 +1029,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.deregister_node(fwd).await;
                 }
                 Err(e) => {
@@ -1001,8 +1066,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.deregister_agent(fwd).await;
                 }
                 Err(e) => {
@@ -1133,8 +1197,7 @@ impl SlurmController for ControllerService {
             {
                 let proxy = &self.leader_proxy;
                 let mut client = proxy.get_leader_client().await?;
-                let mut fwd = Request::new(());
-                *fwd.metadata_mut() = Self::forwarded_metadata();
+                let fwd = Self::forward_request(request);
                 return client.get_rpc_stats(fwd).await;
             }
         }
@@ -1149,8 +1212,7 @@ impl SlurmController for ControllerService {
             {
                 let proxy = &self.leader_proxy;
                 let mut client = proxy.get_leader_client().await?;
-                let mut fwd = Request::new(());
-                *fwd.metadata_mut() = Self::forwarded_metadata();
+                let fwd = Self::forward_request(request);
                 return client.get_sched_stats(fwd).await;
             }
         }
@@ -1165,8 +1227,7 @@ impl SlurmController for ControllerService {
             {
                 let proxy = &self.leader_proxy;
                 let mut client = proxy.get_leader_client().await?;
-                let mut fwd = Request::new(());
-                *fwd.metadata_mut() = Self::forwarded_metadata();
+                let fwd = Self::forward_request(request);
                 return client.reset_diag_stats(fwd).await;
             }
         }
@@ -1184,8 +1245,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.register_agent(fwd).await;
                 }
                 Err(e) => {
@@ -1259,8 +1319,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.report_job_status(fwd).await;
                 }
                 Err(e) => {
@@ -1380,8 +1439,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.heartbeat(fwd).await;
                 }
                 Err(e) => {
@@ -1549,8 +1607,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.create_job_step(fwd).await;
                 }
                 Err(e) => {
@@ -1625,8 +1682,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.create_partition(fwd).await;
                 }
                 Err(e) => {
@@ -1730,8 +1786,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.update_partition(fwd).await;
                 }
                 Err(e) => {
@@ -1835,8 +1890,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.delete_partition(fwd).await;
                 }
                 Err(e) => {
@@ -1859,8 +1913,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.reconfigure(fwd).await;
                 }
                 Err(e) => {
@@ -1885,8 +1938,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.create_reservation(fwd).await;
                 }
                 Err(e) => {
@@ -1938,8 +1990,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.update_reservation(fwd).await;
                 }
                 Err(e) => {
@@ -1974,8 +2025,7 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.delete_reservation(fwd).await;
                 }
                 Err(e) => {
@@ -2039,8 +2089,7 @@ impl SlurmController for ControllerService {
             {
                 let proxy = &self.leader_proxy;
                 let mut client = proxy.get_leader_client().await?;
-                let mut fwd = Request::new(request.into_inner());
-                *fwd.metadata_mut() = Self::forwarded_metadata();
+                let fwd = Self::forward_request(request);
                 return client.exec_in_job(fwd).await;
             }
         }
@@ -2107,8 +2156,7 @@ impl SlurmController for ControllerService {
         if self.check_leader(&request).is_err() {
             let proxy = &self.leader_proxy;
             let mut client = proxy.get_leader_client().await?;
-            let mut fwd = Request::new(request.into_inner());
-            *fwd.metadata_mut() = Self::forwarded_metadata();
+            let fwd = Self::forward_request(request);
             return client.run_step(fwd).await;
         }
 
@@ -2449,8 +2497,7 @@ impl SlurmController for ControllerService {
         if let Err(status) = self.check_leader(&request) {
             match self.leader_proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.cluster_up(fwd).await;
                 }
                 Err(e) => {
@@ -2579,8 +2626,7 @@ impl SlurmController for ControllerService {
         if let Err(status) = self.check_leader(&request) {
             match self.leader_proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    let fwd = Self::forward_request(request);
                     return client.cluster_down(fwd).await;
                 }
                 Err(e) => {
@@ -2616,8 +2662,7 @@ impl SlurmController for ControllerService {
     ) -> Result<Response<ClusterStatusResponse>, Status> {
         if self.check_leader(&request).is_err() {
             let mut client = self.leader_proxy.get_leader_client().await?;
-            let mut fwd = Request::new(request.into_inner());
-            *fwd.metadata_mut() = Self::forwarded_metadata();
+            let fwd = Self::forward_request(request);
             return client.cluster_status(fwd).await;
         }
         let state = self.cluster.k0s_state();
@@ -2637,8 +2682,7 @@ impl SlurmController for ControllerService {
     ) -> Result<Response<ClusterKubeconfigResponse>, Status> {
         if self.check_leader(&request).is_err() {
             let mut client = self.leader_proxy.get_leader_client().await?;
-            let mut fwd = Request::new(request.into_inner());
-            *fwd.metadata_mut() = Self::forwarded_metadata();
+            let fwd = Self::forward_request(request);
             return client.cluster_kubeconfig(fwd).await;
         }
         let req = request.into_inner();
@@ -2733,6 +2777,9 @@ pub async fn serve(
     let leader_proxy = LeaderProxy::new(raft_handle.clone(), client_addrs.clone());
 
     let jwt_key = resolve_startup_jwt_key(&cluster.config());
+    let auth_mode = cluster.config().auth.mode;
+    // Same key the node-admission path already uses; cloned because `jwt_key` moves into the service.
+    let jwt_key_for_auth = jwt_key.clone();
 
     let service = ControllerService {
         cluster,
@@ -2746,8 +2793,13 @@ pub async fn serve(
     };
 
     let stats_layer = RpcStatsLayer::new(rpc_stats, raft_handle);
+    // Applied as a layer, not a per-service interceptor, so it also covers the accounting service —
+    // which carries no authorization of its own yet exposes `add_user(admin_level)`.
+    let auth_layer = crate::auth_middleware::AuthLayer::new(auth_mode, &jwt_key_for_auth);
 
-    let mut builder = tonic::transport::Server::builder().layer(stats_layer);
+    let mut builder = tonic::transport::Server::builder()
+        .layer(stats_layer)
+        .layer(auth_layer);
 
     let mut router = builder.add_service(spur_proto::controller_server(service));
     if let Some(service) = accounting_service {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -344,6 +344,25 @@ impl ControllerService {
         request.extensions().get::<spur_core::auth::Identity>()
     }
 
+    /// Replace a client-asserted identity field with the authenticated one.
+    ///
+    /// Applied at handler entry so every downstream read of that field (ownership checks, admin
+    /// checks, accounting attribution) sees the verified user without each call site having to know
+    /// about authentication. A `None` identity leaves the field alone: that is an unauthenticated
+    /// caller under `permissive`/`disabled`, and `required` never reaches a handler unauthenticated
+    /// because the auth layer rejects first.
+    fn authoritative_user(asserted: &mut String, identity: Option<&spur_core::auth::Identity>) {
+        let Some(id) = identity else { return };
+        if !asserted.is_empty() && *asserted != id.user {
+            warn!(
+                claimed = %asserted,
+                authenticated = %id.user,
+                "request asserted a different user than its credential; using the authenticated one"
+            );
+        }
+        *asserted = id.user.clone();
+    }
+
     /// Bind a submitted spec to the authenticated caller.
     ///
     /// Overwrites `user`/`uid`/`gid` from the verified identity rather than trusting what the client
@@ -553,7 +572,9 @@ impl SlurmController for ControllerService {
         request: Request<GetJobsRequest>,
     ) -> Result<Response<GetJobsResponse>, Status> {
         let forward = self.read_should_forward(&request);
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
         if let Some(resp) = self
             .forward_read_optional(
                 forward.then(|| req.clone()),
@@ -643,7 +664,9 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
         let job_id = req.job_id;
 
         // Snapshot the job before cancelling so we have allocated_nodes
@@ -682,7 +705,9 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
         let job = self
             .cluster
             .finish_srun_job(req.job_id, req.exit_code, &req.user)
@@ -738,7 +763,9 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
         // A real keepalive always carries the caller's username. Reject an empty
         // one explicitly: `check_job_owner` treats empty as authorized, which
         // would let anyone hold any allocation open forever.
@@ -780,7 +807,9 @@ impl SlurmController for ControllerService {
                 }
             }
         }
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
         let job_id = req.job_id;
         // Unknown job ids are NOT_FOUND (consistent with get_job), not a
         // precondition failure. Snapshot up-front for agent dispatch.
@@ -812,7 +841,9 @@ impl SlurmController for ControllerService {
                 }
             }
         }
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
         let job_id = req.job_id;
         // Unknown job ids are NOT_FOUND (consistent with get_job), not a
         // precondition failure. Allocation is retained across resume, so this
@@ -1617,7 +1648,9 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
         let job_id = req.job_id;
 
         let job = self
@@ -1948,7 +1981,9 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
 
         let start_time = if req.start_time.is_empty() || req.start_time.eq_ignore_ascii_case("now")
         {
@@ -2000,7 +2035,9 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
         self.cluster
             .update_reservation(
                 &req.name,
@@ -2035,7 +2072,9 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
         self.cluster
             .delete_reservation(&req.name, &req.user)
             .map_err(reservation_rpc_status)?;
@@ -2096,7 +2135,9 @@ impl SlurmController for ControllerService {
 
         use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
         let job_id = req.job_id;
 
         let job = self
@@ -2506,7 +2547,9 @@ impl SlurmController for ControllerService {
                 }
             }
         }
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.caller, __identity.as_ref());
         if !is_k0s_admin(self.cluster.association_cache(), &req.caller) {
             return Err(Status::permission_denied(
                 "k0s cluster up requires cluster admin",
@@ -2635,7 +2678,9 @@ impl SlurmController for ControllerService {
                 }
             }
         }
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.caller, __identity.as_ref());
         if !is_k0s_admin(self.cluster.association_cache(), &req.caller) {
             return Err(Status::permission_denied(
                 "k0s cluster down requires cluster admin",
@@ -2685,7 +2730,9 @@ impl SlurmController for ControllerService {
             let fwd = Self::forward_request(request);
             return client.cluster_kubeconfig(fwd).await;
         }
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.caller, __identity.as_ref());
         let is_admin = is_k0s_admin(self.cluster.association_cache(), &req.caller);
 
         if req.admin {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -5729,4 +5729,96 @@ mod tests {
             .reservations;
         assert!(none.is_empty());
     }
+
+    // --- authoritative_user ---
+
+    #[test]
+    fn authoritative_user_leaves_field_alone_when_no_identity() {
+        let mut user = "alice".to_string();
+        ControllerService::authoritative_user(&mut user, None);
+        assert_eq!(user, "alice");
+    }
+
+    #[test]
+    fn authoritative_user_overwrites_with_authenticated_user() {
+        let mut user = "alice".to_string();
+        let id = spur_core::auth::Identity {
+            user: "bob".to_string(),
+            uid: 1001,
+            gid: 1001,
+            is_admin: false,
+        };
+        ControllerService::authoritative_user(&mut user, Some(&id));
+        assert_eq!(user, "bob");
+    }
+
+    #[test]
+    fn authoritative_user_fills_an_empty_field() {
+        let mut user = String::new();
+        let id = spur_core::auth::Identity {
+            user: "carol".to_string(),
+            uid: 1002,
+            gid: 1002,
+            is_admin: false,
+        };
+        ControllerService::authoritative_user(&mut user, Some(&id));
+        assert_eq!(user, "carol");
+    }
+
+    // --- bind_spec_to_identity ---
+
+    fn spec_for(user: &str, uid: u32, gid: u32) -> spur_core::job::JobSpec {
+        spur_core::job::JobSpec {
+            user: user.to_string(),
+            uid,
+            gid,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn bind_spec_leaves_spec_alone_when_no_identity() {
+        let mut spec = spec_for("alice", 9999, 9999);
+        ControllerService::bind_spec_to_identity(&mut spec, None).unwrap();
+        assert_eq!(spec.user, "alice");
+        assert_eq!(spec.uid, 9999);
+        assert_eq!(spec.gid, 9999);
+    }
+
+    #[test]
+    fn bind_spec_overwrites_user_uid_gid_from_nss() {
+        // Uses "root" — always present in /etc/passwd so NSS resolves it everywhere.
+        let mut spec = spec_for("impersonated", 9999, 9999);
+        let id = spur_core::auth::Identity {
+            user: "root".to_string(),
+            uid: 9999,
+            gid: 9999,
+            is_admin: true,
+        };
+        ControllerService::bind_spec_to_identity(&mut spec, Some(&id)).unwrap();
+        assert_eq!(spec.user, "root");
+        // uid/gid must come from NSS, not from the wire spec or the token's uid field.
+        assert_eq!(spec.uid, 0, "root's uid is 0 per NSS");
+        assert_eq!(spec.gid, 0, "root's gid is 0 per NSS");
+    }
+
+    #[test]
+    fn bind_spec_fails_closed_for_unknown_user() {
+        let mut spec = spec_for("alice", 1000, 1000);
+        let id = spur_core::auth::Identity {
+            user: "this_user_does_not_exist_in_nss_7f3a".to_string(),
+            uid: 0,
+            gid: 0,
+            is_admin: false,
+        };
+        let err = ControllerService::bind_spec_to_identity(&mut spec, Some(&id)).unwrap_err();
+        assert_eq!(
+            err.code(),
+            tonic::Code::FailedPrecondition,
+            "unknown user must fail closed, not fall back to wire uid"
+        );
+        // Spec must not be partially mutated.
+        assert_eq!(spec.user, "alice");
+        assert_eq!(spec.uid, 1000);
+    }
 }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -290,6 +290,7 @@ impl ControllerService {
     /// Ok/NotFound; a handler with a real error (e.g. InvalidArgument) masks it.
     async fn forward_read_optional<T, R, F, Fut>(
         &self,
+        meta: tonic::metadata::MetadataMap,
         payload: Option<T>,
         rpc: &str,
         call: F,
@@ -301,13 +302,10 @@ impl ControllerService {
         let payload = payload?;
         let client = self.leader_proxy.try_get_leader_client().await?;
         let mut fwd = Request::new(payload);
-        // NOTE: callers consume the request before reaching here, so the original credential is not
-        // available to preserve (unlike `forward_request`). Under `auth.mode = required` the leader
-        // therefore rejects this hop and the error is swallowed below, degrading to a local read —
-        // safe (this helper is documented as best-effort), but it means reads stop being routed to
-        // the leader once auth is enforced. Threading the metadata through these callers is a
-        // follow-up.
-        *fwd.metadata_mut() = Self::forwarded_metadata();
+        // Carry the caller's credential, so a forwarded read is authorized as the original caller
+        // rather than arriving anonymous — otherwise `auth.mode = required` would reject every hop
+        // and silently degrade these reads to local (stale) answers.
+        *fwd.metadata_mut() = Self::forwarded_metadata_preserving(&meta);
         match call(client, fwd).await {
             Ok(resp) => Some(resp),
             Err(e) => {
@@ -572,11 +570,13 @@ impl SlurmController for ControllerService {
         request: Request<GetJobsRequest>,
     ) -> Result<Response<GetJobsResponse>, Status> {
         let forward = self.read_should_forward(&request);
+        let meta = request.metadata().clone();
         let __identity = Self::verified_identity(&request).cloned();
         let mut req = request.into_inner();
         Self::authoritative_user(&mut req.user, __identity.as_ref());
         if let Some(resp) = self
             .forward_read_optional(
+                meta,
                 forward.then(|| req.clone()),
                 "get_jobs",
                 |mut c, r| async move { c.get_jobs(r).await },
@@ -630,11 +630,15 @@ impl SlurmController for ControllerService {
 
     async fn get_job(&self, request: Request<GetJobRequest>) -> Result<Response<JobInfo>, Status> {
         let forward = self.read_should_forward(&request);
+        let meta = request.metadata().clone();
         let req = request.into_inner();
         if let Some(resp) = self
-            .forward_read_optional(forward.then_some(req), "get_job", |mut c, r| async move {
-                c.get_job(r).await
-            })
+            .forward_read_optional(
+                meta,
+                forward.then_some(req),
+                "get_job",
+                |mut c, r| async move { c.get_job(r).await },
+            )
             .await
         {
             return Ok(resp);
@@ -915,9 +919,11 @@ impl SlurmController for ControllerService {
         request: Request<GetNodesRequest>,
     ) -> Result<Response<GetNodesResponse>, Status> {
         let forward = self.read_should_forward(&request);
+        let meta = request.metadata().clone();
         let req = request.into_inner();
         if let Some(resp) = self
             .forward_read_optional(
+                meta,
                 forward.then(|| req.clone()),
                 "get_nodes",
                 |mut c, r| async move { c.get_nodes(r).await },
@@ -955,9 +961,11 @@ impl SlurmController for ControllerService {
         request: Request<GetNodeRequest>,
     ) -> Result<Response<NodeInfo>, Status> {
         let forward = self.read_should_forward(&request);
+        let meta = request.metadata().clone();
         let req = request.into_inner();
         if let Some(resp) = self
             .forward_read_optional(
+                meta,
                 forward.then(|| req.clone()),
                 "get_node",
                 |mut c, r| async move { c.get_node(r).await },
@@ -1144,8 +1152,10 @@ impl SlurmController for ControllerService {
         request: Request<GetPartitionsRequest>,
     ) -> Result<Response<GetPartitionsResponse>, Status> {
         let forward = self.read_should_forward(&request);
+        let meta = request.metadata().clone();
         if let Some(resp) = self
             .forward_read_optional(
+                meta,
                 forward.then(|| request.into_inner()),
                 "get_partitions",
                 |mut c, r| async move { c.get_partitions(r).await },
@@ -1184,8 +1194,10 @@ impl SlurmController for ControllerService {
 
     async fn get_job_metrics(&self, request: Request<()>) -> Result<Response<JobMetrics>, Status> {
         let forward = self.read_should_forward(&request);
+        let meta = request.metadata().clone();
         if let Some(resp) = self
             .forward_read_optional(
+                meta,
                 forward.then_some(()),
                 "get_job_metrics",
                 |mut c, r| async move { c.get_job_metrics(r).await },
@@ -1206,8 +1218,10 @@ impl SlurmController for ControllerService {
         request: Request<()>,
     ) -> Result<Response<NodeMetrics>, Status> {
         let forward = self.read_should_forward(&request);
+        let meta = request.metadata().clone();
         if let Some(resp) = self
             .forward_read_optional(
+                meta,
                 forward.then_some(()),
                 "get_node_metrics",
                 |mut c, r| async move { c.get_node_metrics(r).await },
@@ -1603,9 +1617,11 @@ impl SlurmController for ControllerService {
         request: Request<GetJobStepsRequest>,
     ) -> Result<Response<GetJobStepsResponse>, Status> {
         let forward = self.read_should_forward(&request);
+        let meta = request.metadata().clone();
         let req = request.into_inner();
         if let Some(resp) = self
             .forward_read_optional(
+                meta,
                 forward.then_some(req),
                 "get_job_steps",
                 |mut c, r| async move { c.get_job_steps(r).await },
@@ -2086,9 +2102,11 @@ impl SlurmController for ControllerService {
         request: Request<ListReservationsRequest>,
     ) -> Result<Response<ListReservationsResponse>, Status> {
         let forward = self.read_should_forward(&request);
+        let meta = request.metadata().clone();
         let req = request.into_inner();
         if let Some(resp) = self
             .forward_read_optional(
+                meta,
                 forward.then(|| req.clone()),
                 "list_reservations",
                 |mut c, r| async move { c.list_reservations(r).await },
@@ -3577,6 +3595,34 @@ mod tests {
         let (namespace, sa) = resolve_user_namespace_sa(&cache, "alice").unwrap();
         assert_eq!(namespace, "spur-acct-physics");
         assert_eq!(sa, "spur-user-alice");
+    }
+
+    #[test]
+    fn forwarded_metadata_carries_the_callers_credential_to_the_leader() {
+        // The leader authorizes the request, so a forwarded hop must arrive as the ORIGINAL caller.
+        // Building fresh metadata (the old behaviour) dropped the credential, which would make every
+        // forwarded call anonymous the moment HA + `auth.mode = required` were both on.
+        let mut orig = tonic::metadata::MetadataMap::new();
+        orig.insert("authorization", "Bearer tok123".parse().unwrap());
+
+        let fwd = ControllerService::forwarded_metadata_preserving(&orig);
+        assert_eq!(
+            fwd.get("authorization").map(|v| v.to_str().unwrap()),
+            Some("Bearer tok123"),
+            "the caller's credential must survive forwarding"
+        );
+        assert!(
+            fwd.get(FORWARDED_HEADER).is_some(),
+            "the loop-breaker header is still set"
+        );
+    }
+
+    #[test]
+    fn forwarding_an_unauthenticated_request_adds_no_credential() {
+        let fwd =
+            ControllerService::forwarded_metadata_preserving(&tonic::metadata::MetadataMap::new());
+        assert!(fwd.get("authorization").is_none());
+        assert!(fwd.get(FORWARDED_HEADER).is_some());
     }
 
     #[test]


### PR DESCRIPTION
Addresses the root cause behind #636: **no RPC authenticated its caller**, and the identity used for authorization was a field the client filled in.

#637 closed the paths that turned reachability into *privilege* (root execution, cluster-admin kubeconfig). This closes the paths that turn reachability into *identity*.

> **Stacked on #637** — base branch is `users/powderluv/fix-unauth-rce`, so this diff is just the auth commits. Re-target to `main` once #637 merges.

## Before / after

| | Before | After |
|---|---|---|
| Verification | `spur_core::auth::verify_token` had no caller outside tests | One Tower layer verifies `Authorization: Bearer <jwt>` |
| Coverage | the accounting service had **no** authorization at all, yet exposes `add_user(admin_level)` | Applied as a *layer*, so it gates accounting and the controller alike |
| Authorization | compared a client-supplied string | 14 handlers read the verified identity |
| uid / gid | taken from the wire and **executed** | derived server-side via NSS; `spec.user/uid/gid` overwritten |
| Issuance | none | `spur token user --user X [--admin]` |
| Clients | sent nothing | all 45 CLI connect sites attach a credential |
| REST | unauthenticated | same policy, `/ping` exempt |
| HA forwarding | dropped the credential | preserved on every forwarding path |

## Adoption without an outage

`[auth] mode` — **`permissive` by default**:

- **`disabled`** — no authentication; startup says so.
- **`permissive`** (default) — verify a credential when one is presented; when none is, fall back to the asserted identity **and log the caller**, so an operator rolling credentials out gets a worklist rather than a guess.
- **`required`** — reject anything without a valid credential.

Flipping an existing cluster straight to `required` would lock out every client at once, so the migration is: upgrade the control plane → `spur token user` → clients pick tokens up → flip the mode.

`[auth] plugin` also finally means something: `munge` and typos are **rejected at startup** instead of silently ignored, and `plugin = "none"` with `mode = "required"` is refused as contradictory. Previously an operator could set `plugin = "jwt"`, per the docs, and get no authentication with no warning.

## Decisions worth reviewing

- **An invalid token is rejected even in `permissive`.** Permissive tolerates the *absence* of a credential, never a bad one — otherwise forging a token would be strictly better for an attacker than sending none. A malformed header is likewise rejected rather than silently downgraded to anonymous.
- **uid/gid come from NSS, not the token.** `TokenClaims` has no gid, and a client-chosen uid is what allowed a job to run as an arbitrary user. The token's uid is informational; the controller re-resolves from the authenticated username and **fails closed** if the user cannot be resolved — never falling back to uid 0.
- **Identity is normalised once at handler entry** rather than at each use, so existing downstream reads (ownership checks, `is_k0s_admin`, accounting attribution) are correct without every call site learning about authentication. A claimed-vs-authenticated mismatch is logged.
- **`spur token user` signs locally** from `[auth] jwt_key` rather than over RPC: under `mode = required` an RPC mint would need a credential in order to obtain a credential.
- **A world-readable token file is ignored** with a warning instead of used — a bearer credential readable by other users on a shared login node is not a credential.
- **`forward_read_optional` now carries the credential too.** It initially did not, which would have silently degraded reads to local (stale) answers under `required`; fixed in this PR rather than left as a caveat.

## Not in this PR

**spurd does not authenticate its callers.** Nothing on the agent's port verifies anything today, so an attacker who can reach a node can still ask it to run work directly, bypassing everything here. Agent connections from the controller deliberately keep the raw channel for that reason — there is nothing to present a credential to yet.

That is the next PR, kept separate because it is a different daemon with a different upgrade order (controller first, agents second) and this one is already large. It is the reason this work is not yet sufficient on its own.

Also still open, tracked in #636: TLS on the control-plane ports (a bearer token on plaintext is replayable), authorization on the accounting service's own RPCs (its requests carry no caller field — needs a proto change), and a munge plugin.

## Testing

Verified on Linux (clippy `-D warnings`, fmt, full suites green). New coverage:

- 7 tests over the auth decision (required rejects missing; permissive allows missing but rejects invalid; malformed header rejected; `disabled` ignores even a valid token; token with no configured key rejected).
- 2 over forwarding (a credential survives; an unauthenticated request gains none).
- 3 over the credential loader.

One of my own tests was flaky and is fixed here: two tests mutated the same process-global env var and raced under the parallel harness — it passed by luck, then failed on a repeat run. Merged into one sequential test and confirmed over repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
