### PR TITLE
fix(spur-core): bound array size before expansion and use checked step increment

### DIFF
--- a/crates/spur-core/src/array.rs
+++ b/crates/spur-core/src/array.rs
@@ -122,10 +122,23 @@ pub fn parse_array_spec(spec: &str) -> Result<ArraySpec, ArrayError> {
             if start > end {
                 return Err(ArrayError::InvalidSpec(format!("{} > {}", start, end)));
             }
+
+            // Bound element count BEFORE materializing (u64 avoids overflow in the count itself).
+            let count = (end as u64 - start as u64) / step as u64 + 1;
+            if task_ids.len() as u64 + count > MAX_ARRAY_SIZE as u64 {
+                return Err(ArrayError::TooLarge {
+                    count: (task_ids.len() as u64 + count) as usize,
+                    max: MAX_ARRAY_SIZE,
+                });
+            }
+
             let mut i = start;
             while i <= end {
                 task_ids.push(i);
-                i += step;
+                match i.checked_add(step) {
+                    Some(n) => i = n,
+                    None => break, // reached top of u32 range
+                }
             }
         } else {
             let id: u32 = range_str
@@ -304,5 +317,25 @@ mod tests {
             aggregate_array_state(&[JobState::OutOfMemory, JobState::Failed]),
             Some(JobState::OutOfMemory)
         );
+    }
+
+    #[test]
+    fn rejects_range_overflow_at_u32_max() {
+        let spec = parse_array_spec("4294967293-4294967295:2").unwrap();
+        assert_eq!(spec.task_ids, vec![4294967293, 4294967295]);
+    }
+
+    #[test]
+    fn rejects_oversized_range_before_alloc() {
+        assert!(matches!(
+            parse_array_spec("0-4000000000"),
+            Err(ArrayError::TooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn max_size_boundary_unchanged() {
+        assert!(parse_array_spec("0-99999").is_ok());
+        assert!(parse_array_spec("0-100000").is_err());
     }
 }


### PR DESCRIPTION
## Summary
`parse_array_spec` had two DoS defects reachable from any user's `sbatch --array=...` (via `expand_job_specs()` → `cluster.rs:6452`):

1. **Integer overflow on the loop counter.** `i += step` used unchecked `u32` arithmetic. A range near `u32::MAX` (e.g. `4294967293-4294967295:2`) panicked the controller thread in debug builds and silently wrapped into an **infinite loop + memory blowup** in release builds.
2. **Size limit checked too late.** `MAX_ARRAY_SIZE` was only enforced *after* the whole range was materialized into a `Vec<u32>`, so `--array=0-4000000000` allocated ~16 GB before the guard could reject it — OOM before the check.

## Fix
- Compute the element count in `u64` and reject **before** allocating, tracking the running total across comma-separated ranges. Same `ArrayError::TooLarge`, just raised early.
- Replace `i += step` with `i.checked_add(step)`, breaking cleanly at the top of the `u32` range.
- The existing post-expansion `TooLarge` check is kept as a backstop.

No behavior change for valid input.

Fixes #645

## Test plan
- `cargo test -p spur-core array` — 28 passed, 0 failed, including 3 new regression tests:
  - `rejects_range_overflow_at_u32_max` — `4294967293-4294967295:2` now returns `[4294967293, 4294967295]` instead of panicking/looping
  - `rejects_oversized_range_before_alloc` — `0-4000000000` returns `TooLarge` without allocating
  - `max_size_boundary_unchanged` — `0-99999` ok (exactly 100_000), `0-100000` errors
- Existing array/dependency tests unchanged (no regressions)
- `cargo fmt -p spur-core` clean