### PR TITLE
docs(config): document per-field reload scope for scontrol reconfigure

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,6 +50,7 @@ Raft
 RDMA
 README
 reconfigure
+reloadable
 requeue
 requeued
 requeues
@@ -132,6 +133,7 @@ env
 ExitCode
 failover
 filesystem
+forgeable
 forks
 gapped
 GiB

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -222,10 +222,9 @@ pub enum ScontrolCommand {
         #[arg(long)]
         name: String,
     },
-    /// Re-read spur.conf and apply it live on the leader (partitions, nodes,
-    /// licenses, controller hooks, complete_wait_secs/resv_overrun_minutes, etc.).
-    /// Ports/DB/raft/jwt_key, the scheduler loop cadence, and node-side settings
-    /// need a restart; followers converge on restart.
+    /// Re-read spur.conf and apply it live on the leader. Ports, accounting DB,
+    /// raft, jwt_key, the scheduler loop cadence, and node-side settings need a
+    /// restart; followers converge on restart.
     Reconfigure,
     /// Create a reservation
     #[command(name = "create-reservation")]
@@ -1511,7 +1510,7 @@ async fn reconfigure(controller: &str) -> Result<()> {
     client.reconfigure(()).await.context("reconfigure failed")?;
 
     println!(
-        "Reconfiguration complete on the leader (followers converge on restart; listen ports, accounting DB, raft peers, and jwt_key still require a controller restart)"
+        "Reconfiguration complete on the leader. Followers converge on restart. Some settings are not reloadable: listen ports, accounting DB, Raft peers, jwt_key, and the scheduler loop cadence need a controller restart; node-side settings need a spurd restart."
     );
     Ok(())
 }

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -222,9 +222,9 @@ pub enum ScontrolCommand {
         #[arg(long)]
         name: String,
     },
-    /// Re-read spur.conf and apply it live on the leader. Ports, accounting DB,
-    /// raft, jwt_key, the scheduler loop cadence, and node-side settings need a
-    /// restart; followers converge on restart.
+    /// Re-read spur.conf and apply it live on the leader; followers converge on
+    /// restart. Not every field is reloadable — see docs/admin-guide/configuration.rst,
+    /// "Applying configuration changes", for the per-field reload scope.
     Reconfigure,
     /// Create a reservation
     #[command(name = "create-reservation")]
@@ -1510,7 +1510,9 @@ async fn reconfigure(controller: &str) -> Result<()> {
     client.reconfigure(()).await.context("reconfigure failed")?;
 
     println!(
-        "Reconfiguration complete on the leader. Followers converge on restart. Some settings are not reloadable: listen ports, accounting DB, Raft peers, jwt_key, and the scheduler loop cadence need a controller restart; node-side settings need a spurd restart."
+        "Reconfiguration complete on the leader. Followers converge on restart. \
+         Not every setting is reloadable — see the Reload column in \
+         docs/admin-guide/configuration.rst for what needs a controller or spurd restart."
     );
     Ok(())
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -168,8 +168,8 @@ pub struct MetricsConfig {
     /// `loopback` binds 127.0.0.1; `all` uses `listen_addr` as-is.
     #[serde(default)]
     pub bind: MetricsBind,
-    /// Reserved for `/metrics/jobs-users-accts` (high cardinality; off by default).
-    /// Route exists but returns 404 until a follow-up PR implements the exporter.
+    /// Serves `/metrics/jobs-users-accts`, which 404s while false. Off by default
+    /// because each job, user, and account becomes its own series.
     #[serde(default)]
     pub high_cardinality: bool,
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3464,7 +3464,8 @@ impl ClusterManager {
 
     /// Re-read spur.conf and apply it to the running controller. Leader-only, and
     /// the swap is in-memory here — no WAL entry carries it, so followers keep
-    /// their startup config. Per-field scope: docs/admin-guide/configuration.rst.
+    /// their startup config. Per-field scope: docs/admin-guide/configuration.rst,
+    /// "Applying configuration changes" section.
     pub fn reconfigure(&self) -> Result<(), anyhow::Error> {
         let Some(ref path) = self.config_path else {
             anyhow::bail!("reconfigure requires a config file path, but none is configured");
@@ -3572,7 +3573,7 @@ impl ClusterManager {
             self.reconcile_partitions(&mut nodes);
         }
 
-        info!("reconfigure: applied spur.conf on this leader (followers converge on restart); restart-only sections (listen ports, accounting DB, raft peers, jwt_key, scheduler cadence) unchanged until controller restart");
+        info!("reconfigure: applied spur.conf on the leader (followers converge on restart; see docs/admin-guide/configuration.rst, \"Applying configuration changes\", for per-field reload scope)");
         Ok(())
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3462,38 +3462,9 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Re-read spur.conf and apply it to the running controller.
-    ///
-    /// Makes the config file authoritative, matching `scontrol reconfigure`
-    /// semantics in Slurm: runtime-only changes not reflected in the conf are
-    /// overwritten by the incoming conf values.
-    ///
-    /// **Leader-only.** The command is forwarded to the Raft leader, and this
-    /// swaps only the leader's in-memory config — no WAL entry carries the new
-    /// config. Followers keep the config they read at startup until they
-    /// restart (in Kubernetes they re-read the same ConfigMap). Do not rely on
-    /// reconfigured non-partition state surviving an immediate failover.
-    /// Partition edits DO propagate (via partition WAL ops), but a follower
-    /// re-runs `reconcile_partitions` against its own stale `config().nodes`,
-    /// so after a partition edit followers pick up new partition membership but
-    /// keep old node features until restart. WAL-propagating config is a
-    /// planned follow-up.
-    ///
-    /// Reloaded live on the leader (readers take a fresh snapshot via
-    /// `config()`): `[[partitions]]`, `[[nodes]]` features/weight, `licenses`,
-    /// `burst_buffer`, `scheduler` tunables (`complete_wait`, `resv_overrun`),
-    /// `controller.max_batch_requeue`, `hooks`, `notifications`, `federation`,
-    /// `power` suspend/resume commands, `admission.mode`, and
-    /// `metrics.high_cardinality`.
-    ///
-    /// Restart-only (baked in at startup — mirrors Slurm's restart-required set
-    /// of ports/plugins/StateSaveLocation/AuthType): bind addresses and ports
-    /// (`controller.listen_addr`, `metrics`/`rest_api` listeners), the
-    /// accounting database pool (`accounting.database_url`), Raft identity/peers,
-    /// `controller.first_job_id`, `auth.jwt_key` (swapping it live would
-    /// instantly invalidate every outstanding node token), and the scheduler
-    /// loop cadence (`scheduler.interval_secs`, `max_jobs_per_cycle`,
-    /// `topology`).
+    /// Re-read spur.conf and apply it to the running controller. Leader-only, and
+    /// the swap is in-memory here — no WAL entry carries it, so followers keep
+    /// their startup config. Per-field scope: docs/admin-guide/configuration.rst.
     pub fn reconfigure(&self) -> Result<(), anyhow::Error> {
         let Some(ref path) = self.config_path else {
             anyhow::bail!("reconfigure requires a config file path, but none is configured");

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -63,14 +63,6 @@ manager are all off unless explicitly configured.
    features = ["mi300x", "rocm6"]
    weight = 1
 
-   [network]
-   wg_enabled = false
-   agent_port = 6818
-
-   [logging]
-   level = "info"
-   format = "text"
-
 The full annotated example — including label selectors, account restrictions, and
 the k0s cluster manager — lives at ``examples/spur.conf`` in the repository.
 

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -15,14 +15,17 @@ and meaning.
    ``spurctld`` reads every section of ``spur.conf``. ``spurd`` reads the same file
    but only for local agent settings (``[hooks]``, ``[devices]``, ``rlimits.memlock``,
    ``[cluster]``, and ``[mpi]``); its identity and networking come from CLI flags.
-   Node CPU, memory, and GRES are declared to the controller under ``[[nodes]]`` here.
+   Node CPU, memory, and GRES are reported by each agent when it registers, not
+   declared here — ``[[nodes]]`` only overlays scheduling policy onto nodes that
+   have already registered.
 
 Minimal configuration
 ----------------------
 
-A working single-node configuration needs a cluster name, one partition, and the
-node(s) that back it. Accounting, WireGuard, and the k0s cluster manager are all
-off unless explicitly configured.
+A working single-node configuration needs a cluster name and one partition; nodes
+join by registering, so the ``[[nodes]]`` block below is optional and only tags
+them for ``--constraint`` matching. Accounting, WireGuard, and the k0s cluster
+manager are all off unless explicitly configured.
 
 .. code-block:: toml
 
@@ -56,16 +59,9 @@ off unless explicitly configured.
    priority_tier = 1
 
    [[nodes]]
-   names = "mi300"
-   cpus = 256
-   memory_mb = 2321924
-   gres = ["gpu:mi300x:8"]
-
-   [[nodes]]
-   names = "mi300-2"
-   cpus = 256
-   memory_mb = 2321904
-   gres = ["gpu:mi300x:8"]
+   names = "mi300,mi300-2"
+   features = ["mi300x", "rocm6"]
+   weight = 1
 
    [network]
    wg_enabled = false
@@ -78,27 +74,86 @@ off unless explicitly configured.
 The full annotated example — including label selectors, account restrictions, and
 the k0s cluster manager — lives at ``examples/spur.conf`` in the repository.
 
+.. _reload-scope:
+
+Applying configuration changes
+------------------------------
+
+After editing ``spur.conf``, ``scontrol reconfigure`` re-reads the file and applies
+it to the running controller, which makes the file authoritative: runtime-only
+changes made with ``scontrol update`` are overwritten by the file's values.
+``spurctld`` does not reload on ``SIGHUP`` — ``scontrol reconfigure`` is the only
+trigger.
+
+Not every field can be applied to a running daemon. Each section below records what
+its fields need in a **Reload** column — or, where every field in a section shares
+the same scope, in a single ``Reload:`` line above the table:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Reload
+     - Meaning
+   * - Live
+     - Applied by ``scontrol reconfigure``; no restart needed.
+   * - Restart
+     - Read once when ``spurctld`` starts. ``reconfigure`` re-reads the value but
+       does not apply it; restart the controller.
+   * - Agent restart
+     - Consumed by ``spurd`` on each compute node. ``reconfigure`` reaches only the
+       controller, so restart ``spurd`` on every node.
+   * - Client
+     - Read by the ``spur`` CLI from the submitting host on each invocation. Neither
+       ``reconfigure`` nor a daemon restart applies.
+   * - Not implemented
+     - Parsed and validated, but no code consumes it. Setting it has no effect.
+
+The restart-only set mirrors Slurm, where ports, ``StateSaveLocation``, ``AuthType``,
+and the plugin set also require a daemon restart.
+
+**Leader-only, in an HA cluster.** ``reconfigure`` is handled by the Raft leader and
+swaps only that controller's in-memory config; no Raft log entry carries the new
+file, so followers keep the config they loaded at startup until they restart (in
+Kubernetes they re-read the same ConfigMap). ``[[partitions]]`` is the exception —
+partition changes replicate through the write-ahead log — but a follower re-derives
+node features and weight from its own pre-reconfigure ``[[nodes]]`` blocks. Do not
+rely on reconfigured non-partition state surviving an immediate failover; roll the
+controllers to converge them.
+
+.. warning::
+
+   A partition removed from ``spur.conf`` is skipped rather than deleted when it
+   still has active jobs. ``scontrol reconfigure`` reports success either way, and
+   the skip is recorded only in the controller log. Drain a partition before
+   removing it from the file.
+
 Top-level keys
 --------------
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 20 20 40
+   :widths: 18 18 14 14 36
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``cluster_name``
      - string
      - **(required)**
+     - Live
      - Cluster name. An empty value fails to load with ``missing required field:
-       cluster_name``.
+       cluster_name``. Changing it live re-labels metrics mid-series; prefer a
+       restart.
    * - ``licenses``
      - table<string, integer>
      - ``{}``
+     - Live
      - Cluster-wide license pool, e.g. ``{ fluent = 20, comsol = 5 }``. Jobs
-       consume licenses via ``--licenses``.
+       consume licenses via ``--licenses``. Availability is derived as total minus
+       in-use, so changing a total cannot strand a running job's holding.
 
 ``[controller]``
 ----------------
@@ -108,63 +163,101 @@ and Raft high-availability topology.
 
 .. list-table::
    :header-rows: 1
-   :widths: 24 16 22 38
+   :widths: 24 12 18 14 32
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``listen_addr``
      - string
      - ``"[::]:6817"``
+     - Restart
      - gRPC listen address serving ``SlurmController`` and ``SlurmAccounting``.
    * - ``rest_addr``
      - string
      - ``"[::]:6820"``
+     - Restart
      - REST API listen address.
    * - ``hosts``
      - [string]
      - ``["localhost"]``
-     - Controller hostname(s); the first is primary. Clients and agents build
-       failover endpoints from these hosts plus the port of ``listen_addr``.
+     - Client
+     - Controller hostname(s); the first is primary. The CLI builds failover
+       endpoints from these hosts plus the port of ``listen_addr``. Read by the
+       CLI on each invocation, not by ``spurctld``.
    * - ``state_dir``
      - string
      - ``"/var/spool/spur"``
-     - Directory where the controller persists Raft log and scheduler state.
+     - Not implemented
+     - Ignored. The controller always uses its ``--state-dir`` flag, which
+       defaults to ``/var/spool/spur``.
    * - ``max_job_id``
      - integer
      - ``999999999``
-     - Highest job ID before the counter wraps.
+     - Not implemented
+     - Intended as the job-ID wrap point. No code consumes it; the counter does
+       not wrap.
    * - ``first_job_id``
      - integer
      - ``1``
+     - Restart
      - Job ID assigned to the first submitted job.
    * - ``peers``
      - [string]
      - ``[]``
+     - Restart
      - Raft HA peers as ``"host:port"``. Empty means single-node. The list must be
        identically ordered on every controller — node IDs derive from position.
        Example: ``["node1:6821", "node2:6821", "node3:6821"]``.
    * - ``node_id``
      - integer
      - none
+     - Restart
      - This controller's Raft ID. Normally unset (single-node always uses ``1``).
        When set it must fall in ``1..=peers.len()`` and equal this host's position
        in ``peers``.
    * - ``raft_listen_addr``
      - string
      - ``"[::]:6821"``
+     - Restart
      - Internal Raft gRPC listen address, separate from the client API.
    * - ``heartbeat_timeout_secs``
      - integer
      - none
+     - Restart
      - Seconds without a heartbeat before a node is marked Down. Unset by
        default; the controller applies a 90-second fallback when absent.
    * - ``max_batch_requeue``
      - integer
      - ``5``
+     - Live
      - Maximum automatic requeues (excluding preemption) before a job is held with
        ``JobHoldMaxRequeue``. Must be ``>= 1``; ``0`` is a validation error.
+   * - ``max_launch_backoff_secs``
+     - integer
+     - ``300``
+     - Live
+     - Upper bound on the exponential backoff applied before retrying a failed
+       job launch.
+   * - ``hold_on_prolog_fail``
+     - bool
+     - ``true``
+     - Live
+     - Hold a job whose ``prolog_slurmctld`` hook fails instead of requeuing it.
+   * - ``terminal_job_retention_secs``
+     - integer
+     - ``3600``
+     - Live
+     - How long a completed job stays in controller memory before eviction.
+       Accounting rows in PostgreSQL are unaffected.
+   * - ``dispatch_reject_cooldown_secs``
+     - integer
+     - ``30``
+     - Live
+     - How long a node is skipped for dispatch after rejecting a launch as
+       resources-unavailable.
 
 ``[accounting]``
 ----------------
@@ -175,30 +268,37 @@ in-process inside ``spurctld`` (served on port 6817) — there is no separate
 
 .. list-table::
    :header-rows: 1
-   :widths: 24 12 24 40
+   :widths: 24 10 20 14 32
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``database_url``
      - string
      - ``""``
+     - Restart
      - PostgreSQL connection string. A non-empty value enables accounting; empty
        disables it entirely. Example: ``"postgresql://spur:spur@localhost/spur"``.
+       The connection pool is built at startup.
    * - ``fairshare_refresh_secs``
      - integer
      - ``300``
+     - Restart
      - How often (seconds) to refresh fairshare and QOS caches from the database.
+       The interval is baked into the refresh loops when they are spawned.
    * - ``default_qos``
      - string
      - ``""``
+     - Live
      - Cluster-wide fallback QOS, applied at submit when a job resolves to no QOS
        (the analog of Slurm's ``normal``). Must name an existing QOS; empty means
        no fallback.
    * - ``require_qos``
      - bool
      - ``false``
+     - Live
      - Reject at submit any job that still has no QOS after the resolution chain.
        Mirrors Slurm's ``AccountingStorageEnforce=qos``.
 
@@ -212,31 +312,41 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 12 18 40
+   :widths: 28 10 16 14 32
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``plugin``
      - string
      - ``"backfill"``
-     - Scheduler plugin name.
+     - Restart
+     - Scheduler plugin name. Backfill is the only implemented scheduler; this
+       value is a display label reported by ``sdiag`` and does not select an
+       algorithm.
    * - ``interval_secs``
      - integer
      - ``1``
-     - How often (seconds) the scheduler runs.
+     - Restart
+     - How often (seconds) the scheduler runs. The loop cadence and the
+       preemption requeue hold are fixed at startup; the launch-backoff base
+       does re-read this value live.
    * - ``max_jobs_per_cycle``
      - integer
      - ``10000``
+     - Restart
      - Maximum number of jobs evaluated per scheduling cycle.
    * - ``fairshare_halflife_days``
      - integer
      - ``14``
+     - Restart
      - Fairshare usage decay half-life, in days.
    * - ``default_time_limit_minutes``
      - integer
      - ``0``
+     - Live
      - Cluster-wide fallback wall-time (minutes) for a job that sets no ``-t`` and
        lands on a partition with no ``DefaultTime``. ``0`` disables the fallback,
        leaving such jobs unbounded. Set > 0 to bound otherwise-unlimited jobs.
@@ -250,6 +360,7 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
    * - ``enforce_part_limits``
      - string
      - ``NO``
+     - Live
      - Whether partition wall-time limits are enforced at submit. ``NO`` admits
        over-limit jobs and lets them pend with a ``PartitionTimeLimit`` reason.
        ``ALL`` rejects unless the job fits every requested partition; ``ANY``
@@ -257,10 +368,12 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
    * - ``complete_wait_secs``
      - integer
      - ``300``
+     - Live
      - Maximum seconds a job may sit in COMPLETING before it is force-finished.
    * - ``inactive_limit_secs``
      - integer
      - ``0``
+     - Live
      - Reap an interactive allocation (``salloc``/``srun``) whose client has sent
        no keepalive for this many seconds, freeing the nodes. ``0`` (the default)
        disables reaping. Mirrors Slurm's ``InactiveLimit``. Once enabled, *every*
@@ -272,6 +385,7 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
    * - ``resv_overrun_minutes``
      - integer
      - ``0``
+     - Live
      - Grace minutes after a reservation ends before its still-running jobs are
        cancelled.
 
@@ -282,37 +396,58 @@ Authentication plugin for client requests.
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 16 20 44
+   :widths: 20 10 16 14 40
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``plugin``
      - string
      - ``"jwt"``
-     - Authentication plugin. ``jwt`` and ``none`` are the supported plugins;
-       ``none`` trusts the caller's OS identity (username and real UID/GID, with
-       admin granted to UID 0). The struct default is ``"jwt"``, but
-       ``examples/spur.conf`` ships ``"none"``.
+     - Not implemented
+     - Intended to select an authentication plugin. No code reads it, and no
+       plugin is enforced regardless of its value — see the warning below.
    * - ``jwt_key``
      - string
      - none
-     - JWT secret key, given as a file path or inline value. Required by the ``jwt``
-       plugin.
+     - Restart
+     - Signing key for node admission tokens, given as a file path or inline
+       value. Deliberately not reloadable: swapping it live would immediately
+       invalidate every outstanding node token.
+   * - ``allow_root_jobs``
+     - bool
+     - ``false``
+     - Agent restart
+     - Permit jobs to run as UID 0. Consumed by ``spurd`` at its own startup.
+
+.. warning::
+
+   ``[auth] plugin`` is inert. Setting it to ``"jwt"`` does **not** authenticate
+   RPCs — the controller accepts requests from anyone who can reach its gRPC port,
+   and ``spurctld`` warns about this at startup whenever it binds a non-loopback
+   address. Restrict access to the controller port at the network layer. See
+   :doc:`accounting` for how identity maps to accounts and admin rights.
 
 .. note::
 
-   ``munge`` is accepted as a value but is not documented here as a supported
-   plugin. Use ``jwt`` for cryptographic authentication or ``none`` to trust OS
-   identity. See :doc:`accounting` for how identity maps to accounts and admin
-   rights.
+   ``jwt_key`` is used for node admission tokens (``[admission] mode = "token"``),
+   which is a separate mechanism from the unimplemented ``plugin`` field. When
+   ``jwt_key`` is unset, admission tokens are signed with a well-known built-in
+   key and are therefore forgeable; set an explicit key before enabling token
+   admission.
 
 ``[[partitions]]``
 ------------------
 
 An array of tables — one ``[[partitions]]`` block per partition (queue). Membership
 is the union of the ``nodes`` hostlist pattern and the ``selector`` label match.
+
+**Reload: Live** for every field below. Partitions are the only section that also
+replicates to follower controllers, because ``reconfigure`` applies them through the
+write-ahead log rather than the in-memory config swap. A partition still running
+jobs is skipped rather than deleted (see :ref:`reload-scope`).
 
 .. list-table::
    :header-rows: 1
@@ -383,49 +518,72 @@ is the union of the ``nodes`` hostlist pattern and the ``selector`` label match.
 ``[[nodes]]``
 -------------
 
-An array of tables declaring node capacity to the controller. Match nodes by
-hostlist pattern (``names``) or by label (``selector``).
+An array of tables overlaying scheduling policy onto nodes. Match nodes by hostlist
+pattern (``names``) or by label (``selector``); an entry applies if **either**
+matches, and the first matching entry wins.
 
 .. list-table::
    :header-rows: 1
-   :widths: 22 18 16 44
+   :widths: 20 16 12 16 36
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``names``
      - string
      - ``""``
-     - Hostlist pattern, e.g. ``"gpu[001-008]"``. Optional when ``selector`` is used.
+     - Live
+     - Hostlist pattern, e.g. ``"gpu[001-008]"``, or the literal ``ALL``. Optional
+       when ``selector`` is used.
    * - ``selector``
      - table<string, string>
      - ``{}``
-     - Apply this config to nodes matching **all** key=value pairs.
+     - Live
+     - Apply this entry to nodes matching **all** key=value pairs.
    * - ``cpus``
      - integer
      - ``0``
-     - CPU count.
+     - Not implemented
+     - CPU count. Reported by the agent at registration; this value is ignored.
    * - ``memory_mb``
      - integer
      - ``0``
-     - Memory in MB.
+     - Not implemented
+     - Memory in MB. Reported by the agent at registration; this value is ignored.
    * - ``gres``
      - [string]
      - ``[]``
-     - Generic resources, e.g. ``["gpu:mi300x:8"]``.
+     - Not implemented
+     - Generic resources. Reported by the agent at registration; declare local
+       GRES pools under ``[devices]`` on the node instead.
    * - ``features``
      - [string]
      - ``[]``
-     - Node features/tags for ``--constraint`` matching.
+     - Live
+     - Node features/tags for ``--constraint`` matching. A node matching no entry
+       has its features cleared.
    * - ``address``
      - string
      - none
-     - Override address when it differs from the hostname.
+     - Live
+     - Fallback address used until the agent registers one. It never overrides an
+       address an agent has already reported.
    * - ``weight``
      - integer
      - ``1``
-     - Scheduling weight; higher is preferred.
+     - Live
+     - Scheduling weight; higher is preferred. Reset to ``1`` for a node matching
+       no entry.
+
+.. note::
+
+   ``[[nodes]]`` is not a node roster. A node joins the cluster when ``spurd``
+   registers with the controller, so adding a block here does not create a node,
+   and removing one does not remove a node — it only clears that node's features
+   and weight. Remove a node with ``spur node remove <node>``. This differs from
+   Slurm, where ``NodeName=`` lines in ``slurm.conf`` define the roster.
 
 ``[network]``
 -------------
@@ -434,36 +592,56 @@ WireGuard mesh networking and the agent port.
 
 .. list-table::
    :header-rows: 1
-   :widths: 22 12 24 42
+   :widths: 24 10 18 16 32
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``wg_enabled``
      - bool
      - ``false``
-     - Enable WireGuard mesh networking.
+     - Not implemented
+     - Intended to enable WireGuard mesh networking. No code reads it; the mesh
+       is driven by ``[cluster] enabled`` instead.
    * - ``wg_cidr``
      - string
      - ``"10.44.0.0/16"``
+     - Restart
      - CIDR for WireGuard address allocation. Validated as an IPv4 CIDR when
        ``[cluster]`` is enabled.
    * - ``wg_interface``
      - string
      - ``"spur0"``
-     - WireGuard interface name.
+     - Not implemented
+     - Superseded by the ``SPUR_WG_INTERFACE`` environment variable read by
+       ``spurd``, which defaults to ``spur0``.
    * - ``wg_port``
      - integer
      - ``51820``
-     - WireGuard listen port.
+     - Not implemented
+     - Intended as the WireGuard listen port. No code reads it.
    * - ``agent_port``
      - integer
      - ``6818``
-     - ``spurd`` agent gRPC listen port.
+     - Not implemented
+     - Each agent advertises its own port at registration, and the controller
+       falls back to ``6818`` when it does not. Set the agent's port through its
+       ``--listen`` address instead.
+   * - ``reject_loopback_comm_addr``
+     - bool
+     - ``false``
+     - Live
+     - Reject a node registration whose advertised address is a loopback
+       address, which would otherwise make the node unreachable from the
+       controller.
 
 ``[logging]``
 -------------
+
+**Reload: Not implemented** for every field below. The section is parsed but no
+daemon reads it.
 
 .. list-table::
    :header-rows: 1
@@ -476,20 +654,25 @@ WireGuard mesh networking and the agent port.
    * - ``level``
      - string
      - ``"info"``
-     - Log level.
+     - Intended log level. Use the ``--log-level`` flag or the ``RUST_LOG``
+       environment variable instead.
    * - ``format``
      - string
      - ``"text"``
-     - Log format.
+     - Intended log format. Output format is not configurable.
    * - ``file``
      - string
      - none
-     - Log file path. Unset logs to stderr.
+     - Intended log file path. Logging to a file is not implemented; daemons log
+       to stderr, so redirect via the service manager (for example systemd's
+       journal) instead.
 
 ``[rlimits]``
 -------------
 
 POSIX ``RLIMIT_*`` values ``spurd`` applies to job steps at launch.
+
+**Reload: Agent restart.**
 
 .. list-table::
    :header-rows: 1
@@ -517,36 +700,69 @@ POSIX ``RLIMIT_*`` values ``spurd`` applies to job steps at launch.
 
 PMIx plugin settings for ``--mpi=pmix`` jobs (batch launch and ``srun`` steps).
 
+Plugin loading happens on the node, so those fields need an agent restart; the
+per-step directory and timeouts are sent by the controller with each dispatch and
+are reloadable.
+
 .. list-table::
    :header-rows: 1
-   :widths: 18 12 22 48
+   :widths: 26 10 18 16 30
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``plugin_dir``
      - string
      - ``"/usr/lib/spur"``
+     - Agent restart
      - Directory searched for the PMIx plugin when ``pmix_plugin`` is unset.
    * - ``pmix_plugin``
      - string
      - ``""``
+     - Agent restart
      - Explicit path to the PMIx plugin. When empty, the plugin resolves to
        ``<plugin_dir>/spur_mpi_pmix.so``.
-   * - ``pmix_tmpdir``
-     - string
-     - ``"/tmp/spur-pmix"``
-     - Base directory for per-step PMIx scratch (namespace and rank state).
    * - ``pmix_min_version``
      - string
      - ``"4.1.0"``
+     - Agent restart
      - Minimum PMIx library version accepted when loading the plugin.
+   * - ``pmix_tmpdir``
+     - string
+     - ``"/tmp/spur-pmix"``
+     - Live
+     - Base directory for per-step PMIx scratch (namespace and rank state).
+   * - ``modex_connect_timeout_secs``
+     - integer
+     - ``5``
+     - Live
+     - Timeout for a step's initial connection to the PMIx modex.
+   * - ``modex_fence_timeout_secs``
+     - integer
+     - ``120``
+     - Live
+     - Timeout for a collective fence across the step's ranks.
+   * - ``modex_verify_timeout_secs``
+     - integer
+     - ``30``
+     - Live
+     - Timeout for post-fence modex verification.
 
 ``[update]``
 ------------
 
 Startup update checks and optional auto-download.
+
+**Reload: Restart** for every field below — the controller configures its update
+checker once at startup.
+
+.. note::
+
+   These fields apply to ``spurctld`` only. ``spurd`` runs its own startup update
+   check with built-in defaults and does not read this section, so
+   ``check_on_startup = false`` does not stop agents from checking.
 
 .. list-table::
    :header-rows: 1
@@ -583,6 +799,8 @@ Startup update checks and optional auto-download.
 
 Controls which nodes may register with the controller.
 
+**Reload: Live.**
+
 .. list-table::
    :header-rows: 1
    :widths: 16 12 16 56
@@ -603,6 +821,10 @@ See :doc:`accounting` for managing admission tokens with ``spur token``.
 -------------
 
 GPU and generic-resource discovery.
+
+**Reload: Agent restart** for every field below, including each
+``[[devices.gres]]`` entry — the device registry is built once when ``spurd``
+starts.
 
 .. list-table::
    :header-rows: 1
@@ -646,7 +868,15 @@ and ``flags`` ([string]). Examples:
 ``[isolation]``
 ---------------
 
-Job isolation layers. Each degrades gracefully when the platform does not support it.
+Job isolation layers.
+
+.. warning::
+
+   **Reload: Not implemented** for every field in this section. ``spurd`` does not
+   read ``[isolation]``, so none of these values changes any behaviour — including
+   setting one to ``false`` to disable a layer. Do not treat this section as a
+   security control. The table below records the intended meaning of each field
+   and how the corresponding behaviour is actually selected today.
 
 .. list-table::
    :header-rows: 1
@@ -655,23 +885,29 @@ Job isolation layers. Each degrades gracefully when the platform does not suppor
    * - Field
      - Type
      - Default
-     - Description
+     - Intended meaning / actual behaviour
    * - ``setuid``
      - bool
      - ``true``
-     - Run jobs as the submitting user's UID/GID (requires a root ``spurd``).
+     - Run jobs as the submitting user's UID/GID. Always applied when ``spurd``
+       runs as root; not gated by this field.
    * - ``namespaces``
      - bool
      - ``true``
-     - PID and mount namespace isolation (requires root).
+     - PID and mount namespace isolation. Applied whenever ``spurd`` runs as
+       root, except for multi-rank ``--mpi=pmix`` wrappers which stay in the host
+       namespace; not gated by this field.
    * - ``seccomp``
      - bool
      - ``true``
-     - seccomp-BPF syscall filter (kernel 3.5+; blocks ptrace/mount/bpf).
+     - seccomp-BPF syscall filter. Opt-in via the ``SPUR_SECCOMP=1``
+       environment variable on ``spurd`` and **off** unless that is set.
    * - ``landlock``
      - bool
      - ``true``
-     - Landlock filesystem access control (kernel 5.13+, native-host only).
+     - Landlock filesystem access control. Actually opt-in via the
+       ``SPUR_LANDLOCK=1`` environment variable on ``spurd`` and **off** unless
+       that is set.
 
 ``[metrics]``
 -------------
@@ -680,88 +916,128 @@ OpenMetrics HTTP export from ``spurctld``.
 
 .. list-table::
    :header-rows: 1
-   :widths: 22 12 22 44
+   :widths: 22 10 18 14 36
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``enabled``
      - bool
      - ``true``
+     - Restart
      - Start the metrics HTTP server.
    * - ``listen_addr``
      - string
      - ``"[::]:6822"``
+     - Restart
      - Metrics HTTP listen address; the port is used when ``bind = "loopback"``.
    * - ``bind``
      - string
      - ``"loopback"``
+     - Restart
      - ``loopback`` binds ``127.0.0.1:<port>``; ``all`` uses ``listen_addr`` as-is.
    * - ``high_cardinality``
      - bool
      - ``false``
-     - Reserved for a per-job/user/account metrics route; that route returns 404
-       until implemented.
+     - Live
+     - Serve the per-job/user/account metrics route. While ``false`` that route
+       returns 404. High cardinality on a busy cluster; enable deliberately.
 
 ``[rest_api]``
 --------------
 
 .. list-table::
    :header-rows: 1
-   :widths: 16 12 16 56
+   :widths: 16 10 14 14 46
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``enabled``
      - bool
-     - ``true``
-     - Start the Slurm-compatible REST server (default port 6820).
+     - ``false``
+     - Restart
+     - Start the Slurm-compatible REST server (default port 6820). Off by
+       default: the REST surface performs no authentication, so enabling it on a
+       reachable address exposes unauthenticated job submission. Enable it only
+       behind an authenticating proxy or on a loopback interface.
 
 ``[hooks]``
 -----------
 
-Prolog/epilog scripts. Each field is an optional fully-qualified path; unset means
-no hook. These map one-to-one to Slurm's prolog/epilog parameters.
+Prolog/epilog and job-submit scripts. Each field is an optional fully-qualified
+path; unset means no hook. The prolog/epilog fields map one-to-one to Slurm's
+parameters.
+
+Reload scope follows whichever process executes the hook: controller hooks are
+live, node hooks need an agent restart, and ``srun`` hooks are read from the
+submitting host on each invocation.
 
 .. list-table::
    :header-rows: 1
-   :widths: 24 30 46
+   :widths: 22 24 32 22
 
    * - Spur field
      - Slurm equivalent
      - Runs on
+     - Reload
    * - ``prolog``
      - ``Prolog``
      - compute node, before job launch
+     - Agent restart
    * - ``epilog``
      - ``Epilog``
      - compute node, at job termination
+     - Agent restart
    * - ``prolog_slurmctld``
      - ``PrologSlurmctld``
      - controller, at allocation
+     - Live
    * - ``epilog_slurmctld``
      - ``EpilogSlurmctld``
      - controller, at termination
+     - Live
    * - ``task_prolog``
      - ``TaskProlog``
      - compute node, before each step
+     - Agent restart
    * - ``task_epilog``
      - ``TaskEpilog``
      - compute node, after each step
+     - Agent restart
    * - ``srun_prolog``
      - ``SrunProlog``
      - srun node, before step dispatch
+     - Client
    * - ``srun_epilog``
      - ``SrunEpilog``
      - srun node, after step completion
+     - Client
+   * - ``job_submit``
+     - ``JobSubmitPlugin``
+     - controller, at submit
+     - Live
+   * - ``job_submit_lua``
+     - ``job_submit.lua``
+     - controller, at submit
+     - Live
+
+.. note::
+
+   ``reconfigure`` validates ``job_submit`` and ``job_submit_lua`` before swapping
+   the config, so a broken submit hook is rejected rather than applied — the
+   previous configuration stays in place and the command reports an error.
 
 ``[notifications]``
 -------------------
 
 Job-event notification transports.
+
+**Reload: Live** for every field below.
 
 .. list-table::
    :header-rows: 1
@@ -791,25 +1067,37 @@ Idle-node suspend and resume.
 
 .. list-table::
    :header-rows: 1
-   :widths: 26 12 16 46
+   :widths: 26 10 14 14 36
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``suspend_timeout_secs``
      - integer
      - none
-     - Idle seconds before a node is suspended.
+     - Restart
+     - Idle seconds before a node is suspended. Unset disables power management
+       entirely. Read once when the power-management loop starts, so
+       ``reconfigure`` can neither enable, disable, nor retime it.
    * - ``suspend_command``
      - string
      - none
+     - Live
      - Suspend command; ``{node}`` is replaced with the node name, e.g.
        ``"systemctl suspend"``.
    * - ``resume_command``
      - string
      - none
+     - Live
      - Resume command; ``{node}`` is replaced, e.g. ``"ipmitool chassis power on"``.
+
+.. note::
+
+   Because ``suspend_timeout_secs`` is restart-only, turning power management on
+   for the first time requires a controller restart. Once running, the suspend and
+   resume commands can be changed live.
 
 Kubernetes modes
 ----------------
@@ -820,6 +1108,15 @@ lets Spur **own** and provision a k0s cluster.
 
 ``[kubernetes]``
 ~~~~~~~~~~~~~~~~
+
+.. warning::
+
+   **Reload: Not implemented** for every field in this section. The
+   ``spur-k8s-operator`` binary does not read ``spur.conf`` at all; it takes its
+   node selector from the ``--node-selector`` flag, its namespace from the
+   ``POD_NAMESPACE`` environment variable, and its credentials from the ambient
+   kubeconfig or in-cluster service account. Configure the operator through its
+   deployment manifest, not here.
 
 .. list-table::
    :header-rows: 1
@@ -852,51 +1149,93 @@ lets Spur **own** and provision a k0s cluster.
 Spur-managed k0s cluster. When disabled (the default), ``spurd`` never touches
 systemd or k0s.
 
+This section is split across both daemons: the controller reads the network and
+control-plane fields at startup, while ``spurd`` reads the on-node fields at its
+own startup. Only ``allow_admin_kubeconfig`` is reloadable.
+
 .. list-table::
    :header-rows: 1
-   :widths: 24 12 24 40
+   :widths: 26 10 20 16 28
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``enabled``
      - bool
      - ``false``
-     - Enable the Spur-managed k0s cluster.
+     - Restart
+     - Enable the Spur-managed k0s cluster. Requires restarting the controller
+       **and** every agent.
    * - ``distro``
      - string
      - ``"k0s"``
-     - Kubernetes distribution. Only ``"k0s"`` is supported.
+     - Not implemented
+     - Intended to select a Kubernetes distribution. Validated as ``"k0s"`` on
+       load but otherwise unused; k0s is always the distribution.
    * - ``pod_cidr``
      - string
      - ``"10.42.0.0/16"``
+     - Restart
      - Pod network CIDR. Prefix must be ``<= /24`` (per-node /24 carving).
    * - ``service_cidr``
      - string
      - ``"10.43.0.0/16"``
+     - Restart
      - Service network CIDR.
    * - ``cni``
      - string
      - ``"kuberouter"``
+     - Restart
      - CNI mode: ``"kuberouter"`` (k0s default) or ``"calico"`` (bird native routing
        over the mesh).
    * - ``cni_mtu``
      - integer
      - ``1450``
+     - Restart
      - CNI MTU, leaving headroom for WireGuard overhead.
    * - ``control_plane_node``
      - string
      - none
+     - Restart
      - Hostname running the k0s control plane; empty picks one from inventory.
+   * - ``control_plane_replicas``
+     - integer
+     - ``1``
+     - Restart
+     - Number of control-plane members to provision.
+   * - ``k8s_provisioning_timeout_secs``
+     - integer
+     - ``600``
+     - Restart
+     - How long a node may stay in provisioning before it is marked Degraded.
+   * - ``allow_admin_kubeconfig``
+     - bool
+     - ``false``
+     - Live
+     - Allow the controller to hand out a cluster-admin kubeconfig. Reloadable,
+       so it can be turned off without a restart.
+   * - ``k0s_version``
+     - string
+     - pinned
+     - Agent restart
+     - k0s release the agent installs.
+   * - ``k0s_binary``
+     - string
+     - built-in path
+     - Agent restart
+     - Path to the ``k0s`` binary on the node.
    * - ``storage_provisioner``
      - string
      - ``"local-path"``
+     - Agent restart
      - ``"local-path"`` ships a default node-local StorageClass; ``"none"`` disables
        it. Other values are rejected.
    * - ``local_path_dir``
      - string
      - ``/var/lib/local-path-provisioner``
+     - Agent restart
      - On-node directory for local-path PVs. Must be absolute and free of quotes,
        backslashes, whitespace, and control characters.
 
@@ -906,12 +1245,13 @@ See :doc:`/deployment/managed-kubernetes` for provisioning a Spur-owned cluster.
 ----------------------------------------------------
 
 ``[federation]``
-   Peer clusters for cross-cluster job routing. Each ``[[federation.clusters]]``
-   entry has ``name`` (string) and ``address`` (string, e.g.
-   ``"http://peer-ctrl:6817"``). Defaults to no peers.
+   **Reload: Live.** Peer clusters for cross-cluster job routing. Each
+   ``[[federation.clusters]]`` entry has ``name`` (string) and ``address``
+   (string, e.g. ``"http://peer-ctrl:6817"``). Defaults to no peers.
 
 ``[topology]``
-   Optional switch-hierarchy configuration for locality-aware scheduling.
+   **Reload: Restart.** Optional switch-hierarchy configuration for locality-aware
+   scheduling.
    ``plugin`` (string, default ``"none"``) selects the model: ``"tree"`` for a
    switch hierarchy, ``"block"`` for fixed-size blocks, or ``"none"`` to disable.
    In tree mode, each ``[[topology.switches]]`` entry has ``name`` (string),
@@ -920,7 +1260,8 @@ See :doc:`/deployment/managed-kubernetes` for provisioning a Spur-owned cluster.
    (integer) sets the number of nodes per block. Defaults to no topology.
 
 ``[burst_buffer]``
-   Burst-buffer capacity. ``total_gb`` (integer, default ``0``) sets total capacity
+   **Reload: Live.** Burst-buffer capacity. ``total_gb`` (integer, default ``0``)
+   sets total capacity
    in GiB; jobs reserve via ``--bb capacity=NNN``. ``0`` disables burst buffers, and
    requesting jobs stay pending with ``BurstBufferResources``.
 

--- a/docs/deployment/kubernetes.rst
+++ b/docs/deployment/kubernetes.rst
@@ -84,15 +84,14 @@ Resolution precedence is: explicit ``controller.node_id`` -> position in
 ``1..=len(peers)``; if a pod's hostname matches no entry (or matches more than
 one), the controller fails fast at startup rather than joining with a wrong ID.
 
-Adjust partition definitions and node resources to match your cluster hardware.
-Once the controller is running, ``scontrol reconfigure`` applies most section
-changes (partitions, nodes, licenses, hooks, scheduler tunables) without a
-restart; listen ports, the accounting database, Raft peers, and ``jwt_key``
-still require restarting the controller. ``reconfigure`` runs on the Raft
-leader only — followers keep their startup config until restarted, at which
-point they re-read this same ConfigMap and converge. To roll all controllers
-onto an updated ConfigMap, restart the StatefulSet pods. See
-:doc:`partitioning` for the full breakdown.
+Adjust partition definitions to match your cluster hardware. Once the controller
+is running, ``scontrol reconfigure`` applies many sections live, while others
+need a controller or agent restart — see
+:ref:`the configuration reference <reload-scope>` for the per-field breakdown.
+``reconfigure`` runs on the Raft leader only — followers keep their startup
+config until restarted, at which point they re-read this same ConfigMap and
+converge. To roll all controllers onto an updated ConfigMap, restart the
+StatefulSet pods.
 
 Submitting Jobs
 ---------------

--- a/docs/deployment/partitioning.rst
+++ b/docs/deployment/partitioning.rst
@@ -85,8 +85,7 @@ features and weight; see :doc:`native-host`), keyed by ``names`` (hostlist) or
 Applying Config Changes
 -----------------------
 
-After editing ``spur.conf``, apply the changes to a running controller without
-a restart:
+After editing ``spur.conf``, apply the changes to the running controller:
 
 .. code-block:: bash
 
@@ -95,34 +94,12 @@ a restart:
 ``reconfigure`` re-reads ``spur.conf`` and makes the file authoritative:
 runtime-only changes not reflected in the file are overwritten.
 
-**Applied live** (no restart): ``[[partitions]]`` (created, updated, or deleted
-to match the file), ``[[nodes]]`` features and weight, ``licenses``,
-``burst_buffer``, controller-side ``[hooks]`` (``prolog_slurmctld``,
-``epilog_slurmctld``), ``[notifications]``, ``[federation]``,
-``[power]`` suspend/resume commands, ``[admission]`` mode, and the
-``[scheduler]`` tunables ``complete_wait_secs`` and ``resv_overrun_minutes``.
-Node-side hooks (the per-node prolog/epilog run by ``spurd``), the device
-registry, and memlock are read by the node agent at its own startup;
-``reconfigure`` does not reach compute nodes, so those need a ``spurd`` restart.
-
-**Restart-only**: settings baked in when the daemon starts — listen addresses
-and ports (``[controller]``, ``[metrics]``, ``[rest_api]``), the accounting
-database (``[accounting]``), Raft identity and peers, ``first_job_id``,
-``auth.jwt_key`` (swapping the node-token signing key live would immediately
-invalidate every outstanding node token), and the scheduler loop cadence
-(``interval_secs``, ``max_jobs_per_cycle``, topology). ``reconfigure`` reads
-these but does not apply them; a full controller restart is required. This
-mirrors Slurm, where a documented subset of parameters (ports,
-``StateSaveLocation``, ``AuthType``, plugin set) also require a daemon restart.
-
-**Leader-only, in an HA cluster.** ``reconfigure`` is handled by the Raft
-leader and swaps only the leader's in-memory config; no Raft log entry carries
-the new config, so follower controllers keep the config they loaded at startup
-until they restart (in Kubernetes they re-read the same ConfigMap on restart).
-Partition changes still replicate through the partition write-ahead log, but
-followers recompute node membership from their own (pre-reconfigure) node
-config. Do not rely on reconfigured non-partition state surviving an immediate
-failover; roll the controllers to converge them.
+Partition changes apply immediately, and they are the only part of the file that
+also replicates to follower controllers. Many other sections apply live too, but
+some are read once at daemon startup and some are consumed by ``spurd`` on each
+compute node — see :ref:`the configuration reference <reload-scope>` for the
+per-field breakdown, the leader-only caveat, and the behaviour when a partition
+being removed still has active jobs (drain it first).
 
 Verifying Membership
 --------------------


### PR DESCRIPTION
## What this fixes

The configuration reference documents what each `spur.conf` field means, but not
whether `scontrol reconfigure` can actually apply it. The only reload guidance
lived in the partitioning deployment page and in a doc comment on
`ClusterManager::reconfigure()` — both partial, and both drifted from the code.
An operator editing `spur.conf` had no reliable way to know whether a change
needed nothing, a controller restart, or a `spurd` restart on every node.

## Approach

Each section of the configuration reference now records a reload scope:

| Scope | Meaning |
| --- | --- |
| Live | Applied by `scontrol reconfigure` |
| Restart | Read once at `spurctld` startup |
| Agent restart | Consumed by `spurd`; `reconfigure` never reaches an agent |
| Client | Read by the CLI from the submitting host per invocation |
| Not implemented | Parsed and validated, but no code consumes it |

Sections whose fields all share one scope state it once above the table; mixed
sections carry a per-field column. Current totals: 32 Live, 28 Restart, 12 Agent
restart, 3 Client, 11 Not implemented.

The reference is now the single source of truth. `partitioning.rst`,
`kubernetes.rst`, the `reconfigure()` doc comment, and the `scontrol reconfigure`
success message all defer to it rather than keeping their own partial copies —
the duplication is what let the previous descriptions drift.

## Unimplemented fields

Classifying fields meant tracing each one to its consumer, which surfaced
settings that are parsed and validated but never read. Rather than leave them
looking functional, they are marked Not implemented with a pointer to whatever
actually controls the behaviour.

Two get warnings because they read as security controls:

- `[isolation]` — no field is read. seccomp and Landlock are gated by
  `SPUR_SECCOMP` / `SPUR_LANDLOCK` and are **off** unless those are set, so
  `seccomp = true` yields no filter.
- `auth.plugin` — no RPC authentication runs whatever this is set to. The
  controller already warns about this at startup on a non-loopback bind.

## Corrections made in passing

All verified against the code:

- `rest_api.enabled` was documented as defaulting to `true`; it defaults to
  `false`, and deliberately so.
- `metrics.high_cardinality` was documented as a route that 404s "until
  implemented". The route works and 404s only while the flag is false. The same
  stale claim in `config.rs` is removed.
- `[[nodes]]` was presented as declaring node capacity, including in the
  minimal-config example. Nodes join by registering and report their own
  resources; `cpus`/`memory_mb`/`gres` are never read, and adding or removing a
  block does not add or remove a node.
- `[update]` applies to `spurctld` only. `spurd` runs its own startup check with
  built-in defaults, so `check_on_startup = false` does not stop agents.
- `controller.hosts` is read by the CLI, not by agents.

## Trade-offs

The `reconfigure()` doc comment is cut from ~30 lines to the one invariant a code
reader needs — the swap is in-memory on the leader, with no WAL entry — plus a
pointer to the reference. Keeping a second detailed copy in the source is what
produced the stale `[power]` and `[hooks]` descriptions this PR corrects.

`cpus`/`memory_mb`/`gres` are dropped from the minimal-config example, since
showing fields the same page marks as unimplemented is self-contradictory.

## Known limitations / follow-ups

Not addressed here, since this PR is documentation:

1. The unimplemented fields should either be honoured or rejected at load. Today
   they are silently accepted, which is why documentation is only a partial fix
   for `[isolation]` and `auth.plugin`.
2. `power.suspend_timeout_secs` is read once when the power-management loop
   spawns, so power management cannot be enabled or retimed live even though the
   commands can. Documented as Restart; arguably a bug.
3. A partition removed from the file while it still has running jobs is skipped,
   and the RPC still reports success. Surfacing that to the caller needs a proto
   change. Documented as a warning for now.
4. `reconfigure` swaps config only on the leader; followers converge on restart.
   Already noted in the reference.

## Testing

- `pyspelling -c .spellcheck.yaml` — the two new terms are added to
  `.wordlist.txt` and no longer flagged. One residual `runtime` hit also occurs
  in three files this PR does not touch, so it reflects a local dictionary
  difference rather than a change here.
- All 23 `list-table` directives checked for row/`:widths:` consistency; the new
  `_reload-scope` label resolves from both referring pages.
- `cargo fmt --all --check` and `cargo clippy` on `spur-core`, `spur-cli`, and
  `spurctld`: clean.
- A full Sphinx build was not run locally (the docs image is built in CI), so CI
  is the first `-W` build of these pages.