### PR TITLE
docs(agents): require docs/ updates for user-facing changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ cargo build
 - Proto conversion helpers live in the same file as the gRPC server (e.g., `server.rs` has `proto_to_job_spec`, `job_to_proto`).
 - Write idiomatic Rust. Keep control flow flat — use early returns and `?` instead of deep nesting. Prefer small, focused functions that are independently testable.
 - Slurm compatibility is a migration bridge, not a design constraint. Only user-facing surfaces (CLI, REST API, FFI) need to stay compatible. Internals should prefer simple, modern defaults — do not inherit legacy complexity.
+- User-facing changes ship with docs. Whenever you change CLI flags, REST/gRPC API surface, config fields, or user-visible behavior, check `docs/` and update the pages that describe it; a new feature must always be documented — consider whether it warrants its own page or subsection rather than a passing mention.
 
 ## Git Workflow
 


### PR DESCRIPTION
## What

Adds one bullet to the Conventions section of `AGENTS.md` telling coding agents to keep `docs/` in sync with user-facing changes.

## Why

Agents working in this repo reliably update code, tests, and PR descriptions, but routinely skip `docs/`. CLI flags, REST/gRPC surface, config fields, and behavior changes land documented only in git history. New features in particular tend to ship with no page at all, so the docs drift behind the product.

The new bullet makes the expectation explicit and, for new features, nudges toward a deliberate placement decision — its own page or subsection when warranted, rather than a passing mention appended to an unrelated page.

## Notes

`AGENTS.md` is included by `CLAUDE.md`, so this applies to both entry points. Docs-only change: no code, no build or test impact.