### PR TITLE
fix(spurd): close container sync-pipe fds exactly once

### DIFF
--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1414,7 +1414,6 @@ async fn launch_container_job(
     let cgroup_path = setup_cgroup(job_id, cfg.cpus, cfg.memory_mb, &cfg.cpu_ids)?;
 
     // Sync pipe: child writes status, parent reads.
-    // Convert OwnedFd to raw fds for manual lifecycle management across fork.
     let (pipe_r, pipe_w) = nix::unistd::pipe().context("create sync pipe")?;
     // Prevent read end from leaking into exec'd process
     nix::fcntl::fcntl(
@@ -1424,9 +1423,6 @@ async fn launch_container_job(
     .ok();
     let ready_r = pipe_r.as_raw_fd();
     let ready_w = pipe_w.as_raw_fd();
-    // Keep OwnedFd alive so the fds aren't closed prematurely
-    let _pipe_r_owner = pipe_r;
-    let _pipe_w_owner = pipe_w;
 
     // Snapshot raw I/O fds before fork — the Copy JobIoRaw can be used
     // in the child without owning the fds (parent's OwnedFds keep them alive
@@ -1444,9 +1440,7 @@ async fn launch_container_job(
         nix::unistd::ForkResult::Child => {
             // === CHILD PROCESS ===
             // CRITICAL: synchronous code only. Tokio runtime is broken after fork.
-            unsafe {
-                libc::close(ready_r);
-            }
+            drop(pipe_r);
 
             // Reset signal handlers
             unsafe {
@@ -1482,8 +1476,8 @@ async fn launch_container_job(
             // Signal parent: setup complete
             unsafe {
                 libc::write(ready_w, b"OK".as_ptr() as *const _, 2);
-                libc::close(ready_w);
             }
+            drop(pipe_w);
 
             // Build final environment: base + container_env + hook environ.d
             let mut final_env = env_snapshot;
@@ -1528,9 +1522,7 @@ async fn launch_container_job(
         }
 
         nix::unistd::ForkResult::Parent { child } => {
-            unsafe {
-                libc::close(ready_w);
-            }
+            drop(pipe_w);
 
             // Drop the slave fd immediately so the master gets EOF when the child exits.
             let pty_master = job_io.into_master();
@@ -1550,9 +1542,7 @@ async fn launch_container_job(
             let mut buf = [0u8; 512];
             let n = unsafe { libc::read(ready_r, buf.as_mut_ptr() as *mut _, buf.len()) };
             let n = n.max(0) as usize;
-            unsafe {
-                libc::close(ready_r);
-            }
+            drop(pipe_r);
 
             if n < 2 || &buf[..2] != b"OK" {
                 let msg = String::from_utf8_lossy(&buf[..n]);


### PR DESCRIPTION
## Summary

`launch_container_job` closes both ends of the fork sync pipe twice: once explicitly via
`libc::close`, and once again when the `OwnedFd` values that still own those descriptors are
dropped. This makes every containerized job launch violate Rust's I/O-safety contract.

Fixes #653.

## Root cause

On `main`, `launch_container_job` creates the pipe and then extracts both raw descriptors with
`as_raw_fd()`, which *borrows* rather than transfers ownership. The two `_pipe_*_owner` bindings
deliberately keep the `OwnedFd` values alive:

    let ready_r = pipe_r.as_raw_fd();   // borrow; pipe_r still owns this fd
    let ready_w = pipe_w.as_raw_fd();
    let _pipe_r_owner = pipe_r;
    let _pipe_w_owner = pipe_w;

Each end is then closed manually — the read end in the child arm right after the fork and in the
parent arm after the status read, the write end in the child after the `"OK"` write and in the parent
immediately after the fork — while the owners are still live and will close the same descriptors
again at end of scope.

Consequences:

- **Debug / any build with `debug_assertions`:** the second close trips Rust's I/O-safety guard and
  the process aborts with `IO Safety violation: owned file descriptor already closed`. On a
  single-node cluster this killed `spurd` on 5 out of 5 container job submissions, mid-launch, while
  a non-container job on the same daemon completed normally.
- **Release:** the guard is compiled out, so the extra close is silent. `strace -y` on a release
  build shows both closes of the same pipe fd, the second returning `-1 EBADF`. It is harmless only
  as long as the number has not been reissued; if it has, the stale close lands on an unrelated
  descriptor. The e2e container suite runs against release binaries, which is why it stayed green.

## The change

Make the `OwnedFd` values the sole owners and drop them at exactly the points where the manual
closes used to happen. The `RawFd` copies are kept, since `libc::read`, `libc::write`, and
`close_inherited_fds` need an `i32`.

- child: `libc::close(ready_r)` → `drop(pipe_r)`
- child: `libc::close(ready_w)` → `drop(pipe_w)` (after the `"OK"` write)
- parent: `libc::close(ready_w)` → `drop(pipe_w)`
- parent: `libc::close(ready_r)` → `drop(pipe_r)` (after the status read)

Both match arms move the same bindings, which is fine because only one arm ever runs in a given
process. Close ordering is unchanged, so the handshake still behaves identically: the child releases
the read end before wiring stdio, and the parent releases the write end before the blocking read, so
that read still sees EOF if the child dies without reporting.

## Verification

- `cargo fmt --all -- --check` and `cargo clippy --workspace --exclude spur-ffi --all-targets
  --locked` are clean, and `cargo test --locked` passes with `ulimit -n` raised. On hosts with a very
  high core count the suite hits `Too many open files` at the default 1024; that is pre-existing and
  reproduces identically on unpatched `main`.
- Debug `spurd` built from this branch, single-node cluster, containerized job: job reaches `R`,
  logs `job launched successfully` then `job finished exit_code=0`, the daemon survives on its
  original PID, and there are zero `IO Safety` lines across five consecutive container jobs. The same
  repro script run against unpatched `main` on the same node aborts the daemon every time.
- `strace -y` on the same run shows each pipe end closed exactly once per process, and every
  `fcntl(fd, F_GETFD)` drop-guard probe now succeeds, confirming no earlier close.

## Notes

- No behavior change beyond removing the second close; the fix is contained to the container launch
  path and does not touch non-container jobs.
- #492 moves this function but keeps the same ownership pattern, so this fix applies either way.