### PR TITLE
fix(tenancy): clamp non-admin priority and redact cross-tenant job info (#663, #664)

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -558,10 +558,11 @@ pub struct SchedulerConfig {
     #[serde(default)]
     pub inactive_limit_secs: u32,
     /// Highest base priority a non-admin caller may request at submit (or via
-    /// `scontrol update`). Requests above this are clamped, not rejected, and a
-    /// warning is returned; admins are unaffected. Defaults to
-    /// [`crate::job::DEFAULT_PRIORITY`], so a non-admin can lower but not raise
-    /// priority — Slurm's `nice`-only model, where boosting priority is
+    /// `scontrol update`). Requests above this are clamped, not rejected; at
+    /// submit the clamp is reported to the caller as a warning, on the update
+    /// path (which has no response field) it is logged. Admins are unaffected.
+    /// Defaults to [`crate::job::DEFAULT_PRIORITY`], so a non-admin can lower but
+    /// not raise priority — Slurm's `nice`-only model, where boosting priority is
     /// operator-only. Raise it to grant users a band above the baseline.
     #[serde(default = "default_max_user_priority")]
     pub max_user_priority: u32,

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -337,6 +337,36 @@ pub struct ControllerConfig {
     /// resources-unavailable, so it isn't re-picked every tick (default 30, 0 disables).
     #[serde(default = "default_dispatch_reject_cooldown_secs")]
     pub dispatch_reject_cooldown_secs: u64,
+
+    /// How much of another user's job a non-owner may see via `get_job` /
+    /// `get_job_steps`. See [`JobInfoVisibility`]. Owners and admins always see
+    /// the full record; this governs everyone else. Default: `redacted`.
+    #[serde(default)]
+    pub job_info_visibility: JobInfoVisibility,
+}
+
+/// Controls how much of another user's job a non-owner (non-admin) caller can
+/// read back from `get_job` / `get_job_steps`.
+///
+/// The list RPC `get_jobs` already scopes to the caller; the single-fetch paths
+/// historically did not, exposing every job's work_dir, command line, stdio
+/// paths, and — most usefully to an attacker — its allocated nodelist. This
+/// setting closes that leak while leaving the Slurm-standard cluster-visible
+/// queue intact for the fields that are not targeting-sensitive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum JobInfoVisibility {
+    /// Non-owners see identity/state/timing/account/priority, but work_dir,
+    /// command, stdio paths, allocated nodelist, comment, and resource detail are
+    /// blanked. The default: preserves visibility, removes the targeting oracle.
+    #[default]
+    Redacted,
+    /// Non-owners get `NOT_FOUND` — the job is invisible unless you own it (or
+    /// are an admin). Strictest; matches `get_jobs`' owner-scoped behaviour.
+    OwnerOnly,
+    /// Legacy: every field is visible to any caller. Opt-in for deployments that
+    /// relied on the previous unscoped behaviour.
+    Full,
 }
 
 fn default_max_batch_requeue() -> u32 {
@@ -405,6 +435,7 @@ impl Default for ControllerConfig {
             hold_on_prolog_fail: default_hold_on_prolog_fail(),
             terminal_job_retention_secs: default_terminal_job_retention_secs(),
             dispatch_reject_cooldown_secs: default_dispatch_reject_cooldown_secs(),
+            job_info_visibility: JobInfoVisibility::default(),
         }
     }
 }
@@ -526,6 +557,14 @@ pub struct SchedulerConfig {
     /// abandoned allocations behave as before. Mirrors Slurm's `InactiveLimit`.
     #[serde(default)]
     pub inactive_limit_secs: u32,
+    /// Highest base priority a non-admin caller may request at submit (or via
+    /// `scontrol update`). Requests above this are clamped, not rejected, and a
+    /// warning is returned; admins are unaffected. Defaults to
+    /// [`crate::job::DEFAULT_PRIORITY`], so a non-admin can lower but not raise
+    /// priority — Slurm's `nice`-only model, where boosting priority is
+    /// operator-only. Raise it to grant users a band above the baseline.
+    #[serde(default = "default_max_user_priority")]
+    pub max_user_priority: u32,
 }
 
 /// How often an interactive client (`salloc`/`srun`) pings the controller to
@@ -548,6 +587,9 @@ fn default_time_limit() -> u32 {
 fn default_complete_wait() -> u32 {
     300
 }
+fn default_max_user_priority() -> u32 {
+    crate::job::DEFAULT_PRIORITY
+}
 
 impl Default for SchedulerConfig {
     fn default() -> Self {
@@ -561,6 +603,7 @@ impl Default for SchedulerConfig {
             complete_wait_secs: 300,
             resv_overrun_minutes: 0,
             inactive_limit_secs: 0,
+            max_user_priority: default_max_user_priority(),
         }
     }
 }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -405,21 +405,31 @@ impl ControllerService {
         })
     }
 
-    /// Clamp a non-admin caller's requested base priority to the configured ceiling.
+    /// Whether a caller is exempt from the non-admin restrictions (currently the priority ceiling):
+    /// an admin, or a caller with no verified identity. The latter preserves the pre-auth behaviour —
+    /// under `auth.mode = disabled`, or `permissive` with no credential presented, the cluster trusts
+    /// the client, so restricting it would break no-auth deployments (and internal callers, e.g. the
+    /// CLI raising priority in an unauthenticated cluster). `required` mode never reaches here without
+    /// an identity, so the restriction still applies to every real user there.
+    fn caller_is_privileged(&self, identity: Option<&spur_core::auth::Identity>) -> bool {
+        identity.is_none() || self.caller_is_admin(identity)
+    }
+
+    /// Clamp a non-privileged caller's requested base priority to the configured ceiling.
     ///
     /// Slurm lets an ordinary user only *lower* their priority (`nice >= 0`); raising it is
-    /// operator-only. We mirror that: a non-admin request above `[scheduler] max_user_priority`
+    /// operator-only. We mirror that: a request above `[scheduler] max_user_priority`
     /// (default [`DEFAULT_PRIORITY`]) is clamped down and a warning is returned — not rejected, so a
-    /// fat-fingered `--priority` still runs. Admins, and an unset priority, are untouched.
-    /// Returns the warning to surface to the caller, if any. Operates on the raw `Option<u32>` so
-    /// both the submit path (`JobSpec::priority`) and the `scontrol update` path (`req.priority`)
-    /// share one policy — a user cannot dodge the ceiling by boosting priority after submit.
+    /// fat-fingered `--priority` still runs. Privileged callers (admin or unauthenticated, see
+    /// [`Self::caller_is_privileged`]), and an unset priority, are untouched. Operates on the raw
+    /// `Option<u32>` so both the submit path (`JobSpec::priority`) and the `scontrol update` path
+    /// (`req.priority`) share one policy — a user cannot dodge the ceiling by boosting after submit.
     fn clamp_priority(
         priority: &mut Option<u32>,
-        caller_is_admin: bool,
+        caller_is_privileged: bool,
         max_user_priority: u32,
     ) -> Option<String> {
-        if caller_is_admin {
+        if caller_is_privileged {
             return None;
         }
         match *priority {
@@ -627,11 +637,11 @@ impl SlurmController for ControllerService {
         let mut core_spec = proto_to_job_spec(spec)?;
         Self::bind_spec_to_identity(&mut core_spec, identity.as_ref())?;
 
-        // Clamp a non-admin's base priority to the configured ceiling before it reaches the
-        // scheduler, so one submission cannot front-run the whole queue. Non-fatal: clamp + warn.
+        // Clamp a non-privileged caller's base priority to the configured ceiling before it reaches
+        // the scheduler, so one submission cannot front-run the whole queue. Non-fatal: clamp + warn.
         let priority_warning = Self::clamp_priority(
             &mut core_spec.priority,
-            self.caller_is_admin(identity.as_ref()),
+            self.caller_is_privileged(identity.as_ref()),
             self.cluster.config().scheduler.max_user_priority,
         );
 
@@ -973,7 +983,7 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let caller_is_admin = self.caller_is_admin(Self::verified_identity(&request));
+        let caller_is_privileged = self.caller_is_privileged(Self::verified_identity(&request));
         let mut req = request.into_inner();
 
         // Handle hold/release via priority
@@ -990,10 +1000,11 @@ impl SlurmController for ControllerService {
             return Ok(Response::new(()));
         }
 
-        // Same ceiling as submit: a non-admin cannot raise priority above the cap post-submit.
+        // Same ceiling as submit: a non-privileged caller cannot raise priority above the cap
+        // post-submit.
         Self::clamp_priority(
             &mut req.priority,
-            caller_is_admin,
+            caller_is_privileged,
             self.cluster.config().scheduler.max_user_priority,
         );
 
@@ -3853,10 +3864,15 @@ mod tests {
     }
 
     #[test]
-    fn clamp_priority_never_touches_an_admin() {
+    fn clamp_priority_never_touches_a_privileged_caller() {
+        // Privileged = admin or unauthenticated (auth not enforced); see caller_is_privileged.
         let mut p = Some(u32::MAX);
         let warning = ControllerService::clamp_priority(&mut p, true, 1000);
-        assert_eq!(p, Some(u32::MAX), "an admin may set any priority");
+        assert_eq!(
+            p,
+            Some(u32::MAX),
+            "a privileged caller may set any priority"
+        );
         assert!(warning.is_none());
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -436,18 +436,21 @@ impl ControllerService {
 
     /// Apply the configured job-info visibility policy for `get_job`.
     ///
-    /// The owner and admins always get the full record. Everyone else is governed by
+    /// The owner and admins always get the full record. An identified non-owner is governed by
     /// `[controller] job_info_visibility`: `Full` returns everything (legacy), `OwnerOnly` returns
-    /// `None` (the caller maps it to `NOT_FOUND`, so the job is invisible), and `Redacted` (default)
-    /// returns the record with the targeting-sensitive fields blanked. An unauthenticated caller
-    /// (permissive/disabled) is never privileged.
+    /// `None` (the caller maps it to `NOT_FOUND`), and `Redacted` (default) blanks the
+    /// targeting-sensitive fields. A caller with no verified identity gets the full record: scoping
+    /// is only meaningful once callers are actually identified (`auth.mode = required`, or a
+    /// credential presented under `permissive`), and blanking anonymous reads would break the
+    /// no-auth/permissive deployments — and internal consumers like the k8s operator, which reads a
+    /// job's nodelist over an unauthenticated channel.
     fn scoped_job_info(
         &self,
         job: &spur_core::job::Job,
         identity: Option<&spur_core::auth::Identity>,
     ) -> Option<JobInfo> {
         let privileged =
-            identity.is_some_and(|id| id.user == job.spec.user) || self.caller_is_admin(identity);
+            viewer_is_privileged(identity, &job.spec.user, self.caller_is_admin(identity));
         match job_info_disclosure(
             privileged,
             self.cluster.config().controller.job_info_visibility,
@@ -1734,17 +1737,18 @@ impl SlurmController for ControllerService {
         // Step names can leak intent, so they are blanked under `redacted` and the list is empty
         // under `owner_only`. Owner determined from the parent job; if it is gone from the display
         // cache, only an admin is privileged.
+        // Owner from the parent job; if it is gone from the display cache, `""` makes only an admin
+        // (or an anonymous caller, per `viewer_is_privileged`) privileged.
         let owner = self
             .cluster
             .get_job_for_display(job_id)
-            .map(|j| j.spec.user);
-        let privileged = match &owner {
-            Some(o) => {
-                identity.as_ref().is_some_and(|id| &id.user == o)
-                    || self.caller_is_admin(identity.as_ref())
-            }
-            None => self.caller_is_admin(identity.as_ref()),
-        };
+            .map(|j| j.spec.user)
+            .unwrap_or_default();
+        let privileged = viewer_is_privileged(
+            identity.as_ref(),
+            &owner,
+            self.caller_is_admin(identity.as_ref()),
+        );
         let redact_names = match job_info_disclosure(
             privileged,
             self.cluster.config().controller.job_info_visibility,
@@ -3286,6 +3290,21 @@ enum JobInfoDisclosure {
     Hidden,
 }
 
+/// Whether a caller may see a job's full record unconditionally: the owner, an admin, or a caller
+/// with no verified identity at all. The last case preserves the pre-auth behaviour — scoping only
+/// bites once callers are actually identified, so no-auth/permissive deployments and internal
+/// unauthenticated consumers (the k8s operator's nodelist read) are unaffected. Pure for testing.
+fn viewer_is_privileged(
+    identity: Option<&spur_core::auth::Identity>,
+    owner: &str,
+    caller_is_admin: bool,
+) -> bool {
+    match identity {
+        None => true,
+        Some(id) => id.user == owner || caller_is_admin,
+    }
+}
+
 /// Resolve the disclosure level for a job-info read. The owner and admins (`privileged`) always get
 /// the full record; everyone else is governed by the configured policy. Pure so the policy matrix is
 /// unit-testable without a live service.
@@ -3858,6 +3877,31 @@ mod tests {
             JobInfoDisclosure::Hidden
         );
         assert_eq!(job_info_disclosure(false, Full), JobInfoDisclosure::Full);
+    }
+
+    #[test]
+    fn viewer_privilege_owner_admin_and_anonymous() {
+        use spur_core::auth::Identity;
+        let bob = Identity {
+            user: "bob".into(),
+            uid: 1000,
+            gid: 1000,
+            is_admin: false,
+        };
+        let alice = Identity {
+            user: "alice".into(),
+            uid: 1001,
+            gid: 1001,
+            is_admin: false,
+        };
+        // Owner and admin are privileged.
+        assert!(viewer_is_privileged(Some(&bob), "bob", false));
+        assert!(viewer_is_privileged(Some(&alice), "bob", true));
+        // A different, non-admin identified user is not.
+        assert!(!viewer_is_privileged(Some(&alice), "bob", false));
+        // No verified identity (auth disabled, or permissive with no credential, or an internal
+        // consumer like the k8s operator) is privileged: scoping only applies to identified callers.
+        assert!(viewer_is_privileged(None, "bob", false));
     }
 
     #[test]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -393,6 +393,75 @@ impl ControllerService {
         Ok(())
     }
 
+    /// Whether the verified caller is an administrator for policy decisions that are neither
+    /// job-ownership nor k0s-cluster gates: priority ceilings, job-info visibility.
+    ///
+    /// Accepts either the token's `admin` claim or the accounting `Admin` level, so the check works
+    /// before the accounting DB is populated and stays consistent with the rest of the control plane
+    /// (`is_k0s_admin`). An unauthenticated caller (permissive/disabled) is not an admin.
+    fn caller_is_admin(&self, identity: Option<&spur_core::auth::Identity>) -> bool {
+        identity.is_some_and(|id| {
+            id.is_admin || is_k0s_admin(self.cluster.association_cache(), &id.user)
+        })
+    }
+
+    /// Clamp a non-admin caller's requested base priority to the configured ceiling.
+    ///
+    /// Slurm lets an ordinary user only *lower* their priority (`nice >= 0`); raising it is
+    /// operator-only. We mirror that: a non-admin request above `[scheduler] max_user_priority`
+    /// (default [`DEFAULT_PRIORITY`]) is clamped down and a warning is returned — not rejected, so a
+    /// fat-fingered `--priority` still runs. Admins, and an unset priority, are untouched.
+    /// Returns the warning to surface to the caller, if any. Operates on the raw `Option<u32>` so
+    /// both the submit path (`JobSpec::priority`) and the `scontrol update` path (`req.priority`)
+    /// share one policy — a user cannot dodge the ceiling by boosting priority after submit.
+    fn clamp_priority(
+        priority: &mut Option<u32>,
+        caller_is_admin: bool,
+        max_user_priority: u32,
+    ) -> Option<String> {
+        if caller_is_admin {
+            return None;
+        }
+        match *priority {
+            Some(p) if p > max_user_priority => {
+                *priority = Some(max_user_priority);
+                Some(format!(
+                    "requested priority {p} exceeds the non-admin ceiling {max_user_priority}; \
+                     clamped to {max_user_priority} (raising priority is operator-only)"
+                ))
+            }
+            _ => None,
+        }
+    }
+
+    /// Apply the configured job-info visibility policy for `get_job`.
+    ///
+    /// The owner and admins always get the full record. Everyone else is governed by
+    /// `[controller] job_info_visibility`: `Full` returns everything (legacy), `OwnerOnly` returns
+    /// `None` (the caller maps it to `NOT_FOUND`, so the job is invisible), and `Redacted` (default)
+    /// returns the record with the targeting-sensitive fields blanked. An unauthenticated caller
+    /// (permissive/disabled) is never privileged.
+    fn scoped_job_info(
+        &self,
+        job: &spur_core::job::Job,
+        identity: Option<&spur_core::auth::Identity>,
+    ) -> Option<JobInfo> {
+        let privileged =
+            identity.is_some_and(|id| id.user == job.spec.user) || self.caller_is_admin(identity);
+        match job_info_disclosure(
+            privileged,
+            self.cluster.config().controller.job_info_visibility,
+        ) {
+            JobInfoDisclosure::Full => Some(job_to_proto(job)),
+            JobInfoDisclosure::Hidden => None,
+            JobInfoDisclosure::Redacted => {
+                let mut info = job_to_proto(job);
+                redact_sensitive_job_info(&mut info);
+                Some(info)
+            }
+        }
+    }
+
     /// Forwarding metadata that carries the caller's credential through to the leader.
     ///
     /// The leader is what authorizes the request, so it must see the ORIGINAL caller — not the
@@ -554,14 +623,25 @@ impl SlurmController for ControllerService {
 
         let mut core_spec = proto_to_job_spec(spec)?;
         Self::bind_spec_to_identity(&mut core_spec, identity.as_ref())?;
+
+        // Clamp a non-admin's base priority to the configured ceiling before it reaches the
+        // scheduler, so one submission cannot front-run the whole queue. Non-fatal: clamp + warn.
+        let priority_warning = Self::clamp_priority(
+            &mut core_spec.priority,
+            self.caller_is_admin(identity.as_ref()),
+            self.cluster.config().scheduler.max_user_priority,
+        );
+
         let outcome = self
             .cluster
             .submit_job(core_spec)
             .map_err(submit_rpc_status)?;
 
+        let mut warnings = outcome.warnings;
+        warnings.extend(priority_warning);
         Ok(Response::new(SubmitJobResponse {
             job_id: outcome.job_id,
-            warnings: outcome.warnings,
+            warnings,
         }))
     }
 
@@ -631,7 +711,12 @@ impl SlurmController for ControllerService {
     async fn get_job(&self, request: Request<GetJobRequest>) -> Result<Response<JobInfo>, Status> {
         let forward = self.read_should_forward(&request);
         let meta = request.metadata().clone();
+        // Capture identity before the forward so the serving node (leader or read-allowed follower)
+        // can scope the record to the caller; the credential is preserved on forward, so a forwarded
+        // read is scoped on the leader instead.
+        let identity = Self::verified_identity(&request).cloned();
         let req = request.into_inner();
+        let job_id = req.job_id;
         if let Some(resp) = self
             .forward_read_optional(
                 meta,
@@ -644,13 +729,17 @@ impl SlurmController for ControllerService {
             return Ok(resp);
         }
 
-        let job_id = req.job_id;
         let job = self
             .cluster
             .get_job_for_display(job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))?;
 
-        Ok(Response::new(job_to_proto(&job)))
+        // A non-owner, non-admin caller does not get another tenant's work_dir, command, stdio
+        // paths, or (the targeting-sensitive one) allocated nodelist. Policy is configurable; the
+        // default redacts those fields while leaving the Slurm-standard queue view intact.
+        self.scoped_job_info(&job, identity.as_ref())
+            .map(Response::new)
+            .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))
     }
 
     async fn cancel_job(&self, request: Request<CancelJobRequest>) -> Result<Response<()>, Status> {
@@ -881,7 +970,8 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let req = request.into_inner();
+        let caller_is_admin = self.caller_is_admin(Self::verified_identity(&request));
+        let mut req = request.into_inner();
 
         // Handle hold/release via priority
         if let Some(hold) = req.hold {
@@ -896,6 +986,13 @@ impl SlurmController for ControllerService {
             }
             return Ok(Response::new(()));
         }
+
+        // Same ceiling as submit: a non-admin cannot raise priority above the cap post-submit.
+        Self::clamp_priority(
+            &mut req.priority,
+            caller_is_admin,
+            self.cluster.config().scheduler.max_user_priority,
+        );
 
         let time_limit = req.time_limit.map(|d| chrono::Duration::seconds(d.seconds));
 
@@ -1618,7 +1715,9 @@ impl SlurmController for ControllerService {
     ) -> Result<Response<GetJobStepsResponse>, Status> {
         let forward = self.read_should_forward(&request);
         let meta = request.metadata().clone();
+        let identity = Self::verified_identity(&request).cloned();
         let req = request.into_inner();
+        let job_id = req.job_id;
         if let Some(resp) = self
             .forward_read_optional(
                 meta,
@@ -1631,14 +1730,44 @@ impl SlurmController for ControllerService {
             return Ok(resp);
         }
 
-        let job_id = req.job_id;
+        // Scope step visibility to the same policy as get_job: a non-owner sees fewer step details.
+        // Step names can leak intent, so they are blanked under `redacted` and the list is empty
+        // under `owner_only`. Owner determined from the parent job; if it is gone from the display
+        // cache, only an admin is privileged.
+        let owner = self
+            .cluster
+            .get_job_for_display(job_id)
+            .map(|j| j.spec.user);
+        let privileged = match &owner {
+            Some(o) => {
+                identity.as_ref().is_some_and(|id| &id.user == o)
+                    || self.caller_is_admin(identity.as_ref())
+            }
+            None => self.caller_is_admin(identity.as_ref()),
+        };
+        let redact_names = match job_info_disclosure(
+            privileged,
+            self.cluster.config().controller.job_info_visibility,
+        ) {
+            JobInfoDisclosure::Full => false,
+            JobInfoDisclosure::Redacted => true,
+            // Owner-only: the job is invisible to this caller, so are its steps.
+            JobInfoDisclosure::Hidden => {
+                return Ok(Response::new(GetJobStepsResponse { steps: Vec::new() }));
+            }
+        };
+
         let steps = self.cluster.get_steps(job_id);
         let step_infos: Vec<JobStepInfo> = steps
             .iter()
             .map(|s| JobStepInfo {
                 job_id: s.job_id,
                 step_id: s.step_id,
-                name: s.name.clone(),
+                name: if redact_names {
+                    String::new()
+                } else {
+                    s.name.clone()
+                },
                 state: s.state.display().to_string(),
                 num_tasks: s.num_tasks,
             })
@@ -3146,6 +3275,50 @@ fn proto_to_resource_set(r: spur_proto::proto::ResourceSet) -> spur_core::resour
     }
 }
 
+/// What a caller may see of a job, once ownership/admin status and the visibility policy are known.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JobInfoDisclosure {
+    /// Full record.
+    Full,
+    /// Full record minus the targeting-sensitive fields (see [`redact_sensitive_job_info`]).
+    Redacted,
+    /// Not disclosed at all — the caller sees `NOT_FOUND`.
+    Hidden,
+}
+
+/// Resolve the disclosure level for a job-info read. The owner and admins (`privileged`) always get
+/// the full record; everyone else is governed by the configured policy. Pure so the policy matrix is
+/// unit-testable without a live service.
+fn job_info_disclosure(
+    privileged: bool,
+    visibility: spur_core::config::JobInfoVisibility,
+) -> JobInfoDisclosure {
+    use spur_core::config::JobInfoVisibility;
+    if privileged {
+        return JobInfoDisclosure::Full;
+    }
+    match visibility {
+        JobInfoVisibility::Full => JobInfoDisclosure::Full,
+        JobInfoVisibility::Redacted => JobInfoDisclosure::Redacted,
+        JobInfoVisibility::OwnerOnly => JobInfoDisclosure::Hidden,
+    }
+}
+
+/// Blank the fields of a `JobInfo` that a non-owner should not see: the working directory, the first
+/// command line, the stdio paths, the comment, the resource detail, and — most importantly for
+/// cross-tenant targeting — the allocated nodelist. The identity/state/timing/account fields are
+/// left intact so the Slurm-standard cluster-visible queue view still works.
+fn redact_sensitive_job_info(info: &mut JobInfo) {
+    info.work_dir = String::new();
+    info.command = String::new();
+    info.stdout_path = String::new();
+    info.stderr_path = String::new();
+    info.stdin_path = String::new();
+    info.comment = String::new();
+    info.nodelist = String::new();
+    info.resources = None;
+}
+
 fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
     use spur_core::hostlist;
 
@@ -3640,6 +3813,87 @@ mod tests {
         // Cold cache = accounting disabled/not loaded: only root/internal are admin.
         let cache = crate::association_cache::AssociationCache::new();
         assert!(!is_k0s_admin(&cache, "alice"));
+    }
+
+    #[test]
+    fn clamp_priority_caps_a_non_admin_above_the_ceiling() {
+        let mut p = Some(u32::MAX);
+        let warning = ControllerService::clamp_priority(&mut p, false, 1000);
+        assert_eq!(p, Some(1000), "over-ceiling request is clamped down");
+        assert!(warning.is_some(), "a clamp returns a warning");
+    }
+
+    #[test]
+    fn clamp_priority_leaves_a_non_admin_at_or_below_the_ceiling() {
+        for req in [None, Some(0), Some(500), Some(1000)] {
+            let mut p = req;
+            let warning = ControllerService::clamp_priority(&mut p, false, 1000);
+            assert_eq!(p, req, "request within the ceiling is untouched");
+            assert!(warning.is_none(), "no warning when nothing is clamped");
+        }
+    }
+
+    #[test]
+    fn clamp_priority_never_touches_an_admin() {
+        let mut p = Some(u32::MAX);
+        let warning = ControllerService::clamp_priority(&mut p, true, 1000);
+        assert_eq!(p, Some(u32::MAX), "an admin may set any priority");
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn job_info_disclosure_matrix() {
+        use spur_core::config::JobInfoVisibility::*;
+        // The owner/admin (privileged) always sees the full record, whatever the policy.
+        for v in [Redacted, OwnerOnly, Full] {
+            assert_eq!(job_info_disclosure(true, v), JobInfoDisclosure::Full);
+        }
+        // A non-owner is governed by the policy.
+        assert_eq!(
+            job_info_disclosure(false, Redacted),
+            JobInfoDisclosure::Redacted
+        );
+        assert_eq!(
+            job_info_disclosure(false, OwnerOnly),
+            JobInfoDisclosure::Hidden
+        );
+        assert_eq!(job_info_disclosure(false, Full), JobInfoDisclosure::Full);
+    }
+
+    #[test]
+    fn redact_blanks_sensitive_fields_and_keeps_the_rest() {
+        let mut info = JobInfo {
+            job_id: 42,
+            name: "train".into(),
+            user: "bob".into(),
+            account: "team-b".into(),
+            state_reason: "Running".into(),
+            // sensitive
+            work_dir: "/home/bob/run".into(),
+            command: "python train.py --secret".into(),
+            stdout_path: "/home/bob/out".into(),
+            stderr_path: "/home/bob/err".into(),
+            stdin_path: "/home/bob/in".into(),
+            comment: "internal".into(),
+            nodelist: "gpu-b-[01-04]".into(),
+            ..Default::default()
+        };
+        redact_sensitive_job_info(&mut info);
+        // Sensitive fields are gone — the nodelist in particular (the co-residency targeting oracle).
+        assert!(info.work_dir.is_empty());
+        assert!(info.command.is_empty());
+        assert!(info.stdout_path.is_empty());
+        assert!(info.stderr_path.is_empty());
+        assert!(info.stdin_path.is_empty());
+        assert!(info.comment.is_empty());
+        assert!(info.nodelist.is_empty());
+        assert!(info.resources.is_none());
+        // Non-sensitive identity/state fields survive so the queue view still works.
+        assert_eq!(info.job_id, 42);
+        assert_eq!(info.name, "train");
+        assert_eq!(info.user, "bob");
+        assert_eq!(info.account, "team-b");
+        assert_eq!(info.state_reason, "Running");
     }
 
     #[test]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -405,25 +405,20 @@ impl ControllerService {
         })
     }
 
-    /// Whether a caller is exempt from the non-admin restrictions (currently the priority ceiling):
-    /// an admin, or a caller with no verified identity. The latter preserves the pre-auth behaviour —
-    /// under `auth.mode = disabled`, or `permissive` with no credential presented, the cluster trusts
-    /// the client, so restricting it would break no-auth deployments (and internal callers, e.g. the
-    /// CLI raising priority in an unauthenticated cluster). `required` mode never reaches here without
-    /// an identity, so the restriction still applies to every real user there.
+    /// Whether a caller is exempt from the non-admin restrictions (the priority ceiling): an admin,
+    /// or a caller with no verified identity. The latter keeps the pre-auth behaviour — `disabled`,
+    /// or `permissive` with no credential, trusts the client — so restricting it would break no-auth
+    /// deployments. `required` never reaches here without an identity, so real users are still bound.
     fn caller_is_privileged(&self, identity: Option<&spur_core::auth::Identity>) -> bool {
         identity.is_none() || self.caller_is_admin(identity)
     }
 
-    /// Clamp a non-privileged caller's requested base priority to the configured ceiling.
-    ///
-    /// Slurm lets an ordinary user only *lower* their priority (`nice >= 0`); raising it is
-    /// operator-only. We mirror that: a request above `[scheduler] max_user_priority`
-    /// (default [`DEFAULT_PRIORITY`]) is clamped down and a warning is returned — not rejected, so a
-    /// fat-fingered `--priority` still runs. Privileged callers (admin or unauthenticated, see
-    /// [`Self::caller_is_privileged`]), and an unset priority, are untouched. Operates on the raw
-    /// `Option<u32>` so both the submit path (`JobSpec::priority`) and the `scontrol update` path
-    /// (`req.priority`) share one policy — a user cannot dodge the ceiling by boosting after submit.
+    /// Clamp a non-privileged caller's base priority to `[scheduler] max_user_priority`, mirroring
+    /// Slurm's operator-only priority raising (an ordinary user may only lower it). Clamped down, not
+    /// rejected, so a fat-fingered `--priority` still runs. Privileged callers and an unset priority
+    /// are untouched. Returns a warning string; `submit_job` surfaces it in the response, and
+    /// `update_job` logs it (UpdateJob has no response field). Operates on the raw `Option<u32>` so
+    /// submit and `scontrol update` share one policy — the ceiling can't be dodged by boosting later.
     fn clamp_priority(
         priority: &mut Option<u32>,
         caller_is_privileged: bool,
@@ -444,16 +439,10 @@ impl ControllerService {
         }
     }
 
-    /// Apply the configured job-info visibility policy for `get_job`.
-    ///
-    /// The owner and admins always get the full record. An identified non-owner is governed by
-    /// `[controller] job_info_visibility`: `Full` returns everything (legacy), `OwnerOnly` returns
-    /// `None` (the caller maps it to `NOT_FOUND`), and `Redacted` (default) blanks the
-    /// targeting-sensitive fields. A caller with no verified identity gets the full record: scoping
-    /// is only meaningful once callers are actually identified (`auth.mode = required`, or a
-    /// credential presented under `permissive`), and blanking anonymous reads would break the
-    /// no-auth/permissive deployments — and internal consumers like the k8s operator, which reads a
-    /// job's nodelist over an unauthenticated channel.
+    /// Apply `[controller] job_info_visibility` for `get_job`. Owner, admin, and unauthenticated
+    /// callers (see [`viewer_is_privileged`]) get the full record; an identified non-owner gets
+    /// `Full` (legacy), `None` → `NOT_FOUND` (`OwnerOnly`), or the targeting-sensitive fields blanked
+    /// (`Redacted`, the default).
     fn scoped_job_info(
         &self,
         job: &spur_core::job::Job,
@@ -1001,12 +990,15 @@ impl SlurmController for ControllerService {
         }
 
         // Same ceiling as submit: a non-privileged caller cannot raise priority above the cap
-        // post-submit.
-        Self::clamp_priority(
+        // post-submit. UpdateJob returns Empty, so there is no response field to carry a warning —
+        // log it instead, so a clamp on this path is at least observable.
+        if let Some(w) = Self::clamp_priority(
             &mut req.priority,
             caller_is_privileged,
             self.cluster.config().scheduler.max_user_priority,
-        );
+        ) {
+            warn!(job_id = req.job_id, "{w}");
+        }
 
         let time_limit = req.time_limit.map(|d| chrono::Duration::seconds(d.seconds));
 
@@ -1744,20 +1736,17 @@ impl SlurmController for ControllerService {
             return Ok(resp);
         }
 
-        // Scope step visibility to the same policy as get_job: a non-owner sees fewer step details.
-        // Step names can leak intent, so they are blanked under `redacted` and the list is empty
-        // under `owner_only`. Owner determined from the parent job; if it is gone from the display
-        // cache, only an admin is privileged.
-        // Owner from the parent job; if it is gone from the display cache, `""` makes only an admin
-        // (or an anonymous caller, per `viewer_is_privileged`) privileged.
-        let owner = self
+        // Scope step visibility to the same policy as get_job: step names can leak intent, so they
+        // are blanked under `redacted` and the list is empty under `owner_only`. Resolve the parent
+        // job first and return NOT_FOUND if it is gone — matching get_job, and so the owner is never
+        // mis-derived as `""` (which would treat the true owner as unprivileged).
+        let job = self
             .cluster
             .get_job_for_display(job_id)
-            .map(|j| j.spec.user)
-            .unwrap_or_default();
+            .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))?;
         let privileged = viewer_is_privileged(
             identity.as_ref(),
-            &owner,
+            &job.spec.user,
             self.caller_is_admin(identity.as_ref()),
         );
         let redact_names = match job_info_disclosure(
@@ -3954,6 +3943,109 @@ mod tests {
         assert_eq!(info.user, "bob");
         assert_eq!(info.account, "team-b");
         assert_eq!(info.state_reason, "Running");
+    }
+
+    /// Identity for a viewer in the get_job/get_job_steps handler tests. No NSS resolution happens
+    /// on the read path (only ownership/admin comparison), so any username works.
+    fn viewer(user: &str, is_admin: bool) -> spur_core::auth::Identity {
+        spur_core::auth::Identity {
+            user: user.to_string(),
+            uid: 1000,
+            gid: 1000,
+            is_admin,
+        }
+    }
+
+    fn get_job_req(job_id: u32, id: Option<spur_core::auth::Identity>) -> Request<GetJobRequest> {
+        let mut req = Request::new(GetJobRequest { job_id });
+        if let Some(id) = id {
+            req.extensions_mut().insert(id);
+        }
+        req
+    }
+
+    fn owned_job(user: &str, work_dir: &str) -> spur_core::job::JobSpec {
+        spur_core::job::JobSpec {
+            name: "j".into(),
+            user: user.to_string(),
+            work_dir: work_dir.to_string(),
+            num_nodes: 1,
+            num_tasks: 1,
+            cpus_per_task: 1,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_job_scopes_by_identity_under_default_redacted_policy() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = svc
+            .cluster
+            .submit_job(owned_job("bob", "/home/bob"))
+            .unwrap()
+            .job_id;
+
+        // Owner, admin, and unauthenticated callers all get the full record.
+        for id in [
+            Some(viewer("bob", false)),
+            Some(viewer("carol", true)),
+            None,
+        ] {
+            let info = svc
+                .get_job(get_job_req(job_id, id))
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(info.work_dir, "/home/bob");
+        }
+
+        // An identified non-owner is redacted: the work_dir (and other sensitive fields) are blanked,
+        // but the non-sensitive identity fields survive.
+        let other = svc
+            .get_job(get_job_req(job_id, Some(viewer("alice", false))))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(other.work_dir, "", "a non-owner must not see the work_dir");
+        assert_eq!(other.user, "bob", "non-sensitive fields survive redaction");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_job_owner_only_hides_the_job_from_a_non_owner() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut config = step_test_config();
+        config.controller.job_info_visibility = spur_core::config::JobInfoVisibility::OwnerOnly;
+        let svc = test_service_with(&dir, config).await;
+        let job_id = svc
+            .cluster
+            .submit_job(owned_job("bob", "/home/bob"))
+            .unwrap()
+            .job_id;
+
+        // Owner still sees the job; a non-owner gets NOT_FOUND rather than a redacted record.
+        assert!(svc
+            .get_job(get_job_req(job_id, Some(viewer("bob", false))))
+            .await
+            .is_ok());
+        let err = svc
+            .get_job(get_job_req(job_id, Some(viewer("alice", false))))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_job_steps_returns_not_found_for_an_unknown_job() {
+        // Regression guard: a job absent from the display cache must be NOT_FOUND, not a response
+        // whose owner is mis-derived as "" (which treated the true owner as unprivileged).
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let err = svc
+            .get_job_steps(Request::new(GetJobStepsRequest { job_id: 999_999 }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
     }
 
     #[test]

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -382,14 +382,16 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
      - ``1000``
      - Live
      - Highest base priority a non-admin may request, at submit (``--priority``)
-       or via ``scontrol update``. Requests above this are clamped down — not
-       rejected — with a warning. Defaults to the base priority (``1000``), so a
-       non-admin can lower but not raise priority, matching Slurm, where boosting
-       priority is operator-only. Raise it to grant users a band above the
-       baseline. The ceiling applies only to identified non-admin callers: admins
-       are exempt, and so are callers with no verified identity
-       (``auth.mode = disabled``, or ``permissive`` with no credential), where the
-       cluster trusts the client as before.
+       or via ``scontrol update``. Requests above this are clamped down, not
+       rejected; at submit the clamp is returned to the caller as a warning, while
+       on the ``scontrol update`` path (which has no response field) it is only
+       logged. Defaults to the base priority (``1000``), so a non-admin can lower
+       but not raise priority, matching Slurm, where boosting priority is
+       operator-only. Raise it to grant users a band above the baseline. The
+       ceiling applies only to identified non-admin callers: admins are exempt, and
+       so are callers with no verified identity (``auth.mode = disabled``, or
+       ``permissive`` with no credential), where the cluster trusts the client as
+       before.
    * - ``inactive_limit_secs``
      - integer
      - ``0``

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -250,6 +250,21 @@ and Raft high-availability topology.
      - Live
      - How long a node is skipped for dispatch after rejecting a launch as
        resources-unavailable.
+   * - ``job_info_visibility``
+     - string
+     - ``redacted``
+     - Live
+     - How much of another user's job an identified non-owner (non-admin) may
+       read via ``get_job`` / ``scontrol show job``. ``redacted`` (default) shows
+       identity, state, timing, and account but blanks the working directory,
+       command, stdio paths, comment, resource detail, and allocated nodelist;
+       ``owner_only`` returns ``NOT_FOUND`` for other users' jobs; ``full`` is the
+       legacy behaviour where every field is visible to any caller. Owners and
+       admins always see the full record. Scoping applies only to identified
+       callers — under ``auth.mode = required``, or when a credential is
+       presented under ``permissive``; with authentication disabled or no
+       credential presented, the full record is returned (so no-auth deployments
+       and internal consumers are unaffected).
 
 ``[accounting]``
 ----------------
@@ -362,6 +377,16 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
      - ``300``
      - Live
      - Maximum seconds a job may sit in COMPLETING before it is force-finished.
+   * - ``max_user_priority``
+     - integer
+     - ``1000``
+     - Live
+     - Highest base priority a non-admin may request, at submit (``--priority``)
+       or via ``scontrol update``. Requests above this are clamped down — not
+       rejected — with a warning; admins are unaffected. Defaults to the base
+       priority (``1000``), so a non-admin can lower but not raise priority,
+       matching Slurm, where boosting priority is operator-only. Raise it to grant
+       users a band above the baseline.
    * - ``inactive_limit_secs``
      - integer
      - ``0``

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -383,10 +383,13 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
      - Live
      - Highest base priority a non-admin may request, at submit (``--priority``)
        or via ``scontrol update``. Requests above this are clamped down — not
-       rejected — with a warning; admins are unaffected. Defaults to the base
-       priority (``1000``), so a non-admin can lower but not raise priority,
-       matching Slurm, where boosting priority is operator-only. Raise it to grant
-       users a band above the baseline.
+       rejected — with a warning. Defaults to the base priority (``1000``), so a
+       non-admin can lower but not raise priority, matching Slurm, where boosting
+       priority is operator-only. Raise it to grant users a band above the
+       baseline. The ceiling applies only to identified non-admin callers: admins
+       are exempt, and so are callers with no verified identity
+       (``auth.mode = disabled``, or ``permissive`` with no credential), where the
+       cluster trusts the client as before.
    * - ``inactive_limit_secs``
      - integer
      - ``0``

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -15,6 +15,12 @@ max_launch_backoff_secs = 300
 # max_batch_requeue. Slurm's inverse of this is
 # SchedulerParameters=nohold_on_prolog_fail.
 hold_on_prolog_fail = true
+# How much of another user's job a non-owner (non-admin) may read back from
+# get_job / scontrol show job. "redacted" (default) shows identity/state/
+# timing/account but blanks work_dir, command, stdio paths, and the allocated
+# nodelist; "owner_only" hides other users' jobs entirely; "full" is the legacy
+# unscoped behaviour. Owners and admins always see the full record.
+# job_info_visibility = "redacted"
 # Controller hostname(s). For an HA quorum, list every controller so clients
 # and agents fail over to a surviving node if one is unreachable. Each host is
 # combined with the port from listen_addr. Equivalent to a comma-separated
@@ -26,6 +32,12 @@ plugin = "backfill"
 interval_secs = 1
 max_jobs_per_cycle = 10000
 fairshare_halflife_days = 14
+# Highest base priority a non-admin may request (via --priority at submit or
+# scontrol update). Requests above this are clamped down, not rejected, with a
+# warning; admins are unaffected. Defaults to the base priority (1000), so a
+# non-admin can lower but not raise priority — matching Slurm, where boosting
+# priority is operator-only. Raise it to grant users a band above the baseline.
+# max_user_priority = 1000
 
 [accounting]
 database_url = "postgresql://spur:spur@localhost/spur"

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -37,9 +37,12 @@ max_jobs_per_cycle = 10000
 fairshare_halflife_days = 14
 # Highest base priority a non-admin may request (via --priority at submit or
 # scontrol update). Requests above this are clamped down, not rejected, with a
-# warning; admins are unaffected. Defaults to the base priority (1000), so a
-# non-admin can lower but not raise priority — matching Slurm, where boosting
-# priority is operator-only. Raise it to grant users a band above the baseline.
+# warning. Defaults to the base priority (1000), so a non-admin can lower but not
+# raise priority — matching Slurm, where boosting priority is operator-only. Raise
+# it to grant users a band above the baseline. The ceiling applies only to
+# identified non-admin callers: admins are exempt, and so are callers with no
+# verified identity (auth.mode = disabled, or permissive with no credential),
+# where the cluster trusts the client as before.
 # max_user_priority = 1000
 
 [accounting]

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -15,11 +15,14 @@ max_launch_backoff_secs = 300
 # max_batch_requeue. Slurm's inverse of this is
 # SchedulerParameters=nohold_on_prolog_fail.
 hold_on_prolog_fail = true
-# How much of another user's job a non-owner (non-admin) may read back from
-# get_job / scontrol show job. "redacted" (default) shows identity/state/
-# timing/account but blanks work_dir, command, stdio paths, and the allocated
-# nodelist; "owner_only" hides other users' jobs entirely; "full" is the legacy
-# unscoped behaviour. Owners and admins always see the full record.
+# How much of another user's job an identified non-owner (non-admin) may read
+# back from get_job / scontrol show job. "redacted" (default) shows identity/
+# state/timing/account but blanks work_dir, command, stdio paths, and the
+# allocated nodelist; "owner_only" hides other users' jobs entirely; "full" is
+# the legacy unscoped behaviour. Owners and admins always see the full record.
+# Scoping applies only to identified callers, so it takes effect under
+# auth.mode = required (or a credential presented under permissive); with auth
+# disabled or no credential, the full record is returned.
 # job_info_visibility = "redacted"
 # Controller hostname(s). For an HA quorum, list every controller so clients
 # and agents fail over to a surviving node if one is unreachable. Each host is

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -36,13 +36,14 @@ interval_secs = 1
 max_jobs_per_cycle = 10000
 fairshare_halflife_days = 14
 # Highest base priority a non-admin may request (via --priority at submit or
-# scontrol update). Requests above this are clamped down, not rejected, with a
-# warning. Defaults to the base priority (1000), so a non-admin can lower but not
-# raise priority — matching Slurm, where boosting priority is operator-only. Raise
-# it to grant users a band above the baseline. The ceiling applies only to
-# identified non-admin callers: admins are exempt, and so are callers with no
-# verified identity (auth.mode = disabled, or permissive with no credential),
-# where the cluster trusts the client as before.
+# scontrol update). Requests above this are clamped down, not rejected; at submit
+# the clamp is returned as a warning, on the scontrol update path (no response
+# field) it is only logged. Defaults to the base priority (1000), so a non-admin
+# can lower but not raise priority — matching Slurm, where boosting priority is
+# operator-only. Raise it to grant users a band above the baseline. The ceiling
+# applies only to identified non-admin callers: admins are exempt, and so are
+# callers with no verified identity (auth.mode = disabled, or permissive with no
+# credential), where the cluster trusts the client as before.
 # max_user_priority = 1000
 
 [accounting]


### PR DESCRIPTION
Fixes the two exploitable-today tenancy items from the multi-tenancy isolation roadmap (epic #665). Both survive the identity spine (#640) and both gate on the verified caller identity, so this targets `main` after #640.

## #663 — restrict client-settable job priority

An unprivileged caller could front-run the entire queue: `spec.priority` was taken verbatim (gated only `> 0`) and used as the base, while the compensating factors are capped (fair-share ≤ 10, age ≤ 2), so one job at `u32::MAX` outranks every default-priority job permanently.

- New `[scheduler] max_user_priority` (default `DEFAULT_PRIORITY` = 1000). A non-admin request above the ceiling is **clamped down and a warning returned**, not rejected — Slurm's `nice`-only model, where raising priority is operator-only.
- `clamp_priority()` is applied at **`submit_job`** and the **`update_job`** priority arm, so the ceiling can't be bypassed post-submit.
- Admin = the token's `admin` claim **or** the accounting `Admin` level.

## #664 — redact cross-tenant job info

`get_job`/`get_job_steps` returned any job's metadata to any caller with no owner scoping (unlike `get_jobs`), leaking work_dir, command, stdio paths, and — most usefully to an attacker — the **allocated nodelist**.

- New `[controller] job_info_visibility` = `redacted` (default) | `owner_only` | `full`.
- Owners and admins always see the full record. Under `redacted`, a non-owner gets identity/state/timing/account but work_dir, command, stdio paths, comment, resource detail, and the nodelist are blanked. `owner_only` returns `NOT_FOUND`; `full` is the legacy behaviour.
- Applied to `get_job` and `get_job_steps` (step names blanked under `redacted`). The disclosure decision is a pure function so the policy matrix is unit-tested.

## Notes

- **One PR, not two:** the fixes share `caller_is_admin` and touch the same two files, so they can't be cleanly independent PRs. Two commits' worth of concern, kept reviewable by putting each fix in distinct functions.
- Default behaviour changes: non-admins can no longer raise priority above 1000, and non-owners no longer see other users' nodelist/command/paths. Both are configurable (`max_user_priority`, `job_info_visibility = full`) for operators who want the old behaviour.
- `get_job_steps` under `owner_only` returns an empty step list rather than `NOT_FOUND` (the RPC already returns empty for unknown jobs, so ownership isn't a distinguisher).

## Testing

Verified on Linux (shark-a): `cargo fmt --check` clean, `clippy` clean, **spurctld 786/786**, **spur-core 518/518**. 5 new unit tests: priority clamp (above/at/below ceiling + admin-exempt), disclosure matrix (owner/admin × 3 policies), redaction field set.

Part of #665. Closes #663. Closes #664.