### PR TITLE
fix(spur-core): deny GPU visibility when zero devices are allocated

### DIFF
--- a/crates/spur-core/src/task_launch.rs
+++ b/crates/spur-core/src/task_launch.rs
@@ -224,12 +224,32 @@ pub fn apply_gpu_bind_env(
             .join(","),
     };
     if visible.is_empty() {
+        gpu_deny_visibility(target);
         return;
     }
     target.insert("SPUR_JOB_GPUS".into(), visible.clone());
     target.insert("ROCR_VISIBLE_DEVICES".into(), visible.clone());
     target.insert("CUDA_VISIBLE_DEVICES".into(), visible.clone());
     target.insert("GPU_DEVICE_ORDINAL".into(), visible);
+}
+
+/// Hide all GPUs from the common vendor runtimes for a zero-GPU job.
+///
+/// Unset/empty isn't reliably "no devices", so each selector gets a deny token:
+/// `-1` for the ROCm/CUDA/Level-Zero index selectors, `void` for
+/// nvidia-container-runtime, empty for Spur's own `SPUR_JOB_GPUS`. Advisory.
+pub fn gpu_deny_visibility(target: &mut HashMap<String, String>) {
+    for var in [
+        "ROCR_VISIBLE_DEVICES",
+        "HIP_VISIBLE_DEVICES",
+        "CUDA_VISIBLE_DEVICES",
+        "GPU_DEVICE_ORDINAL",
+        "ZE_AFFINITY_MASK",
+    ] {
+        target.insert(var.to_string(), "-1".to_string());
+    }
+    target.insert("NVIDIA_VISIBLE_DEVICES".to_string(), "void".to_string());
+    target.insert("SPUR_JOB_GPUS".to_string(), String::new());
 }
 
 /// True when env requests CPU bind that the single-`mpirun` PMIx wrapper does not apply.
@@ -922,6 +942,48 @@ mod tests {
         apply_gpu_bind_env(&mut target, &env, &[0, 1]);
         assert_eq!(target.get("ROCR_VISIBLE_DEVICES").unwrap(), "2,3");
         assert_eq!(target.get("SPUR_JOB_GPUS").unwrap(), "2,3");
+    }
+
+    #[test]
+    fn gpu_deny_visibility_sets_no_device_sentinels() {
+        let mut env = HashMap::new();
+        gpu_deny_visibility(&mut env);
+        for var in [
+            "ROCR_VISIBLE_DEVICES",
+            "HIP_VISIBLE_DEVICES",
+            "CUDA_VISIBLE_DEVICES",
+            "GPU_DEVICE_ORDINAL",
+            "ZE_AFFINITY_MASK",
+        ] {
+            assert_eq!(
+                env.get(var).map(String::as_str),
+                Some("-1"),
+                "{var} must be -1 (invalid index = no devices)"
+            );
+        }
+        // nvidia-container-runtime has its own no-GPU token, not an index.
+        assert_eq!(
+            env.get("NVIDIA_VISIBLE_DEVICES").map(String::as_str),
+            Some("void")
+        );
+        // Spur's own allocated-GPU list: empty is "none", not a device index.
+        assert_eq!(env.get("SPUR_JOB_GPUS").map(String::as_str), Some(""));
+    }
+
+    #[test]
+    fn apply_gpu_bind_env_denies_when_no_gpus_allocated() {
+        let mut target = HashMap::new();
+        let mut source = HashMap::new();
+        source.insert("SPUR_GPU_BIND".to_string(), "closest".to_string());
+        apply_gpu_bind_env(&mut target, &source, &[]);
+        assert_eq!(
+            target.get("ROCR_VISIBLE_DEVICES").map(String::as_str),
+            Some("-1")
+        );
+        assert_eq!(
+            target.get("CUDA_VISIBLE_DEVICES").map(String::as_str),
+            Some("-1")
+        );
     }
 
     #[test]

--- a/crates/spur-core/src/task_launch.rs
+++ b/crates/spur-core/src/task_launch.rs
@@ -213,6 +213,12 @@ pub fn apply_gpu_bind_env(
     else {
         return;
     };
+    // Zero allocated GPUs is authoritative: deny regardless of bind mode, so a
+    // map_gpu/mask_gpu cannot name a device the job was not granted.
+    if allocated.is_empty() {
+        gpu_deny_visibility(target);
+        return;
+    }
     let bind = bind_str.parse::<GpuBind>().unwrap_or(GpuBind::None);
     let visible = match bind {
         GpuBind::Map(ids) => ids,
@@ -975,6 +981,22 @@ mod tests {
         let mut target = HashMap::new();
         let mut source = HashMap::new();
         source.insert("SPUR_GPU_BIND".to_string(), "closest".to_string());
+        apply_gpu_bind_env(&mut target, &source, &[]);
+        assert_eq!(
+            target.get("ROCR_VISIBLE_DEVICES").map(String::as_str),
+            Some("-1")
+        );
+        assert_eq!(
+            target.get("CUDA_VISIBLE_DEVICES").map(String::as_str),
+            Some("-1")
+        );
+    }
+
+    #[test]
+    fn apply_gpu_bind_env_denies_map_gpu_when_no_gpus_allocated() {
+        let mut target = HashMap::new();
+        let mut source = HashMap::new();
+        source.insert("SPUR_GPU_BIND".to_string(), "map_gpu:0".to_string());
         apply_gpu_bind_env(&mut target, &source, &[]);
         assert_eq!(
             target.get("ROCR_VISIBLE_DEVICES").map(String::as_str),

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1429,6 +1429,9 @@ impl SlurmAgent for AgentService {
 
         if let Some(ref mut cfg) = container_config {
             cfg.environment = env.clone();
+            // container_env (user `--container-env`) is layered over environment
+            // at launch, so a zero-GPU job could re-enable visibility through it.
+            maybe_deny_gpu_env(&mut cfg.container_env, &allocated_device_ids);
         }
 
         let cpu_ids: Vec<u32> = alloc_result.cpu_ids.clone();

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -33,6 +33,38 @@ use crate::executor;
 use crate::mpi_plugin::{self, MpiPluginHost, PmixLaunchGuard};
 use crate::reporter::NodeReporter;
 
+/// Apply GPU-deny sentinels to a job env when no GPUs were allocated.
+///
+/// Keeps the GPU-job path untouched; only zero-GPU jobs are forced to "no
+/// devices" so they cannot inherit the runtime's all-visible default.
+fn maybe_deny_gpu_env(env: &mut HashMap<String, String>, allocated_device_ids: &[u32]) {
+    if allocated_device_ids.is_empty() {
+        spur_core::task_launch::gpu_deny_visibility(env);
+    }
+}
+
+#[cfg(test)]
+mod gpu_deny_tests {
+    use std::collections::HashMap;
+
+    #[test]
+    fn empty_allocation_denies_gpu_env() {
+        let mut env = HashMap::new();
+        super::maybe_deny_gpu_env(&mut env, &[]);
+        assert_eq!(
+            env.get("ROCR_VISIBLE_DEVICES").map(String::as_str),
+            Some("-1")
+        );
+    }
+
+    #[test]
+    fn nonempty_allocation_leaves_gpu_env_untouched() {
+        let mut env = HashMap::new();
+        super::maybe_deny_gpu_env(&mut env, &[0u32, 1]);
+        assert!(!env.contains_key("ROCR_VISIBLE_DEVICES"));
+    }
+}
+
 pub(crate) struct TrackedJob {
     job: executor::RunningJob,
     rootfs_mode: crate::container::RootfsMode,
@@ -1393,6 +1425,8 @@ impl SlurmAgent for AgentService {
             }
         }
 
+        maybe_deny_gpu_env(&mut env, &allocated_device_ids);
+
         if let Some(ref mut cfg) = container_config {
             cfg.environment = env.clone();
         }
@@ -1947,7 +1981,7 @@ impl SlurmAgent for AgentService {
             .position(|n| *n == agent_hostname)
             .unwrap_or(0) as u32;
 
-        let gpu_env = if gpu_devices.is_empty() {
+        let mut gpu_env = if gpu_devices.is_empty() {
             HashMap::new()
         } else {
             self.device_registry
@@ -1960,6 +1994,7 @@ impl SlurmAgent for AgentService {
                 .0
                 .env
         };
+        maybe_deny_gpu_env(&mut gpu_env, &gpu_devices);
 
         let mut senv = SpurEnv::new();
         senv.extend(&req.environment);

--- a/tests/native_host/e2e/test_gpu_deny.py
+++ b/tests/native_host/e2e/test_gpu_deny.py
@@ -57,3 +57,25 @@ class TestGpuVisibilityDeny:
         code, output = cluster.srun_with_exit(["-N", "1", "bash", "-c", _probe_body()])
         assert code == 0, f"srun step failed (exit {code}):\n{output}"
         _assert_all_denied(output, f"exit {code}\noutput:\n{output}")
+
+    def test_zero_gpu_container_denies_user_container_env(self, cluster, tmp_path):
+        # --container-env is layered over the base env at launch, so a zero-GPU
+        # job must not be able to re-enable GPUs by setting it.
+        cluster.container_preflight()
+        img = cluster.build_container_image(tmp_path)
+        script = cluster.write_file("gpu-deny-ctr.sh", f"#!/bin/bash\n{_probe_body()}")
+        out_path = f"{cluster.remote_dir}/gpu-deny-ctr.out"
+
+        sb = cluster.sbatch([
+            "-J", "gpu-deny-ctr", "-N", "1",
+            f"--container-image={img}",
+            "--container-env", "CUDA_VISIBLE_DEVICES=0",
+            "--container-env", "NVIDIA_VISIBLE_DEVICES=all",
+            "-o", out_path, script,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch failed: {sb}"
+
+        wait_job(cluster, job_id, timeout=120)
+        content = cluster.wait_output(out_path, "DENY_OK", timeout=120)
+        _assert_all_denied(content, f"{cluster.debug_job(job_id)}\noutput:\n{content}")

--- a/tests/native_host/e2e/test_gpu_deny.py
+++ b/tests/native_host/e2e/test_gpu_deny.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for zero-GPU visibility deny.
+
+A job allocated no GPUs must have the vendor GPU selectors set to a "no device"
+token (invalid index -1 for ROCm/CUDA, `void` for the nvidia-container-runtime)
+and SPUR_JOB_GPUS empty, so runtimes see no devices instead of defaulting to
+all-visible. These need no GPU hardware; the assertions are on env values.
+"""
+
+from cluster import parse_job_id, wait_job
+
+# Deny tokens gpu_deny_visibility writes for a zero-GPU job: -1 for the ROCm/CUDA
+# index selectors, `void` for nvidia-container-runtime, empty for Spur's own list.
+_EXPECTED_DENY = {
+    "ROCR_VISIBLE_DEVICES": "-1",
+    "HIP_VISIBLE_DEVICES": "-1",
+    "CUDA_VISIBLE_DEVICES": "-1",
+    "GPU_DEVICE_ORDINAL": "-1",
+    "ZE_AFFINITY_MASK": "-1",
+    "NVIDIA_VISIBLE_DEVICES": "void",
+    "SPUR_JOB_GPUS": "",
+}
+
+
+def _probe_body() -> str:
+    # ${VAR+SET} prints "SET" only when VAR is defined, distinguishing a denied
+    # value from an unset var (the pre-fix state).
+    lines = "\n".join(f'echo "{v}:${{{v}+SET}}:[${{{v}-}}]"' for v in _EXPECTED_DENY)
+    return f"{lines}\necho DENY_OK\n"
+
+
+def _assert_all_denied(output: str, context: str) -> None:
+    for var, expected in _EXPECTED_DENY.items():
+        assert f"{var}:SET:[{expected}]" in output, (
+            f"{var} must be denied ([{expected}]) for a zero-GPU job.\n{context}"
+        )
+
+
+class TestGpuVisibilityDeny:
+    def test_zero_gpu_batch_job_denies_visibility(self, cluster):
+        script = cluster.write_file("gpu-deny.sh", f"#!/bin/bash\n{_probe_body()}")
+        out_path = f"{cluster.remote_dir}/gpu-deny.out"
+
+        sb = cluster.sbatch(["-J", "gpu-deny", "-N", "1", "-o", out_path, script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch failed: {sb}"
+
+        wait_job(cluster, job_id, timeout=120)
+        content = cluster.wait_output(out_path, "DENY_OK", timeout=120)
+        _assert_all_denied(content, f"{cluster.debug_job(job_id)}\noutput:\n{content}")
+
+    def test_zero_gpu_srun_step_denies_visibility(self, cluster):
+        # A standalone srun step launches via run_command, a different path than
+        # sbatch, so a zero-GPU step must be denied there too.
+        code, output = cluster.srun_with_exit(["-N", "1", "bash", "-c", _probe_body()])
+        assert code == 0, f"srun step failed (exit {code}):\n{output}"
+        _assert_all_denied(output, f"exit {code}\noutput:\n{output}")

--- a/tests/native_host/e2e/test_gpu_deny.py
+++ b/tests/native_host/e2e/test_gpu_deny.py
@@ -58,6 +58,15 @@ class TestGpuVisibilityDeny:
         assert code == 0, f"srun step failed (exit {code}):\n{output}"
         _assert_all_denied(output, f"exit {code}\noutput:\n{output}")
 
+    def test_zero_gpu_srun_gpu_bind_map_denies_visibility(self, cluster):
+        # --gpu-bind=map_gpu:0 names a device directly; a zero-GPU step must
+        # still be denied rather than exposing GPU 0.
+        code, output = cluster.srun_with_exit(
+            ["-N", "1", "--gpu-bind=map_gpu:0", "bash", "-c", _probe_body()]
+        )
+        assert code == 0, f"srun step failed (exit {code}):\n{output}"
+        _assert_all_denied(output, f"exit {code}\noutput:\n{output}")
+
     def test_zero_gpu_container_denies_user_container_env(self, cluster, tmp_path):
         # --container-env is layered over the base env at launch, so a zero-GPU
         # job must not be able to re-enable GPUs by setting it.


### PR DESCRIPTION
## What & why
A job allocated zero GPUs previously left `ROCR_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` and friends **unset**, so ROCm/CUDA and the nvidia-container-runtime defaulted to *all devices visible*. On a shared node this let a co-scheduled zero-GPU job reach another user's GPUs. This closes the advisory (Phase 0) half of SPUR-192.

## Approach
New `gpu_deny_visibility` helper in `spur-core::task_launch` writes explicit "no device" tokens when the allocation is empty:
- **`-1`** for the ROCm/CUDA/Level-Zero index selectors (`ROCR_`/`HIP_`/`CUDA_VISIBLE_DEVICES`, `GPU_DEVICE_ORDINAL`, `ZE_AFFINITY_MASK`) — an empty string is not reliably "none".
- **`void`** for `NVIDIA_VISIBLE_DEVICES` — highest precedence (`void > none > all`), so it overrides the `NVIDIA_VISIBLE_DEVICES=all` baked into `nvidia/cuda` base images.
- **empty** for `SPUR_JOB_GPUS` — Spur's own allocated-GPU list, where empty already means "none".

Applied on the batch/host and container paths (`launch_job`) and the srun-step path (`run_command`). GPU jobs are unaffected.

## Notes & trade-offs
- **Advisory, not enforced.** A user can re-export these vars; this only changes the launch-time default from all-visible to deny. The durable, kernel-enforced fix is the Phase 1 device cgroup.
- **Behavior change.** Every zero-GPU job now has these vars *present* (previously unset), and any user-supplied `*_VISIBLE_DEVICES` are overridden at launch for zero-GPU jobs.
- **Not covered here:** `exec_in_job` and `--pty`/attach enter a running job via `nsenter`, bypassing the launch env path — deferred to the Phase 1 cgroup, which constrains every process in the job.

## Testing
- `spur-core` + `spurd` unit tests for the helper, the `--gpu-bind` path, and the spurd deny wiring.
- Hardware-independent e2e test (`test_gpu_deny.py`) submitting zero-GPU `sbatch` and `srun` jobs and asserting the exact tokens.
- `cargo clippy --workspace --exclude spur-ffi --all-targets` clean; `cargo test` green.
- That the runtimes actually honor these tokens (empty vs `-1`) is confirmed on GPU nodes via CI.