### PR TITLE
feat(auth): authenticate callers of the agent (spurd) surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3881,6 +3881,7 @@ dependencies = [
  "chrono",
  "clap",
  "hostname",
+ "http",
  "libc",
  "libloading",
  "nix",
@@ -3900,6 +3901,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/spur-cli/src/authclient.rs
+++ b/crates/spur-cli/src/authclient.rs
@@ -79,9 +79,10 @@ fn interceptor() -> AuthInterceptor {
     AuthInterceptor { header }
 }
 
-/// Wrap an already-established channel, for callers that build one directly (a lazily connected
-/// test channel) instead of going through [`connect`]. Test-only today.
-#[cfg(test)]
+/// Wrap an already-established channel with the caller's credential.
+///
+/// Used when the channel is built by the caller (e.g. agent connections, test channels) rather
+/// than going through [`connect`].
 pub fn wrap(channel: Channel) -> AuthChannel {
     InterceptedService::new(channel, interceptor())
 }

--- a/crates/spur-cli/src/interactive.rs
+++ b/crates/spur-cli/src/interactive.rs
@@ -65,16 +65,23 @@ pub fn spawn_keepalive(
     KeepaliveGuard(handle)
 }
 
-/// Connect to a spurd agent, applying the standard gRPC size limits.
-pub async fn connect_agent(addr: &str) -> Result<SlurmAgentClient<tonic::transport::Channel>> {
-    // Raw channel: the agent does not authenticate its callers yet (tracked separately), so there
-    // is nothing to present a controller credential to.
+/// Connect to a spurd agent, presenting the caller's credential if one is available.
+///
+/// The agent authenticates callers with the same JWT mechanism as the controller. A user token
+/// from `$SPUR_AUTH_TOKEN` / `~/.spur/token` is signed with the cluster key and will be accepted.
+/// Without a token the connection still succeeds against agents in `permissive` mode, but will be
+/// refused in `required` mode.
+pub async fn connect_agent(
+    addr: &str,
+) -> Result<SlurmAgentClient<crate::authclient::AuthChannel>> {
     let channel = spur_client::connect_channel(addr)
         .await
         .context("cannot connect to agent")?;
-    Ok(SlurmAgentClient::new(channel)
-        .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-        .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE))
+    Ok(
+        SlurmAgentClient::new(crate::authclient::wrap(channel))
+            .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE),
+    )
 }
 
 /// Local username sent with authenticated job requests.
@@ -106,7 +113,7 @@ pub struct InteractiveSessionHandle {
 ///
 /// Returns `Err(tonic::Status)` on RPC failure.
 pub async fn open_interactive_session(
-    agent: &mut SlurmAgentClient<tonic::transport::Channel>,
+    agent: &mut SlurmAgentClient<crate::authclient::AuthChannel>,
     job_id: u32,
     step_id: u32,
     argv: Vec<String>,
@@ -235,7 +242,7 @@ pub async fn drive_interactive_session(handle: InteractiveSessionHandle) -> Resu
 /// Run a full interactive PTY session over the InteractiveSession RPC.
 /// Returns the remote exit code.
 pub async fn run_interactive_session(
-    agent: &mut SlurmAgentClient<tonic::transport::Channel>,
+    agent: &mut SlurmAgentClient<crate::authclient::AuthChannel>,
     job_id: u32,
     step_id: u32,
     argv: Vec<String>,

--- a/crates/spur-cli/src/interactive.rs
+++ b/crates/spur-cli/src/interactive.rs
@@ -71,17 +71,13 @@ pub fn spawn_keepalive(
 /// from `$SPUR_AUTH_TOKEN` / `~/.spur/token` is signed with the cluster key and will be accepted.
 /// Without a token the connection still succeeds against agents in `permissive` mode, but will be
 /// refused in `required` mode.
-pub async fn connect_agent(
-    addr: &str,
-) -> Result<SlurmAgentClient<crate::authclient::AuthChannel>> {
+pub async fn connect_agent(addr: &str) -> Result<SlurmAgentClient<crate::authclient::AuthChannel>> {
     let channel = spur_client::connect_channel(addr)
         .await
         .context("cannot connect to agent")?;
-    Ok(
-        SlurmAgentClient::new(crate::authclient::wrap(channel))
-            .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-            .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE),
-    )
+    Ok(SlurmAgentClient::new(crate::authclient::wrap(channel))
+        .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE))
 }
 
 /// Local username sent with authenticated job requests.

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -87,7 +87,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
 /// Stream job output without interactive input (legacy behavior).
 async fn stream_output_only(
-    agent: &mut SlurmAgentClient<tonic::transport::Channel>,
+    agent: &mut SlurmAgentClient<crate::authclient::AuthChannel>,
     job_id: u32,
     stream_name: &str,
 ) -> Result<()> {
@@ -130,7 +130,7 @@ async fn stream_output_only(
 
 /// Interactive attach via InteractiveSession RPC. Returns the remote exit code.
 async fn interactive_attach(
-    agent: &mut SlurmAgentClient<tonic::transport::Channel>,
+    agent: &mut SlurmAgentClient<crate::authclient::AuthChannel>,
     job_id: u32,
 ) -> Result<i32> {
     let winsize = crate::interactive::get_terminal_size();

--- a/crates/spur-core/src/auth.rs
+++ b/crates/spur-core/src/auth.rs
@@ -368,4 +368,120 @@ mod tests {
         assert!(user.require_admin().is_err());
         assert!(Identity::admin().require_admin().is_ok());
     }
+
+    // --- authenticate_bearer ---
+    //
+    // The function is the shared ruling used by both the controller and the agent. Testing it
+    // directly (not just through the middleware wrappers) ensures the contract holds at the source
+    // so neither daemon can silently diverge.
+
+    fn bearer(key: &[u8]) -> String {
+        format!(
+            "Bearer {}",
+            generate_token("alice", 1000, false, key, 3600).unwrap()
+        )
+    }
+
+    #[test]
+    fn required_rejects_missing_credential() {
+        assert!(matches!(
+            authenticate_bearer(
+                crate::config::AuthMode::Required,
+                TEST_SECRET,
+                None,
+                "hint"
+            ),
+            BearerOutcome::Reject(_)
+        ));
+    }
+
+    #[test]
+    fn permissive_allows_missing_credential() {
+        assert!(matches!(
+            authenticate_bearer(
+                crate::config::AuthMode::Permissive,
+                TEST_SECRET,
+                None,
+                "hint"
+            ),
+            BearerOutcome::Anonymous
+        ));
+    }
+
+    #[test]
+    fn disabled_allows_missing_credential() {
+        assert!(matches!(
+            authenticate_bearer(crate::config::AuthMode::Disabled, TEST_SECRET, None, "hint"),
+            BearerOutcome::Anonymous
+        ));
+    }
+
+    #[test]
+    fn valid_token_is_authenticated_in_required_mode() {
+        let h = bearer(TEST_SECRET);
+        match authenticate_bearer(
+            crate::config::AuthMode::Required,
+            TEST_SECRET,
+            Some(&h),
+            "hint",
+        ) {
+            BearerOutcome::Authenticated(id) => {
+                assert_eq!(id.user, "alice");
+                assert_eq!(id.uid, 1000);
+            }
+            other => panic!("expected Authenticated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forged_token_rejected_in_permissive_mode() {
+        // permissive tolerates absence of a credential, never a bad one.
+        let forged = bearer(b"attacker-key");
+        assert!(matches!(
+            authenticate_bearer(
+                crate::config::AuthMode::Permissive,
+                TEST_SECRET,
+                Some(&forged),
+                "hint"
+            ),
+            BearerOutcome::Reject(_)
+        ));
+    }
+
+    #[test]
+    fn malformed_header_always_rejected() {
+        for bad in &["token-without-bearer-prefix", "Bearer ", "bearer", ""] {
+            assert!(
+                matches!(
+                    authenticate_bearer(
+                        crate::config::AuthMode::Permissive,
+                        TEST_SECRET,
+                        Some(bad),
+                        "hint"
+                    ),
+                    BearerOutcome::Reject(_)
+                ),
+                "header {bad:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn disabled_ignores_a_valid_token() {
+        // disabled must not silently verify — that would make `disabled` secretly stricter.
+        let h = bearer(TEST_SECRET);
+        assert!(matches!(
+            authenticate_bearer(crate::config::AuthMode::Disabled, TEST_SECRET, Some(&h), "hint"),
+            BearerOutcome::Anonymous
+        ));
+    }
+
+    #[test]
+    fn token_presented_but_no_key_configured_is_rejected() {
+        let h = bearer(TEST_SECRET);
+        assert!(matches!(
+            authenticate_bearer(crate::config::AuthMode::Required, b"", Some(&h), "hint"),
+            BearerOutcome::Reject(_)
+        ));
+    }
 }

--- a/crates/spur-core/src/auth.rs
+++ b/crates/spur-core/src/auth.rs
@@ -191,6 +191,71 @@ pub fn verify_token(token: &str, secret: &[u8]) -> Result<Identity, AuthError> {
     })
 }
 
+/// What to do with one request's `Authorization` header.
+///
+/// Shared by both daemons so the controller and the agent cannot drift apart on a security
+/// decision: they wrap this in their own Tower layer, but the ruling itself lives here.
+#[derive(Debug)]
+pub enum BearerOutcome {
+    /// Verified; carry this identity to the handler.
+    Authenticated(Box<Identity>),
+    /// No credential presented, and the mode tolerates that.
+    Anonymous,
+    /// Refuse the request with this message.
+    Reject(String),
+}
+
+/// Rule the `Authorization` header against the configured mode.
+///
+/// Deliberate properties:
+/// * an INVALID credential is rejected in every mode that verifies — `permissive` tolerates the
+///   *absence* of a credential, never a bad one, or forging would beat sending none;
+/// * a malformed header is rejected rather than silently downgraded to anonymous;
+/// * `disabled` ignores even a valid token, so it cannot be quietly stricter than it claims.
+pub fn authenticate_bearer(
+    mode: crate::config::AuthMode,
+    jwt_key: &[u8],
+    header: Option<&str>,
+    missing_credential_hint: &str,
+) -> BearerOutcome {
+    use crate::config::AuthMode;
+
+    let token = match header {
+        Some(h) => match h
+            .strip_prefix("Bearer ")
+            .or_else(|| h.strip_prefix("bearer "))
+        {
+            Some(t) if !t.trim().is_empty() => t.trim(),
+            _ => {
+                return BearerOutcome::Reject(
+                    "malformed authorization header: expected 'Bearer <token>'".into(),
+                )
+            }
+        },
+        None => {
+            return match mode {
+                AuthMode::Required => BearerOutcome::Reject(format!(
+                    "authentication required: {missing_credential_hint}"
+                )),
+                _ => BearerOutcome::Anonymous,
+            }
+        }
+    };
+
+    if mode == AuthMode::Disabled {
+        return BearerOutcome::Anonymous;
+    }
+    if jwt_key.is_empty() {
+        return BearerOutcome::Reject(
+            "a token was presented but no auth.jwt_key is configured".into(),
+        );
+    }
+    match verify_token(token, jwt_key) {
+        Ok(identity) => BearerOutcome::Authenticated(Box::new(identity)),
+        Err(e) => BearerOutcome::Reject(format!("invalid credential: {e}")),
+    }
+}
+
 /// "none" auth — always returns an identity based on UNIX user.
 pub fn auth_none() -> Identity {
     Identity {

--- a/crates/spur-core/src/auth.rs
+++ b/crates/spur-core/src/auth.rs
@@ -385,12 +385,7 @@ mod tests {
     #[test]
     fn required_rejects_missing_credential() {
         assert!(matches!(
-            authenticate_bearer(
-                crate::config::AuthMode::Required,
-                TEST_SECRET,
-                None,
-                "hint"
-            ),
+            authenticate_bearer(crate::config::AuthMode::Required, TEST_SECRET, None, "hint"),
             BearerOutcome::Reject(_)
         ));
     }
@@ -471,7 +466,12 @@ mod tests {
         // disabled must not silently verify — that would make `disabled` secretly stricter.
         let h = bearer(TEST_SECRET);
         assert!(matches!(
-            authenticate_bearer(crate::config::AuthMode::Disabled, TEST_SECRET, Some(&h), "hint"),
+            authenticate_bearer(
+                crate::config::AuthMode::Disabled,
+                TEST_SECRET,
+                Some(&h),
+                "hint"
+            ),
             BearerOutcome::Anonymous
         ));
     }

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Agent connections that carry the controller's credential.
+//!
+//! The agent authenticates its callers (see spurd's `auth_middleware`), so every controller → agent
+//! call goes through here rather than `SlurmAgentClient::connect` directly. That keeps a new call
+//! site from silently becoming an unauthenticated one.
+//!
+//! The credential is a short-lived token signed with the cluster's `[auth] jwt_key` — the same key
+//! the node-admission path already uses — so no new secret is introduced. It is minted per
+//! connection rather than cached: the TTL is short, connections are not hot, and a cache would have
+//! to handle rotation.
+
+use std::sync::Arc;
+
+use tonic::metadata::MetadataValue;
+use tonic::service::interceptor::InterceptedService;
+use tonic::transport::Channel;
+use tonic::{Request, Status};
+
+use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
+
+/// How long a controller credential is valid. Short because it is minted per connection; long
+/// enough to tolerate clock skew between the controller and a node.
+const CREDENTIAL_TTL_SECS: u64 = 300;
+
+/// Subject the agent sees for controller-issued credentials.
+const CONTROLLER_SUBJECT: &str = "spurctld";
+
+/// An agent channel that presents the controller's credential.
+pub type AgentChannel = InterceptedService<Channel, ControllerCredential>;
+
+#[derive(Clone, Default)]
+pub struct ControllerCredential {
+    header: Option<MetadataValue<tonic::metadata::Ascii>>,
+}
+
+impl tonic::service::Interceptor for ControllerCredential {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        if let Some(value) = &self.header {
+            request
+                .metadata_mut()
+                .insert("authorization", value.clone());
+        }
+        Ok(request)
+    }
+}
+
+/// The controller's signing key, set once at startup.
+///
+/// Held globally because agent connections are made from many places (the scheduler loop, the k0s
+/// reconciler, PMIx dispatch) that have no natural path to thread config through, and it is a single
+/// process-wide fact rather than per-call state.
+static SIGNING_KEY: std::sync::OnceLock<Arc<String>> = std::sync::OnceLock::new();
+
+/// Install the signing key. Called once from `main`; later calls are ignored.
+pub fn set_signing_key(key: String) {
+    let _ = SIGNING_KEY.set(Arc::new(key));
+}
+
+fn credential() -> ControllerCredential {
+    let Some(key) = SIGNING_KEY.get().filter(|k| !k.is_empty()) else {
+        // No key configured: present nothing. Agents in `permissive` still accept the call and log
+        // it; agents in `required` refuse, which is the intended outcome for a misconfigured
+        // controller — better a clear refusal than silently unauthenticated execution.
+        return ControllerCredential::default();
+    };
+    let header = spur_core::auth::generate_token(
+        CONTROLLER_SUBJECT,
+        0,
+        true,
+        key.as_bytes(),
+        CREDENTIAL_TTL_SECS,
+    )
+    .ok()
+    .and_then(|t| MetadataValue::try_from(format!("Bearer {t}")).ok());
+    ControllerCredential { header }
+}
+
+/// Connect to an agent, presenting the controller's credential.
+///
+/// Same signature shape as `SlurmAgentClient::connect`, so call sites only change which function
+/// they call.
+pub async fn connect(
+    endpoint: String,
+) -> Result<SlurmAgentClient<AgentChannel>, tonic::transport::Error> {
+    let channel = tonic::transport::Endpoint::from_shared(endpoint)?
+        .connect()
+        .await?;
+    Ok(SlurmAgentClient::new(InterceptedService::new(
+        channel,
+        credential(),
+    )))
+}

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -10,7 +10,9 @@
 //! The credential is a short-lived token signed with the cluster's `[auth] jwt_key` — the same key
 //! the node-admission path already uses — so no new secret is introduced. It is minted per
 //! connection rather than cached: the TTL is short, connections are not hot, and a cache would have
-//! to handle rotation.
+//! to handle rotation. This design assumes connections are short-lived (one RPC per connect); a
+//! long-lived connection would hold a credential that expires mid-session and get rejected on the
+//! next call without an obvious reason.
 
 use std::sync::Arc;
 
@@ -18,6 +20,7 @@ use tonic::metadata::MetadataValue;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 use tonic::{Request, Status};
+use tracing::error;
 
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 
@@ -59,23 +62,45 @@ pub fn set_signing_key(key: String) {
     let _ = SIGNING_KEY.set(Arc::new(key));
 }
 
-fn credential() -> ControllerCredential {
-    let Some(key) = SIGNING_KEY.get().filter(|k| !k.is_empty()) else {
+/// Build a credential from an explicit key string. Extracted from `credential()` for testability —
+/// the global `OnceLock` cannot be reset between tests.
+fn credential_with_key(key: &str) -> ControllerCredential {
+    if key.is_empty() {
         // No key configured: present nothing. Agents in `permissive` still accept the call and log
         // it; agents in `required` refuse, which is the intended outcome for a misconfigured
         // controller — better a clear refusal than silently unauthenticated execution.
         return ControllerCredential::default();
-    };
-    let header = spur_core::auth::generate_token(
+    }
+    let header = match spur_core::auth::generate_token(
         CONTROLLER_SUBJECT,
         0,
         true,
         key.as_bytes(),
         CREDENTIAL_TTL_SECS,
-    )
-    .ok()
-    .and_then(|t| MetadataValue::try_from(format!("Bearer {t}")).ok());
+    ) {
+        Ok(t) => MetadataValue::try_from(format!("Bearer {t}")).ok(),
+        Err(e) => {
+            // Token minting failed despite the key being present. This should not happen in
+            // practice (HMAC-SHA256 signing has no failure mode for a non-empty key), but if it
+            // does the controller will silently become unauthenticated, and agents in `required`
+            // mode will refuse every launch. Logging here makes that diagnosable.
+            error!(
+                "failed to mint controller credential for agent calls: {e}; \
+                 connections will carry no credential — agents in `required` mode will refuse them"
+            );
+            None
+        }
+    };
     ControllerCredential { header }
+}
+
+fn credential() -> ControllerCredential {
+    let key = SIGNING_KEY
+        .get()
+        .filter(|k| !k.is_empty())
+        .map(|k| k.as_str().to_string())
+        .unwrap_or_default();
+    credential_with_key(&key)
 }
 
 /// Connect to an agent, presenting the controller's credential.
@@ -92,4 +117,73 @@ pub async fn connect(
         channel,
         credential(),
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spur_core::auth::{generate_token, verify_token};
+
+    const TEST_KEY: &str = "test-cluster-key";
+
+    #[test]
+    fn empty_key_produces_no_credential() {
+        let cred = credential_with_key("");
+        assert!(
+            cred.header.is_none(),
+            "an empty key must not produce a credential"
+        );
+    }
+
+    #[test]
+    fn valid_key_produces_a_verifiable_credential() {
+        let cred = credential_with_key(TEST_KEY);
+        let header = cred.header.expect("a non-empty key must produce a credential");
+        let header_str = header.to_str().expect("header must be valid ASCII");
+        let token = header_str
+            .strip_prefix("Bearer ")
+            .expect("header must be 'Bearer <token>'");
+        let identity = verify_token(token, TEST_KEY.as_bytes())
+            .expect("token must be verifiable with the same key");
+        assert_eq!(identity.user, CONTROLLER_SUBJECT);
+        assert!(identity.is_admin);
+    }
+
+    #[test]
+    fn credential_signed_with_wrong_key_is_rejected_by_verifier() {
+        let cred = credential_with_key(TEST_KEY);
+        let header = cred.header.unwrap();
+        let token = header
+            .to_str()
+            .unwrap()
+            .strip_prefix("Bearer ")
+            .unwrap();
+        assert!(
+            verify_token(token, b"attacker-key").is_err(),
+            "a credential signed with one key must not verify against a different key"
+        );
+    }
+
+    #[test]
+    fn credential_token_subject_identifies_the_controller() {
+        // The agent does not enforce the subject today, but the field is there so a future
+        // per-principal policy can distinguish controller calls from user calls.
+        let cred = credential_with_key(TEST_KEY);
+        let token = cred
+            .header
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .strip_prefix("Bearer ")
+            .unwrap()
+            .to_string();
+        // generate_token for comparison — confirm our subject constant matches what we mint
+        let reference = generate_token(CONTROLLER_SUBJECT, 0, true, TEST_KEY.as_bytes(), 300)
+            .unwrap();
+        // Both tokens are signed with the same key and subject; verify both decode consistently.
+        let id1 = verify_token(&token, TEST_KEY.as_bytes()).unwrap();
+        let id2 = verify_token(&reference, TEST_KEY.as_bytes()).unwrap();
+        assert_eq!(id1.user, id2.user);
+        assert_eq!(id1.is_admin, id2.is_admin);
+    }
 }

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -138,7 +138,9 @@ mod tests {
     #[test]
     fn valid_key_produces_a_verifiable_credential() {
         let cred = credential_with_key(TEST_KEY);
-        let header = cred.header.expect("a non-empty key must produce a credential");
+        let header = cred
+            .header
+            .expect("a non-empty key must produce a credential");
         let header_str = header.to_str().expect("header must be valid ASCII");
         let token = header_str
             .strip_prefix("Bearer ")
@@ -153,11 +155,7 @@ mod tests {
     fn credential_signed_with_wrong_key_is_rejected_by_verifier() {
         let cred = credential_with_key(TEST_KEY);
         let header = cred.header.unwrap();
-        let token = header
-            .to_str()
-            .unwrap()
-            .strip_prefix("Bearer ")
-            .unwrap();
+        let token = header.to_str().unwrap().strip_prefix("Bearer ").unwrap();
         assert!(
             verify_token(token, b"attacker-key").is_err(),
             "a credential signed with one key must not verify against a different key"
@@ -178,8 +176,8 @@ mod tests {
             .unwrap()
             .to_string();
         // generate_token for comparison — confirm our subject constant matches what we mint
-        let reference = generate_token(CONTROLLER_SUBJECT, 0, true, TEST_KEY.as_bytes(), 300)
-            .unwrap();
+        let reference =
+            generate_token(CONTROLLER_SUBJECT, 0, true, TEST_KEY.as_bytes(), 300).unwrap();
         // Both tokens are signed with the same key and subject; verify both decode consistently.
         let id1 = verify_token(&token, TEST_KEY.as_bytes()).unwrap();
         let id2 = verify_token(&reference, TEST_KEY.as_bytes()).unwrap();

--- a/crates/spurctld/src/auth_middleware.rs
+++ b/crates/spurctld/src/auth_middleware.rs
@@ -21,7 +21,7 @@ use http::{Request, Response};
 use tower::{Layer, Service};
 use tracing::warn;
 
-use spur_core::auth::{verify_token, Identity};
+use spur_core::auth::BearerOutcome;
 use spur_core::config::AuthMode;
 
 /// Marker inserted alongside the identity so handlers can tell "verified" from "asserted" without
@@ -69,57 +69,15 @@ pub struct AuthMiddleware<S> {
     config: Arc<AuthConfig>,
 }
 
-/// Outcome of inspecting one request's credential.
-enum Decision {
-    /// Verified; carry this identity to the handler.
-    Authenticated(Box<Identity>),
-    /// No credential presented, and the mode tolerates that.
-    Anonymous,
-    /// Reject with this gRPC status message.
-    Reject(String),
-}
-
-fn decide(config: &AuthConfig, header: Option<&str>) -> Decision {
-    let token = match header {
-        Some(h) => match h
-            .strip_prefix("Bearer ")
-            .or_else(|| h.strip_prefix("bearer "))
-        {
-            Some(t) if !t.trim().is_empty() => t.trim(),
-            // A malformed header is a client bug, not an anonymous call — say so rather than
-            // silently downgrading to unauthenticated.
-            _ => {
-                return Decision::Reject(
-                    "malformed authorization header: expected 'Bearer <token>'".into(),
-                )
-            }
-        },
-        None => {
-            return match config.mode {
-                AuthMode::Required => Decision::Reject(
-                    "authentication required: pass a token (see `spur auth token`)".into(),
-                ),
-                _ => Decision::Anonymous,
-            }
-        }
-    };
-
-    if config.mode == AuthMode::Disabled {
-        // Do not verify what we have declared we do not enforce; treating a token as authoritative
-        // here would make `disabled` quietly stricter than it claims.
-        return Decision::Anonymous;
-    }
-    if config.jwt_key.is_empty() {
-        return Decision::Reject("a token was presented but no auth.jwt_key is configured".into());
-    }
-
-    match verify_token(token, &config.jwt_key) {
-        Ok(identity) => Decision::Authenticated(Box::new(identity)),
-        // An invalid token is always a rejection, even in `permissive`: permissive tolerates the
-        // ABSENCE of a credential, never a bad one. Otherwise a forged token would be strictly
-        // better for an attacker than sending none.
-        Err(e) => Decision::Reject(format!("invalid credential: {e}")),
-    }
+/// The ruling itself lives in `spur_core::auth` so the controller and the agent cannot drift apart
+/// on a security decision; this module only supplies the Tower plumbing.
+fn decide(config: &AuthConfig, header: Option<&str>) -> BearerOutcome {
+    spur_core::auth::authenticate_bearer(
+        config.mode,
+        &config.jwt_key,
+        header,
+        "pass a token (see `spur token user`)",
+    )
 }
 
 impl<S, B> Service<Request<B>> for AuthMiddleware<S>
@@ -147,11 +105,11 @@ where
             .map(str::to_owned);
 
         match decide(&config, header.as_deref()) {
-            Decision::Authenticated(identity) => {
+            BearerOutcome::Authenticated(identity) => {
                 req.extensions_mut().insert(*identity);
                 req.extensions_mut().insert(Verified);
             }
-            Decision::Anonymous => {
+            BearerOutcome::Anonymous => {
                 if config.mode == AuthMode::Permissive {
                     // Name the caller so an operator rolling out credentials can see exactly who is
                     // still unauthenticated instead of guessing.
@@ -162,7 +120,7 @@ where
                     );
                 }
             }
-            Decision::Reject(msg) => {
+            BearerOutcome::Reject(msg) => {
                 let resp = tonic::Status::unauthenticated(msg).into_http();
                 return Box::pin(async move { Ok(resp) });
             }
@@ -193,7 +151,7 @@ mod tests {
     fn required_rejects_a_missing_credential() {
         assert!(matches!(
             decide(&cfg(AuthMode::Required, "k"), None),
-            Decision::Reject(_)
+            BearerOutcome::Reject(_)
         ));
     }
 
@@ -201,7 +159,7 @@ mod tests {
     fn permissive_allows_a_missing_credential() {
         assert!(matches!(
             decide(&cfg(AuthMode::Permissive, "k"), None),
-            Decision::Anonymous
+            BearerOutcome::Anonymous
         ));
     }
 
@@ -210,7 +168,7 @@ mod tests {
         let t = token("k");
         let header = format!("Bearer {t}");
         match decide(&cfg(AuthMode::Required, "k"), Some(&header)) {
-            Decision::Authenticated(id) => {
+            BearerOutcome::Authenticated(id) => {
                 assert_eq!(id.user, "alice");
                 assert_eq!(id.uid, 1000);
                 assert!(!id.is_admin);
@@ -226,7 +184,7 @@ mod tests {
         let forged = format!("Bearer {}", token("attacker-key"));
         assert!(matches!(
             decide(&cfg(AuthMode::Permissive, "real-key"), Some(&forged)),
-            Decision::Reject(_)
+            BearerOutcome::Reject(_)
         ));
     }
 
@@ -236,7 +194,7 @@ mod tests {
             assert!(
                 matches!(
                     decide(&cfg(AuthMode::Permissive, "k"), Some(h)),
-                    Decision::Reject(_)
+                    BearerOutcome::Reject(_)
                 ),
                 "header {h:?} must be rejected"
             );
@@ -249,7 +207,7 @@ mod tests {
         let header = format!("Bearer {t}");
         assert!(matches!(
             decide(&cfg(AuthMode::Disabled, "k"), Some(&header)),
-            Decision::Anonymous
+            BearerOutcome::Anonymous
         ));
     }
 
@@ -258,7 +216,7 @@ mod tests {
         let header = format!("Bearer {}", token("k"));
         assert!(matches!(
             decide(&cfg(AuthMode::Permissive, ""), Some(&header)),
-            Decision::Reject(_)
+            BearerOutcome::Reject(_)
         ));
     }
 }

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -553,7 +553,7 @@ fn agent_endpoint(cluster: &ClusterManager, node: &str) -> Option<String> {
 /// control-plane node is assigned yet or none is reachable.
 async fn connect_control_plane(
     cluster: &ClusterManager,
-) -> anyhow::Result<SlurmAgentClient<tonic::transport::Channel>> {
+) -> anyhow::Result<SlurmAgentClient<crate::agent_client::AgentChannel>> {
     let state = cluster.k0s_state();
     let mut candidates = state.controllers();
     if candidates.is_empty() {
@@ -571,7 +571,7 @@ async fn connect_control_plane(
             last_err = format!("control-plane node {cp} has no agent address");
             continue;
         };
-        match tokio::time::timeout(AGENT_TIMEOUT, SlurmAgentClient::connect(endpoint)).await {
+        match tokio::time::timeout(AGENT_TIMEOUT, crate::agent_client::connect(endpoint)).await {
             Ok(Ok(client)) => return Ok(client),
             Ok(Err(e)) => last_err = format!("connect to control-plane agent {cp} failed: {e}"),
             Err(_) => last_err = format!("connect to control-plane agent {cp} timed out"),
@@ -632,7 +632,7 @@ pub async fn fetch_user_kubeconfig(
 async fn fetch_component_status(cluster: &ClusterManager, node: &str) -> Option<(String, bool)> {
     let endpoint = agent_endpoint(cluster, node)?;
     let fut = async {
-        let mut client = SlurmAgentClient::connect(endpoint).await.ok()?;
+        let mut client = crate::agent_client::connect(endpoint).await.ok()?;
         let resp = client
             .get_cluster_component_status(GetClusterComponentStatusRequest {})
             .await
@@ -865,7 +865,7 @@ fn spawn_start_component(
     let node = node.to_string();
     let role = role_str(role);
     tokio::spawn(async move {
-        match SlurmAgentClient::connect(endpoint).await {
+        match crate::agent_client::connect(endpoint).await {
             Ok(mut client) => {
                 let req = StartClusterComponentRequest {
                     role,
@@ -889,7 +889,7 @@ fn spawn_stop_component(cluster: &ClusterManager, node: &str, reset: bool) {
     };
     let node = node.to_string();
     tokio::spawn(async move {
-        match SlurmAgentClient::connect(endpoint).await {
+        match crate::agent_client::connect(endpoint).await {
             Ok(mut client) => {
                 match client
                     .stop_cluster_component(StopClusterComponentRequest { reset })
@@ -947,7 +947,7 @@ fn spawn_apply_mesh(cluster: &ClusterManager, node: &str, mesh: &MeshMembership)
         // Bound connect + RPC so a hung/blackholed agent can't leak accumulating detached tasks
         // (this fires every reconcile tick).
         let fut = async {
-            let mut client = SlurmAgentClient::connect(endpoint)
+            let mut client = crate::agent_client::connect(endpoint)
                 .await
                 .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
             client.apply_mesh(proto).await

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod accounting;
+mod agent_client;
 mod association_cache;
 mod auth_middleware;
 mod cluster;
@@ -358,6 +359,9 @@ async fn main() -> anyhow::Result<()> {
 
     // Start gRPC server
     let addr: std::net::SocketAddr = listen_addr.parse()?;
+    // The controller presents this key as its credential to agents (spurd authenticates callers).
+    crate::agent_client::set_signing_key(config.auth.jwt_key.clone().unwrap_or_default());
+
     // State the authentication posture explicitly at startup: it determines whether the listening
     // port is the trust boundary or merely the transport.
     match config.auth.mode {

--- a/crates/spurctld/src/pmix_dispatch.rs
+++ b/crates/spurctld/src/pmix_dispatch.rs
@@ -6,7 +6,6 @@
 use tracing::{error, warn};
 
 use spur_core::node::NodeSource;
-use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 use spur_proto::proto::{PreparePmixRequest, ReleasePmixRequest};
 
 pub const MULTI_NODE_PMIX_K8S_UNSUPPORTED: &str =
@@ -58,7 +57,7 @@ pub async fn prepare_pmix_on_agent(
     run_attempt: u32,
     pmix_plan: spur_proto::proto::PmixLaunchPlan,
 ) -> Result<(), String> {
-    let mut client = SlurmAgentClient::connect(agent_addr.to_string())
+    let mut client = crate::agent_client::connect(agent_addr.to_string())
         .await
         .map_err(|e| format!("connect failed: {e}"))?
         .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
@@ -83,7 +82,7 @@ pub async fn prepare_pmix_on_agent(
 
 pub async fn release_pmix_on_agent(agent_addr: &str, job_id: u32) {
     let result = async {
-        let mut client = SlurmAgentClient::connect(agent_addr.to_string())
+        let mut client = crate::agent_client::connect(agent_addr.to_string())
             .await
             .map_err(|e| tonic::Status::unavailable(e.to_string()))?
             .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -11,7 +11,6 @@ use tracing::{debug, error, info, warn};
 use spur_core::node::{Node, NodeSource};
 use spur_core::partition::requested_partition_names;
 use spur_core::task_launch::batch_dispatched_multi_node_pmix;
-use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
     AgentCancelJobRequest, AgentSuspendJobRequest, JobSpec as ProtoJobSpec, LaunchJobRequest,
@@ -898,7 +897,7 @@ async fn dispatch_to_agent(
     agent_addr: &str,
     params: &AgentDispatchParams<'_>,
 ) -> Result<LaunchOutcome, DispatchError> {
-    let mut client = SlurmAgentClient::connect(agent_addr.to_string())
+    let mut client = crate::agent_client::connect(agent_addr.to_string())
         .await?
         .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
         .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
@@ -1116,7 +1115,7 @@ async fn register_allocation_to_agent(
     agent_addr: &str,
     params: &AllocationRegisterParams,
 ) -> anyhow::Result<()> {
-    let mut client = SlurmAgentClient::connect(agent_addr.to_string())
+    let mut client = crate::agent_client::connect(agent_addr.to_string())
         .await?
         .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
         .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
@@ -2066,7 +2065,7 @@ async fn cancel_one_step_agent(
     use spur_proto::proto::CancelStepRequest;
 
     let attempt = async {
-        match SlurmAgentClient::connect(agent_addr.clone())
+        match crate::agent_client::connect(agent_addr.clone())
             .await
             .map(|c| {
                 c.max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
@@ -2155,7 +2154,7 @@ fn cancel_agent_addrs(
 /// must not block the caller past the timeout.
 async fn cancel_one_agent(agent_addr: String, job_id: spur_core::job::JobId, signal: i32) {
     let attempt = async {
-        match SlurmAgentClient::connect(agent_addr.clone())
+        match crate::agent_client::connect(agent_addr.clone())
             .await
             .map(|c| {
                 c.max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
@@ -2224,7 +2223,7 @@ pub async fn send_suspend_to_agents(
         };
         let job_id = job.job_id;
         tokio::spawn(async move {
-            match SlurmAgentClient::connect(agent_addr.clone())
+            match crate::agent_client::connect(agent_addr.clone())
                 .await
                 .map(|c| {
                     c.max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2151,8 +2151,6 @@ impl SlurmController for ControllerService {
             }
         }
 
-        use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
-
         let __identity = Self::verified_identity(&request).cloned();
         let mut req = request.into_inner();
         Self::authoritative_user(&mut req.user, __identity.as_ref());
@@ -2185,7 +2183,7 @@ impl SlurmController for ControllerService {
             .ok_or_else(|| Status::not_found(format!("node {} not found", node_name)))?;
         let agent_addr = node_comm_http_url(&node, &node_name)?;
 
-        let mut agent = SlurmAgentClient::connect(agent_addr.clone())
+        let mut agent = crate::agent_client::connect(agent_addr.clone())
             .await
             .map_err(|e| {
                 Status::unavailable(format!("cannot reach agent at {}: {}", agent_addr, e))
@@ -2218,8 +2216,6 @@ impl SlurmController for ControllerService {
             let fwd = Self::forward_request(request);
             return client.run_step(fwd).await;
         }
-
-        use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 
         let req = request.into_inner();
         let job_id = req.job_id;
@@ -2429,7 +2425,7 @@ impl SlurmController for ControllerService {
             let environment = environment.clone();
             let step_mpi = mpi.clone();
             set.spawn(async move {
-                let mut agent = SlurmAgentClient::connect(agent_addr.clone())
+                let mut agent = crate::agent_client::connect(agent_addr.clone())
                     .await
                     .map_err(|e| {
                         Status::unavailable(format!("cannot reach agent at {}: {}", agent_addr, e))

--- a/crates/spurd/Cargo.toml
+++ b/crates/spurd/Cargo.toml
@@ -20,6 +20,9 @@ spur-spank = { path = "../spur-spank" }
 spur-devices = { path = "../spur-devices" }
 tokio = { workspace = true }
 tonic = { workspace = true }
+# agent-side auth middleware (Tower layer over the gRPC surface)
+http = "1"
+tower = { workspace = true }
 prost-types = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/spurd/src/auth_middleware.rs
+++ b/crates/spurd/src/auth_middleware.rs
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tower middleware that authenticates callers of the agent's gRPC surface.
+//!
+//! Without this, reaching a node's agent port is enough to ask it to run work — the controller's
+//! authentication can simply be stepped around. The agent therefore verifies that a request carries
+//! a credential signed with the cluster's `[auth] jwt_key`, which the controller attaches to every
+//! agent call.
+//!
+//! The signing key is a cluster-wide shared secret, like Slurm's `munge.key`: any holder can mint a
+//! credential, so a compromised node can present itself to another node as the controller. That is
+//! the accepted HPC model and a large improvement on "any peer at all", but it is not the same as
+//! asymmetric signing, where only the controller could ever mint. Moving to an asymmetric key so
+//! nodes can verify but not sign is the natural hardening step.
+//!
+//! The ruling itself is `spur_core::auth::authenticate_bearer`, shared with the controller so the
+//! two daemons cannot drift apart on a security decision.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use http::{Request, Response};
+use tower::{Layer, Service};
+use tracing::warn;
+
+use spur_core::auth::BearerOutcome;
+use spur_core::config::AuthMode;
+
+#[derive(Clone)]
+pub struct AgentAuthLayer {
+    inner: Arc<AgentAuthConfig>,
+}
+
+struct AgentAuthConfig {
+    mode: AuthMode,
+    jwt_key: Vec<u8>,
+}
+
+impl AgentAuthLayer {
+    pub fn new(mode: AuthMode, jwt_key: &str) -> Self {
+        Self {
+            inner: Arc::new(AgentAuthConfig {
+                mode,
+                jwt_key: jwt_key.as_bytes().to_vec(),
+            }),
+        }
+    }
+}
+
+impl<S> Layer<S> for AgentAuthLayer {
+    type Service = AgentAuthMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AgentAuthMiddleware {
+            inner,
+            config: self.inner.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AgentAuthMiddleware<S> {
+    inner: S,
+    config: Arc<AgentAuthConfig>,
+}
+
+fn decide(config: &AgentAuthConfig, header: Option<&str>) -> BearerOutcome {
+    spur_core::auth::authenticate_bearer(
+        config.mode,
+        &config.jwt_key,
+        header,
+        "this agent only accepts calls carrying the cluster credential",
+    )
+}
+
+impl<S, B> Service<Request<B>> for AgentAuthMiddleware<S>
+where
+    S: Service<Request<B>, Response = Response<tonic::body::Body>> + Clone + Send + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Future: Send + 'static,
+    B: Send + 'static,
+{
+    type Response = Response<tonic::body::Body>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let header = req
+            .headers()
+            .get(http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+
+        match decide(&self.config, header.as_deref()) {
+            // The agent does not act *as* the caller — it runs what the controller allocated — so
+            // the identity is not carried into handlers; verifying the credential is the point.
+            BearerOutcome::Authenticated(_) => {}
+            BearerOutcome::Anonymous => {
+                if self.config.mode == AuthMode::Permissive {
+                    warn!(
+                        path = %req.uri().path(),
+                        "unauthenticated agent request accepted (auth.mode = permissive): any peer \
+                         that can reach this port can ask this node to run work"
+                    );
+                }
+            }
+            BearerOutcome::Reject(msg) => {
+                let resp = tonic::Status::unauthenticated(msg).into_http();
+                return Box::pin(async move { Ok(resp) });
+            }
+        }
+
+        let mut inner = self.inner.clone();
+        Box::pin(async move { inner.call(req).await.map_err(Into::into) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spur_core::auth::generate_token;
+
+    fn cfg(mode: AuthMode, key: &str) -> AgentAuthConfig {
+        AgentAuthConfig {
+            mode,
+            jwt_key: key.as_bytes().to_vec(),
+        }
+    }
+
+    fn controller_token(key: &str) -> String {
+        generate_token("spurctld", 0, true, key.as_bytes(), 300).unwrap()
+    }
+
+    #[test]
+    fn required_refuses_an_uncredentialed_caller() {
+        assert!(matches!(
+            decide(&cfg(AuthMode::Required, "k"), None),
+            BearerOutcome::Reject(_)
+        ));
+    }
+
+    #[test]
+    fn permissive_still_accepts_an_uncredentialed_caller() {
+        // The migration window: controllers start presenting a credential before agents demand one.
+        assert!(matches!(
+            decide(&cfg(AuthMode::Permissive, "k"), None),
+            BearerOutcome::Anonymous
+        ));
+    }
+
+    #[test]
+    fn a_controller_credential_is_accepted() {
+        let header = format!("Bearer {}", controller_token("cluster-key"));
+        assert!(matches!(
+            decide(&cfg(AuthMode::Required, "cluster-key"), Some(&header)),
+            BearerOutcome::Authenticated(_)
+        ));
+    }
+
+    #[test]
+    fn a_credential_signed_with_another_key_is_refused_even_in_permissive() {
+        let forged = format!("Bearer {}", controller_token("attacker-key"));
+        assert!(matches!(
+            decide(&cfg(AuthMode::Permissive, "cluster-key"), Some(&forged)),
+            BearerOutcome::Reject(_)
+        ));
+    }
+}

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod agent_server;
+mod auth_middleware;
 mod cluster;
 pub mod container;
 mod executor;
@@ -358,7 +359,38 @@ async fn main() -> anyhow::Result<()> {
     let addr = args.listen.parse()?;
     info!(%addr, "agent gRPC server listening");
 
+    // Authenticate callers of the agent surface: without this, reaching this port is enough to ask
+    // the node to run work, which steps around the controller's authentication entirely.
+    let auth_mode = config.as_ref().map(|c| c.auth.mode).unwrap_or_default();
+    let jwt_key = config
+        .as_ref()
+        .and_then(|c| c.auth.jwt_key.clone())
+        .unwrap_or_default();
+    match auth_mode {
+        spur_core::config::AuthMode::Required if jwt_key.is_empty() => {
+            anyhow::bail!(
+                "[auth] mode = \"required\" but no jwt_key is configured on this node: the agent \
+                 could never verify a credential and would refuse every launch"
+            )
+        }
+        spur_core::config::AuthMode::Required => {
+            info!("agent requires a cluster credential on every RPC")
+        }
+        spur_core::config::AuthMode::Permissive => warn!(
+            "agent accepts uncredentialed RPCs (auth.mode = permissive): any peer that can reach \
+             this port can ask this node to run work. Set mode = \"required\" once controllers are \
+             upgraded."
+        ),
+        spur_core::config::AuthMode::Disabled => warn!(
+            "agent does NOT authenticate callers (auth.mode = disabled): treat this port as an \
+             administrative boundary."
+        ),
+    }
+
     let server_future = tonic::transport::Server::builder()
+        .layer(crate::auth_middleware::AgentAuthLayer::new(
+            auth_mode, &jwt_key,
+        ))
         .add_service(spur_proto::agent_server(agent_service))
         .serve(addr);
 

--- a/crates/spurd/src/privdrop.rs
+++ b/crates/spurd/src/privdrop.rs
@@ -17,7 +17,6 @@ pub(crate) fn spurd_runs_as_root() -> bool {
     nix::unistd::geteuid().is_root()
 }
 
-
 /// Refuse to execute work as uid 0 unless the operator opted in.
 ///
 /// `PrivDrop::resolve_if_needed` returns `None` for uid 0, which means "no privilege drop" — so a

--- a/crates/spurd/src/privdrop.rs
+++ b/crates/spurd/src/privdrop.rs
@@ -17,6 +17,7 @@ pub(crate) fn spurd_runs_as_root() -> bool {
     nix::unistd::geteuid().is_root()
 }
 
+
 /// Refuse to execute work as uid 0 unless the operator opted in.
 ///
 /// `PrivDrop::resolve_if_needed` returns `None` for uid 0, which means "no privilege drop" — so a


### PR DESCRIPTION
Closes the last path by which **reaching a machine was enough to run work on it**.

Until now spurd verified nothing. An attacker who could reach a node's agent port could ask it to launch jobs directly, stepping around every control the controller gained in #637 and #640 — which is why I flagged this as the reason that work was not sufficient on its own.

> **Stacked on #640** (which is stacked on #637). Base branch is `users/powderluv/auth-identity-spine`; re-target down the chain as each merges.

## What changed

- **spurd gates its gRPC surface** with a Tower layer that verifies a credential signed with the cluster's `[auth] jwt_key`, honouring the same `disabled` / `permissive` / `required` modes as the controller.
- **The controller presents a credential** — minted short-lived per agent connection — through a single `agent_client::connect` used by all **14** call sites, so a new call site cannot silently become an unauthenticated one.
- **The ruling moved to `spur_core::auth::authenticate_bearer`**, shared by both daemons so the controller and the agent cannot drift apart on a security decision. The controller's middleware now delegates to it; its seven tests pass unchanged.
- **spurd refuses to start in `required` without a key**, rather than booting into a state where it would reject every launch.

## Rollout order

`permissive` is the default, and the order matters: **upgrade controllers first** (they begin presenting a credential), then flip agents to `required`. Doing it the other way round would refuse every launch from a controller that has not yet been upgraded. Permissive logs each uncredentialed call, so the migration is observable rather than guessed at.

## The honest limitation

The signing key is a **cluster-wide shared secret**, like Slurm's `munge.key`. Any holder can mint, so a compromised node can present itself to another node as the controller.

That is the accepted HPC model and a large improvement over "any peer at all" — but it is not the same as asymmetric signing, where nodes could verify and only the controller could sign. That is the natural hardening step; it is called out in the module docs rather than left for a reader to discover.

Two consequences worth naming: `[auth] jwt_key` must now be distributed to nodes (it previously only needed to exist on the controller), and it is a genuine secret on every node.

## Testing

Verified on Linux — clippy `-D warnings`, fmt, full suites green (1861 tests; spurd gains 4).

New agent-side coverage: `required` refuses an uncredentialed caller; `permissive` still accepts one (the migration window); a controller credential is accepted; and a credential signed with **another key is refused even in `permissive`** — permissive tolerates the absence of a credential, never a forged one.

## After this

The remaining items on #636 are TLS (a bearer token on plaintext is replayable), per-RPC authorization on the accounting service (needs a proto caller field), and a munge plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
