### PR TITLE
fix(spur-core): prevent stray ']' from merging hosts in split_top_level

### DIFF
--- a/crates/spur-core/src/hostlist.rs
+++ b/crates/spur-core/src/hostlist.rs
@@ -268,7 +268,7 @@ fn split_top_level(s: &str) -> Vec<&str> {
     for (i, c) in s.char_indices() {
         match c {
             '[' => depth += 1,
-            ']' => depth -= 1,
+            ']' => depth = (depth - 1).max(0),
             ',' if depth == 0 => {
                 parts.push(&s[start..i]);
                 start = i + 1;
@@ -603,5 +603,21 @@ mod tests {
         assert!(expand("a]b[1-2]").is_err());
         assert!(expand("][").is_err());
         assert!(expand("node]1").is_ok()); // ']' with no '[' is a plain hostname
+    }
+
+    #[test]
+    fn stray_bracket_before_comma_now_splits() {
+        assert_eq!(expand("x],y").unwrap(), vec!["x]", "y"]);
+        assert_eq!(expand("node01],node02").unwrap(), vec!["node01]", "node02"]);
+    }
+
+    #[test]
+    fn lone_stray_bracket_stays_literal() {
+        assert_eq!(expand("x]").unwrap(), vec!["x]"]);
+    }
+
+    #[test]
+    fn recursive_suffix_bracket_order_rejected() {
+        assert!(expand("node[1-2]a]b[3-4]").is_err());
     }
 }

--- a/crates/spur-core/src/hostlist.rs
+++ b/crates/spur-core/src/hostlist.rs
@@ -609,6 +609,9 @@ mod tests {
     fn stray_bracket_before_comma_now_splits() {
         assert_eq!(expand("x],y").unwrap(), vec!["x]", "y"]);
         assert_eq!(expand("node01],node02").unwrap(), vec!["node01]", "node02"]);
+        assert_eq!(expand("],y").unwrap(), vec!["]", "y"]);
+        assert_eq!(expand("x,]y").unwrap(), vec!["x", "]y"]);
+        assert_eq!(expand("x]],y").unwrap(), vec!["x]]", "y"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
`split_top_level` decremented its bracket-depth counter on every `]` without a floor. A stray `]` before a top-level comma drove `depth` negative, so the comma was treated as "inside brackets" and the split was suppressed — `expand("x],y")` returned `Ok(["x],y"])` (one merged, bogus host) instead of `["x]", "y"]`.

This clamps the counter with `(depth - 1).max(0)` so a top-level comma always splits. It preserves #639's convention that a lone `]` with no `[` is a valid literal hostname (`expand("node]1").is_ok()`) and leaves every valid pattern unchanged.

**Scope:** this only fixes the comma-split merge. It intentionally does **not** change how a
lone `]` with no `[` is handled — that stays a literal hostname per #639
(`expand("node]1").is_ok()`). Whether a lone `]` should be rejected is a separate question
I'll raise in a Discussion.

Fixes #642.

## Test plan
- `expand("x],y")` → `["x]", "y"]`, `expand("node01],node02")` → `["node01]", "node02"]`
- `expand("node[1-2]a]b[3-4]")` → `Err` (recursive-suffix bracket order still rejected)
- `expand("gpu[01-02],cpu[01-02]")` unchanged
- Full spur-core suite: 520 passed, 0 failed; `cargo fmt --all --check` clean
