### PR TITLE
fix(spur-cli): accept Slurm's -n, -p and -P output flags on sacctmgr

### DIFF
--- a/crates/spur-cli/src/format_engine.rs
+++ b/crates/spur-cli/src/format_engine.rs
@@ -227,13 +227,115 @@ fn format_field(value: &str, field: &FormatField) -> String {
 
 /// Print a header row followed by a separator line (dashes under text, spaces under spaces).
 pub fn print_header(tokens: &[FormatToken]) {
-    let header = format_header(tokens);
-    let sep: String = header
-        .chars()
-        .map(|c| if c == ' ' { ' ' } else { '-' })
-        .collect();
-    println!("{header}");
-    println!("{sep}");
+    OutputStyle::default().print_header(tokens);
+}
+
+/// Separator used by Slurm's `--parsable` family.
+const DELIMITER: char = '|';
+
+/// How a row's fields are separated.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RowLayout {
+    /// Padded to each field's width, the human-readable table.
+    #[default]
+    Aligned,
+    /// Slurm's `-P`/`--parsable2`: delimited, no closing delimiter.
+    Delimited,
+    /// Slurm's `-p`/`--parsable`: delimited, with a closing delimiter.
+    DelimitedTrailing,
+}
+
+/// Header visibility and row layout, resolved once from a command's flags and passed to
+/// wherever it prints.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OutputStyle {
+    noheader: bool,
+    layout: RowLayout,
+}
+
+impl OutputStyle {
+    pub fn new(noheader: bool, layout: RowLayout) -> Self {
+        Self { noheader, layout }
+    }
+
+    /// The header block: nothing when suppressed, a single delimited line, or a padded
+    /// header plus its dashed rule.
+    pub fn header_lines(&self, tokens: &[FormatToken]) -> Vec<String> {
+        if self.noheader {
+            return Vec::new();
+        }
+
+        if let Some(trailing) = self.delimited() {
+            return vec![join_fields(tokens, &|field| field.header.clone(), trailing)];
+        }
+
+        let header = format_header(tokens);
+        let rule = header
+            .chars()
+            .map(|c| if c == ' ' { ' ' } else { '-' })
+            .collect();
+        vec![header, rule]
+    }
+
+    pub fn print_header(&self, tokens: &[FormatToken]) {
+        for line in self.header_lines(tokens) {
+            println!("{line}");
+        }
+    }
+
+    /// For callers printing a fixed-width table that `format_engine` does not model.
+    pub fn shows_header(&self) -> bool {
+        !self.noheader
+    }
+
+    pub fn is_delimited(&self) -> bool {
+        self.delimited().is_some()
+    }
+
+    pub fn row(&self, tokens: &[FormatToken], resolver: &dyn Fn(char) -> String) -> String {
+        match self.delimited() {
+            Some(trailing) => join_fields(tokens, &|field| resolver(field.spec), trailing),
+            None => format_row(tokens, resolver),
+        }
+    }
+
+    /// `Some(trailing)` when delimited, where `trailing` asks for a closing delimiter.
+    fn delimited(&self) -> Option<bool> {
+        match self.layout {
+            RowLayout::Aligned => None,
+            RowLayout::Delimited => Some(false),
+            RowLayout::DelimitedTrailing => Some(true),
+        }
+    }
+}
+
+/// Join field values with the delimiter, unpadded and untruncated. Literal tokens are
+/// dropped: the delimiter replaces whatever spacing the format string asked for. Empty
+/// values keep their separators, so the field count stays fixed for the caller parsing it.
+fn join_fields(
+    tokens: &[FormatToken],
+    value: &dyn Fn(&FormatField) -> String,
+    trailing: bool,
+) -> String {
+    let mut out = String::new();
+    let mut seen_field = false;
+
+    for token in tokens {
+        let FormatToken::Field(field) = token else {
+            continue;
+        };
+        if seen_field {
+            out.push(DELIMITER);
+        }
+        out.push_str(&value(field));
+        seen_field = true;
+    }
+
+    if trailing && seen_field {
+        out.push(DELIMITER);
+    }
+
+    out
 }
 
 /// Resolve a `format=` parameter into tokens.
@@ -500,5 +602,87 @@ mod tests {
             .filter(|t| matches!(t, FormatToken::Field(_)))
             .count();
         assert_eq!(field_count, 2);
+    }
+
+    /// Two padded columns, `JOBID` then `NAME`, with a literal space between them.
+    fn styled_tokens() -> Vec<FormatToken> {
+        parse_format("%.10i %.8j", &squeue_header)
+    }
+
+    fn styled_row(style: OutputStyle, name: &str) -> String {
+        style.row(&styled_tokens(), &|spec| match spec {
+            'i' => "42".to_string(),
+            'j' => name.to_string(),
+            other => panic!("unexpected spec {other}"),
+        })
+    }
+
+    #[test]
+    fn aligned_style_is_byte_identical_to_the_padded_helpers() {
+        let tokens = styled_tokens();
+        let style = OutputStyle::default();
+
+        assert_eq!(styled_row(style, "train"), "        42    train");
+        assert_eq!(
+            style.header_lines(&tokens),
+            vec!["     JOBID     NAME", "     -----     ----"]
+        );
+    }
+
+    #[test]
+    fn parsable2_joins_fields_with_a_pipe_and_no_trailing_pipe() {
+        let style = OutputStyle::new(false, RowLayout::Delimited);
+
+        assert_eq!(styled_row(style, "train"), "42|train");
+        assert_eq!(style.header_lines(&styled_tokens()), vec!["JOBID|NAME"]);
+    }
+
+    #[test]
+    fn parsable_appends_a_trailing_pipe() {
+        let style = OutputStyle::new(false, RowLayout::DelimitedTrailing);
+
+        assert_eq!(styled_row(style, "train"), "42|train|");
+        assert_eq!(style.header_lines(&styled_tokens()), vec!["JOBID|NAME|"]);
+    }
+
+    #[test]
+    fn delimited_rows_keep_an_empty_trailing_field() {
+        // Trimming here would drop the last separator and change the field count a
+        // script sees, which is the whole point of asking for delimited output.
+        assert_eq!(
+            styled_row(OutputStyle::new(false, RowLayout::Delimited), ""),
+            "42|"
+        );
+        assert_eq!(
+            styled_row(OutputStyle::new(false, RowLayout::DelimitedTrailing), ""),
+            "42||"
+        );
+    }
+
+    #[test]
+    fn delimited_output_drops_padding_and_truncation() {
+        let tokens = parse_format("%.3i", &squeue_header);
+        let long = |_: char| "1234567890".to_string();
+
+        assert_eq!(format_row(&tokens, &long), "123");
+        assert_eq!(
+            OutputStyle::new(false, RowLayout::Delimited).row(&tokens, &long),
+            "1234567890"
+        );
+    }
+
+    #[test]
+    fn noheader_suppresses_the_header_in_every_layout() {
+        for layout in [
+            RowLayout::Aligned,
+            RowLayout::Delimited,
+            RowLayout::DelimitedTrailing,
+        ] {
+            let style = OutputStyle::new(true, layout);
+            assert!(
+                style.header_lines(&styled_tokens()).is_empty(),
+                "{layout:?} emitted a header"
+            );
+        }
     }
 }

--- a/crates/spur-cli/src/format_engine.rs
+++ b/crates/spur-cli/src/format_engine.rs
@@ -309,9 +309,8 @@ impl OutputStyle {
     }
 }
 
-/// Join field values with the delimiter, unpadded and untruncated. Literal tokens are
-/// dropped: the delimiter replaces whatever spacing the format string asked for. Empty
-/// values keep their separators, so the field count stays fixed for the caller parsing it.
+/// Join field values with the delimiter, unpadded and untruncated; literal spacing tokens
+/// are dropped. Empty values keep their separators so the field count stays fixed.
 fn join_fields(
     tokens: &[FormatToken],
     value: &dyn Fn(&FormatField) -> String,

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -88,16 +88,11 @@ pub enum SacctmgrCommand {
     Show {
         /// Entity type: account, user, qos, association
         entity: String,
-        /// Optional filter
-        #[arg(trailing_var_arg = true)]
+        /// Optional `key=value` filters; a global flag may sit anywhere among them.
         params: Vec<String>,
     },
     /// List entities (alias for show)
-    List {
-        entity: String,
-        #[arg(trailing_var_arg = true)]
-        params: Vec<String>,
-    },
+    List { entity: String, params: Vec<String> },
 }
 
 pub async fn main() -> Result<()> {
@@ -866,23 +861,12 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
     }
 }
 
-/// Entities `show` prints as fixed-width tables, with no field-spec table behind them.
-/// A new entity rendered that way belongs here.
-const FIXED_WIDTH_ENTITIES: [&str; 8] = [
-    "user",
-    "users",
-    "association",
-    "associations",
-    "tres",
-    "txn",
-    "transaction",
-    "transactions",
-];
+/// Entities `show` prints as hardcoded fixed-width tables, with no field-spec table behind
+/// them. A new entity rendered that way belongs here.
+const FIXED_WIDTH_ENTITIES: [&str; 5] = ["user", "users", "association", "associations", "tres"];
 
-/// Accepting `-p`/`-P` for a fixed-width entity would hand a script padded text where it
-/// expects delimited fields, so refuse loudly instead of returning output that silently
-/// will not parse. Unrecognized entities are left to `show`, so they still report the
-/// unknown entity rather than a delimiter complaint.
+/// Delimiting a fixed-width table hands a script padded text it cannot parse, so refuse it.
+/// Unknown entities fall through to `show`, which reports them itself.
 fn reject_unsupported_delimiter(entity: &str, style: format_engine::OutputStyle) -> Result<()> {
     if !style.is_delimited() || !FIXED_WIDTH_ENTITIES.contains(&entity) {
         return Ok(());
@@ -890,7 +874,7 @@ fn reject_unsupported_delimiter(entity: &str, style: format_engine::OutputStyle)
 
     bail!(
         "sacctmgr: delimited output (-p/-P) is not supported for '{entity}'. \
-         Supported entities: account, qos"
+         Supported entities: account, qos, txn"
     )
 }
 
@@ -1029,12 +1013,9 @@ async fn show(
                 .into_inner()
                 .transactions;
 
-            format_engine::print_header(&fields);
+            style.print_header(&fields);
             for t in &txns {
-                println!(
-                    "{}",
-                    format_engine::format_row(&fields, &|spec| resolve_txn_field(t, spec))
-                );
+                println!("{}", style.row(&fields, &|spec| resolve_txn_field(t, spec)));
             }
             Ok(())
         }
@@ -2498,6 +2479,42 @@ mod tests {
         assert_eq!(params, vec!["format=Name,Priority".to_string()]);
     }
 
+    #[test]
+    fn a_delimiter_flag_after_a_param_is_still_parsed() {
+        let args =
+            SacctmgrArgs::try_parse_from(["sacctmgr", "show", "qos", "format=Name,Priority", "-P"])
+                .expect("a flag after a param must parse");
+
+        assert!(args.parsable2);
+        let SacctmgrCommand::Show { params, .. } = args.command else {
+            panic!("expected a show command");
+        };
+        assert_eq!(params, vec!["format=Name,Priority".to_string()]);
+    }
+
+    #[test]
+    fn a_delimiter_flag_between_params_does_not_swallow_the_next() {
+        let args = SacctmgrArgs::try_parse_from([
+            "sacctmgr",
+            "show",
+            "qos",
+            "name=gpu",
+            "-P",
+            "format=Name",
+        ])
+        .expect("a flag between params must parse");
+
+        assert!(args.parsable2);
+        let SacctmgrCommand::Show { params, .. } = args.command else {
+            panic!("expected a show command");
+        };
+        assert_eq!(
+            params,
+            vec!["name=gpu".to_string(), "format=Name".to_string()],
+            "the flag must not consume the following filter as its value"
+        );
+    }
+
     fn style_from(flags: &[&str]) -> format_engine::OutputStyle {
         let mut argv = vec!["sacctmgr"];
         argv.extend_from_slice(flags);
@@ -2559,28 +2576,71 @@ mod tests {
     }
 
     #[test]
-    fn header_suppression_applies_to_fixed_width_entities_too() {
+    fn noheader_flag_resolves_into_the_style() {
         assert!(style_from(&[]).shows_header());
         assert!(!style_from(&["-n"]).shows_header());
+    }
+
+    fn stub_txn() -> TransactionRecord {
+        TransactionRecord {
+            id: 7,
+            timestamp: None,
+            actor: "bob".into(),
+            actor_uid: 1000,
+            verified: true,
+            source: "api".into(),
+            action: "create".into(),
+            entity_type: "qos".into(),
+            entity_name: "gpu".into(),
+            outcome: "success".into(),
+            details: "{}".into(),
+        }
+    }
+
+    /// A `show txn` header block and row for the given flags, mirroring the arm's rendering.
+    fn txn_render(flags: &[&str], format: &str) -> (Vec<String>, String) {
+        let fields = txn_format_fields(Some(format)).expect("txn format must parse");
+        let style = SacctmgrArgs::try_parse_from(
+            ["sacctmgr"]
+                .iter()
+                .chain(flags)
+                .chain(&["show", "txn"])
+                .copied()
+                .collect::<Vec<_>>(),
+        )
+        .expect("flags must parse")
+        .output_style();
+        let row = style.row(&fields, &|spec| resolve_txn_field(&stub_txn(), spec));
+        (style.header_lines(&fields), row)
+    }
+
+    #[test]
+    fn txn_honours_noheader_and_delimited_output() {
+        let (header, row) = txn_render(&["-n", "-P"], "Action,Actor");
+        assert!(header.is_empty(), "-n must suppress the txn header");
+        assert_eq!(row, "create|bob");
+
+        let (header, _) = txn_render(&[], "Action,Actor");
+        assert!(!header.is_empty(), "the txn header must print by default");
     }
 
     #[test]
     fn delimited_output_is_refused_only_where_columns_are_not_modelled() {
         let delimited = style_from(&["-P"]);
-        for entity in ["account", "accounts", "qos"] {
+        for entity in [
+            "account",
+            "accounts",
+            "qos",
+            "txn",
+            "transaction",
+            "transactions",
+        ] {
             assert!(
                 reject_unsupported_delimiter(entity, delimited).is_ok(),
                 "{entity} should support delimited output"
             );
         }
-        for entity in [
-            "user",
-            "users",
-            "association",
-            "tres",
-            "txn",
-            "transactions",
-        ] {
+        for entity in FIXED_WIDTH_ENTITIES {
             assert!(
                 reject_unsupported_delimiter(entity, delimited).is_err(),
                 "{entity} should refuse delimited output"
@@ -2589,7 +2649,7 @@ mod tests {
 
         // Padded output stays available for every entity.
         let padded = style_from(&[]);
-        for entity in ["user", "association", "tres"] {
+        for entity in FIXED_WIDTH_ENTITIES {
             assert!(reject_unsupported_delimiter(entity, padded).is_ok());
         }
     }

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -28,6 +28,34 @@ pub struct SacctmgrArgs {
     /// Immediate mode (no confirmation)
     #[arg(short = 'i', long, global = true)]
     pub immediate: bool,
+
+    /// Omit the header line
+    #[arg(short = 'n', long, global = true)]
+    pub noheader: bool,
+
+    /// Output '|' delimited with a trailing '|'
+    #[arg(short = 'p', long, global = true)]
+    pub parsable: bool,
+
+    /// Output '|' delimited without a trailing '|'
+    #[arg(short = 'P', long, global = true)]
+    pub parsable2: bool,
+}
+
+impl SacctmgrArgs {
+    /// Slurm takes whichever delimiter flag came last; clap's derive cannot see flag order,
+    /// so `-P` wins when both are given rather than rejecting input Slurm accepts.
+    fn output_style(&self) -> format_engine::OutputStyle {
+        let layout = if self.parsable2 {
+            format_engine::RowLayout::Delimited
+        } else if self.parsable {
+            format_engine::RowLayout::DelimitedTrailing
+        } else {
+            format_engine::RowLayout::Aligned
+        };
+
+        format_engine::OutputStyle::new(self.noheader, layout)
+    }
 }
 
 #[derive(Subcommand, Debug)]
@@ -79,13 +107,14 @@ pub async fn main() -> Result<()> {
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let args = SacctmgrArgs::try_parse_from(&args)?;
     let addr = args.controller.clone();
+    let style = args.output_style();
 
     match args.command {
         SacctmgrCommand::Add { entity, params } => add(&entity, &params, &addr).await,
         SacctmgrCommand::Delete { entity, params } => delete(&entity, &params, &addr).await,
         SacctmgrCommand::Modify { entity, params } => modify(&entity, &params, &addr).await,
         SacctmgrCommand::Show { entity, params } | SacctmgrCommand::List { entity, params } => {
-            show(&entity, &params, &addr).await
+            show(&entity, &params, &addr, style).await
         }
     }
 }
@@ -837,10 +866,34 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
     }
 }
 
-async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
-    let p = parse_params(params);
+/// Entities whose columns come from `format_engine`, and so can be delimited.
+const DELIMITABLE_ENTITIES: [&str; 3] = ["account", "accounts", "qos"];
 
-    match entity.to_lowercase().as_str() {
+/// The remaining entities print fixed-width tables with no field-spec table behind them.
+/// Accepting `-p`/`-P` there would hand a script padded text where it expects delimited
+/// fields, so refuse loudly instead of returning output that silently will not parse.
+fn reject_unsupported_delimiter(entity: &str, style: format_engine::OutputStyle) -> Result<()> {
+    if !style.is_delimited() || DELIMITABLE_ENTITIES.contains(&entity) {
+        return Ok(());
+    }
+
+    bail!(
+        "sacctmgr: delimited output (-p/-P) is not supported for '{entity}'. \
+         Supported entities: account, qos"
+    )
+}
+
+async fn show(
+    entity: &str,
+    params: &[String],
+    addr: &str,
+    style: format_engine::OutputStyle,
+) -> Result<()> {
+    let p = parse_params(params);
+    let entity = entity.to_lowercase();
+    reject_unsupported_delimiter(&entity, style)?;
+
+    match entity.as_str() {
         "account" | "accounts" => {
             let fields = account_format_fields(p.get("format").map(String::as_str))?;
 
@@ -852,12 +905,12 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
 
             let accounts = resp.into_inner().accounts;
 
-            format_engine::print_header(&fields);
+            style.print_header(&fields);
 
             for a in &accounts {
                 println!(
                     "{}",
-                    format_engine::format_row(&fields, &|spec| resolve_account_field(a, spec))
+                    style.row(&fields, &|spec| resolve_account_field(a, spec))
                 );
             }
             Ok(())
@@ -876,8 +929,11 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
 
             let users = resp.into_inner().users;
 
-            println!("{}", user_header_row());
-            println!("{}", "-".repeat(180));
+            if style.shows_header() {
+                println!("{}", user_header_row());
+                println!("{}", "-".repeat(180));
+            }
+
             for u in &users {
                 println!("{}", format_user_row(u));
             }
@@ -907,7 +963,7 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 filter_qos_by_name(&mut qos_list, name_filter);
             }
 
-            format_engine::print_header(&fields);
+            style.print_header(&fields);
 
             if qos_list.is_empty() && !has_name_filter {
                 let default_qos = QosInfo {
@@ -918,32 +974,30 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 };
                 println!(
                     "{}",
-                    format_engine::format_row(&fields, &|spec| resolve_qos_field(
-                        &default_qos,
-                        spec
-                    ))
+                    style.row(&fields, &|spec| resolve_qos_field(&default_qos, spec))
                 );
             } else {
                 for q in &qos_list {
-                    println!(
-                        "{}",
-                        format_engine::format_row(&fields, &|spec| resolve_qos_field(q, spec))
-                    );
+                    println!("{}", style.row(&fields, &|spec| resolve_qos_field(q, spec)));
                 }
             }
             Ok(())
         }
         "association" | "associations" => {
-            println!(
-                "{:<15} {:<20} {:<15} {:<10} {:<10}",
-                "User", "Account", "Partition", "Share", "Default"
-            );
-            println!("{}", "-".repeat(70));
+            if style.shows_header() {
+                println!(
+                    "{:<15} {:<20} {:<15} {:<10} {:<10}",
+                    "User", "Account", "Partition", "Share", "Default"
+                );
+                println!("{}", "-".repeat(70));
+            }
             Ok(())
         }
         "tres" => {
-            println!("{:<5} {:<15} {:<10}", "ID", "Type", "Name");
-            println!("{}", "-".repeat(30));
+            if style.shows_header() {
+                println!("{:<5} {:<15} {:<10}", "ID", "Type", "Name");
+                println!("{}", "-".repeat(30));
+            }
             println!("{:<5} {:<15} {:<10}", "1", "cpu", "");
             println!("{:<5} {:<15} {:<10}", "2", "mem", "");
             println!("{:<5} {:<15} {:<10}", "3", "energy", "");
@@ -2375,6 +2429,164 @@ mod tests {
         assert!(
             build_modify_qos_request(&p).is_err(),
             "malformed preemptexempttime should error"
+        );
+    }
+
+    #[test]
+    fn scripted_query_with_header_and_delimiter_flags_parses() {
+        let args = SacctmgrArgs::try_parse_from([
+            "sacctmgr",
+            "-n",
+            "-P",
+            "show",
+            "qos",
+            "format=Name,Priority,MaxWall",
+        ])
+        .expect("-n -P must parse");
+
+        assert!(args.noheader);
+        assert!(args.parsable2);
+        assert!(!args.parsable);
+    }
+
+    #[test]
+    fn delimiter_flag_long_names_match_slurm() {
+        let trailing =
+            SacctmgrArgs::try_parse_from(["sacctmgr", "--noheader", "--parsable", "show", "qos"])
+                .expect("--parsable must parse");
+        assert!(trailing.noheader);
+        assert!(trailing.parsable);
+        assert!(!trailing.parsable2);
+
+        let no_trailing = SacctmgrArgs::try_parse_from(["sacctmgr", "--parsable2", "show", "qos"])
+            .expect("--parsable2 must parse");
+        assert!(no_trailing.parsable2);
+        assert!(!no_trailing.parsable);
+    }
+
+    #[test]
+    fn header_and_delimiter_flags_leave_other_arguments_alone() {
+        let args = SacctmgrArgs::try_parse_from([
+            "sacctmgr",
+            "-i",
+            "-n",
+            "-P",
+            "show",
+            "qos",
+            "format=Name,Priority",
+        ])
+        .expect("flags must compose with existing globals");
+
+        assert!(args.immediate);
+        assert_eq!(args.controller, "http://localhost:6817");
+
+        let SacctmgrCommand::Show { entity, params } = args.command else {
+            panic!("expected a show command");
+        };
+        assert_eq!(entity, "qos");
+        assert_eq!(params, vec!["format=Name,Priority".to_string()]);
+    }
+
+    fn style_from(flags: &[&str]) -> format_engine::OutputStyle {
+        let mut argv = vec!["sacctmgr"];
+        argv.extend_from_slice(flags);
+        argv.extend_from_slice(&["show", "qos"]);
+
+        SacctmgrArgs::try_parse_from(argv)
+            .expect("flags must parse")
+            .output_style()
+    }
+
+    /// A `show qos` row for the given flags, rendered through the real QOS resolver.
+    fn qos_row(flags: &[&str], format: &str) -> String {
+        let fields = format_engine::parse_named_format(format, &qos_field_spec, &qos_header);
+        style_from(flags).row(&fields, &|spec| resolve_qos_field(&stub_qos(), spec))
+    }
+
+    #[test]
+    fn parsable2_row_has_no_trailing_delimiter() {
+        assert_eq!(qos_row(&["-P"], "Name,Priority"), "gpuqos|100");
+    }
+
+    #[test]
+    fn parsable_row_has_a_trailing_delimiter() {
+        assert_eq!(qos_row(&["-p"], "Name,Priority"), "gpuqos|100|");
+    }
+
+    #[test]
+    fn delimited_values_containing_commas_stay_unambiguous() {
+        // TRES values are comma-separated internally, which is why Slurm's parsable output
+        // uses '|' rather than ','.
+        assert_eq!(qos_row(&["-P"], "Name,GrpTRES"), "gpuqos|node=4,cpu=256");
+    }
+
+    #[test]
+    fn format_ordering_is_preserved_in_delimited_output() {
+        assert_eq!(qos_row(&["-P"], "Priority,Name"), "100|gpuqos");
+    }
+
+    #[test]
+    fn both_delimiter_flags_resolve_to_parsable2() {
+        assert_eq!(qos_row(&["-p", "-P"], "Name,Priority"), "gpuqos|100");
+    }
+
+    #[test]
+    fn without_a_delimiter_flag_rows_are_byte_identical_to_today() {
+        let fields =
+            format_engine::parse_named_format(QOS_DEFAULT_FORMAT, &qos_field_spec, &qos_header);
+        let q = stub_qos();
+        let expected = format_engine::format_row(&fields, &|spec| resolve_qos_field(&q, spec));
+
+        assert_eq!(
+            style_from(&[]).row(&fields, &|spec| resolve_qos_field(&q, spec)),
+            expected
+        );
+        assert_eq!(
+            style_from(&["-n"]).row(&fields, &|spec| resolve_qos_field(&q, spec)),
+            expected
+        );
+    }
+
+    #[test]
+    fn header_suppression_applies_to_fixed_width_entities_too() {
+        assert!(style_from(&[]).shows_header());
+        assert!(!style_from(&["-n"]).shows_header());
+    }
+
+    #[test]
+    fn delimited_output_is_refused_only_where_columns_are_not_modelled() {
+        let delimited = style_from(&["-P"]);
+        for entity in ["account", "accounts", "qos"] {
+            assert!(
+                reject_unsupported_delimiter(entity, delimited).is_ok(),
+                "{entity} should support delimited output"
+            );
+        }
+        for entity in ["user", "users", "association", "tres"] {
+            assert!(
+                reject_unsupported_delimiter(entity, delimited).is_err(),
+                "{entity} should refuse delimited output"
+            );
+        }
+
+        // Padded output stays available for every entity.
+        let padded = style_from(&[]);
+        for entity in ["user", "association", "tres"] {
+            assert!(reject_unsupported_delimiter(entity, padded).is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn unsupported_delimiter_fails_before_contacting_the_controller() {
+        // Port 1 is unroutable: reaching the network at all would surface a connect error
+        // instead, so this also pins that the check runs first.
+        let err = show("user", &[], "http://127.0.0.1:1", style_from(&["-P"]))
+            .await
+            .expect_err("delimited show user must fail");
+
+        assert!(
+            err.to_string().contains("not supported for 'user'"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -64,24 +64,21 @@ pub enum SacctmgrCommand {
     Add {
         /// Entity type: account, user, qos
         entity: String,
-        /// key=value pairs
-        #[arg(trailing_var_arg = true)]
+        /// Optional `key=value` pairs; a global flag may sit anywhere among them.
         params: Vec<String>,
     },
     /// Delete entities
     Delete {
         /// Entity type: account, user, qos
         entity: String,
-        /// key=value pairs (name= or where clause)
-        #[arg(trailing_var_arg = true)]
+        /// Optional `key=value` pairs (name= or where clause); a global flag may sit anywhere among them.
         params: Vec<String>,
     },
     /// Modify entities
     Modify {
         /// Entity type: account, user, qos
         entity: String,
-        /// key=value pairs
-        #[arg(trailing_var_arg = true)]
+        /// Optional `key=value` pairs; a global flag may sit anywhere among them.
         params: Vec<String>,
     },
     /// List/show entities
@@ -2512,6 +2509,30 @@ mod tests {
             params,
             vec!["name=gpu".to_string(), "format=Name".to_string()],
             "the flag must not consume the following filter as its value"
+        );
+    }
+
+    #[test]
+    fn a_flag_among_modify_params_does_not_swallow_an_update() {
+        let args = SacctmgrArgs::try_parse_from([
+            "sacctmgr",
+            "modify",
+            "qos",
+            "gpu",
+            "set",
+            "-i",
+            "priority=10",
+        ])
+        .expect("a flag among modify params must parse");
+
+        assert!(args.immediate);
+        let SacctmgrCommand::Modify { params, .. } = args.command else {
+            panic!("expected a modify command");
+        };
+        assert_eq!(
+            parse_params(&params).get("priority").map(String::as_str),
+            Some("10"),
+            "a swallowed flag would consume the update and silently apply nothing"
         );
     }
 

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -866,14 +866,25 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
     }
 }
 
-/// Entities whose columns come from `format_engine`, and so can be delimited.
-const DELIMITABLE_ENTITIES: [&str; 3] = ["account", "accounts", "qos"];
+/// Entities `show` prints as fixed-width tables, with no field-spec table behind them.
+/// A new entity rendered that way belongs here.
+const FIXED_WIDTH_ENTITIES: [&str; 8] = [
+    "user",
+    "users",
+    "association",
+    "associations",
+    "tres",
+    "txn",
+    "transaction",
+    "transactions",
+];
 
-/// The remaining entities print fixed-width tables with no field-spec table behind them.
-/// Accepting `-p`/`-P` there would hand a script padded text where it expects delimited
-/// fields, so refuse loudly instead of returning output that silently will not parse.
+/// Accepting `-p`/`-P` for a fixed-width entity would hand a script padded text where it
+/// expects delimited fields, so refuse loudly instead of returning output that silently
+/// will not parse. Unrecognized entities are left to `show`, so they still report the
+/// unknown entity rather than a delimiter complaint.
 fn reject_unsupported_delimiter(entity: &str, style: format_engine::OutputStyle) -> Result<()> {
-    if !style.is_delimited() || DELIMITABLE_ENTITIES.contains(&entity) {
+    if !style.is_delimited() || !FIXED_WIDTH_ENTITIES.contains(&entity) {
         return Ok(());
     }
 
@@ -2562,7 +2573,14 @@ mod tests {
                 "{entity} should support delimited output"
             );
         }
-        for entity in ["user", "users", "association", "tres"] {
+        for entity in [
+            "user",
+            "users",
+            "association",
+            "tres",
+            "txn",
+            "transactions",
+        ] {
             assert!(
                 reject_unsupported_delimiter(entity, delimited).is_err(),
                 "{entity} should refuse delimited output"
@@ -2586,6 +2604,18 @@ mod tests {
 
         assert!(
             err.to_string().contains("not supported for 'user'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unknown_entity_reports_itself_rather_than_the_delimiter() {
+        let err = show("wombat", &[], "http://127.0.0.1:1", style_from(&["-P"]))
+            .await
+            .expect_err("unknown entity must fail");
+
+        assert!(
+            err.to_string().contains("unknown entity 'wombat'"),
             "unexpected error: {err}"
         );
     }

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -862,6 +862,51 @@ in the cluster and silently exceeding the cap. ``MaxTRESPerJob``'s and
 a job's actual requested node count, since they bound a single job's or
 user's own footprint rather than group-wide capacity reuse.
 
+Scripted output
+---------------
+
+``sacctmgr show`` prints a column-aligned table for reading. For scripts, three
+Slurm flags change that rendering; they are global, so they may appear before or
+after the subcommand.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 74
+
+   * - Flag
+     - Effect
+   * - ``-n``, ``--noheader``
+     - Omit the header line and its dashed rule.
+   * - ``-p``, ``--parsable``
+     - Print fields ``|`` delimited, **with** a trailing ``|``.
+   * - ``-P``, ``--parsable2``
+     - Print fields ``|`` delimited, **without** a trailing ``|``.
+
+.. code-block:: bash
+
+   sacctmgr -n -P show qos format=Name,Priority,MaxWall
+   sacctmgr -n -P show qos format=Name,Priority | cut -d'|' -f1
+
+The trailing delimiter is the only difference between ``-p`` and ``-P``, and it
+changes the field count that ``cut``, ``awk``, and ``IFS`` splitting see. Choose
+one deliberately. Delimited output keeps empty fields as empty, so a row whose
+last columns are unset still carries its separators and the field count stays
+stable across rows.
+
+Delimited output ignores column widths and truncation, so a long value is printed
+in full rather than clipped to fit a column.
+
+.. note::
+
+   ``-p`` and ``-P`` work for ``show account`` and ``show qos``.
+   For ``show user``, ``show association``, and ``show tres``, Spur does not
+   model the columns, so it refuses the flag with an error naming the entity
+   rather than printing padded text a script cannot parse. ``-n`` works for
+   every entity.
+
+   Passing both ``-p`` and ``-P`` gives ``-P``. Slurm applies whichever came
+   last; the flag order is not visible here, so the no-trailing form wins.
+
 Managing nodes at runtime
 -------------------------
 

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -867,7 +867,12 @@ Scripted output
 
 ``sacctmgr show`` prints a column-aligned table for reading. For scripts, three
 Slurm flags change that rendering; they are global, so they may appear anywhere on
-the command line, including after the entity and its ``key=value`` filters.
+the command line, including after the entity and its ``key=value`` filters. The
+same holds for ``add``, ``delete``, and ``modify``: a global flag among their
+``key=value`` pairs is parsed as a flag, not absorbed as a pair. An
+**unrecognised** token there is now an error naming the argument, where earlier
+releases silently absorbed it — and, if a ``key=value`` pair followed, dropped
+that pair too.
 
 .. list-table::
    :header-rows: 1

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -866,8 +866,8 @@ Scripted output
 ---------------
 
 ``sacctmgr show`` prints a column-aligned table for reading. For scripts, three
-Slurm flags change that rendering; they are global, so they may appear before or
-after the subcommand.
+Slurm flags change that rendering; they are global, so they may appear anywhere on
+the command line, including after the entity and its ``key=value`` filters.
 
 .. list-table::
    :header-rows: 1
@@ -896,13 +896,17 @@ stable across rows.
 Delimited output ignores column widths and truncation, so a long value is printed
 in full rather than clipped to fit a column.
 
+Field values are not escaped. A free-text field carrying a literal ``|`` (an
+account ``Descr``/``Org``, or a transaction's ``Info``) shifts every field after
+it, so ``cut -d'|'`` reads the wrong column. Slurm behaves identically; treat
+delimited output as unambiguous only when the fields you select cannot contain ``|``.
+
 .. note::
 
-   ``-p`` and ``-P`` work for ``show account`` and ``show qos``.
-   For ``show user``, ``show association``, ``show tres``, and ``show txn``,
-   Spur does not model the columns, so it refuses the flag with an error naming
-   the entity rather than printing padded text a script cannot parse. ``-n``
-   works for every entity.
+   ``-p`` and ``-P`` work for ``show account``, ``show qos``, and ``show txn``.
+   For ``show user``, ``show association``, and ``show tres``, Spur does not model
+   the columns, so it refuses the flag with an error naming the entity rather than
+   printing padded text a script cannot parse. ``-n`` works for every entity.
 
    Passing both ``-p`` and ``-P`` gives ``-P``. Slurm applies whichever came
    last; the flag order is not visible here, so the no-trailing form wins.

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -899,10 +899,10 @@ in full rather than clipped to fit a column.
 .. note::
 
    ``-p`` and ``-P`` work for ``show account`` and ``show qos``.
-   For ``show user``, ``show association``, and ``show tres``, Spur does not
-   model the columns, so it refuses the flag with an error naming the entity
-   rather than printing padded text a script cannot parse. ``-n`` works for
-   every entity.
+   For ``show user``, ``show association``, ``show tres``, and ``show txn``,
+   Spur does not model the columns, so it refuses the flag with an error naming
+   the entity rather than printing padded text a script cannot parse. ``-n``
+   works for every entity.
 
    Passing both ``-p`` and ``-P`` gives ``-P``. Slurm applies whichever came
    last; the flag order is not visible here, so the no-trailing form wins.

--- a/docs/migration-from-slurm.rst
+++ b/docs/migration-from-slurm.rst
@@ -70,7 +70,7 @@ noted as "accepted for compatibility" parse without error but have no effect yet
    * - ``sprio``
      - The ``FAIRSHARE`` column is a placeholder and does not yet reflect usage.
    * - ``sacctmgr`` ``-p``/``-P``
-     - Delimited output covers ``show account`` and ``show qos``; for ``show user``, ``show association``, and ``show tres`` it errors instead of printing a table no script can parse. ``-n`` works for every entity.
+     - Delimited output covers ``show account`` and ``show qos``; for ``show user``, ``show association``, ``show tres``, and ``show txn`` it errors instead of printing a table no script can parse. ``-n`` works for every entity.
    * - ``scancel`` arrays
      - Array-element syntax (``123_4``) is not yet supported client-side; cancel by plain job id.
    * - ``scontrol show``

--- a/docs/migration-from-slurm.rst
+++ b/docs/migration-from-slurm.rst
@@ -69,6 +69,8 @@ noted as "accepted for compatibility" parse without error but have no effect yet
      - Per-process ``Ave*`` and ``Max*`` metrics (for example ``AveRSS``, ``MaxVMSize``) show ``N/A``.
    * - ``sprio``
      - The ``FAIRSHARE`` column is a placeholder and does not yet reflect usage.
+   * - ``sacctmgr`` ``-p``/``-P``
+     - Delimited output covers ``show account`` and ``show qos``; for ``show user``, ``show association``, and ``show tres`` it errors instead of printing a table no script can parse. ``-n`` works for every entity.
    * - ``scancel`` arrays
      - Array-element syntax (``123_4``) is not yet supported client-side; cancel by plain job id.
    * - ``scontrol show``

--- a/docs/migration-from-slurm.rst
+++ b/docs/migration-from-slurm.rst
@@ -70,7 +70,7 @@ noted as "accepted for compatibility" parse without error but have no effect yet
    * - ``sprio``
      - The ``FAIRSHARE`` column is a placeholder and does not yet reflect usage.
    * - ``sacctmgr`` ``-p``/``-P``
-     - Delimited output covers ``show account`` and ``show qos``; for ``show user``, ``show association``, ``show tres``, and ``show txn`` it errors instead of printing a table no script can parse. ``-n`` works for every entity.
+     - Delimited output covers ``show account``, ``show qos``, and ``show txn``; for ``show user``, ``show association``, and ``show tres`` it errors instead of printing a table no script can parse. ``-n`` works for every entity.
    * - ``scancel`` arrays
      - Array-element syntax (``123_4``) is not yet supported client-side; cancel by plain job id.
    * - ``scontrol show``


### PR DESCRIPTION
## What this fixes

`sacctmgr` defines only `--controller` and `-i/--immediate` as global flags, so Slurm's header
and delimiter flags are rejected before the command runs:

```
$ sacctmgr -n -P show qos format=Name,Priority,MaxWall
error: unexpected argument '-n' found
```

`-n` is only the first flag clap trips over — fixing it alone moves the error to `-P`. The
underlying gap is that `sacctmgr` has no machine-readable output mode at all, so a script
migrated from Slurm has to parse the column-aligned human table, which is precisely what these
flags exist to avoid.

Semantics follow the `sacctmgr` manual:

| Flag | Behaviour |
| --- | --- |
| `-n`, `--noheader` | no header line |
| `-p`, `--parsable` | `\|` delimited, with a trailing `\|` |
| `-P`, `--parsable2` | `\|` delimited, without a trailing `\|` |

The trailing delimiter is the only difference between the two, and it is load-bearing: it
changes the field count that `cut`, `awk`, or `IFS` splitting sees. Both are added, since either
may appear in an existing script. Note the long name for `-P` is `--parsable2`.

## Approach

`format_engine` is shared by `sacctmgr`, `sacct`, `sinfo`, and `squeue`, so its existing
functions are left untouched and the new behaviour is additive: a `RowLayout` enum and an
`OutputStyle` that carries header visibility plus layout, resolved once from the flags and
passed to `show`. `OutputStyle::Aligned` delegates to the existing `format_row` /
`format_header`, so the default path runs the same code as before rather than a
reimplementation of it. The only structural change is that `print_header`'s body moved into
`OutputStyle::header_lines`, with the free function now delegating, so the dashed-rule logic
exists in one place.

Two details worth flagging for review:

- **Delimited rows are not trimmed.** `format_row` ends with `trim_end`, which is right for
  padded output. QOS and account resolvers return `""` for unset limits, so trimming delimited
  output would drop trailing separators and silently shrink the field count.
- **Delimited output ignores widths and truncation**, matching Slurm, and skips the literal
  spacing tokens that `parse_named_format` inserts between fields.

## Trade-offs

**`-p` and `-P` together.** Slurm's parser takes whichever came last. clap's derive cannot see
flag order, so `-P` wins when both are passed. Declaring them mutually exclusive was the
alternative, but that would reject input Slurm accepts.

**Entities without field specs.** `account`, `qos`, and `txn` resolve their columns through
`format_engine`, so delimited output works for them. `user`, `association`, and `tres` print
hardcoded fixed-width tables with no spec table behind them. Rather than accept `-p`/`-P` there
and emit padded text that no script can parse, those combinations fail with a message naming the
entity and the supported ones. Loud beats silently unparseable. `-n` is honoured for every
entity, since suppressing a header needs no column model. Giving the remaining entities proper
field-spec tables would unlock `format=` for them as well, and is better done deliberately than
folded in here.

**Field values are not escaped.** A free-text field carrying a literal `|` (account
`Descr`/`Org`, transaction `Info`) shifts every field after it, so `cut -d'|'` reads the wrong
column. Slurm behaves identically; this is documented rather than worked around.

**Flags may appear after `key=value` params.** `Show`/`List` no longer declare `params` as
`trailing_var_arg`. That attribute captured every token after the first param verbatim, so a
delimiter flag placed after a param was silently swallowed — `show qos format=Name -P` produced
aligned output, and `show qos name=gpu -P format=Name` dropped the `format=` filter and its
following token. With it removed, clap parses a global flag anywhere among the params. The
params are only ever `key=value`/`where`/`set` tokens, so nothing depended on the trailing
capture. A visible consequence: an unrecognised flag after the params now surfaces a clap
"unexpected argument" error instead of being captured as a param — which is the intended
correction.

`Add`/`Delete`/`Modify` carried the same attribute, and there the swallow was worse than
unparsable output: `parse_params` takes the token after a bare word as that word's value, so
`sacctmgr modify qos gpu set -i priority=10` bound `priority=10` to `-i`, applied nothing, and
reported success. They are now declared the same way as `Show`/`List`, with a test that fails
if the attribute comes back.

## Documentation

`docs/admin-guide/accounting.rst` gains a "Scripted output" section covering all three flags,
the trailing-delimiter difference and why it matters to a script's field count, that empty
fields keep their separators so the field count stays stable, that widths and truncation do not
apply, and that field values are not escaped. It also states the two things an operator cannot
infer: delimited output covers `account`, `qos`, and `txn`, and `-P` wins when both delimiter
flags are passed. The migration table carries the entity restriction as a limitation row, since
that is where someone migrating looks first.

## Testing

New unit tests across the two files, including:

- the reported invocation parses, and the flags compose with existing globals
- a delimiter flag placed after, and between, `key=value` params is parsed rather than swallowed
- `-P` has no trailing delimiter, `-p` has one, and a row whose last field is empty keeps its
  separators under both
- `format=` ordering is preserved in delimited output, and values containing commas (TRES
  strings) stay unambiguous
- delimited output drops padding and truncation
- `show txn` honours `-n` and renders delimited output through the resolved style
- **the default path is byte-identical** with no flag and with `-n`, asserted against the
  existing padded helpers, and the padded header block is pinned to exact expected strings
- the unsupported-entity refusal happens before any controller connection, and an unknown
  entity reports itself rather than the delimiter

Gates: `cargo fmt`, `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` (no
warnings), `cargo test --locked` (all passing), `cargo deny check`.

## Follow-up, not addressed here

A `format=` name that Spur does not recognise is silently dropped rather than reported — the
column simply vanishes (`format=Name,Flags` on `show qos` prints only `Name`). That predates
this change and is visible on `main`, but it matters more for delimited output, where a
dropped column shifts every field index after it. Fixing it means choosing between rejecting
unknown names, which changes behaviour for current `format=` callers, and implementing the
missing fields. Worth its own change.

