### PR TITLE
fix(spur-cli): accept Slurm's --noconvert on squeue and sinfo

### DIFF
--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -45,8 +45,7 @@ pub struct SinfoArgs {
     #[arg(short = 'h', long)]
     pub noheader: bool,
 
-    /// Report values without unit conversion. Accepted for Slurm compatibility:
-    /// Spur already emits unconverted values, so there is nothing to suppress.
+    /// Accepted for Slurm compatibility; has no effect
     #[arg(long)]
     pub noconvert: bool,
 
@@ -352,7 +351,7 @@ mod tests {
     use super::*;
     use spur_proto::proto as pb;
     use spur_proto::proto::slurm_controller_server::SlurmController;
-    use spur_proto::proto::NodeState;
+    use spur_proto::proto::{NodeState, ResourceSet};
     use std::sync::{Arc, Mutex};
     use tonic::{Request, Response, Status};
 
@@ -402,16 +401,37 @@ mod tests {
     }
 
     #[test]
-    fn noconvert_changes_nothing_else() {
-        // Spur never humanizes units, so the flag has nothing to suppress. If unit
-        // conversion is ever added, this is what should force the flag to be honoured.
-        let plain = parse_sinfo_args(&["sinfo", "-N", "-h", "-o", "%n %m"]);
-        let flagged = parse_sinfo_args(&["sinfo", "-N", "-h", "-o", "%n %m", "--noconvert"]);
-        assert_eq!(plain.format, flagged.format);
-        assert_eq!(plain.noheader, flagged.noheader);
-        assert_eq!(plain.node_oriented, flagged.node_oriented);
-        assert!(!plain.noconvert);
-        assert!(flagged.noconvert);
+    fn memory_columns_render_as_raw_megabytes_with_and_without_noconvert() {
+        // The flag is inert only because these cells are already raw MB. Driving the
+        // real render path pins that: humanizing memory_mb or free_memory_mb later
+        // turns this red, which a parse-only test would not.
+        let mut node = make_node("gpu001", NodeState::NodeIdle, "gpu");
+        node.total_resources = Some(ResourceSet {
+            memory_mb: 2_321_924,
+            ..Default::default()
+        });
+        node.free_memory_mb = 11_077;
+        let partitions = vec![make_partition("gpu", true)];
+
+        for argv in [
+            ["sinfo", "-N", "-h", "-o", "%m %e"].as_slice(),
+            ["sinfo", "-N", "-h", "-o", "%m %e", "--noconvert"].as_slice(),
+        ] {
+            let args = parse_sinfo_args(argv);
+            let fields = format_engine::parse_format(
+                args.format.as_deref().expect("-o sets format"),
+                &format_engine::sinfo_header,
+            );
+
+            let lines = render_sinfo_output(
+                &fields,
+                &partitions,
+                std::slice::from_ref(&node),
+                args.node_oriented,
+            );
+
+            assert_eq!(lines, ["2321924 11077"], "argv: {argv:?}");
+        }
     }
 
     #[test]

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -402,9 +402,7 @@ mod tests {
 
     #[test]
     fn memory_columns_render_as_raw_megabytes_with_and_without_noconvert() {
-        // The flag is inert only because these cells are already raw MB. Driving the
-        // real render path pins that: humanizing memory_mb or free_memory_mb later
-        // turns this red, which a parse-only test would not.
+        // Pins that %m/%e are raw MB today; humanizing them later turns this red.
         let mut node = make_node("gpu001", NodeState::NodeIdle, "gpu");
         node.total_resources = Some(ResourceSet {
             memory_mb: 2_321_924,

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -45,6 +45,11 @@ pub struct SinfoArgs {
     #[arg(short = 'h', long)]
     pub noheader: bool,
 
+    /// Report values without unit conversion. Accepted for Slurm compatibility:
+    /// Spur already emits unconverted values, so there is nothing to suppress.
+    #[arg(long)]
+    pub noconvert: bool,
+
     /// Controller address
     #[arg(
         long,
@@ -387,6 +392,26 @@ mod tests {
         let args = parse_sinfo_args(&["sinfo", "-t", "idle"]);
         let req = build_get_nodes_request(&args).unwrap();
         assert_eq!(req.states, vec![NodeState::NodeIdle as i32]);
+    }
+
+    #[test]
+    fn noconvert_is_accepted() {
+        // Slurm scripts pass --noconvert to keep output machine-parseable.
+        let args = parse_sinfo_args(&["sinfo", "--noconvert"]);
+        assert!(args.noconvert);
+    }
+
+    #[test]
+    fn noconvert_changes_nothing_else() {
+        // Spur never humanizes units, so the flag has nothing to suppress. If unit
+        // conversion is ever added, this is what should force the flag to be honoured.
+        let plain = parse_sinfo_args(&["sinfo", "-N", "-h", "-o", "%n %m"]);
+        let flagged = parse_sinfo_args(&["sinfo", "-N", "-h", "-o", "%n %m", "--noconvert"]);
+        assert_eq!(plain.format, flagged.format);
+        assert_eq!(plain.noheader, flagged.noheader);
+        assert_eq!(plain.node_oriented, flagged.node_oriented);
+        assert!(!plain.noconvert);
+        assert!(flagged.noconvert);
     }
 
     #[test]

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -57,6 +57,11 @@ pub struct SqueueArgs {
     #[arg(short = 'h', long)]
     pub noheader: bool,
 
+    /// Report values without unit conversion. Accepted for Slurm compatibility:
+    /// Spur already emits unconverted values, so there is nothing to suppress.
+    #[arg(long)]
+    pub noconvert: bool,
+
     /// Print help
     #[arg(long, action = clap::ArgAction::Help)]
     pub help: Option<bool>,
@@ -458,6 +463,27 @@ mod tests {
         // -h is reclaimed for --noheader, but --help must still print help.
         let err = SqueueArgs::try_parse_from(["squeue", "--help"]).unwrap_err();
         assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
+    }
+
+    #[test]
+    fn noconvert_is_accepted() {
+        // Slurm scripts pass --noconvert to keep output machine-parseable.
+        let args = SqueueArgs::try_parse_from(["squeue", "--noconvert"]).unwrap();
+        assert!(args.noconvert);
+    }
+
+    #[test]
+    fn noconvert_changes_nothing_else() {
+        // Spur never humanizes units, so the flag has nothing to suppress. If unit
+        // conversion is ever added, this is what should force the flag to be honoured.
+        let plain = SqueueArgs::try_parse_from(["squeue", "-h", "-o", "%i %m"]).unwrap();
+        let flagged =
+            SqueueArgs::try_parse_from(["squeue", "-h", "-o", "%i %m", "--noconvert"]).unwrap();
+        assert_eq!(plain.format, flagged.format);
+        assert_eq!(plain.noheader, flagged.noheader);
+        assert_eq!(plain.long, flagged.long);
+        assert!(!plain.noconvert);
+        assert!(flagged.noconvert);
     }
 
     #[test]

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -57,8 +57,7 @@ pub struct SqueueArgs {
     #[arg(short = 'h', long)]
     pub noheader: bool,
 
-    /// Report values without unit conversion. Accepted for Slurm compatibility:
-    /// Spur already emits unconverted values, so there is nothing to suppress.
+    /// Accepted for Slurm compatibility; has no effect
     #[arg(long)]
     pub noconvert: bool,
 
@@ -470,20 +469,6 @@ mod tests {
         // Slurm scripts pass --noconvert to keep output machine-parseable.
         let args = SqueueArgs::try_parse_from(["squeue", "--noconvert"]).unwrap();
         assert!(args.noconvert);
-    }
-
-    #[test]
-    fn noconvert_changes_nothing_else() {
-        // Spur never humanizes units, so the flag has nothing to suppress. If unit
-        // conversion is ever added, this is what should force the flag to be honoured.
-        let plain = SqueueArgs::try_parse_from(["squeue", "-h", "-o", "%i %m"]).unwrap();
-        let flagged =
-            SqueueArgs::try_parse_from(["squeue", "-h", "-o", "%i %m", "--noconvert"]).unwrap();
-        assert_eq!(plain.format, flagged.format);
-        assert_eq!(plain.noheader, flagged.noheader);
-        assert_eq!(plain.long, flagged.long);
-        assert!(!plain.noconvert);
-        assert!(flagged.noconvert);
     }
 
     #[test]

--- a/docs/migration-from-slurm.rst
+++ b/docs/migration-from-slurm.rst
@@ -56,7 +56,7 @@ noted as "accepted for compatibility" parse without error but have no effect yet
    * - Partitions
      - Defined in ``spur.conf``; there is no runtime ``scontrol create/update/delete partition``. Edit the config and reload the controller to change a partition.
    * - ``squeue``/``sinfo`` ``--noconvert``
-     - Accepted for compatibility; Spur already reports raw values (memory in MB), so there is nothing to suppress. Slurm also defines the flag on ``sacct``, ``sstat``, ``sshare`` and ``sreport``, where it is not accepted yet.
+     - Accepted for compatibility; Spur already reports raw values where applicable (``sinfo``'s memory columns are MB integers; ``squeue`` has no memory column yet), so there is nothing to suppress. Slurm also defines the flag on ``sacct``, ``sstat``, ``sshare`` and ``sreport``, where it is not accepted yet.
    * - ``sacct --jobs``
      - Accepted for compatibility; the job-id filter is not yet applied server-side.
    * - ``sacct`` ``ReqMem``

--- a/docs/migration-from-slurm.rst
+++ b/docs/migration-from-slurm.rst
@@ -55,10 +55,8 @@ noted as "accepted for compatibility" parse without error but have no effect yet
      - Difference
    * - Partitions
      - Defined in ``spur.conf``; there is no runtime ``scontrol create/update/delete partition``. Edit the config and reload the controller to change a partition.
-   * - ``squeue --sort``
-     - Accepted for compatibility; result ordering is not yet applied.
-   * - ``sinfo --states``
-     - Accepted for compatibility; the state filter is not yet applied (all node states are returned).
+   * - ``squeue``/``sinfo`` ``--noconvert``
+     - Accepted for compatibility; Spur already reports raw values (memory in MB), so there is nothing to suppress. Slurm also defines the flag on ``sacct``, ``sstat``, ``sshare`` and ``sreport``, where it is not accepted yet.
    * - ``sacct --jobs``
      - Accepted for compatibility; the job-id filter is not yet applied server-side.
    * - ``sacct`` ``ReqMem``


### PR DESCRIPTION
## Summary

`squeue` and `sinfo` did not define Slurm's `--noconvert`, so `clap` rejected it as an
unknown argument and the command exited non-zero having done nothing:

```
$ squeue --noconvert
Error: error: unexpected argument '--noconvert' found

Usage: squeue [OPTIONS]
```

`--noconvert` is widely scripted in Slurm to keep output machine-parseable, so a wrapper
carried over from Slurm fails at the argument parser rather than at anything real. The user
sees an argument error, not a scheduler problem.

## Approach

The flag is accepted and deliberately does nothing, because Spur already produces what it
asks for. In Slurm, `--noconvert` means "do not humanize units" — print `2048` rather than
`2G`. Spur never humanizes units in these commands:

- `sinfo` renders memory as `r.memory_mb.to_string()` and `node.free_memory_mb.to_string()`
  — raw integers, no suffix.
- `format_engine.rs` contains no unit conversion of any kind.
- The CLI's only `format_bytes` lives in `sdiag.rs`, an unrelated command.

So accepting the flag without branching on it is the correct implementation rather than a
stub, and output is byte-identical whether or not it is passed. Confirmed on a running
cluster:

```
$ sinfo --noconvert -N -o '%n %m %e'
HOSTNAMES MEMORY FREE_MEM
node01    24035  11077
```

Long-only, matching Slurm, which gives `--noconvert` no short form.

## Design notes

**Inertness is pinned by a test, not a comment.** `noconvert_changes_nothing_else` asserts
that parsing with the flag leaves every other output-affecting argument identical. If unit
conversion is ever added to these commands, that test is the thing that should force someone
to decide whether the flag must now be honoured. A comment would not.

**No unit conversion was added.** Implementing conversion so the flag had something to
disable would change the output of every existing user to make a compatibility flag
meaningful — a far larger change than the incompatibility it fixes.

**Not swallowed by a catch-all.** Accepting arbitrary unknown arguments would fix this
invocation and hide genuine typos and future incompatibilities, turning a loud failure into
a silent one. The flag is declared explicitly.

## Compatibility

No change to persisted state, the Raft log, proto, the config schema, or any existing flag,
default, or output format. Purely additive: an invocation that used to fail now succeeds, and
every other invocation behaves exactly as before.

## Testing

`cargo test --locked` → **2894 passed, 0 failed, 25 ignored** (ignored tests need
PostgreSQL). Four new tests, two per command, following each file's existing arg-test idiom.

Gates green: `cargo fmt --all --check`; `cargo clippy --workspace --exclude spur-ffi
--all-targets --locked` with `RUSTFLAGS="-D warnings"`; `cargo test --locked`;
`cargo deny check` (`advisories ok, bans ok, licenses ok, sources ok`).

The failure was reproduced against a built binary before the fix, and the fix verified
against a live single-node cluster afterwards:

| Check | Result |
|---|---|
| `squeue --noconvert` before the change | `unexpected argument '--noconvert' found`, exit 1 |
| `sinfo --noconvert` before the change | `unexpected argument '--noconvert' found`, exit 1 |
| `diff` of `squeue` vs `squeue --noconvert` | **empty**, both exit 0 |
| `diff` of `sinfo` vs `sinfo --noconvert` | **empty**, both exit 0 |
| `squeue --noconvert -h -o '%i %m'` | exit 0 |
| `squeue --help`, `sinfo --help` | `--noconvert` documented |

The two empty diffs are the checks that matter: they are what guarantee no existing user's
output moved.

## Scope: the other four commands

Slurm also defines `--noconvert` on `sacct`, `sstat`, `sshare` and `sreport`, and none of
them accept it after this change, so a migrated script that uses it there still hits the
same clap error one command later. That is deliberately left out of this PR and tracked as
a follow-up, for one reason: on `sacct`, `sshare` and `sreport` the flag would be inert as
it is here, but on `sstat` it would not. `sstat` renders `format!("{}M", res.memory_mb)`,
so that output is genuinely unit-suffixed and the flag has something to suppress. Honouring
it there means changing what an existing command prints, which is a different kind of
change from accepting an inert flag and deserves its own review rather than riding along
with this one.

`docs/migration-from-slurm.rst` records both halves: that the flag is accepted and inert on
`squeue` and `sinfo`, and that the other four do not accept it yet.

## Two unrelated rows removed from that table

While adding the row: the `squeue --sort` and `sinfo --states` entries claimed both flags
are accepted but not applied, and both have since been implemented. Sorting is applied at
`squeue.rs:150` after `parse_sort_arg`, and node states are filtered server-side at
`server.rs:846` from the states the client puts in the request. A limitations table that
lists working features teaches migrating admins the wrong thing, so those two rows are
gone. No code changed for this.
