### PR TITLE
feat(spurctld)!: enforce QOS and association submit-time limits

### DIFF
--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -125,9 +125,15 @@ const QOS_KEYS: &[&str] = &[
     "maxwall",
     "maxtresperjob",
     "maxsubmitjobsperuser",
+    "maxsubmitjobsperaccount",
+    "maxsubmitpa",
+    "maxsubmitjobspa",
+    "grpsubmit",
+    "grpsubmitjobs",
     "maxtresperuser",
     "grptres",
     "grpwall",
+    "flags",
 ];
 
 /// Input keys the `add`/`modify user` handlers read (names + aliases). Gates
@@ -143,6 +149,8 @@ const USER_KEYS: &[&str] = &[
     "maxrunningjobs",
     "maxjobs",
     "maxsubmitjobs",
+    "grpsubmit",
+    "grpsubmitjobs",
     "maxtresperjob",
     "grptres",
     "maxwall",
@@ -187,17 +195,31 @@ async fn connect(addr: &str) -> Result<SlurmAccountingClient<crate::authclient::
     Ok(spur_proto::accounting_client(channel))
 }
 
-/// Parse a numeric limit value where `0` is a keyword meaning "no limit".
-/// Fails loudly instead of silently defaulting to `0` so a typo or
-/// out-of-range value never accidentally lifts a limit.
+/// Parse a numeric limit value. `-1` is Slurm's keyword for "no limit" and maps
+/// to the INFINITE sentinel (clears the stored limit); `0` is a literal value
+/// meaning "block all". Any other negative, or a value at/above INFINITE, is
+/// rejected. Fails loudly instead of silently defaulting so a typo never
+/// accidentally lifts or sets a limit.
 fn parse_limit(key: &str, val: &str) -> Result<u32> {
-    val.parse()
-        .map_err(|_| anyhow::anyhow!("invalid value for {key}=: '{val}'"))
+    let n: i64 = val
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid value for {key}=: '{val}'"))?;
+    if n == -1 {
+        return Ok(spur_core::accounting::INFINITE);
+    }
+    if n < 0 || n >= spur_core::accounting::INFINITE as i64 {
+        bail!("invalid value for {key}=: '{val}'");
+    }
+    Ok(n as u32)
 }
 
 /// Same as `parse_limit`, but for wall-time fields that also accept Slurm's
-/// `d-hh:mm:ss`/`hh:mm:ss` duration syntax (see `parse_wall_time`).
+/// `d-hh:mm:ss`/`hh:mm:ss` duration syntax (see `parse_wall_time`). `-1` clears
+/// the limit (INFINITE sentinel).
 fn parse_wall_limit(key: &str, val: &str) -> Result<u32> {
+    if val == "-1" {
+        return Ok(spur_core::accounting::INFINITE);
+    }
     parse_wall_time(val).ok_or_else(|| anyhow::anyhow!("invalid value for {key}=: '{val}'"))
 }
 
@@ -254,6 +276,7 @@ struct UserUpsertFields {
     allowed_qos: String,
     max_running_jobs: u32,
     max_submit_jobs: u32,
+    grp_submit_jobs: u32,
     max_tres_per_job: String,
     grp_tres: String,
     max_wall_minutes: u32,
@@ -308,21 +331,28 @@ fn build_add_user_request(
     {
         bail!("defaultqos={default_qos} must be included in qos={allowed_qos}");
     }
+    // An unset numeric limit sends INFINITE (clear/no-limit) on `add`; a literal
+    // 0 would mean "block all" under the sentinel semantics.
+    let no_limit = spur_core::accounting::INFINITE;
     let max_running_jobs: u32 = find_alias(p, &["maxrunningjobs", "maxjobs"])
         .map(|(k, v)| parse_limit(k, v))
         .transpose()?
-        .unwrap_or(0);
+        .unwrap_or(no_limit);
     let max_submit_jobs: u32 = p
         .get("maxsubmitjobs")
         .map(|v| parse_limit("maxsubmitjobs", v))
         .transpose()?
-        .unwrap_or(0);
+        .unwrap_or(no_limit);
+    let grp_submit_jobs: u32 = find_alias(p, &["grpsubmit", "grpsubmitjobs"])
+        .map(|(k, v)| parse_limit(k, v))
+        .transpose()?
+        .unwrap_or(no_limit);
     let max_tres_per_job = p.get("maxtresperjob").cloned().unwrap_or_default();
     let grp_tres = p.get("grptres").cloned().unwrap_or_default();
     let max_wall_minutes: u32 = find_alias(p, &["maxwall", "maxwallduration"])
         .map(|(k, v)| parse_wall_limit(k, v))
         .transpose()?
-        .unwrap_or(0);
+        .unwrap_or(no_limit);
 
     Ok(UserUpsertFields {
         name,
@@ -332,6 +362,7 @@ fn build_add_user_request(
         allowed_qos,
         max_running_jobs,
         max_submit_jobs,
+        grp_submit_jobs,
         max_tres_per_job,
         grp_tres,
         max_wall_minutes,
@@ -368,7 +399,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
             let max_jobs: u32 = find_alias(&p, &["maxrunningjobs", "maxjobs"])
                 .map(|(k, v)| parse_limit(k, v))
                 .transpose()?
-                .unwrap_or(0);
+                .unwrap_or(spur_core::accounting::INFINITE);
             let grp_tres = p.get("grptres").cloned().unwrap_or_default();
 
             let mut client = connect(addr).await?;
@@ -412,6 +443,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                     allowed_qos: Some(fields.allowed_qos.clone()),
                     max_running_jobs: Some(fields.max_running_jobs),
                     max_submit_jobs: Some(fields.max_submit_jobs),
+                    grp_submit_jobs: Some(fields.grp_submit_jobs),
                     max_tres_per_job: Some(fields.max_tres_per_job.clone()),
                     grp_tres: Some(fields.grp_tres.clone()),
                     max_wall_minutes: Some(fields.max_wall_minutes),
@@ -429,13 +461,17 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
             if !fields.default_qos.is_empty() {
                 println!("  DefQOS     = {}", fields.default_qos);
             }
-            if fields.max_running_jobs > 0 {
+            let unset = spur_core::accounting::INFINITE;
+            if fields.max_running_jobs != unset {
                 println!("  MaxJobs    = {}", fields.max_running_jobs);
             }
-            if fields.max_submit_jobs > 0 {
+            if fields.max_submit_jobs != unset {
                 println!("  MaxSubmit  = {}", fields.max_submit_jobs);
             }
-            if fields.max_wall_minutes > 0 {
+            if fields.grp_submit_jobs != unset {
+                println!("  GrpSubmit  = {}", fields.grp_submit_jobs);
+            }
+            if fields.max_wall_minutes != unset {
                 println!("  MaxWall    = {} min", fields.max_wall_minutes);
             }
             if !fields.max_tres_per_job.is_empty() {
@@ -463,21 +499,22 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 .get("usagefactor")
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(1.0);
+            let no_limit = spur_core::accounting::INFINITE;
             let max_jobs: u32 = find_alias(&p, &["maxjobsperuser", "maxjobspu"])
                 .map(|(k, v)| parse_limit(k, v))
                 .transpose()?
-                .unwrap_or(0);
+                .unwrap_or(no_limit);
             let max_wall: u32 = p
                 .get("maxwall")
                 .map(|v| parse_wall_limit("maxwall", v))
                 .transpose()?
-                .unwrap_or(0);
+                .unwrap_or(no_limit);
             let max_tres = p.get("maxtresperjob").cloned().unwrap_or_default();
             let grp_wall: u32 = p
                 .get("grpwall")
                 .map(|v| parse_wall_limit("grpwall", v))
                 .transpose()?
-                .unwrap_or(0);
+                .unwrap_or(no_limit);
 
             let mut client = connect(addr).await?;
             client
@@ -495,7 +532,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                         p.get("maxsubmitjobsperuser")
                             .map(|v| parse_limit("maxsubmitjobsperuser", v))
                             .transpose()?
-                            .unwrap_or(0),
+                            .unwrap_or(no_limit),
                     ),
                     max_tres_per_user: Some(p.get("maxtresperuser").cloned().unwrap_or_default()),
                     grp_tres: Some(p.get("grptres").cloned().unwrap_or_default()),
@@ -505,6 +542,22 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                         .map(|v| parse_u32("preemptexempttime", v))
                         .transpose()?,
                     clear_preempt_exempt_time: false,
+                    max_submit_jobs_per_account: Some(
+                        find_alias(
+                            &p,
+                            &["maxsubmitjobsperaccount", "maxsubmitpa", "maxsubmitjobspa"],
+                        )
+                        .map(|(k, v)| parse_limit(k, v))
+                        .transpose()?
+                        .unwrap_or(no_limit),
+                    ),
+                    grp_submit_jobs: Some(
+                        find_alias(&p, &["grpsubmit", "grpsubmitjobs"])
+                            .map(|(k, v)| parse_limit(k, v))
+                            .transpose()?
+                            .unwrap_or(no_limit),
+                    ),
+                    flags: Some(p.get("flags").cloned().unwrap_or_default()),
                 })
                 .await
                 .context("CreateQos RPC failed")?;
@@ -513,10 +566,10 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 " Adding QOS(s)\n  Name       = {}\n  Priority   = {}\n  Preempt    = {}",
                 name, priority, preempt
             );
-            if max_wall > 0 {
+            if max_wall != no_limit {
                 println!("  MaxWall    = {} min", max_wall);
             }
-            if max_jobs > 0 {
+            if max_jobs != no_limit {
                 println!("  MaxJobsPU  = {}", max_jobs);
             }
             println!(" QOS added.");
@@ -676,6 +729,16 @@ fn build_modify_qos_request(
             .get("clearpreemptexempttime")
             .map(|v| is_truthy(v))
             .unwrap_or(false),
+        max_submit_jobs_per_account: find_alias(
+            p,
+            &["maxsubmitjobsperaccount", "maxsubmitpa", "maxsubmitjobspa"],
+        )
+        .map(|(k, v)| parse_limit(k, v))
+        .transpose()?,
+        grp_submit_jobs: find_alias(p, &["grpsubmit", "grpsubmitjobs"])
+            .map(|(k, v)| parse_limit(k, v))
+            .transpose()?,
+        flags: p.get("flags").cloned(),
     })
 }
 
@@ -713,6 +776,9 @@ fn build_modify_user_request(
         max_submit_jobs: p
             .get("maxsubmitjobs")
             .map(|v| parse_limit("maxsubmitjobs", v))
+            .transpose()?,
+        grp_submit_jobs: find_alias(p, &["grpsubmit", "grpsubmitjobs"])
+            .map(|(k, v)| parse_limit(k, v))
             .transpose()?,
         max_tres_per_job: p.get("maxtresperjob").cloned(),
         grp_tres: p.get("grptres").cloned(),
@@ -804,22 +870,10 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
 
             let users = resp.into_inner().users;
 
-            println!(
-                "{:<15} {:<20} {:<10} {:<20} {:<20} {:<15}",
-                "User", "Account", "Admin", "Default Acct", "QOS", "Def QOS"
-            );
-            println!("{}", "-".repeat(95));
-
+            println!("{}", user_header_row());
+            println!("{}", "-".repeat(180));
             for u in &users {
-                println!(
-                    "{:<15} {:<20} {:<10} {:<20} {:<20} {:<15}",
-                    u.name,
-                    u.account,
-                    u.admin_level,
-                    u.default_account,
-                    u.allowed_qos,
-                    u.default_qos,
-                );
+                println!("{}", format_user_row(u));
             }
             Ok(())
         }
@@ -949,13 +1003,60 @@ fn account_format_fields(
     )
 }
 
-/// Render a numeric limit, blank when zero (Slurm shows "unlimited" as an empty cell).
+/// Render a numeric limit, blank when unset/unlimited (the INFINITE sentinel);
+/// Slurm shows "no limit" as an empty cell. A literal 0 renders as "0".
+fn blank_if_unset(v: u32) -> String {
+    if v == spur_core::accounting::INFINITE {
+        String::new()
+    } else {
+        v.to_string()
+    }
+}
+
+/// Render a numeric value, blank when zero. Used for `preempt_exempt_time`,
+/// whose absence is carried as `None` (not the `INFINITE` sentinel).
 fn blank_if_zero(v: u32) -> String {
     if v == 0 {
         String::new()
     } else {
         v.to_string()
     }
+}
+
+fn user_header_row() -> String {
+    format!(
+        "{:<15} {:<20} {:<10} {:<20} {:<20} {:<15} {:<10} {:<10} {:<10} {:<10} {:<16} {:<16}",
+        "User",
+        "Account",
+        "Admin",
+        "Default Acct",
+        "QOS",
+        "Def QOS",
+        "MaxJobs",
+        "MaxSubmit",
+        "GrpSubmit",
+        "MaxWall",
+        "MaxTRES",
+        "GrpTRES",
+    )
+}
+
+fn format_user_row(u: &UserInfo) -> String {
+    format!(
+        "{:<15} {:<20} {:<10} {:<20} {:<20} {:<15} {:<10} {:<10} {:<10} {:<10} {:<16} {:<16}",
+        u.name,
+        u.account,
+        u.admin_level,
+        u.default_account,
+        u.allowed_qos,
+        u.default_qos,
+        blank_if_unset(u.max_running_jobs),
+        blank_if_unset(u.max_submit_jobs),
+        blank_if_unset(u.grp_submit_jobs),
+        blank_if_unset(u.max_wall_minutes),
+        u.max_tres_per_job,
+        u.grp_tres,
+    )
 }
 
 fn resolve_account_field(a: &AccountInfo, spec: char) -> String {
@@ -966,15 +1067,16 @@ fn resolve_account_field(a: &AccountInfo, spec: char) -> String {
         'P' => a.parent_account.clone(),
         'S' => (a.fairshare_weight as u32).to_string(),
         'G' => a.grp_tres.clone(),
-        'J' => blank_if_zero(a.max_running_jobs),
+        'J' => blank_if_unset(a.max_running_jobs),
         _ => "?".into(),
     }
 }
 
-const QOS_DEFAULT_FORMAT: &str = "%-15N %-8p %-10P %-12U %-10J %-10S %-10W %-10w %-20T %-20V %-20G";
+const QOS_DEFAULT_FORMAT: &str =
+    "%-15N %-8p %-10P %-12U %-10J %-10S %-10W %-10w %-14F %-20T %-20V %-20G";
 
 const QOS_ALL_FORMAT: &str =
-    "%-15N %-30D %-8p %-10P %-12U %-10J %-10S %-10W %-10w %-20T %-20V %-20G";
+    "%-15N %-30D %-8p %-10P %-12U %-10J %-10S %-12A %-12B %-10W %-10w %-14F %-20T %-20V %-20G";
 
 fn qos_header(spec: char) -> &'static str {
     match spec {
@@ -990,8 +1092,11 @@ fn qos_header(spec: char) -> &'static str {
         'V' => "MaxTRESPU",
         'J' => "MaxJobsPU",
         'S' => "MaxSubmitPU",
+        'A' => "MaxSubmitPA",
+        'B' => "GrpSubmit",
         'W' => "MaxWall",
         'w' => "GrpWall",
+        'F' => "Flags",
         _ => "?",
     }
 }
@@ -1010,8 +1115,11 @@ fn qos_field_spec(name: &str) -> Option<char> {
         "maxtrespu" | "maxtresperuser" => Some('V'),
         "maxjobspu" | "maxjobsperuser" => Some('J'),
         "maxsubmitpu" | "maxsubmitjobspu" | "maxsubmitjobsperuser" => Some('S'),
+        "maxsubmitpa" | "maxsubmitjobspa" | "maxsubmitjobsperaccount" => Some('A'),
+        "grpsubmit" | "grpsubmitjobs" => Some('B'),
         "maxwall" | "maxwalldurationperjob" => Some('W'),
         "grpwall" => Some('w'),
+        "flags" => Some('F'),
         _ => None,
     }
 }
@@ -1028,10 +1136,13 @@ fn resolve_qos_field(q: &QosInfo, spec: char) -> String {
         'G' => q.grp_tres.clone(),
         'T' => q.max_tres_per_job.clone(),
         'V' => q.max_tres_per_user.clone(),
-        'J' => blank_if_zero(q.max_jobs_per_user),
-        'S' => blank_if_zero(q.max_submit_jobs_per_user),
-        'W' => blank_if_zero(q.max_wall_minutes),
-        'w' => blank_if_zero(q.grp_wall_minutes),
+        'J' => blank_if_unset(q.max_jobs_per_user),
+        'S' => blank_if_unset(q.max_submit_jobs_per_user),
+        'A' => blank_if_unset(q.max_submit_jobs_per_account),
+        'B' => blank_if_unset(q.grp_submit_jobs),
+        'W' => blank_if_unset(q.max_wall_minutes),
+        'w' => blank_if_unset(q.grp_wall_minutes),
+        'F' => q.flags.clone(),
         _ => "?".into(),
     }
 }
@@ -1159,9 +1270,12 @@ mod tests {
             "maxwall",
             "maxtresperjob",
             "maxsubmitjobsperuser",
+            "maxsubmitjobsperaccount",
+            "grpsubmit",
             "maxtresperuser",
             "grptres",
             "grpwall",
+            "flags",
         ];
         for field in parsed_fields {
             let p = parse_params(&["name=normal".into(), format!("{field}=1")]);
@@ -1185,6 +1299,7 @@ mod tests {
             "maxrunningjobs",
             "maxjobs",
             "maxsubmitjobs",
+            "grpsubmit",
             "maxtresperjob",
             "grptres",
             "maxwall",
@@ -1317,14 +1432,17 @@ mod tests {
     }
 
     #[test]
-    fn build_add_user_request_account_limits_absent_are_zero() {
+    fn build_add_user_request_account_limits_absent_are_unset() {
+        // Absent numeric limits default to the INFINITE sentinel (leave
+        // unchanged / no limit), not a literal 0 which would block all.
+        let unset = spur_core::accounting::INFINITE;
         let p = parse_params(&["name=testuser".into(), "account=testacct".into()]);
         let fields = build_add_user_request(&p).unwrap();
-        assert_eq!(fields.max_running_jobs, 0);
-        assert_eq!(fields.max_submit_jobs, 0);
+        assert_eq!(fields.max_running_jobs, unset);
+        assert_eq!(fields.max_submit_jobs, unset);
         assert_eq!(fields.max_tres_per_job, "");
         assert_eq!(fields.grp_tres, "");
-        assert_eq!(fields.max_wall_minutes, 0);
+        assert_eq!(fields.max_wall_minutes, unset);
     }
 
     #[test]
@@ -1383,11 +1501,23 @@ mod tests {
     }
 
     #[test]
-    fn build_add_user_request_rejects_negative_maxsubmitjobs() {
+    fn build_add_user_request_maxsubmitjobs_minus_one_clears() {
+        // -1 is the clear sentinel (INFINITE), not an error.
         let p = parse_params(&[
             "name=testuser".into(),
             "account=testacct".into(),
             "maxsubmitjobs=-1".into(),
+        ]);
+        let fields = build_add_user_request(&p).unwrap();
+        assert_eq!(fields.max_submit_jobs, spur_core::accounting::INFINITE);
+    }
+
+    #[test]
+    fn build_add_user_request_rejects_other_negative_maxsubmitjobs() {
+        let p = parse_params(&[
+            "name=testuser".into(),
+            "account=testacct".into(),
+            "maxsubmitjobs=-5".into(),
         ]);
         assert!(build_add_user_request(&p).is_err());
     }
@@ -1651,17 +1781,88 @@ mod tests {
     }
 
     #[test]
-    fn qos_resolve_zero_fields_are_blank() {
+    fn qos_resolve_unset_fields_are_blank_and_zero_is_shown() {
+        // Post sentinel-flip: the INFINITE sentinel renders blank (no limit);
+        // a literal 0 renders as "0" (block all).
+        let unset = spur_core::accounting::INFINITE;
         let q = QosInfo {
             name: "normal".into(),
             preempt_mode: "off".into(),
             usage_factor: 1.0,
+            max_jobs_per_user: unset,
+            max_submit_jobs_per_user: unset,
+            max_wall_minutes: unset,
+            grp_wall_minutes: unset,
+            max_submit_jobs_per_account: unset,
+            grp_submit_jobs: unset,
             ..Default::default()
         };
         assert_eq!(resolve_qos_field(&q, 'J'), "");
         assert_eq!(resolve_qos_field(&q, 'S'), "");
         assert_eq!(resolve_qos_field(&q, 'W'), "");
         assert_eq!(resolve_qos_field(&q, 'w'), "");
+        assert_eq!(resolve_qos_field(&q, 'A'), "");
+        assert_eq!(resolve_qos_field(&q, 'B'), "");
+
+        let blocking = QosInfo {
+            max_jobs_per_user: 0,
+            ..q
+        };
+        assert_eq!(resolve_qos_field(&blocking, 'J'), "0");
+    }
+
+    #[test]
+    fn format_user_row_renders_limits_and_blanks_unset() {
+        let unset = spur_core::accounting::INFINITE;
+        let header = user_header_row();
+        for column in [
+            "User",
+            "Account",
+            "MaxJobs",
+            "MaxSubmit",
+            "GrpSubmit",
+            "MaxWall",
+            "MaxTRES",
+            "GrpTRES",
+        ] {
+            assert!(header.contains(column), "header missing {column}: {header}");
+        }
+
+        let u = UserInfo {
+            name: "carol".into(),
+            account: "ml".into(),
+            admin_level: "None".into(),
+            max_running_jobs: 4,
+            max_submit_jobs: 8,
+            grp_submit_jobs: unset,
+            max_wall_minutes: 1440,
+            max_tres_per_job: "cpu=64".into(),
+            grp_tres: String::new(),
+            ..Default::default()
+        };
+        let row = format_user_row(&u);
+        let cols: Vec<&str> = row.split_whitespace().collect();
+        assert!(cols.contains(&"carol"));
+        assert!(cols.contains(&"4"));
+        assert!(cols.contains(&"8"));
+        assert!(cols.contains(&"1440"));
+        assert!(cols.contains(&"cpu=64"));
+        // grp_submit_jobs is the INFINITE sentinel: rendered as a blank cell, so
+        // no stray value shows up between MaxSubmit and MaxWall.
+        assert!(row.contains("8"));
+    }
+
+    #[test]
+    fn parse_limit_minus_one_clears_to_infinite() {
+        assert_eq!(
+            parse_limit("maxjobs", "-1").unwrap(),
+            spur_core::accounting::INFINITE
+        );
+    }
+
+    #[test]
+    fn parse_limit_zero_is_literal_block_all() {
+        assert_eq!(parse_limit("maxjobs", "0").unwrap(), 0);
     }
 
     #[test]
@@ -1810,12 +2011,20 @@ mod tests {
     }
 
     #[test]
-    fn account_resolve_zero_maxjobs_is_blank() {
-        let a = AccountInfo {
+    fn account_resolve_unset_maxjobs_is_blank_and_zero_is_shown() {
+        // Post sentinel-flip: INFINITE renders blank (no limit); a literal 0
+        // renders "0" (block all).
+        let unset = AccountInfo {
+            max_running_jobs: spur_core::accounting::INFINITE,
+            ..stub_account()
+        };
+        assert_eq!(resolve_account_field(&unset, 'J'), "");
+
+        let blocking = AccountInfo {
             max_running_jobs: 0,
             ..stub_account()
         };
-        assert_eq!(resolve_account_field(&a, 'J'), "");
+        assert_eq!(resolve_account_field(&blocking, 'J'), "0");
     }
 
     #[test]

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -220,7 +220,12 @@ fn parse_wall_limit(key: &str, val: &str) -> Result<u32> {
     if val == "-1" {
         return Ok(spur_core::accounting::INFINITE);
     }
-    parse_wall_time(val).ok_or_else(|| anyhow::anyhow!("invalid value for {key}=: '{val}'"))
+    let minutes =
+        parse_wall_time(val).ok_or_else(|| anyhow::anyhow!("invalid value for {key}=: '{val}'"))?;
+    if minutes == spur_core::accounting::INFINITE {
+        bail!("invalid value for {key}=: '{val}'");
+    }
+    Ok(minutes)
 }
 
 /// Parse a floating-point field (e.g. `fairshare=`/`usagefactor=`), failing
@@ -1847,9 +1852,16 @@ mod tests {
         assert!(cols.contains(&"8"));
         assert!(cols.contains(&"1440"));
         assert!(cols.contains(&"cpu=64"));
-        // grp_submit_jobs is the INFINITE sentinel: rendered as a blank cell, so
-        // no stray value shows up between MaxSubmit and MaxWall.
-        assert!(row.contains("8"));
+        // grp_submit_jobs is the INFINITE sentinel: it must render as a blank
+        // cell. The header and row share the same fixed-width layout, so the
+        // GrpSubmit column occupies the same byte range in both; assert that
+        // slice of the row is all whitespace.
+        let start = header.find("GrpSubmit").expect("header has GrpSubmit");
+        let cell = &row[start..start + "GrpSubmit".len()];
+        assert!(
+            cell.trim().is_empty(),
+            "GrpSubmit cell should be blank, got {cell:?}"
+        );
     }
 
     #[test]

--- a/crates/spur-core/src/account_limits.rs
+++ b/crates/spur-core/src/account_limits.rs
@@ -22,7 +22,75 @@ pub enum AccountCheckResult {
     Blocked(PendingReason),
 }
 
-/// Check if a job would violate its account/association limits.
+/// Whether the job's requested wall time exceeds `max_wall` minutes.
+fn wall_breach(job: &Job, max_wall: u32) -> bool {
+    job.spec
+        .time_limit
+        .is_some_and(|w| w.num_minutes() > max_wall as i64)
+}
+
+/// The four TRES quantities a single job requests: (cpu, node, mem_mb, gpu).
+fn job_tres(job: &Job) -> (u64, u64, u64, u64) {
+    let cpus = (job.spec.num_tasks * job.spec.cpus_per_task) as u64;
+    let nodes = job.spec.num_nodes as u64;
+    let mem = effective_memory_mb(&job.spec, job.spec.num_nodes);
+    let gpus = effective_gpus(&job.spec, job.spec.num_nodes);
+    (cpus, nodes, mem, gpus)
+}
+
+/// Standalone TRES breach for an association: does this job, folded onto
+/// `account_running_tres` (empty for the submit-time standalone evaluation),
+/// exceed the per-job or account-group cap? Wall is handled separately because
+/// the association wall cap denies unconditionally at submission.
+fn account_resource_breach(
+    job: &Job,
+    limits: &AccountLimits,
+    account_running_tres: &TresRecord,
+) -> Option<PendingReason> {
+    let (job_cpu, job_node, job_mem, job_gpu) = job_tres(job);
+
+    if let Some(ref max_tres) = limits.max_tres_per_job {
+        if max_tres.get(TresType::Cpu) > 0 && job_cpu > max_tres.get(TresType::Cpu) {
+            return Some(PendingReason::AssocMaxCpuPerJobLimit);
+        }
+        if max_tres.get(TresType::Node) > 0 && job_node > max_tres.get(TresType::Node) {
+            return Some(PendingReason::AssocMaxNodePerJobLimit);
+        }
+        if max_tres.get(TresType::Memory) > 0 && job_mem > max_tres.get(TresType::Memory) {
+            return Some(PendingReason::AssocMaxMemPerJob);
+        }
+        if max_tres.get(TresType::Gpu) > 0 && job_gpu > max_tres.get(TresType::Gpu) {
+            return Some(PendingReason::AssocMaxGpuPerJobLimit);
+        }
+    }
+
+    if let Some(ref grp) = limits.grp_tres {
+        if grp.get(TresType::Cpu) > 0
+            && account_running_tres.get(TresType::Cpu) + job_cpu > grp.get(TresType::Cpu)
+        {
+            return Some(PendingReason::AssocGrpCpuLimit);
+        }
+        if grp.get(TresType::Node) > 0
+            && account_running_tres.get(TresType::Node) + job_node > grp.get(TresType::Node)
+        {
+            return Some(PendingReason::AssocGrpNodeLimit);
+        }
+        if grp.get(TresType::Memory) > 0
+            && account_running_tres.get(TresType::Memory) + job_mem > grp.get(TresType::Memory)
+        {
+            return Some(PendingReason::AssocGrpMemLimit);
+        }
+        if grp.get(TresType::Gpu) > 0
+            && account_running_tres.get(TresType::Gpu) + job_gpu > grp.get(TresType::Gpu)
+        {
+            return Some(PendingReason::AssocGrpGpuLimit);
+        }
+    }
+
+    None
+}
+
+/// Check if a job would violate its account/association limits (scheduler path).
 ///
 /// `user_running_count`/`user_submitted_count` are the requesting user's
 /// running/(pending+running) job count under this account; `account_running_tres`
@@ -47,66 +115,55 @@ pub fn check_account_limits(
     }
 
     if let Some(max_wall) = limits.max_wall_minutes {
-        if let Some(job_wall) = job.spec.time_limit {
-            if job_wall.num_minutes() > max_wall as i64 {
-                return AccountCheckResult::Blocked(PendingReason::AssocMaxWallDurationPerJobLimit);
-            }
+        if wall_breach(job, max_wall) {
+            return AccountCheckResult::Blocked(PendingReason::AssocMaxWallDurationPerJobLimit);
         }
     }
 
-    if let Some(ref max_tres) = limits.max_tres_per_job {
-        let job_cpus = (job.spec.num_tasks * job.spec.cpus_per_task) as u64;
-        if max_tres.get(TresType::Cpu) > 0 && job_cpus > max_tres.get(TresType::Cpu) {
-            return AccountCheckResult::Blocked(PendingReason::AssocMaxCpuPerJobLimit);
-        }
+    match account_resource_breach(job, limits, account_running_tres) {
+        Some(reason) => AccountCheckResult::Blocked(reason),
+        None => AccountCheckResult::Allowed,
+    }
+}
 
-        let job_nodes = job.spec.num_nodes as u64;
-        if max_tres.get(TresType::Node) > 0 && job_nodes > max_tres.get(TresType::Node) {
-            return AccountCheckResult::Blocked(PendingReason::AssocMaxNodePerJobLimit);
-        }
-
-        let total_mem = effective_memory_mb(&job.spec, job.spec.num_nodes);
-        if max_tres.get(TresType::Memory) > 0 && total_mem > max_tres.get(TresType::Memory) {
-            return AccountCheckResult::Blocked(PendingReason::AssocMaxMemPerJob);
-        }
-
-        let job_gpus = effective_gpus(&job.spec, job.spec.num_nodes);
-        if max_tres.get(TresType::Gpu) > 0 && job_gpus > max_tres.get(TresType::Gpu) {
-            return AccountCheckResult::Blocked(PendingReason::AssocMaxGpuPerJobLimit);
+/// Association submit-count limits (`MaxSubmitJobs`, `GrpSubmitJobs`). These
+/// always deny at submission, independent of `DenyOnLimit`. `incoming` is how
+/// many jobs this submission adds (array size or 1).
+pub fn check_account_submit_limits(
+    limits: &AccountLimits,
+    user_submitted: u32,
+    account_submitted: u32,
+    incoming: u32,
+) -> Option<PendingReason> {
+    if let Some(max) = limits.max_submit_jobs {
+        if user_submitted.saturating_add(incoming) > max {
+            return Some(PendingReason::AssocMaxSubmitJobLimit);
         }
     }
-
-    if let Some(ref grp) = limits.grp_tres {
-        let job_cpus = (job.spec.num_tasks * job.spec.cpus_per_task) as u64;
-        if grp.get(TresType::Cpu) > 0
-            && account_running_tres.get(TresType::Cpu) + job_cpus > grp.get(TresType::Cpu)
-        {
-            return AccountCheckResult::Blocked(PendingReason::AssocGrpCpuLimit);
-        }
-
-        let job_nodes = job.spec.num_nodes as u64;
-        if grp.get(TresType::Node) > 0
-            && account_running_tres.get(TresType::Node) + job_nodes > grp.get(TresType::Node)
-        {
-            return AccountCheckResult::Blocked(PendingReason::AssocGrpNodeLimit);
-        }
-
-        let job_mem = effective_memory_mb(&job.spec, job.spec.num_nodes);
-        if grp.get(TresType::Memory) > 0
-            && account_running_tres.get(TresType::Memory) + job_mem > grp.get(TresType::Memory)
-        {
-            return AccountCheckResult::Blocked(PendingReason::AssocGrpMemLimit);
-        }
-
-        let job_gpus = effective_gpus(&job.spec, job.spec.num_nodes);
-        if grp.get(TresType::Gpu) > 0
-            && account_running_tres.get(TresType::Gpu) + job_gpus > grp.get(TresType::Gpu)
-        {
-            return AccountCheckResult::Blocked(PendingReason::AssocGrpGpuLimit);
+    if let Some(max) = limits.grp_submit_jobs {
+        if account_submitted.saturating_add(incoming) > max {
+            return Some(PendingReason::AssocGrpSubmitJobsLimit);
         }
     }
+    None
+}
 
-    AccountCheckResult::Allowed
+/// Association `MaxWallDurationPerJob` breach. Slurm denies this
+/// unconditionally at submission (it does not depend on `DenyOnLimit`).
+pub fn check_account_wall_limit(job: &Job, limits: &AccountLimits) -> Option<PendingReason> {
+    match limits.max_wall_minutes {
+        Some(max_wall) if wall_breach(job, max_wall) => {
+            Some(PendingReason::AssocMaxWallDurationPerJobLimit)
+        }
+        _ => None,
+    }
+}
+
+/// Standalone association TRES breach for the submission gate: evaluates the
+/// job on its own. Denied at submit only when the governing QOS has
+/// `DenyOnLimit`; otherwise the scheduler pends it.
+pub fn check_account_standalone_limits(job: &Job, limits: &AccountLimits) -> Option<PendingReason> {
+    account_resource_breach(job, limits, &TresRecord::new())
 }
 
 #[cfg(test)]

--- a/crates/spur-core/src/account_limits.rs
+++ b/crates/spur-core/src/account_limits.rs
@@ -11,7 +11,7 @@
 //! across all its users.
 
 use crate::accounting::{AccountLimits, TresRecord, TresType};
-use crate::job::{effective_gpus, effective_memory_mb, Job, PendingReason};
+use crate::job::{effective_gpus, effective_memory_mb, Job, JobSpec, PendingReason};
 
 /// Result of an account/association limit check.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,21 +25,20 @@ pub enum AccountCheckResult {
 /// Whether the job's requested wall time exceeds `max_wall` minutes. A cap of 0
 /// is "block all" per the limit convention, so it breaches even a job with no
 /// explicit time limit.
-fn wall_breach(job: &Job, max_wall: u32) -> bool {
+fn wall_breach(spec: &JobSpec, max_wall: u32) -> bool {
     if max_wall == 0 {
         return true;
     }
-    job.spec
-        .time_limit
+    spec.time_limit
         .is_some_and(|w| w.num_minutes() > max_wall as i64)
 }
 
 /// The four TRES quantities a single job requests: (cpu, node, mem_mb, gpu).
-fn job_tres(job: &Job) -> (u64, u64, u64, u64) {
-    let cpus = (job.spec.num_tasks * job.spec.cpus_per_task) as u64;
-    let nodes = job.spec.num_nodes as u64;
-    let mem = effective_memory_mb(&job.spec, job.spec.num_nodes);
-    let gpus = effective_gpus(&job.spec, job.spec.num_nodes);
+fn job_tres(spec: &JobSpec) -> (u64, u64, u64, u64) {
+    let cpus = (spec.num_tasks * spec.cpus_per_task) as u64;
+    let nodes = spec.num_nodes as u64;
+    let mem = effective_memory_mb(spec, spec.num_nodes);
+    let gpus = effective_gpus(spec, spec.num_nodes);
     (cpus, nodes, mem, gpus)
 }
 
@@ -48,11 +47,11 @@ fn job_tres(job: &Job) -> (u64, u64, u64, u64) {
 /// exceed the per-job or account-group cap? Wall is handled separately because
 /// the association wall cap denies unconditionally at submission.
 fn account_resource_breach(
-    job: &Job,
+    spec: &JobSpec,
     limits: &AccountLimits,
     account_running_tres: &TresRecord,
 ) -> Option<PendingReason> {
-    let (job_cpu, job_node, job_mem, job_gpu) = job_tres(job);
+    let (job_cpu, job_node, job_mem, job_gpu) = job_tres(spec);
 
     if let Some(ref max_tres) = limits.max_tres_per_job {
         if max_tres.get(TresType::Cpu) > 0 && job_cpu > max_tres.get(TresType::Cpu) {
@@ -120,12 +119,12 @@ pub fn check_account_limits(
     }
 
     if let Some(max_wall) = limits.max_wall_minutes {
-        if wall_breach(job, max_wall) {
+        if wall_breach(&job.spec, max_wall) {
             return AccountCheckResult::Blocked(PendingReason::AssocMaxWallDurationPerJobLimit);
         }
     }
 
-    match account_resource_breach(job, limits, account_running_tres) {
+    match account_resource_breach(&job.spec, limits, account_running_tres) {
         Some(reason) => AccountCheckResult::Blocked(reason),
         None => AccountCheckResult::Allowed,
     }
@@ -155,9 +154,9 @@ pub fn check_account_submit_limits(
 
 /// Association `MaxWallDurationPerJob` breach. Slurm denies this
 /// unconditionally at submission (it does not depend on `DenyOnLimit`).
-pub fn check_account_wall_limit(job: &Job, limits: &AccountLimits) -> Option<PendingReason> {
+pub fn check_account_wall_limit(spec: &JobSpec, limits: &AccountLimits) -> Option<PendingReason> {
     match limits.max_wall_minutes {
-        Some(max_wall) if wall_breach(job, max_wall) => {
+        Some(max_wall) if wall_breach(spec, max_wall) => {
             Some(PendingReason::AssocMaxWallDurationPerJobLimit)
         }
         _ => None,
@@ -167,8 +166,11 @@ pub fn check_account_wall_limit(job: &Job, limits: &AccountLimits) -> Option<Pen
 /// Standalone association TRES breach for the submission gate: evaluates the
 /// job on its own. Denied at submit only when the governing QOS has
 /// `DenyOnLimit`; otherwise the scheduler pends it.
-pub fn check_account_standalone_limits(job: &Job, limits: &AccountLimits) -> Option<PendingReason> {
-    account_resource_breach(job, limits, &TresRecord::new())
+pub fn check_account_standalone_limits(
+    spec: &JobSpec,
+    limits: &AccountLimits,
+) -> Option<PendingReason> {
+    account_resource_breach(spec, limits, &TresRecord::new())
 }
 
 #[cfg(test)]
@@ -261,7 +263,7 @@ mod tests {
         let mut job = make_test_job();
         job.spec.time_limit = None;
         assert_eq!(
-            check_account_wall_limit(&job, &limits),
+            check_account_wall_limit(&job.spec, &limits),
             Some(PendingReason::AssocMaxWallDurationPerJobLimit)
         );
     }
@@ -274,7 +276,7 @@ mod tests {
         };
         let mut job = make_test_job();
         job.spec.time_limit = None;
-        assert_eq!(check_account_wall_limit(&job, &limits), None);
+        assert_eq!(check_account_wall_limit(&job.spec, &limits), None);
     }
 
     #[test]

--- a/crates/spur-core/src/account_limits.rs
+++ b/crates/spur-core/src/account_limits.rs
@@ -22,8 +22,13 @@ pub enum AccountCheckResult {
     Blocked(PendingReason),
 }
 
-/// Whether the job's requested wall time exceeds `max_wall` minutes.
+/// Whether the job's requested wall time exceeds `max_wall` minutes. A cap of 0
+/// is "block all" per the limit convention, so it breaches even a job with no
+/// explicit time limit.
 fn wall_breach(job: &Job, max_wall: u32) -> bool {
+    if max_wall == 0 {
+        return true;
+    }
     job.spec
         .time_limit
         .is_some_and(|w| w.num_minutes() > max_wall as i64)
@@ -245,6 +250,31 @@ mod tests {
             result,
             AccountCheckResult::Blocked(PendingReason::AssocMaxWallDurationPerJobLimit)
         );
+    }
+
+    #[test]
+    fn max_wall_zero_blocks_time_less_job() {
+        let limits = AccountLimits {
+            max_wall_minutes: Some(0), // 0 = block all
+            ..Default::default()
+        };
+        let mut job = make_test_job();
+        job.spec.time_limit = None;
+        assert_eq!(
+            check_account_wall_limit(&job, &limits),
+            Some(PendingReason::AssocMaxWallDurationPerJobLimit)
+        );
+    }
+
+    #[test]
+    fn positive_max_wall_leaves_time_less_job_alone() {
+        let limits = AccountLimits {
+            max_wall_minutes: Some(60),
+            ..Default::default()
+        };
+        let mut job = make_test_job();
+        job.spec.time_limit = None;
+        assert_eq!(check_account_wall_limit(&job, &limits), None);
     }
 
     #[test]

--- a/crates/spur-core/src/accounting.rs
+++ b/crates/spur-core/src/accounting.rs
@@ -9,6 +9,12 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
+/// Slurm's `INFINITE` sentinel for numeric limits carried over the wire as
+/// `uint32`. It marks "clear to no limit" (stored as SQL `NULL`), distinct
+/// from a literal `0`, which means "block all". See `nullable_limit` and the
+/// sacctmgr `-1` keyword.
+pub const INFINITE: u32 = u32::MAX;
+
 /// Trackable RESource types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TresType {
@@ -128,6 +134,9 @@ pub struct AccountLimits {
     pub max_running_jobs: Option<u32>,
     /// Max submitted (pending + running) jobs for a single user within this account.
     pub max_submit_jobs: Option<u32>,
+    /// Max submitted (pending + running) jobs across all users in this account.
+    #[serde(default)]
+    pub grp_submit_jobs: Option<u32>,
     /// Max TRES per job.
     pub max_tres_per_job: Option<TresRecord>,
     /// Max total TRES across all running jobs in this account, summed over every user.
@@ -153,6 +162,11 @@ pub struct Qos {
     /// field on a QOS.
     #[serde(default)]
     pub preempt: Vec<String>,
+    /// When set, a stand-alone resource/wall limit breach is denied at
+    /// submission instead of leaving the job pending. Mirrors Slurm's QOS
+    /// `DenyOnLimit` flag; the submit-count family always denies regardless.
+    #[serde(default)]
+    pub deny_on_limit: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -182,6 +196,12 @@ impl FromStr for QosPreemptMode {
 pub struct QosLimits {
     pub max_jobs_per_user: Option<u32>,
     pub max_submit_jobs_per_user: Option<u32>,
+    /// Max submitted (pending + running) jobs per account within this QOS.
+    #[serde(default)]
+    pub max_submit_jobs_per_account: Option<u32>,
+    /// Max submitted (pending + running) jobs across all users in this QOS.
+    #[serde(default)]
+    pub grp_submit_jobs: Option<u32>,
     pub max_tres_per_job: Option<TresRecord>,
     pub max_tres_per_user: Option<TresRecord>,
     pub grp_tres: Option<TresRecord>,
@@ -218,6 +238,7 @@ impl Default for Qos {
             limits: QosLimits::default(),
             usage_factor: 1.0,
             preempt: Vec::new(),
+            deny_on_limit: false,
         }
     }
 }

--- a/crates/spur-core/src/accounting.rs
+++ b/crates/spur-core/src/accounting.rs
@@ -15,6 +15,21 @@ use serde::{Deserialize, Serialize};
 /// sacctmgr `-1` keyword.
 pub const INFINITE: u32 = u32::MAX;
 
+/// Convert a stored nullable limit (`Option<i32>` from the DB) into the
+/// in-memory `Option<u32>`: SQL `NULL` (`None`) is "no limit", a literal `0`
+/// survives as `Some(0)` ("block all"), and a stray negative (predates the
+/// sentinel flip) is treated as unset.
+pub fn limit_from_db(v: Option<i32>) -> Option<u32> {
+    v.filter(|&x| x >= 0).map(|x| x as u32)
+}
+
+/// Convert a stored nullable limit into its proto `uint32`: NULL (and any
+/// stray negative) becomes the `INFINITE` sentinel so the CLI can tell "no
+/// limit" apart from a literal `0`; a stored value is emitted as-is.
+pub fn limit_to_wire(v: Option<i32>) -> u32 {
+    limit_from_db(v).unwrap_or(INFINITE)
+}
+
 /// Trackable RESource types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TresType {
@@ -266,6 +281,24 @@ mod tests {
     #[test]
     fn test_tres_parse_rejects_unknown_type() {
         assert!(TresRecord::parse("bogus=5").is_err());
+    }
+
+    #[test]
+    fn limit_from_db_maps_sentinels() {
+        assert_eq!(limit_from_db(None), None);
+        // A literal 0 is a real value ("block all"), not a clear.
+        assert_eq!(limit_from_db(Some(0)), Some(0));
+        assert_eq!(limit_from_db(Some(5)), Some(5));
+        // A stray negative predates the sentinel flip; treat as unset.
+        assert_eq!(limit_from_db(Some(-1)), None);
+    }
+
+    #[test]
+    fn limit_to_wire_maps_null_and_values() {
+        assert_eq!(limit_to_wire(None), INFINITE);
+        assert_eq!(limit_to_wire(Some(-1)), INFINITE);
+        assert_eq!(limit_to_wire(Some(0)), 0);
+        assert_eq!(limit_to_wire(Some(7)), 7);
     }
 
     #[test]

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -316,6 +316,11 @@ pub enum PendingReason {
     AssocGrpMemLimit,
     AssocGrpGpuLimit,
     AssocMaxWallDurationPerJobLimit,
+
+    // Submit-count group limits (deny unconditionally at submission).
+    AssocGrpSubmitJobsLimit,
+    QosGrpSubmitJobsLimit,
+    QosMaxSubmitJobPerAccountLimit,
     K8sReserved,
 }
 
@@ -395,7 +400,46 @@ impl PendingReason {
             Self::AssocGrpMemLimit => "AssocGrpMemLimit",
             Self::AssocGrpGpuLimit => "AssocGrpGRES",
             Self::AssocMaxWallDurationPerJobLimit => "AssocMaxWallDurationPerJobLimit",
+            Self::AssocGrpSubmitJobsLimit => "AssocGrpSubmitJobsLimit",
+            Self::QosGrpSubmitJobsLimit => "QOSGrpSubmitJobsLimit",
+            Self::QosMaxSubmitJobPerAccountLimit => "MaxSubmitJobsPerAccount",
             Self::K8sReserved => "ReqNodeNotAvail, Reserved for Kubernetes cluster",
+        }
+    }
+
+    /// Human-readable explanation for a submit-time denial, shown alongside the
+    /// exact Slurm code (which `display()` yields for squeue scrapers). Reasons
+    /// outside the submit gate fall back to a generic phrase.
+    pub fn submit_denial_message(&self) -> &'static str {
+        match self {
+            Self::AssocMaxJobsLimit => {
+                "your association has reached its maximum number of running jobs"
+            }
+            Self::AssocMaxSubmitJobLimit => {
+                "you have reached the maximum submitted (pending + running) jobs for your association"
+            }
+            Self::AssocGrpSubmitJobsLimit => {
+                "your association has reached its aggregate submitted-jobs limit"
+            }
+            Self::AssocMaxWallDurationPerJobLimit => {
+                "the requested wall time exceeds your association's per-job limit"
+            }
+            Self::QoSMaxJobsPerUser => {
+                "you have reached the QOS limit on running jobs per user"
+            }
+            Self::QosMaxSubmitJobPerUserLimit => {
+                "you have reached the QOS limit on submitted jobs per user"
+            }
+            Self::QosMaxSubmitJobPerAccountLimit => {
+                "your account has reached the QOS limit on submitted jobs per account"
+            }
+            Self::QosGrpSubmitJobsLimit => {
+                "the QOS has reached its aggregate submitted-jobs limit"
+            }
+            Self::QosMaxWallDurationPerJobLimit => {
+                "the requested wall time exceeds the QOS per-job limit"
+            }
+            _ => "the job exceeds a configured accounting or QOS limit",
         }
     }
 }
@@ -2169,6 +2213,18 @@ mod tests {
             PendingReason::AssocMaxWallDurationPerJobLimit,
             "AssocMaxWallDurationPerJobLimit",
         ),
+        (
+            PendingReason::AssocGrpSubmitJobsLimit,
+            "AssocGrpSubmitJobsLimit",
+        ),
+        (
+            PendingReason::QosGrpSubmitJobsLimit,
+            "QOSGrpSubmitJobsLimit",
+        ),
+        (
+            PendingReason::QosMaxSubmitJobPerAccountLimit,
+            "MaxSubmitJobsPerAccount",
+        ),
     ];
 
     #[test]
@@ -2177,6 +2233,23 @@ mod tests {
             assert_eq!(reason.display(), *expected, "Display for {reason:?}");
             assert_eq!(format!("{reason}"), *expected, "fmt for {reason:?}");
         }
+    }
+
+    #[test]
+    fn submit_denial_message_is_human_readable_and_not_the_bare_code() {
+        // Submit-count reasons get a specific sentence, distinct from the
+        // machine-facing Slurm code.
+        let per_account = PendingReason::QosMaxSubmitJobPerAccountLimit;
+        assert_ne!(per_account.submit_denial_message(), per_account.display());
+        assert!(per_account
+            .submit_denial_message()
+            .contains("submitted jobs per account"));
+
+        // Reasons outside the submit gate fall back to a generic sentence.
+        assert_eq!(
+            PendingReason::BurstBufferResources.submit_denial_message(),
+            "the job exceeds a configured accounting or QOS limit"
+        );
     }
 
     #[test]

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -412,9 +412,6 @@ impl PendingReason {
     /// outside the submit gate fall back to a generic phrase.
     pub fn submit_denial_message(&self) -> &'static str {
         match self {
-            Self::AssocMaxJobsLimit => {
-                "your association has reached its maximum number of running jobs"
-            }
             Self::AssocMaxSubmitJobLimit => {
                 "you have reached the maximum submitted (pending + running) jobs for your association"
             }
@@ -423,9 +420,6 @@ impl PendingReason {
             }
             Self::AssocMaxWallDurationPerJobLimit => {
                 "the requested wall time exceeds your association's per-job limit"
-            }
-            Self::QoSMaxJobsPerUser => {
-                "you have reached the QOS limit on running jobs per user"
             }
             Self::QosMaxSubmitJobPerUserLimit => {
                 "you have reached the QOS limit on submitted jobs per user"

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -38,7 +38,126 @@ pub enum QosCheckResult {
     Blocked(PendingReason),
 }
 
-/// Check if a job would violate QOS limits.
+/// Whether the job's requested wall time exceeds `max_wall` minutes.
+fn wall_breach(job: &Job, max_wall: u32) -> bool {
+    job.spec
+        .time_limit
+        .is_some_and(|w| w.num_minutes() > max_wall as i64)
+}
+
+/// The four TRES quantities a single job requests: (cpu, node, mem_mb, gpu).
+fn job_tres(job: &Job) -> (u64, u64, u64, u64) {
+    let cpus = (job.spec.num_tasks * job.spec.cpus_per_task) as u64;
+    let nodes = job.spec.num_nodes as u64;
+    let mem = effective_memory_mb(&job.spec, job.spec.num_nodes);
+    let gpus = effective_gpus(&job.spec, job.spec.num_nodes);
+    (cpus, nodes, mem, gpus)
+}
+
+/// Per-job TRES cap breach. Each dimension is checked only when the cap is set
+/// (> 0). `reasons` names the reason for (cpu, node, mem, gpu) so callers can
+/// distinguish the per-job vs per-user/grp variants.
+fn tres_cap_breach(
+    job_cpu: u64,
+    job_node: u64,
+    job_mem: u64,
+    job_gpu: u64,
+    cap: &TresRecord,
+    reasons: (PendingReason, PendingReason, PendingReason, PendingReason),
+) -> Option<PendingReason> {
+    if cap.get(TresType::Cpu) > 0 && job_cpu > cap.get(TresType::Cpu) {
+        return Some(reasons.0);
+    }
+    if cap.get(TresType::Node) > 0 && job_node > cap.get(TresType::Node) {
+        return Some(reasons.1);
+    }
+    if cap.get(TresType::Memory) > 0 && job_mem > cap.get(TresType::Memory) {
+        return Some(reasons.2);
+    }
+    if cap.get(TresType::Gpu) > 0 && job_gpu > cap.get(TresType::Gpu) {
+        return Some(reasons.3);
+    }
+    None
+}
+
+/// Standalone TRES/wall breach: does this job, evaluated on its own (no other
+/// load), exceed any QOS resource cap? This is what Slurm's `DenyOnLimit`
+/// converts into a submission denial, and what the scheduler also re-checks
+/// with real aggregates folded in. `running_*` fold in existing load; pass
+/// empty records for the standalone (submit-time) evaluation.
+fn qos_resource_breach(
+    job: &Job,
+    qos: &Qos,
+    user_running_tres: &TresRecord,
+    qos_running_tres: &TresRecord,
+) -> Option<PendingReason> {
+    let limits = &qos.limits;
+    let (job_cpu, job_node, job_mem, job_gpu) = job_tres(job);
+
+    if let Some(max_wall) = limits.max_wall_minutes {
+        if wall_breach(job, max_wall) {
+            return Some(PendingReason::QosMaxWallDurationPerJobLimit);
+        }
+    }
+
+    if let Some(ref max_tres) = limits.max_tres_per_job {
+        if let Some(reason) = tres_cap_breach(
+            job_cpu,
+            job_node,
+            job_mem,
+            job_gpu,
+            max_tres,
+            (
+                PendingReason::QosMaxCpuPerJobLimit,
+                PendingReason::QosMaxNodePerJobLimit,
+                PendingReason::QosMaxMemoryPerJob,
+                PendingReason::QosMaxGpuPerJobLimit,
+            ),
+        ) {
+            return Some(reason);
+        }
+    }
+
+    if let Some(ref max_tres) = limits.max_tres_per_user {
+        if let Some(reason) = tres_cap_breach(
+            user_running_tres.get(TresType::Cpu) + job_cpu,
+            user_running_tres.get(TresType::Node) + job_node,
+            user_running_tres.get(TresType::Memory) + job_mem,
+            user_running_tres.get(TresType::Gpu) + job_gpu,
+            max_tres,
+            (
+                PendingReason::QosMaxCpuPerUserLimit,
+                PendingReason::QosMaxNodePerUserLimit,
+                PendingReason::QosMaxMemoryPerUser,
+                PendingReason::QosMaxGpuPerUserLimit,
+            ),
+        ) {
+            return Some(reason);
+        }
+    }
+
+    if let Some(ref grp) = limits.grp_tres {
+        if let Some(reason) = tres_cap_breach(
+            qos_running_tres.get(TresType::Cpu) + job_cpu,
+            qos_running_tres.get(TresType::Node) + job_node,
+            qos_running_tres.get(TresType::Memory) + job_mem,
+            qos_running_tres.get(TresType::Gpu) + job_gpu,
+            grp,
+            (
+                PendingReason::QosGrpCpuLimit,
+                PendingReason::QosGrpNodeLimit,
+                PendingReason::QosGrpMemLimit,
+                PendingReason::QosGrpGpuLimit,
+            ),
+        ) {
+            return Some(reason);
+        }
+    }
+
+    None
+}
+
+/// Check if a job would violate QOS limits (scheduler path).
 ///
 /// `user_running_*` aggregate the requesting user's load; `qos_running_tres`
 /// aggregates all running jobs in the QOS (for the `Grp*` group limits).
@@ -55,114 +174,64 @@ pub fn check_qos_limits(
 ) -> QosCheckResult {
     let limits = &qos.limits;
 
-    // Max jobs per user
+    // Max jobs per user (running count).
     if let Some(max) = limits.max_jobs_per_user {
         if user_running_count >= max {
             return QosCheckResult::Blocked(PendingReason::QoSMaxJobsPerUser);
         }
     }
 
-    // Max submit jobs per user
+    // Max submit jobs per user. Slurm distinguishes the submit-job cap
+    // (WAIT_QOS_MAX_SUB_JOB, "QOSMaxSubmitJobPerUserLimit") from the
+    // running-job cap above.
     if let Some(max) = limits.max_submit_jobs_per_user {
         if user_submitted_count >= max {
-            // Slurm distinguishes the submit-job cap (WAIT_QOS_MAX_SUB_JOB,
-            // "QOSMaxSubmitJobPerUserLimit") from the running-job cap above.
             return QosCheckResult::Blocked(PendingReason::QosMaxSubmitJobPerUserLimit);
         }
     }
 
-    // Max wall time
-    if let Some(max_wall) = limits.max_wall_minutes {
-        if let Some(job_wall) = job.spec.time_limit {
-            if job_wall.num_minutes() > max_wall as i64 {
-                // This is a QOS wall cap, not a partition cap: Slurm reports
-                // WAIT_QOS_MAX_WALL_PER_JOB ("QOSMaxWallDurationPerJobLimit").
-                return QosCheckResult::Blocked(PendingReason::QosMaxWallDurationPerJobLimit);
-            }
+    match qos_resource_breach(job, qos, user_running_tres, qos_running_tres) {
+        Some(reason) => QosCheckResult::Blocked(reason),
+        None => QosCheckResult::Allowed,
+    }
+}
+
+/// QOS submit-count limits (`MaxSubmitJobsPerUser`, `MaxSubmitJobsPerAccount`,
+/// `GrpSubmitJobs`). These always deny at submission (Slurm's
+/// `acct_policy_validate`), independent of `DenyOnLimit`, because admitting the
+/// job would itself increment the counted quantity. `incoming` is how many jobs
+/// this submission adds (array size or 1).
+pub fn check_qos_submit_limits(
+    qos: &Qos,
+    user_submitted: u32,
+    account_submitted: u32,
+    qos_submitted: u32,
+    incoming: u32,
+) -> Option<PendingReason> {
+    let limits = &qos.limits;
+    if let Some(max) = limits.max_submit_jobs_per_user {
+        if user_submitted.saturating_add(incoming) > max {
+            return Some(PendingReason::QosMaxSubmitJobPerUserLimit);
         }
     }
-
-    // Max TRES per job
-    if let Some(ref max_tres) = limits.max_tres_per_job {
-        let job_cpus = (job.spec.num_tasks * job.spec.cpus_per_task) as u64;
-        if max_tres.get(TresType::Cpu) > 0 && job_cpus > max_tres.get(TresType::Cpu) {
-            return QosCheckResult::Blocked(PendingReason::QosMaxCpuPerJobLimit);
-        }
-
-        let job_nodes = job.spec.num_nodes as u64;
-        if max_tres.get(TresType::Node) > 0 && job_nodes > max_tres.get(TresType::Node) {
-            return QosCheckResult::Blocked(PendingReason::QosMaxNodePerJobLimit);
-        }
-
-        let total_mem = effective_memory_mb(&job.spec, job.spec.num_nodes);
-        if max_tres.get(TresType::Memory) > 0 && total_mem > max_tres.get(TresType::Memory) {
-            return QosCheckResult::Blocked(PendingReason::QosMaxMemoryPerJob);
-        }
-
-        let job_gpus = effective_gpus(&job.spec, job.spec.num_nodes);
-        if max_tres.get(TresType::Gpu) > 0 && job_gpus > max_tres.get(TresType::Gpu) {
-            return QosCheckResult::Blocked(PendingReason::QosMaxGpuPerJobLimit);
+    if let Some(max) = limits.max_submit_jobs_per_account {
+        if account_submitted.saturating_add(incoming) > max {
+            return Some(PendingReason::QosMaxSubmitJobPerAccountLimit);
         }
     }
-
-    // Max TRES per user (group limit)
-    if let Some(ref max_tres) = limits.max_tres_per_user {
-        let job_cpus = (job.spec.num_tasks * job.spec.cpus_per_task) as u64;
-        let new_total_cpu = user_running_tres.get(TresType::Cpu) + job_cpus;
-        if max_tres.get(TresType::Cpu) > 0 && new_total_cpu > max_tres.get(TresType::Cpu) {
-            return QosCheckResult::Blocked(PendingReason::QosMaxCpuPerUserLimit);
-        }
-
-        let job_nodes = job.spec.num_nodes as u64;
-        let new_total_nodes = user_running_tres.get(TresType::Node) + job_nodes;
-        if max_tres.get(TresType::Node) > 0 && new_total_nodes > max_tres.get(TresType::Node) {
-            return QosCheckResult::Blocked(PendingReason::QosMaxNodePerUserLimit);
-        }
-
-        let job_mem = effective_memory_mb(&job.spec, job.spec.num_nodes);
-        let new_total_mem = user_running_tres.get(TresType::Memory) + job_mem;
-        if max_tres.get(TresType::Memory) > 0 && new_total_mem > max_tres.get(TresType::Memory) {
-            return QosCheckResult::Blocked(PendingReason::QosMaxMemoryPerUser);
-        }
-
-        let job_gpus = effective_gpus(&job.spec, job.spec.num_nodes);
-        let new_total_gpus = user_running_tres.get(TresType::Gpu) + job_gpus;
-        if max_tres.get(TresType::Gpu) > 0 && new_total_gpus > max_tres.get(TresType::Gpu) {
-            return QosCheckResult::Blocked(PendingReason::QosMaxGpuPerUserLimit);
+    if let Some(max) = limits.grp_submit_jobs {
+        if qos_submitted.saturating_add(incoming) > max {
+            return Some(PendingReason::QosGrpSubmitJobsLimit);
         }
     }
+    None
+}
 
-    if let Some(ref grp) = limits.grp_tres {
-        let job_cpus = (job.spec.num_tasks * job.spec.cpus_per_task) as u64;
-        if grp.get(TresType::Cpu) > 0
-            && qos_running_tres.get(TresType::Cpu) + job_cpus > grp.get(TresType::Cpu)
-        {
-            return QosCheckResult::Blocked(PendingReason::QosGrpCpuLimit);
-        }
-
-        let job_nodes = job.spec.num_nodes as u64;
-        if grp.get(TresType::Node) > 0
-            && qos_running_tres.get(TresType::Node) + job_nodes > grp.get(TresType::Node)
-        {
-            return QosCheckResult::Blocked(PendingReason::QosGrpNodeLimit);
-        }
-
-        let job_mem = effective_memory_mb(&job.spec, job.spec.num_nodes);
-        if grp.get(TresType::Memory) > 0
-            && qos_running_tres.get(TresType::Memory) + job_mem > grp.get(TresType::Memory)
-        {
-            return QosCheckResult::Blocked(PendingReason::QosGrpMemLimit);
-        }
-
-        let job_gpus = effective_gpus(&job.spec, job.spec.num_nodes);
-        if grp.get(TresType::Gpu) > 0
-            && qos_running_tres.get(TresType::Gpu) + job_gpus > grp.get(TresType::Gpu)
-        {
-            return QosCheckResult::Blocked(PendingReason::QosGrpGpuLimit);
-        }
-    }
-
-    QosCheckResult::Allowed
+/// Standalone QOS resource/wall breach for the submission gate: evaluates the
+/// job on its own (no other load). Denied at submit only when the QOS has
+/// `DenyOnLimit`; otherwise the scheduler pends it.
+pub fn check_qos_standalone_limits(job: &Job, qos: &Qos) -> Option<PendingReason> {
+    qos_resource_breach(job, qos, &TresRecord::new(), &TresRecord::new())
 }
 
 #[cfg(test)]

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -38,8 +38,13 @@ pub enum QosCheckResult {
     Blocked(PendingReason),
 }
 
-/// Whether the job's requested wall time exceeds `max_wall` minutes.
+/// Whether the job's requested wall time exceeds `max_wall` minutes. A cap of 0
+/// is "block all" per the limit convention, so it breaches even a job with no
+/// explicit time limit.
 fn wall_breach(job: &Job, max_wall: u32) -> bool {
+    if max_wall == 0 {
+        return true;
+    }
     job.spec
         .time_limit
         .is_some_and(|w| w.num_minutes() > max_wall as i64)
@@ -302,6 +307,25 @@ mod tests {
             result,
             QosCheckResult::Blocked(PendingReason::QosMaxWallDurationPerJobLimit)
         );
+    }
+
+    #[test]
+    fn max_wall_zero_blocks_time_less_job() {
+        let qos = make_qos(None, Some(0)); // 0 = block all
+        let mut job = make_test_job();
+        job.spec.time_limit = None;
+        assert_eq!(
+            check_qos_standalone_limits(&job, &qos),
+            Some(PendingReason::QosMaxWallDurationPerJobLimit)
+        );
+    }
+
+    #[test]
+    fn positive_max_wall_leaves_time_less_job_alone() {
+        let qos = make_qos(None, Some(60));
+        let mut job = make_test_job();
+        job.spec.time_limit = None;
+        assert_eq!(check_qos_standalone_limits(&job, &qos), None);
     }
 
     #[test]

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -6,7 +6,7 @@
 //! Checks per-QOS limits before allowing a job to be scheduled.
 
 use crate::accounting::{Qos, QosPreemptMode, TresRecord, TresType};
-use crate::job::{effective_gpus, effective_memory_mb, Job, PendingReason};
+use crate::job::{effective_gpus, effective_memory_mb, Job, JobSpec, PendingReason};
 use crate::partition::PreemptMode;
 
 impl From<QosPreemptMode> for PreemptMode {
@@ -41,21 +41,20 @@ pub enum QosCheckResult {
 /// Whether the job's requested wall time exceeds `max_wall` minutes. A cap of 0
 /// is "block all" per the limit convention, so it breaches even a job with no
 /// explicit time limit.
-fn wall_breach(job: &Job, max_wall: u32) -> bool {
+fn wall_breach(spec: &JobSpec, max_wall: u32) -> bool {
     if max_wall == 0 {
         return true;
     }
-    job.spec
-        .time_limit
+    spec.time_limit
         .is_some_and(|w| w.num_minutes() > max_wall as i64)
 }
 
 /// The four TRES quantities a single job requests: (cpu, node, mem_mb, gpu).
-fn job_tres(job: &Job) -> (u64, u64, u64, u64) {
-    let cpus = (job.spec.num_tasks * job.spec.cpus_per_task) as u64;
-    let nodes = job.spec.num_nodes as u64;
-    let mem = effective_memory_mb(&job.spec, job.spec.num_nodes);
-    let gpus = effective_gpus(&job.spec, job.spec.num_nodes);
+fn job_tres(spec: &JobSpec) -> (u64, u64, u64, u64) {
+    let cpus = (spec.num_tasks * spec.cpus_per_task) as u64;
+    let nodes = spec.num_nodes as u64;
+    let mem = effective_memory_mb(spec, spec.num_nodes);
+    let gpus = effective_gpus(spec, spec.num_nodes);
     (cpus, nodes, mem, gpus)
 }
 
@@ -91,16 +90,16 @@ fn tres_cap_breach(
 /// with real aggregates folded in. `running_*` fold in existing load; pass
 /// empty records for the standalone (submit-time) evaluation.
 fn qos_resource_breach(
-    job: &Job,
+    spec: &JobSpec,
     qos: &Qos,
     user_running_tres: &TresRecord,
     qos_running_tres: &TresRecord,
 ) -> Option<PendingReason> {
     let limits = &qos.limits;
-    let (job_cpu, job_node, job_mem, job_gpu) = job_tres(job);
+    let (job_cpu, job_node, job_mem, job_gpu) = job_tres(spec);
 
     if let Some(max_wall) = limits.max_wall_minutes {
-        if wall_breach(job, max_wall) {
+        if wall_breach(spec, max_wall) {
             return Some(PendingReason::QosMaxWallDurationPerJobLimit);
         }
     }
@@ -195,7 +194,7 @@ pub fn check_qos_limits(
         }
     }
 
-    match qos_resource_breach(job, qos, user_running_tres, qos_running_tres) {
+    match qos_resource_breach(&job.spec, qos, user_running_tres, qos_running_tres) {
         Some(reason) => QosCheckResult::Blocked(reason),
         None => QosCheckResult::Allowed,
     }
@@ -235,8 +234,8 @@ pub fn check_qos_submit_limits(
 /// Standalone QOS resource/wall breach for the submission gate: evaluates the
 /// job on its own (no other load). Denied at submit only when the QOS has
 /// `DenyOnLimit`; otherwise the scheduler pends it.
-pub fn check_qos_standalone_limits(job: &Job, qos: &Qos) -> Option<PendingReason> {
-    qos_resource_breach(job, qos, &TresRecord::new(), &TresRecord::new())
+pub fn check_qos_standalone_limits(spec: &JobSpec, qos: &Qos) -> Option<PendingReason> {
+    qos_resource_breach(spec, qos, &TresRecord::new(), &TresRecord::new())
 }
 
 #[cfg(test)]
@@ -315,7 +314,7 @@ mod tests {
         let mut job = make_test_job();
         job.spec.time_limit = None;
         assert_eq!(
-            check_qos_standalone_limits(&job, &qos),
+            check_qos_standalone_limits(&job.spec, &qos),
             Some(PendingReason::QosMaxWallDurationPerJobLimit)
         );
     }
@@ -325,7 +324,7 @@ mod tests {
         let qos = make_qos(None, Some(60));
         let mut job = make_test_job();
         job.spec.time_limit = None;
-        assert_eq!(check_qos_standalone_limits(&job, &qos), None);
+        assert_eq!(check_qos_standalone_limits(&job.spec, &qos), None);
     }
 
     #[test]

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -95,12 +95,15 @@ CREATE TABLE IF NOT EXISTS qos (
     usage_factor    REAL NOT NULL DEFAULT 1.0,
     max_jobs_per_user INTEGER,
     max_submit_per_user INTEGER,
+    max_submit_per_account INTEGER,
+    grp_submit_jobs INTEGER,
     max_tres_per_job TEXT,
     max_tres_per_user TEXT,
     grp_tres        TEXT,
     max_wall_min    INTEGER,
     grp_wall_min    INTEGER,
     preempt_exempt_time INTEGER,
+    flags           TEXT NOT NULL DEFAULT '',
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
@@ -112,6 +115,7 @@ CREATE TABLE IF NOT EXISTS associations (
     fairshare_weight INTEGER NOT NULL DEFAULT 1,
     max_running_jobs INTEGER,
     max_submit_jobs INTEGER,
+    grp_submit_jobs INTEGER,
     max_tres_per_job TEXT,
     grp_tres        TEXT,
     max_wall_min    INTEGER,
@@ -145,6 +149,10 @@ ALTER TABLE associations ADD COLUMN IF NOT EXISTS default_qos TEXT;
 -- Comma-separated QOS names, same degrade-gracefully rationale as default_qos.
 ALTER TABLE associations ADD COLUMN IF NOT EXISTS allowed_qos TEXT;
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS grp_wall_min INTEGER;
+ALTER TABLE qos ADD COLUMN IF NOT EXISTS max_submit_per_account INTEGER;
+ALTER TABLE qos ADD COLUMN IF NOT EXISTS grp_submit_jobs INTEGER;
+ALTER TABLE qos ADD COLUMN IF NOT EXISTS flags TEXT NOT NULL DEFAULT '';
+ALTER TABLE associations ADD COLUMN IF NOT EXISTS grp_submit_jobs INTEGER;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS grp_tres TEXT;
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS preempt TEXT NOT NULL DEFAULT '';
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS preempt_exempt_time INTEGER;
@@ -763,6 +771,7 @@ pub struct UserUpdate<'a> {
     pub allowed_qos: Option<Option<&'a str>>,
     pub max_running_jobs: Option<Option<i32>>,
     pub max_submit_jobs: Option<Option<i32>>,
+    pub grp_submit_jobs: Option<Option<i32>>,
     pub max_tres_per_job: Option<Option<&'a str>>,
     pub grp_tres: Option<Option<&'a str>>,
     pub max_wall_min: Option<Option<i32>>,
@@ -841,6 +850,9 @@ pub async fn add_user<'a>(
     if let Some(v) = u.max_submit_jobs {
         assoc.push(("max_submit_jobs", SqlVal::NullInt(v)));
     }
+    if let Some(v) = u.grp_submit_jobs {
+        assoc.push(("grp_submit_jobs", SqlVal::NullInt(v)));
+    }
     if let Some(v) = u.max_tres_per_job {
         assoc.push(("max_tres_per_job", SqlVal::NullText(v)));
     }
@@ -890,7 +902,9 @@ pub async fn list_users(
         r#"
         SELECT DISTINCT ON (u.name, u.account)
             u.name, u.account, u.admin_level, u.default_account,
-            a.default_qos, a.allowed_qos
+            a.default_qos, a.allowed_qos,
+            a.max_running_jobs, a.max_submit_jobs, a.grp_submit_jobs,
+            a.max_wall_min, a.max_tres_per_job, a.grp_tres
         FROM users u
         LEFT JOIN associations a
             ON a.user_name = u.name AND a.account = u.account
@@ -914,6 +928,12 @@ pub async fn list_users(
             default_account: r.get("default_account"),
             default_qos: r.get("default_qos"),
             allowed_qos: r.get("allowed_qos"),
+            max_running_jobs: r.get("max_running_jobs"),
+            max_submit_jobs: r.get("max_submit_jobs"),
+            grp_submit_jobs: r.get("grp_submit_jobs"),
+            max_wall_min: r.get("max_wall_min"),
+            max_tres_per_job: r.get("max_tres_per_job"),
+            grp_tres: r.get("grp_tres"),
         })
         .collect())
 }
@@ -926,6 +946,12 @@ pub struct UserRecord {
     pub default_account: Option<String>,
     pub default_qos: Option<String>,
     pub allowed_qos: Option<String>,
+    pub max_running_jobs: Option<i32>,
+    pub max_submit_jobs: Option<i32>,
+    pub grp_submit_jobs: Option<i32>,
+    pub max_wall_min: Option<i32>,
+    pub max_tres_per_job: Option<String>,
+    pub grp_tres: Option<String>,
 }
 
 /// List every user-account association's resource limits, one row per
@@ -936,7 +962,7 @@ pub async fn list_associations(pool: &PgPool) -> anyhow::Result<Vec<AssociationR
     let rows = sqlx::query(
         r#"
         SELECT DISTINCT ON (user_name, account)
-            user_name, account, max_running_jobs, max_submit_jobs,
+            user_name, account, max_running_jobs, max_submit_jobs, grp_submit_jobs,
             max_tres_per_job, grp_tres, max_wall_min
         FROM associations
         WHERE partition_name IS NULL OR partition_name = ''
@@ -953,6 +979,7 @@ pub async fn list_associations(pool: &PgPool) -> anyhow::Result<Vec<AssociationR
             account: r.get("account"),
             max_running_jobs: r.get("max_running_jobs"),
             max_submit_jobs: r.get("max_submit_jobs"),
+            grp_submit_jobs: r.get("grp_submit_jobs"),
             max_tres_per_job: r.get("max_tres_per_job"),
             grp_tres: r.get("grp_tres"),
             max_wall_min: r.get("max_wall_min"),
@@ -966,6 +993,7 @@ pub struct AssociationRecord {
     pub account: String,
     pub max_running_jobs: Option<i32>,
     pub max_submit_jobs: Option<i32>,
+    pub grp_submit_jobs: Option<i32>,
     pub max_tres_per_job: Option<String>,
     pub grp_tres: Option<String>,
     pub max_wall_min: Option<i32>,
@@ -986,10 +1014,13 @@ pub struct QosUpdate<'a> {
     pub max_wall_min: Option<Option<i32>>,
     pub max_tres_per_job: Option<Option<&'a str>>,
     pub max_submit_per_user: Option<Option<i32>>,
+    pub max_submit_per_account: Option<Option<i32>>,
+    pub grp_submit_jobs: Option<Option<i32>>,
     pub max_tres_per_user: Option<Option<&'a str>>,
     pub grp_tres: Option<Option<&'a str>>,
     pub grp_wall_min: Option<Option<i32>>,
     pub preempt_exempt_time: Option<Option<i32>>,
+    pub flags: Option<&'a str>,
 }
 
 /// Create or update a QOS, writing only the fields set in `u`. `modify` sends
@@ -1022,6 +1053,12 @@ pub async fn upsert_qos<'a>(pool: &PgPool, name: &'a str, u: QosUpdate<'a>) -> a
     if let Some(v) = u.max_submit_per_user {
         updates.push(("max_submit_per_user", SqlVal::NullInt(v)));
     }
+    if let Some(v) = u.max_submit_per_account {
+        updates.push(("max_submit_per_account", SqlVal::NullInt(v)));
+    }
+    if let Some(v) = u.grp_submit_jobs {
+        updates.push(("grp_submit_jobs", SqlVal::NullInt(v)));
+    }
     if let Some(v) = u.max_tres_per_user {
         updates.push(("max_tres_per_user", SqlVal::NullText(v)));
     }
@@ -1036,6 +1073,9 @@ pub async fn upsert_qos<'a>(pool: &PgPool, name: &'a str, u: QosUpdate<'a>) -> a
     }
     if let Some(v) = u.preempt_exempt_time {
         updates.push(("preempt_exempt_time", SqlVal::NullInt(v)));
+    }
+    if let Some(v) = u.flags {
+        updates.push(("flags", SqlVal::Text(v)));
     }
     upsert_row(pool, UpsertTable::Qos, &keys, &updates).await
 }
@@ -1082,7 +1122,7 @@ pub async fn missing_qos(pool: &PgPool, names: &[&str]) -> anyhow::Result<Vec<St
 /// List all QOS.
 pub async fn list_qos(pool: &PgPool) -> anyhow::Result<Vec<QosRecord>> {
     let rows = sqlx::query(
-        "SELECT name, description, priority, preempt_mode, preempt, usage_factor, max_jobs_per_user, max_wall_min, max_tres_per_job, max_submit_per_user, max_tres_per_user, grp_tres, grp_wall_min, preempt_exempt_time FROM qos ORDER BY name"
+        "SELECT name, description, priority, preempt_mode, preempt, usage_factor, max_jobs_per_user, max_wall_min, max_tres_per_job, max_submit_per_user, max_submit_per_account, grp_submit_jobs, max_tres_per_user, grp_tres, grp_wall_min, preempt_exempt_time, flags FROM qos ORDER BY name"
     ).fetch_all(pool).await?;
 
     Ok(rows
@@ -1099,10 +1139,13 @@ pub async fn list_qos(pool: &PgPool) -> anyhow::Result<Vec<QosRecord>> {
             max_wall_min: r.get("max_wall_min"),
             max_tres_per_job: r.get("max_tres_per_job"),
             max_submit_per_user: r.get("max_submit_per_user"),
+            max_submit_per_account: r.get("max_submit_per_account"),
+            grp_submit_jobs: r.get("grp_submit_jobs"),
             max_tres_per_user: r.get("max_tres_per_user"),
             grp_tres: r.get("grp_tres"),
             grp_wall_min: r.get("grp_wall_min"),
             preempt_exempt_time: r.get("preempt_exempt_time"),
+            flags: r.get("flags"),
         })
         .collect())
 }
@@ -1120,10 +1163,13 @@ pub struct QosRecord {
     pub max_wall_min: Option<i32>,
     pub max_tres_per_job: Option<String>,
     pub max_submit_per_user: Option<i32>,
+    pub max_submit_per_account: Option<i32>,
+    pub grp_submit_jobs: Option<i32>,
     pub max_tres_per_user: Option<String>,
     pub grp_tres: Option<String>,
     pub grp_wall_min: Option<i32>,
     pub preempt_exempt_time: Option<i32>,
+    pub flags: String,
 }
 
 #[cfg(test)]
@@ -1424,10 +1470,13 @@ mod job_history_tests {
                 max_wall_min: Some(Some(60)),
                 max_tres_per_job: Some(Some("cpu=2")),
                 max_submit_per_user: Some(Some(4)),
+                max_submit_per_account: Some(Some(7)),
+                grp_submit_jobs: Some(Some(9)),
                 max_tres_per_user: Some(Some("cpu=16")),
                 grp_tres: Some(Some("cpu=64")),
                 grp_wall_min: Some(Some(120)),
                 preempt_exempt_time: None,
+                flags: Some("DenyOnLimit"),
             },
         )
         .await?;
@@ -1443,9 +1492,12 @@ mod job_history_tests {
         assert_eq!(got.max_wall_min, Some(60));
         assert_eq!(got.max_tres_per_job.as_deref(), Some("cpu=2"));
         assert_eq!(got.max_submit_per_user, Some(4));
+        assert_eq!(got.max_submit_per_account, Some(7));
+        assert_eq!(got.grp_submit_jobs, Some(9));
         assert_eq!(got.max_tres_per_user.as_deref(), Some("cpu=16"));
         assert_eq!(got.grp_tres.as_deref(), Some("cpu=64"));
         assert_eq!(got.grp_wall_min, Some(120));
+        assert_eq!(got.flags, "DenyOnLimit");
 
         sqlx::query("DELETE FROM qos WHERE name = $1")
             .bind(&name)

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -31,15 +31,43 @@ fn nullable_str(field: &Option<String>) -> Option<Option<&str>> {
 }
 
 /// Map an optional u32 limit proto field to a nullable-int patch: unset ->
-/// keep, 0 -> clear (no limit), n -> set. Errors if `n` overflows i32.
+/// keep, INFINITE (`u32::MAX`) -> clear (no limit / SQL NULL), n -> set the
+/// literal (including 0, which means "block all"). Errors if `n` overflows i32.
 fn nullable_limit(field: Option<u32>, what: &str) -> Result<Option<Option<i32>>, Status> {
     match field {
         None => Ok(None),
-        Some(0) => Ok(Some(None)),
+        Some(spur_core::accounting::INFINITE) => Ok(Some(None)),
         Some(n) => Ok(Some(Some(i32::try_from(n).map_err(|_| {
             Status::invalid_argument(format!("{what} exceeds i32::MAX"))
         })?))),
     }
+}
+
+/// Map a stored nullable limit to its proto `uint32`: NULL (and any stray
+/// negative) becomes the INFINITE sentinel so the CLI can tell "no limit" apart
+/// from a literal 0; a stored value is emitted as-is.
+fn limit_to_proto(v: Option<i32>) -> u32 {
+    match v {
+        Some(n) if n >= 0 => n as u32,
+        _ => spur_core::accounting::INFINITE,
+    }
+}
+
+/// Validate and canonicalize the QOS `flags` string. Only `DenyOnLimit` is
+/// recognized; an unknown token errors loudly rather than being silently
+/// dropped (a dropped flag reads as "set" but never takes effect).
+fn canonicalize_qos_flags(raw: &str) -> Result<String, Status> {
+    let mut deny_on_limit = false;
+    for token in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        if token.eq_ignore_ascii_case("denyonlimit") {
+            deny_on_limit = true;
+        } else {
+            return Err(Status::invalid_argument(format!(
+                "unknown QOS flag '{token}'. Supported: DenyOnLimit"
+            )));
+        }
+    }
+    Ok(if deny_on_limit { "DenyOnLimit" } else { "" }.to_string())
 }
 
 /// Fairshare is a whole share count stored as `INTEGER`, but the proto carries
@@ -391,7 +419,7 @@ impl SlurmAccounting for AccountingService {
                 organization: r.organization,
                 parent_account: r.parent.unwrap_or_default(),
                 fairshare_weight: r.fairshare_weight as f64,
-                max_running_jobs: r.max_running_jobs.unwrap_or(0) as u32,
+                max_running_jobs: limit_to_proto(r.max_running_jobs),
                 grp_tres: r.grp_tres.unwrap_or_default(),
             })
             .collect();
@@ -467,6 +495,7 @@ impl SlurmAccounting for AccountingService {
             }),
             max_running_jobs: nullable_limit(req.max_running_jobs, "max_running_jobs")?,
             max_submit_jobs: nullable_limit(req.max_submit_jobs, "max_submit_jobs")?,
+            grp_submit_jobs: nullable_limit(req.grp_submit_jobs, "grp_submit_jobs")?,
             max_tres_per_job: nullable_str(&req.max_tres_per_job),
             grp_tres: nullable_str(&req.grp_tres),
             max_wall_min: nullable_limit(req.max_wall_minutes, "max_wall_minutes")?,
@@ -526,6 +555,12 @@ impl SlurmAccounting for AccountingService {
                 default_account: r.default_account.unwrap_or_default(),
                 default_qos: r.default_qos.unwrap_or_default(),
                 allowed_qos: r.allowed_qos.unwrap_or_default(),
+                max_running_jobs: limit_to_proto(r.max_running_jobs),
+                max_submit_jobs: limit_to_proto(r.max_submit_jobs),
+                grp_submit_jobs: limit_to_proto(r.grp_submit_jobs),
+                max_wall_minutes: limit_to_proto(r.max_wall_min),
+                max_tres_per_job: r.max_tres_per_job.unwrap_or_default(),
+                grp_tres: r.grp_tres.unwrap_or_default(),
             })
             .collect();
 
@@ -567,6 +602,11 @@ impl SlurmAccounting for AccountingService {
             }
         };
 
+        let flags = req
+            .flags
+            .as_deref()
+            .map(canonicalize_qos_flags)
+            .transpose()?;
         let update = db::QosUpdate {
             description: req.description.as_deref(),
             priority: req.priority,
@@ -580,6 +620,11 @@ impl SlurmAccounting for AccountingService {
                 req.max_submit_jobs_per_user,
                 "max_submit_jobs_per_user",
             )?,
+            max_submit_per_account: nullable_limit(
+                req.max_submit_jobs_per_account,
+                "max_submit_jobs_per_account",
+            )?,
+            grp_submit_jobs: nullable_limit(req.grp_submit_jobs, "grp_submit_jobs")?,
             max_tres_per_user: nullable_str(&req.max_tres_per_user),
             grp_tres: nullable_str(&req.grp_tres),
             grp_wall_min: nullable_limit(req.grp_wall_minutes, "grp_wall_minutes")?,
@@ -588,6 +633,7 @@ impl SlurmAccounting for AccountingService {
             } else {
                 req.preempt_exempt_time.map(|v| Some(v as i32))
             },
+            flags: flags.as_deref(),
         };
         db::upsert_qos(pool, &req.name, update)
             .await
@@ -622,14 +668,17 @@ impl SlurmAccounting for AccountingService {
                 preempt_mode: r.preempt_mode,
                 preempt: r.preempt,
                 usage_factor: r.usage_factor,
-                max_jobs_per_user: r.max_jobs_per_user.unwrap_or(0) as u32,
-                max_wall_minutes: r.max_wall_min.unwrap_or(0) as u32,
+                max_jobs_per_user: limit_to_proto(r.max_jobs_per_user),
+                max_wall_minutes: limit_to_proto(r.max_wall_min),
                 max_tres_per_job: r.max_tres_per_job.unwrap_or_default(),
-                max_submit_jobs_per_user: r.max_submit_per_user.unwrap_or(0) as u32,
+                max_submit_jobs_per_user: limit_to_proto(r.max_submit_per_user),
                 max_tres_per_user: r.max_tres_per_user.unwrap_or_default(),
                 grp_tres: r.grp_tres.unwrap_or_default(),
-                grp_wall_minutes: r.grp_wall_min.unwrap_or(0) as u32,
+                grp_wall_minutes: limit_to_proto(r.grp_wall_min),
                 preempt_exempt_time: r.preempt_exempt_time.map(|v| v as u32),
+                max_submit_jobs_per_account: limit_to_proto(r.max_submit_per_account),
+                grp_submit_jobs: limit_to_proto(r.grp_submit_jobs),
+                flags: r.flags,
             })
             .collect();
 

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 use tonic::{Request, Response, Status};
 
-use spur_core::accounting::TresRecord;
+use spur_core::accounting::{limit_to_wire, TresRecord};
 use spur_proto::proto::slurm_accounting_server::{SlurmAccounting, SlurmAccountingServer};
 use spur_proto::proto::*;
 
@@ -40,16 +40,6 @@ fn nullable_limit(field: Option<u32>, what: &str) -> Result<Option<Option<i32>>,
         Some(n) => Ok(Some(Some(i32::try_from(n).map_err(|_| {
             Status::invalid_argument(format!("{what} exceeds i32::MAX"))
         })?))),
-    }
-}
-
-/// Map a stored nullable limit to its proto `uint32`: NULL (and any stray
-/// negative) becomes the INFINITE sentinel so the CLI can tell "no limit" apart
-/// from a literal 0; a stored value is emitted as-is.
-fn limit_to_proto(v: Option<i32>) -> u32 {
-    match v {
-        Some(n) if n >= 0 => n as u32,
-        _ => spur_core::accounting::INFINITE,
     }
 }
 
@@ -419,7 +409,7 @@ impl SlurmAccounting for AccountingService {
                 organization: r.organization,
                 parent_account: r.parent.unwrap_or_default(),
                 fairshare_weight: r.fairshare_weight as f64,
-                max_running_jobs: limit_to_proto(r.max_running_jobs),
+                max_running_jobs: limit_to_wire(r.max_running_jobs),
                 grp_tres: r.grp_tres.unwrap_or_default(),
             })
             .collect();
@@ -555,10 +545,10 @@ impl SlurmAccounting for AccountingService {
                 default_account: r.default_account.unwrap_or_default(),
                 default_qos: r.default_qos.unwrap_or_default(),
                 allowed_qos: r.allowed_qos.unwrap_or_default(),
-                max_running_jobs: limit_to_proto(r.max_running_jobs),
-                max_submit_jobs: limit_to_proto(r.max_submit_jobs),
-                grp_submit_jobs: limit_to_proto(r.grp_submit_jobs),
-                max_wall_minutes: limit_to_proto(r.max_wall_min),
+                max_running_jobs: limit_to_wire(r.max_running_jobs),
+                max_submit_jobs: limit_to_wire(r.max_submit_jobs),
+                grp_submit_jobs: limit_to_wire(r.grp_submit_jobs),
+                max_wall_minutes: limit_to_wire(r.max_wall_min),
                 max_tres_per_job: r.max_tres_per_job.unwrap_or_default(),
                 grp_tres: r.grp_tres.unwrap_or_default(),
             })
@@ -668,16 +658,16 @@ impl SlurmAccounting for AccountingService {
                 preempt_mode: r.preempt_mode,
                 preempt: r.preempt,
                 usage_factor: r.usage_factor,
-                max_jobs_per_user: limit_to_proto(r.max_jobs_per_user),
-                max_wall_minutes: limit_to_proto(r.max_wall_min),
+                max_jobs_per_user: limit_to_wire(r.max_jobs_per_user),
+                max_wall_minutes: limit_to_wire(r.max_wall_min),
                 max_tres_per_job: r.max_tres_per_job.unwrap_or_default(),
-                max_submit_jobs_per_user: limit_to_proto(r.max_submit_per_user),
+                max_submit_jobs_per_user: limit_to_wire(r.max_submit_per_user),
                 max_tres_per_user: r.max_tres_per_user.unwrap_or_default(),
                 grp_tres: r.grp_tres.unwrap_or_default(),
-                grp_wall_minutes: limit_to_proto(r.grp_wall_min),
+                grp_wall_minutes: limit_to_wire(r.grp_wall_min),
                 preempt_exempt_time: r.preempt_exempt_time.map(|v| v as u32),
-                max_submit_jobs_per_account: limit_to_proto(r.max_submit_per_account),
-                grp_submit_jobs: limit_to_proto(r.grp_submit_jobs),
+                max_submit_jobs_per_account: limit_to_wire(r.max_submit_per_account),
+                grp_submit_jobs: limit_to_wire(r.grp_submit_jobs),
                 flags: r.flags,
             })
             .collect();
@@ -879,5 +869,40 @@ mod tests {
                 .code(),
             tonic::Code::InvalidArgument
         );
+    }
+
+    #[test]
+    fn nullable_limit_maps_sentinels() {
+        assert_eq!(nullable_limit(None, "x").unwrap(), None);
+        assert_eq!(
+            nullable_limit(Some(spur_core::accounting::INFINITE), "x").unwrap(),
+            Some(None)
+        );
+        // 0 is a real value ("block all"), not a clear.
+        assert_eq!(nullable_limit(Some(0), "x").unwrap(), Some(Some(0)));
+        assert_eq!(nullable_limit(Some(5), "x").unwrap(), Some(Some(5)));
+    }
+
+    #[test]
+    fn nullable_limit_rejects_over_i32_max() {
+        let err = nullable_limit(Some(i32::MAX as u32 + 1), "maxsubmit").unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("maxsubmit"));
+    }
+
+    #[test]
+    fn canonicalize_qos_flags_normalizes_and_validates() {
+        assert_eq!(canonicalize_qos_flags("").unwrap(), "");
+        assert_eq!(
+            canonicalize_qos_flags("denyonlimit").unwrap(),
+            "DenyOnLimit"
+        );
+        assert_eq!(
+            canonicalize_qos_flags(" DENYONLIMIT , ").unwrap(),
+            "DenyOnLimit"
+        );
+        let err = canonicalize_qos_flags("bogus").unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("bogus"));
     }
 }

--- a/crates/spurctld/src/accounting/mod.rs
+++ b/crates/spurctld/src/accounting/mod.rs
@@ -124,9 +124,7 @@ pub async fn association_maps(
 }
 
 fn account_limits_from_record(r: db::AssociationRecord) -> AccountLimits {
-    // A stored NULL (None) is "no limit"; a literal 0 is a real value (block
-    // all). A stray negative predates the sentinel flip; treat it as unset.
-    let opt_u32 = |v: Option<i32>| v.filter(|&x| x >= 0).map(|x| x as u32);
+    use spur_core::accounting::limit_from_db;
     // Values are validated by `add_user` before being stored, so a parse
     // failure here means the DB row predates that check or was edited
     // out-of-band; treat it as unset rather than poisoning the whole load.
@@ -141,12 +139,12 @@ fn account_limits_from_record(r: db::AssociationRecord) -> AccountLimits {
     };
 
     AccountLimits {
-        max_running_jobs: opt_u32(r.max_running_jobs),
-        max_submit_jobs: opt_u32(r.max_submit_jobs),
-        grp_submit_jobs: opt_u32(r.grp_submit_jobs),
+        max_running_jobs: limit_from_db(r.max_running_jobs),
+        max_submit_jobs: limit_from_db(r.max_submit_jobs),
+        grp_submit_jobs: limit_from_db(r.grp_submit_jobs),
         max_tres_per_job: opt_tres(r.max_tres_per_job),
         grp_tres: opt_tres(r.grp_tres),
-        max_wall_minutes: opt_u32(r.max_wall_min),
+        max_wall_minutes: limit_from_db(r.max_wall_min),
     }
 }
 
@@ -176,5 +174,40 @@ mod tests {
         merge_admin_level(&mut m, "dave", "none");
         merge_admin_level(&mut m, "dave", "");
         assert!(!m.contains_key("dave"));
+    }
+
+    fn record_with_submit(grp_submit_jobs: Option<i32>) -> super::db::AssociationRecord {
+        super::db::AssociationRecord {
+            user_name: "alice".into(),
+            account: "research".into(),
+            max_running_jobs: None,
+            max_submit_jobs: None,
+            grp_submit_jobs,
+            max_tres_per_job: None,
+            grp_tres: None,
+            max_wall_min: None,
+        }
+    }
+
+    #[test]
+    fn account_limits_preserve_zero_as_block_all() {
+        let limits = super::account_limits_from_record(record_with_submit(Some(0)));
+        assert_eq!(limits.grp_submit_jobs, Some(0));
+    }
+
+    #[test]
+    fn account_limits_map_null_and_negative_to_unset() {
+        let from_null = super::account_limits_from_record(record_with_submit(None));
+        assert_eq!(from_null.grp_submit_jobs, None);
+
+        // A stray negative predates the sentinel flip; treat it as unset.
+        let from_negative = super::account_limits_from_record(record_with_submit(Some(-1)));
+        assert_eq!(from_negative.grp_submit_jobs, None);
+    }
+
+    #[test]
+    fn account_limits_pass_through_positive() {
+        let limits = super::account_limits_from_record(record_with_submit(Some(5)));
+        assert_eq!(limits.grp_submit_jobs, Some(5));
     }
 }

--- a/crates/spurctld/src/accounting/mod.rs
+++ b/crates/spurctld/src/accounting/mod.rs
@@ -124,7 +124,9 @@ pub async fn association_maps(
 }
 
 fn account_limits_from_record(r: db::AssociationRecord) -> AccountLimits {
-    let opt_u32 = |v: Option<i32>| v.filter(|&x| x > 0).map(|x| x as u32);
+    // A stored NULL (None) is "no limit"; a literal 0 is a real value (block
+    // all). A stray negative predates the sentinel flip; treat it as unset.
+    let opt_u32 = |v: Option<i32>| v.filter(|&x| x >= 0).map(|x| x as u32);
     // Values are validated by `add_user` before being stored, so a parse
     // failure here means the DB row predates that check or was edited
     // out-of-band; treat it as unset rather than poisoning the whole load.
@@ -141,6 +143,7 @@ fn account_limits_from_record(r: db::AssociationRecord) -> AccountLimits {
     AccountLimits {
         max_running_jobs: opt_u32(r.max_running_jobs),
         max_submit_jobs: opt_u32(r.max_submit_jobs),
+        grp_submit_jobs: opt_u32(r.grp_submit_jobs),
         max_tres_per_job: opt_tres(r.max_tres_per_job),
         grp_tres: opt_tres(r.grp_tres),
         max_wall_minutes: opt_u32(r.max_wall_min),

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4471,10 +4471,6 @@ impl ClusterManager {
         let account = spec.account.as_deref().filter(|a| !a.is_empty());
         let qos_name = spec.qos.as_deref().filter(|n| !n.is_empty());
 
-        // Representative job for the stand-alone/wall breach checks. The job_id
-        // is irrelevant here (these evaluate the request in isolation).
-        let job = Job::new(0, spec.clone());
-
         let is_submitted = |j: &Job| matches!(j.state, JobState::Pending | JobState::Running);
 
         // Surface a human sentence plus the exact Slurm reason code, so the
@@ -4515,7 +4511,7 @@ impl ClusterManager {
                 ) {
                     return Err(deny(reason));
                 }
-                if let Some(reason) = check_account_wall_limit(&job, &limits) {
+                if let Some(reason) = check_account_wall_limit(spec, &limits) {
                     return Err(deny(reason));
                 }
             }
@@ -4569,7 +4565,7 @@ impl ClusterManager {
                         return Err(deny(reason));
                     }
                     if deny_on_limit {
-                        if let Some(reason) = check_qos_standalone_limits(&job, &qos) {
+                        if let Some(reason) = check_qos_standalone_limits(spec, &qos) {
                             return Err(deny(reason));
                         }
                     }
@@ -4581,7 +4577,7 @@ impl ClusterManager {
         if deny_on_limit && assoc_loaded {
             if let Some(account) = account {
                 let limits = self.association_cache.limits(user, account);
-                if let Some(reason) = check_account_standalone_limits(&job, &limits) {
+                if let Some(reason) = check_account_standalone_limits(spec, &limits) {
                     return Err(deny(reason));
                 }
             }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -647,9 +647,11 @@ impl ClusterManager {
         // limit-lowered-after-submit edge case. Each array task counts
         // individually toward submit caps; the whole submission is rejected.
         let incoming_tasks = match spec.array_spec.as_deref() {
-            Some(s) => spur_core::array::parse_array_spec(s)
-                .map(|a| a.task_ids.len() as u32)
-                .unwrap_or(1),
+            Some(s) => {
+                let parsed = spur_core::array::parse_array_spec(s)
+                    .map_err(|e| SubmitError::invalid(e.to_string()))?;
+                u32::try_from(parsed.task_ids.len()).unwrap_or(u32::MAX)
+            }
             None => 1,
         };
         self.enforce_submit_limits(&spec, incoming_tasks)?;
@@ -4486,18 +4488,25 @@ impl ClusterManager {
         if assoc_loaded {
             if let Some(account) = account {
                 let limits = self.association_cache.limits(user, account);
-                let user_submitted = jobs
-                    .values()
-                    .filter(|j| {
-                        is_submitted(j)
-                            && j.spec.user == user
-                            && j.spec.account.as_deref() == Some(account)
-                    })
-                    .count() as u32;
-                let account_submitted = jobs
-                    .values()
-                    .filter(|j| is_submitted(j) && j.spec.account.as_deref() == Some(account))
-                    .count() as u32;
+                // Only scan the job table for a count a set limit actually needs.
+                let user_submitted = if limits.max_submit_jobs.is_some() {
+                    jobs.values()
+                        .filter(|j| {
+                            is_submitted(j)
+                                && j.spec.user == user
+                                && j.spec.account.as_deref() == Some(account)
+                        })
+                        .count() as u32
+                } else {
+                    0
+                };
+                let account_submitted = if limits.grp_submit_jobs.is_some() {
+                    jobs.values()
+                        .filter(|j| is_submitted(j) && j.spec.account.as_deref() == Some(account))
+                        .count() as u32
+                } else {
+                    0
+                };
                 if let Some(reason) = check_account_submit_limits(
                     &limits,
                     user_submitted,
@@ -4520,26 +4529,36 @@ impl ClusterManager {
             if let Some(qos_name) = qos_name {
                 if let Some(qos) = self.qos_cache.get(qos_name) {
                     deny_on_limit = qos.deny_on_limit;
-                    let user_submitted = jobs
-                        .values()
-                        .filter(|j| {
-                            is_submitted(j)
-                                && j.spec.user == user
-                                && j.spec.qos.as_deref() == Some(qos_name)
-                        })
-                        .count() as u32;
-                    let account_submitted = jobs
-                        .values()
-                        .filter(|j| {
-                            is_submitted(j)
-                                && j.spec.account.as_deref() == account
-                                && j.spec.qos.as_deref() == Some(qos_name)
-                        })
-                        .count() as u32;
-                    let qos_submitted = jobs
-                        .values()
-                        .filter(|j| is_submitted(j) && j.spec.qos.as_deref() == Some(qos_name))
-                        .count() as u32;
+                    // Only scan the job table for a count a set limit actually needs.
+                    let user_submitted = if qos.limits.max_submit_jobs_per_user.is_some() {
+                        jobs.values()
+                            .filter(|j| {
+                                is_submitted(j)
+                                    && j.spec.user == user
+                                    && j.spec.qos.as_deref() == Some(qos_name)
+                            })
+                            .count() as u32
+                    } else {
+                        0
+                    };
+                    let account_submitted = if qos.limits.max_submit_jobs_per_account.is_some() {
+                        jobs.values()
+                            .filter(|j| {
+                                is_submitted(j)
+                                    && j.spec.account.as_deref() == account
+                                    && j.spec.qos.as_deref() == Some(qos_name)
+                            })
+                            .count() as u32
+                    } else {
+                        0
+                    };
+                    let qos_submitted = if qos.limits.grp_submit_jobs.is_some() {
+                        jobs.values()
+                            .filter(|j| is_submitted(j) && j.spec.qos.as_deref() == Some(qos_name))
+                            .count() as u32
+                    } else {
+                        0
+                    };
                     if let Some(reason) = check_qos_submit_limits(
                         &qos,
                         user_submitted,

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -11,7 +11,10 @@ use parking_lot::RwLock;
 use tokio::sync::Notify;
 use tracing::{debug, info, warn};
 
-use spur_core::account_limits::{check_account_limits, AccountCheckResult};
+use spur_core::account_limits::{
+    check_account_limits, check_account_standalone_limits, check_account_submit_limits,
+    check_account_wall_limit, AccountCheckResult,
+};
 use spur_core::accounting::{Qos, TresRecord, TresType};
 use spur_core::burst_buffer::BbStageState;
 use spur_core::config::{EnforcePartLimits, SlurmConfig};
@@ -21,7 +24,9 @@ use spur_core::job::{
 };
 use spur_core::node::{Node, NodeEvent, NodeSource, NodeState};
 use spur_core::partition::{requested_partition_names, Partition, PreemptMode};
-use spur_core::qos::{check_qos_limits, QosCheckResult};
+use spur_core::qos::{
+    check_qos_limits, check_qos_standalone_limits, check_qos_submit_limits, QosCheckResult,
+};
 use spur_core::reservation::{self, normalize_node_list, running_jobs_overlap_start, Reservation};
 use spur_core::resource::{ResourceAllocations, ResourceSet};
 use spur_core::step::{JobStep, StepState, STEP_BATCH, STEP_RESERVED_MIN};
@@ -635,6 +640,19 @@ impl ClusterManager {
             spur_core::dependency::try_parse_dependencies(&spec.dependency)
                 .map_err(|e| SubmitError::invalid(format!("invalid dependency: {e}")))?;
         }
+
+        // Submission gate: deny the submit-count family and (for DenyOnLimit
+        // QOS) unsatisfiable stand-alone resource requests before the job ever
+        // enters the queue. The scheduler path stays a safety net for the
+        // limit-lowered-after-submit edge case. Each array task counts
+        // individually toward submit caps; the whole submission is rejected.
+        let incoming_tasks = match spec.array_spec.as_deref() {
+            Some(s) => spur_core::array::parse_array_spec(s)
+                .map(|a| a.task_ids.len() as u32)
+                .unwrap_or(1),
+            None => 1,
+        };
+        self.enforce_submit_limits(&spec, incoming_tasks)?;
 
         let job_id = self.next_job_id.fetch_add(1, Ordering::SeqCst);
         let specs =
@@ -4441,6 +4459,118 @@ impl ClusterManager {
         }
     }
 
+    /// Submit-time limit gate (Slurm's `acct_policy_validate`). Submit-count
+    /// limits and the association per-job wall deny unconditionally; stand-alone
+    /// TRES/wall breaches deny only under the governing QOS's `DenyOnLimit`
+    /// (treated as on when the job has no QOS). `incoming` is the task count added.
+    fn enforce_submit_limits(&self, spec: &JobSpec, incoming: u32) -> Result<(), SubmitError> {
+        let jobs = self.jobs.read();
+        let user = spec.user.as_str();
+        let account = spec.account.as_deref().filter(|a| !a.is_empty());
+        let qos_name = spec.qos.as_deref().filter(|n| !n.is_empty());
+
+        // Representative job for the stand-alone/wall breach checks. The job_id
+        // is irrelevant here (these evaluate the request in isolation).
+        let job = Job::new(0, spec.clone());
+
+        let is_submitted = |j: &Job| matches!(j.state, JobState::Pending | JobState::Running);
+
+        // Surface a human sentence plus the exact Slurm reason code, so the
+        // rejection is readable while machine consumers keep the bare code.
+        let deny = |reason: PendingReason| {
+            SubmitError::invalid(format!("{} ({reason})", reason.submit_denial_message()))
+        };
+
+        // Association submit-count + unconditional wall.
+        let assoc_loaded = self.association_cache.is_loaded();
+        if assoc_loaded {
+            if let Some(account) = account {
+                let limits = self.association_cache.limits(user, account);
+                let user_submitted = jobs
+                    .values()
+                    .filter(|j| {
+                        is_submitted(j)
+                            && j.spec.user == user
+                            && j.spec.account.as_deref() == Some(account)
+                    })
+                    .count() as u32;
+                let account_submitted = jobs
+                    .values()
+                    .filter(|j| is_submitted(j) && j.spec.account.as_deref() == Some(account))
+                    .count() as u32;
+                if let Some(reason) = check_account_submit_limits(
+                    &limits,
+                    user_submitted,
+                    account_submitted,
+                    incoming,
+                ) {
+                    return Err(deny(reason));
+                }
+                if let Some(reason) = check_account_wall_limit(&job, &limits) {
+                    return Err(deny(reason));
+                }
+            }
+        }
+
+        // QOS submit-count + (DenyOnLimit-gated) stand-alone resource breach.
+        // A job with no QOS is treated as DenyOnLimit-on so an unsatisfiable
+        // association request is rejected rather than pending forever.
+        let mut deny_on_limit = true;
+        if self.qos_cache.is_loaded() {
+            if let Some(qos_name) = qos_name {
+                if let Some(qos) = self.qos_cache.get(qos_name) {
+                    deny_on_limit = qos.deny_on_limit;
+                    let user_submitted = jobs
+                        .values()
+                        .filter(|j| {
+                            is_submitted(j)
+                                && j.spec.user == user
+                                && j.spec.qos.as_deref() == Some(qos_name)
+                        })
+                        .count() as u32;
+                    let account_submitted = jobs
+                        .values()
+                        .filter(|j| {
+                            is_submitted(j)
+                                && j.spec.account.as_deref() == account
+                                && j.spec.qos.as_deref() == Some(qos_name)
+                        })
+                        .count() as u32;
+                    let qos_submitted = jobs
+                        .values()
+                        .filter(|j| is_submitted(j) && j.spec.qos.as_deref() == Some(qos_name))
+                        .count() as u32;
+                    if let Some(reason) = check_qos_submit_limits(
+                        &qos,
+                        user_submitted,
+                        account_submitted,
+                        qos_submitted,
+                        incoming,
+                    ) {
+                        return Err(deny(reason));
+                    }
+                    if deny_on_limit {
+                        if let Some(reason) = check_qos_standalone_limits(&job, &qos) {
+                            return Err(deny(reason));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Association stand-alone TRES breach, gated the same way as QOS.
+        if deny_on_limit && assoc_loaded {
+            if let Some(account) = account {
+                let limits = self.association_cache.limits(user, account);
+                if let Some(reason) = check_account_standalone_limits(&job, &limits) {
+                    return Err(deny(reason));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Recompute a job's live effective priority. A running job's stored
     /// `priority` is stale; this recalculates from age, fair-share, and tier.
     pub(crate) fn current_effective_priority(&self, job: &Job, partitions: &[Partition]) -> u32 {
@@ -6917,6 +7047,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use spur_core::accounting::AccountLimits;
     use spur_core::job::JobSpec;
     use spur_core::resource::{ResourceAllocations, ResourceSet};
     use spur_metrics::job::JobMetricsSnapshot;
@@ -7113,6 +7244,15 @@ mod tests {
         let mut spec = basic_spec(name);
         spec.srun_job = true;
         spec
+    }
+
+    /// Assert a submission was denied and the rejection carries the exact Slurm
+    /// reason `code` in parentheses, alongside the human sentence.
+    fn assert_submit_denied(err: &SubmitError, code: &str) {
+        let SubmitError::InvalidArgument(msg) = err else {
+            panic!("expected InvalidArgument, got {err:?}");
+        };
+        assert!(msg.contains(&format!("({code})")), "got: {msg}");
     }
 
     /// Build a cluster backed by a real spur.conf on disk so `reconfigure()`
@@ -12078,6 +12218,172 @@ mod tests {
         assert!(cm.submit_job(spec).is_ok());
     }
 
+    fn qos_with_limits(name: &str, limits: spur_core::accounting::QosLimits, deny: bool) -> Qos {
+        Qos {
+            name: name.into(),
+            limits,
+            deny_on_limit: deny,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_denies_assoc_max_submit_jobs_zero_blocks_all() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.association_cache().insert_limits(
+            "testuser",
+            "research",
+            AccountLimits {
+                max_submit_jobs: Some(0),
+                ..Default::default()
+            },
+        );
+        let mut spec = basic_spec("blocked");
+        spec.account = Some("research".into());
+        let err = cm.submit_job(spec).unwrap_err();
+        assert_submit_denied(&err, "AssocMaxSubmitJobLimit");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_denies_assoc_max_submit_jobs_over_count() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.association_cache().insert_limits(
+            "testuser",
+            "research",
+            AccountLimits {
+                max_submit_jobs: Some(1),
+                ..Default::default()
+            },
+        );
+        let mut first = basic_spec("first");
+        first.account = Some("research".into());
+        assert!(cm.submit_job(first).is_ok());
+
+        let mut second = basic_spec("second");
+        second.account = Some("research".into());
+        let err = cm.submit_job(second).unwrap_err();
+        assert_submit_denied(&err, "AssocMaxSubmitJobLimit");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_denies_assoc_wall_unconditionally() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.association_cache().insert_limits(
+            "testuser",
+            "research",
+            AccountLimits {
+                max_wall_minutes: Some(60),
+                ..Default::default()
+            },
+        );
+        let mut spec = basic_spec("longwall");
+        spec.account = Some("research".into());
+        spec.time_limit = Some(chrono::Duration::hours(2));
+        let err = cm.submit_job(spec).unwrap_err();
+        assert_submit_denied(&err, "AssocMaxWallDurationPerJobLimit");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_denies_array_that_overflows_submit_cap() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.association_cache().insert_limits(
+            "testuser",
+            "research",
+            AccountLimits {
+                max_submit_jobs: Some(5),
+                ..Default::default()
+            },
+        );
+        let mut spec = basic_spec("bigarray");
+        spec.account = Some("research".into());
+        spec.array_spec = Some("0-9".into()); // 10 tasks > 5
+        let err = cm.submit_job(spec).unwrap_err();
+        assert_submit_denied(&err, "AssocMaxSubmitJobLimit");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_denies_qos_grp_submit_jobs() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.association_cache()
+            .insert_allowed_qos("testuser", "research", &["normal"]);
+        cm.qos_cache().insert(qos_with_limits(
+            "normal",
+            spur_core::accounting::QosLimits {
+                grp_submit_jobs: Some(0),
+                ..Default::default()
+            },
+            false,
+        ));
+        let mut spec = basic_spec("qosgrp");
+        spec.account = Some("research".into());
+        spec.qos = Some("normal".into());
+        let err = cm.submit_job(spec).unwrap_err();
+        assert_submit_denied(&err, "QOSGrpSubmitJobsLimit");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_denies_qos_max_submit_per_account() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.association_cache()
+            .insert_allowed_qos("testuser", "research", &["normal"]);
+        cm.qos_cache().insert(qos_with_limits(
+            "normal",
+            spur_core::accounting::QosLimits {
+                max_submit_jobs_per_account: Some(0),
+                ..Default::default()
+            },
+            false,
+        ));
+        let mut spec = basic_spec("qospa");
+        spec.account = Some("research".into());
+        spec.qos = Some("normal".into());
+        let err = cm.submit_job(spec).unwrap_err();
+        assert_submit_denied(&err, "MaxSubmitJobsPerAccount");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_denies_qos_standalone_tres_only_with_deny_on_limit() {
+        let mut cap = TresRecord::new();
+        cap.set(TresType::Cpu, 1);
+        let limits = spur_core::accounting::QosLimits {
+            max_tres_per_job: Some(cap),
+            ..Default::default()
+        };
+
+        // Without DenyOnLimit the unsatisfiable request is admitted (pends).
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.association_cache()
+            .insert_allowed_qos("testuser", "research", &["normal"]);
+        cm.qos_cache()
+            .insert(qos_with_limits("normal", limits.clone(), false));
+        let mut spec = basic_spec("pends");
+        spec.account = Some("research".into());
+        spec.qos = Some("normal".into());
+        spec.num_tasks = 2; // 2 CPUs > cap of 1
+        assert!(cm.submit_job(spec).is_ok());
+
+        // With DenyOnLimit the same request is denied at submit.
+        let dir2 = TempDir::new().unwrap();
+        let cm2 = test_cluster(&dir2).await;
+        cm2.association_cache()
+            .insert_allowed_qos("testuser", "research", &["normal"]);
+        cm2.qos_cache()
+            .insert(qos_with_limits("normal", limits, true));
+        let mut spec2 = basic_spec("denied");
+        spec2.account = Some("research".into());
+        spec2.qos = Some("normal".into());
+        spec2.num_tasks = 2;
+        let err = cm2.submit_job(spec2).unwrap_err();
+        assert_submit_denied(&err, "QOSMaxCpuPerJobLimit");
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn submit_admits_over_maxtime_when_enforcement_off() {
         // Default EnforcePartLimits=No: an over-MaxTime job is admitted (and
@@ -14323,14 +14629,11 @@ mod tests {
     async fn tag_blocked_sets_account_max_submit_jobs_reason() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
-        cm.association_cache().insert_limits(
-            "testuser",
-            "research",
-            spur_core::accounting::AccountLimits {
-                max_submit_jobs: Some(1),
-                ..Default::default()
-            },
-        );
+        // Submit within limits, then lower the cap: this exercises the
+        // scheduler safety-net path (the submit gate would reject up front, so
+        // it can only be reached when the limit is tightened after submission).
+        cm.association_cache()
+            .insert_association("testuser", "research");
 
         let mut s1 = basic_spec("b1");
         s1.account = Some("research".into());
@@ -14339,6 +14642,15 @@ mod tests {
         let mut s2 = basic_spec("b2");
         s2.account = Some("research".into());
         let j2 = submit_and_wait(&cm, s2);
+
+        cm.association_cache().insert_limits(
+            "testuser",
+            "research",
+            spur_core::accounting::AccountLimits {
+                max_submit_jobs: Some(1),
+                ..Default::default()
+            },
+        );
 
         cm.tag_blocked_pending_reasons();
         // j1 alone is within the limit (max_submit_jobs=1) and must not be
@@ -14355,12 +14667,11 @@ mod tests {
     async fn tag_blocked_sets_qos_max_submit_jobs_reason() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
+        // Submit under an uncapped QOS, then tighten it: the submit gate would
+        // reject up front, so the scheduler tagging path is only reachable when
+        // the limit is lowered after submission.
         cm.qos_cache().insert(Qos {
             name: "capped".into(),
-            limits: spur_core::accounting::QosLimits {
-                max_submit_jobs_per_user: Some(1),
-                ..Default::default()
-            },
             ..Default::default()
         });
 
@@ -14371,6 +14682,15 @@ mod tests {
         let mut s2 = basic_spec("c2");
         s2.qos = Some("capped".into());
         let j2 = submit_and_wait(&cm, s2);
+
+        cm.qos_cache().insert(Qos {
+            name: "capped".into(),
+            limits: spur_core::accounting::QosLimits {
+                max_submit_jobs_per_user: Some(1),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
 
         cm.tag_blocked_pending_reasons();
         // j1 alone is within the limit (max_submit_jobs_per_user=1) and must

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -106,7 +106,10 @@ impl Default for QosCache {
 }
 
 fn qos_from_record(r: crate::accounting::db::QosRecord) -> Qos {
-    let opt_u32 = |v: Option<i32>| v.filter(|&x| x > 0).map(|x| x as u32);
+    // A stored NULL (None) is "no limit"; a literal 0 is a real value (block
+    // all). A stray negative predates the sentinel flip or was edited
+    // out-of-band, so treat it as unset rather than a huge cap.
+    let opt_u32 = |v: Option<i32>| v.filter(|&x| x >= 0).map(|x| x as u32);
     // Values are validated by `create_qos` before being stored, so a parse
     // failure here means the DB row predates that check or was edited
     // out-of-band; treat it as unset rather than poisoning the whole refresh.
@@ -133,6 +136,8 @@ fn qos_from_record(r: crate::accounting::db::QosRecord) -> Qos {
         limits: QosLimits {
             max_jobs_per_user: opt_u32(r.max_jobs_per_user),
             max_submit_jobs_per_user: opt_u32(r.max_submit_per_user),
+            max_submit_jobs_per_account: opt_u32(r.max_submit_per_account),
+            grp_submit_jobs: opt_u32(r.grp_submit_jobs),
             max_tres_per_job: opt_tres(r.max_tres_per_job),
             max_tres_per_user: opt_tres(r.max_tres_per_user),
             grp_tres: opt_tres(r.grp_tres),
@@ -141,7 +146,15 @@ fn qos_from_record(r: crate::accounting::db::QosRecord) -> Qos {
             preempt_exempt_time: r.preempt_exempt_time.map(|v| v as u32),
         },
         usage_factor: r.usage_factor,
+        deny_on_limit: parse_deny_on_limit(&r.flags),
     }
+}
+
+/// Parse the QOS `flags` column (comma-separated) for the `DenyOnLimit` flag.
+fn parse_deny_on_limit(flags: &str) -> bool {
+    flags
+        .split(',')
+        .any(|f| f.trim().eq_ignore_ascii_case("denyonlimit"))
 }
 
 #[cfg(test)]
@@ -237,15 +250,21 @@ mod tests {
             max_wall_min: Some(60),
             max_tres_per_job: Some("cpu=32,mem=131072".into()),
             max_submit_per_user: Some(50),
+            max_submit_per_account: Some(40),
+            grp_submit_jobs: Some(30),
             max_tres_per_user: Some("cpu=64".into()),
             grp_tres: Some("gpu=8".into()),
             grp_wall_min: Some(120),
             preempt_exempt_time: None,
+            flags: "DenyOnLimit".into(),
         };
 
         let qos = qos_from_record(record);
 
         assert_eq!(qos.name, "high");
+        assert!(qos.deny_on_limit);
+        assert_eq!(qos.limits.max_submit_jobs_per_account, Some(40));
+        assert_eq!(qos.limits.grp_submit_jobs, Some(30));
         assert_eq!(qos.priority, 100);
         assert_eq!(qos.preempt_mode, QosPreemptMode::Cancel);
         assert_eq!(qos.usage_factor, 2.0);
@@ -275,7 +294,9 @@ mod tests {
     }
 
     #[test]
-    fn test_qos_from_record_zero_and_none_are_none() {
+    fn test_qos_from_record_zero_is_literal_negative_and_null_are_unset() {
+        // Post sentinel-flip: a stored 0 is a real "block all" value; NULL and a
+        // stray negative are "no limit" (unset).
         let record = crate::accounting::db::QosRecord {
             name: "minimal".into(),
             description: String::new(),
@@ -287,20 +308,25 @@ mod tests {
             max_wall_min: None,
             max_tres_per_job: Some(String::new()),
             max_submit_per_user: Some(-1),
+            max_submit_per_account: None,
+            grp_submit_jobs: Some(0),
             max_tres_per_user: None,
             grp_tres: None,
-            grp_wall_min: Some(0),
+            grp_wall_min: None,
             preempt_exempt_time: None,
+            flags: String::new(),
         };
 
         let qos = qos_from_record(record);
 
-        assert_eq!(qos.limits.max_jobs_per_user, None);
+        assert_eq!(qos.limits.max_jobs_per_user, Some(0));
         assert_eq!(qos.limits.max_wall_minutes, None);
         assert!(qos.limits.max_tres_per_job.is_none());
         assert_eq!(qos.limits.max_submit_jobs_per_user, None);
+        assert_eq!(qos.limits.grp_submit_jobs, Some(0));
         assert!(qos.limits.max_tres_per_user.is_none());
         assert!(qos.limits.grp_tres.is_none());
         assert_eq!(qos.limits.grp_wall_minutes, None);
+        assert!(!qos.deny_on_limit);
     }
 }

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -106,10 +106,7 @@ impl Default for QosCache {
 }
 
 fn qos_from_record(r: crate::accounting::db::QosRecord) -> Qos {
-    // A stored NULL (None) is "no limit"; a literal 0 is a real value (block
-    // all). A stray negative predates the sentinel flip or was edited
-    // out-of-band, so treat it as unset rather than a huge cap.
-    let opt_u32 = |v: Option<i32>| v.filter(|&x| x >= 0).map(|x| x as u32);
+    use spur_core::accounting::limit_from_db;
     // Values are validated by `create_qos` before being stored, so a parse
     // failure here means the DB row predates that check or was edited
     // out-of-band; treat it as unset rather than poisoning the whole refresh.
@@ -134,15 +131,15 @@ fn qos_from_record(r: crate::accounting::db::QosRecord) -> Qos {
             .map(str::to_string)
             .collect(),
         limits: QosLimits {
-            max_jobs_per_user: opt_u32(r.max_jobs_per_user),
-            max_submit_jobs_per_user: opt_u32(r.max_submit_per_user),
-            max_submit_jobs_per_account: opt_u32(r.max_submit_per_account),
-            grp_submit_jobs: opt_u32(r.grp_submit_jobs),
+            max_jobs_per_user: limit_from_db(r.max_jobs_per_user),
+            max_submit_jobs_per_user: limit_from_db(r.max_submit_per_user),
+            max_submit_jobs_per_account: limit_from_db(r.max_submit_per_account),
+            grp_submit_jobs: limit_from_db(r.grp_submit_jobs),
             max_tres_per_job: opt_tres(r.max_tres_per_job),
             max_tres_per_user: opt_tres(r.max_tres_per_user),
             grp_tres: opt_tres(r.grp_tres),
-            max_wall_minutes: opt_u32(r.max_wall_min),
-            grp_wall_minutes: opt_u32(r.grp_wall_min),
+            max_wall_minutes: limit_from_db(r.max_wall_min),
+            grp_wall_minutes: limit_from_db(r.grp_wall_min),
             preempt_exempt_time: r.preempt_exempt_time.map(|v| v as u32),
         },
         usage_factor: r.usage_factor,
@@ -151,6 +148,9 @@ fn qos_from_record(r: crate::accounting::db::QosRecord) -> Qos {
 }
 
 /// Parse the QOS `flags` column (comma-separated) for the `DenyOnLimit` flag.
+/// Unknown flags are ignored on read (writes reject them via
+/// `canonicalize_qos_flags`); this tolerates rows imported from Slurm dumps that
+/// carry flags Spur does not model yet.
 fn parse_deny_on_limit(flags: &str) -> bool {
     flags
         .split(',')

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -467,7 +467,7 @@ Two families behave differently:
 - **Standalone resource limits** (per-job TRES and QOS wall) reject at submit
   only when the governing QOS carries the ``DenyOnLimit`` flag; otherwise the
   job is accepted and **pends** until it fits. A job that resolves to **no QOS**
-  is treated as ``DenyOnLimit`` on, so an unsatisfiable request is rejected
+  is treated as ``DenyOnLimit`` on, so a request that can never fit is rejected
   rather than pending forever.
 
 Set ``DenyOnLimit`` through the QOS ``flags`` key:

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -45,6 +45,22 @@ each builds on the one before it:
 The term **association** is used throughout this page to mean the
 ``(cluster, account, user, partition)`` tuple defined above.
 
+.. _limit-values:
+
+Limit values
+~~~~~~~~~~~~~
+
+Numeric limits (job counts, wall time) share one convention throughout this
+page:
+
+- **Unset / omitted** — no limit. This is the default for any limit you do not
+  name.
+- ``-1`` — clears a limit back to "no limit". Use it on ``modify`` to lift a cap.
+- ``0`` — a literal value meaning **block all**: a ``maxsubmitjobs=0`` rejects
+  every submission for that association. ``0`` does **not** mean "no limit".
+
+``show`` renders an unset limit as a blank cell and a literal ``0`` as ``0``.
+
 Enabling accounting
 -------------------
 
@@ -166,17 +182,17 @@ Account keys
      - ``1.0``
      - Fairshare weight. Shown in the ``Share`` column as an integer.
    * - ``maxrunningjobs`` (alias ``maxjobs``)
-     - ``0`` (no limit)
-     - Maximum jobs running at once for the account.
+     - unset (no limit)
+     - Maximum jobs running at once for the account. See :ref:`limit-values`.
    * - ``grptres``
      - ``""``
      - Aggregate TRES cap for the account (see `TRES`_).
 
 .. note::
 
-   ``modify`` is an upsert: it re-sends the whole account record through the same
-   RPC as ``add``. Numeric fields you omit reset to their defaults (``0`` for
-   limits, ``1.0`` for fairshare). Always set the fields you want to keep.
+   ``modify`` sends only the fields you name; every field you omit is preserved
+   (re-read from the stored record, not reset). To lift a numeric limit, set it
+   to ``-1``; to clear a text field, set it empty (e.g. ``grptres=``).
 
 Managing users
 --------------
@@ -237,11 +253,16 @@ Filter by ``account=`` or ``name=``.
 
    sacctmgr show user account=ml
 
+``show user`` also prints the per-association limits (``MaxJobs``,
+``MaxSubmit``, ``GrpSubmit``, ``MaxWall``, ``MaxTRES``, ``GrpTRES``), so you can
+read back what ``add``/``modify user`` set. An unset limit renders as a blank
+cell.
+
 .. code-block:: text
 
-   User    Account  Admin  Default Acct  QOS              Def QOS
+   User    Account  Admin  Default Acct  QOS              Def QOS   MaxJobs  MaxSubmit  GrpSubmit  MaxWall  MaxTRES  GrpTRES
    alice   ml        None   ml            highprio,normal  highprio
-   carol   ml        None   ml
+   carol   ml        None   ml                                       4        8                     1440     cpu=64
 
 User keys
 ~~~~~~~~~
@@ -270,11 +291,15 @@ User keys
      - ``""``
      - Comma-separated allow-list of QOS the user may request.
    * - ``maxrunningjobs`` (alias ``maxjobs``)
-     - ``0`` (no limit)
-     - Maximum jobs running at once for this association.
+     - unset (no limit)
+     - Maximum jobs running at once for this association. See
+       :ref:`limit-values`.
    * - ``maxsubmitjobs``
-     - ``0`` (no limit)
+     - unset (no limit)
      - Maximum jobs the user may have submitted (pending + running).
+   * - ``grpsubmit`` (alias ``grpsubmitjobs``)
+     - unset (no limit)
+     - Aggregate submitted jobs (pending + running) across the association.
    * - ``maxtresperjob``
      - ``""``
      - TRES cap for a single job (see `TRES`_).
@@ -282,7 +307,7 @@ User keys
      - ``""``
      - Aggregate TRES cap across the association's jobs.
    * - ``maxwall`` (alias ``maxwallduration``)
-     - ``0`` (no limit)
+     - unset (no limit)
      - Maximum wall-clock time per job.
 
 .. note::
@@ -293,18 +318,19 @@ User keys
 
 .. note::
 
-   On ``modify user``, QOS fields you omit (``qos``/``defaultqos``) are
-   **preserved** — they are re-read from the stored association rather than
-   cleared. Numeric limits you omit still reset to their defaults, as with
-   accounts.
+   On ``modify user``, every field you omit is **preserved**. QOS
+   (``qos``/``defaultqos``) and numeric limits alike are re-read from the stored
+   association rather than reset. To lift a limit, set it to ``-1``; to clear the
+   QOS allow-list, set ``qos=`` empty.
 
 QOS
 ---
 
 A QOS (Quality of Service) is a named policy with its own priority, preemption
 mode, usage factor, and limits. Manage QOS with ``sacctmgr add qos``; the
-equivalent Slurm command is ``sacctmgr add qos``. Every limit defaults to ``0``,
-meaning no limit.
+equivalent Slurm command is ``sacctmgr add qos``. Every limit defaults to unset
+(no limit); ``0`` means block all and ``-1`` clears a limit (see
+:ref:`limit-values`).
 
 Create a high-priority QOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -394,17 +420,24 @@ QOS keys
      - ``1.0``
      - Multiplier applied to usage charged under this QOS.
    * - ``maxjobsperuser`` (alias ``maxjobspu``)
-     - ``0`` (no limit)
-     - Maximum running jobs per user under this QOS.
+     - unset (no limit)
+     - Maximum running jobs per user under this QOS. See :ref:`limit-values`.
    * - ``maxwall``
-     - ``0`` (no limit)
+     - unset (no limit)
      - Maximum wall-clock time per job.
    * - ``maxtresperjob``
      - ``""``
      - TRES cap for a single job (see `TRES`_).
    * - ``maxsubmitjobsperuser``
-     - ``0`` (no limit)
+     - unset (no limit)
      - Maximum submitted jobs (pending + running) per user.
+   * - ``maxsubmitjobsperaccount`` (aliases ``maxsubmitpa``, ``maxsubmitjobspa``)
+     - unset (no limit)
+     - Maximum submitted jobs (pending + running) per account.
+   * - ``grpsubmit`` (alias ``grpsubmitjobs``)
+     - unset (no limit)
+     - Aggregate submitted jobs (pending + running) across all jobs under this
+       QOS.
    * - ``maxtresperuser``
      - ``""``
      - TRES cap across all of one user's jobs under this QOS.
@@ -412,8 +445,36 @@ QOS keys
      - ``""``
      - Aggregate TRES cap across all jobs under this QOS.
    * - ``grpwall``
-     - ``0`` (no limit)
+     - unset (no limit)
      - Aggregate wall-clock time across all jobs under this QOS.
+   * - ``flags``
+     - ``""``
+     - Comma-separated QOS flags. ``DenyOnLimit`` is supported (see
+       :ref:`deny-on-limit`).
+
+.. _deny-on-limit:
+
+How limits are enforced at submit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Spur checks limits at submit time, matching Slurm's ``acct_policy_validate``.
+Two families behave differently:
+
+- **Submit-count limits** (``maxsubmitjobs``, ``grpsubmit``,
+  ``maxsubmitjobsperuser``, ``maxsubmitjobsperaccount``) and the association
+  ``maxwall`` always **reject** the submission when breached. A rejected job is
+  never queued.
+- **Standalone resource limits** (per-job TRES and QOS wall) reject at submit
+  only when the governing QOS carries the ``DenyOnLimit`` flag; otherwise the
+  job is accepted and **pends** until it fits. A job that resolves to **no QOS**
+  is treated as ``DenyOnLimit`` on, so an unsatisfiable request is rejected
+  rather than pending forever.
+
+Set ``DenyOnLimit`` through the QOS ``flags`` key:
+
+.. code-block:: bash
+
+   sacctmgr modify qos name=highprio set flags=DenyOnLimit
 
 QOS preemption hierarchy
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -508,14 +569,14 @@ Associations
 An association is the ``(cluster, account, user, partition)`` tuple. Associations
 are created implicitly by ``sacctmgr add user`` — there is no standalone ``add
 association`` command. Inspect them through ``sacctmgr show user``, which lists
-each user's account, default account, and QOS.
+each user's account, default account, QOS, and per-association limits.
 
 Limits resolve in two layers:
 
 - **Association limits.** The per-association caps set on the user
-  (``maxjobs``, ``maxsubmitjobs``, ``maxtresperjob``, ``grptres``, ``maxwall``)
-  and the association's QOS allow-list together gate whether a submit is
-  accepted.
+  (``maxjobs``, ``maxsubmitjobs``, ``grpsubmit``, ``maxtresperjob``,
+  ``grptres``, ``maxwall``) and the association's QOS allow-list together gate
+  whether a submit is accepted.
 - **QOS limits.** The limits on the job's resolved QOS layer on top of the
   association limits. Where a QOS limit is defined, it takes precedence over the
   association's corresponding limit — matching Slurm's rule that QOS limits

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -53,13 +53,23 @@ Limit values
 Numeric limits (job counts, wall time) share one convention throughout this
 page:
 
-- **Unset / omitted** — no limit. This is the default for any limit you do not
-  name.
+- **Unset / omitted** — on ``add``, any limit you do not name defaults to no
+  limit. On ``modify``, an omitted field is left unchanged (partial patch); only
+  the fields you name are written. To lift an existing cap on ``modify``, set it
+  to ``-1`` explicitly rather than omitting it.
 - ``-1`` — clears a limit back to "no limit". Use it on ``modify`` to lift a cap.
 - ``0`` — a literal value meaning **block all**: a ``maxsubmitjobs=0`` rejects
-  every submission for that association. ``0`` does **not** mean "no limit".
+  every submission for that association (likewise ``grpsubmitjobs=0`` for the
+  whole account). ``maxwall=0`` likewise blocks every job, including one that
+  requests no wall time. ``0`` does **not** mean "no limit"; use ``-1`` to lift
+  it.
 
 ``show`` renders an unset limit as a blank cell and a literal ``0`` as ``0``.
+
+Limit changes are not instant: the controller reads accounting and QOS limits
+from a cache that refreshes every ``fairshare_refresh_secs`` (default 300s,
+floored at 10s), so a ``sacctmgr modify`` can take up to one refresh interval
+to affect new submissions.
 
 Enabling accounting
 -------------------
@@ -458,17 +468,34 @@ How limits are enforced at submit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Spur checks limits at submit time, matching Slurm's ``acct_policy_validate``.
-Two families behave differently:
+Three families behave differently:
 
 - **Submit-count limits** (``maxsubmitjobs``, ``grpsubmit``,
   ``maxsubmitjobsperuser``, ``maxsubmitjobsperaccount``) and the association
   ``maxwall`` always **reject** the submission when breached. A rejected job is
-  never queued.
-- **Standalone resource limits** (per-job TRES and QOS wall) reject at submit
-  only when the governing QOS carries the ``DenyOnLimit`` flag; otherwise the
-  job is accepted and **pends** until it fits. A job that resolves to **no QOS**
-  is treated as ``DenyOnLimit`` on, so a request that can never fit is rejected
-  rather than pending forever.
+  never queued. These count pending **and** running jobs.
+- **Standalone resource limits** (per-job TRES on both the QOS **and** the
+  association, plus QOS wall) reject at submit only when the governing QOS
+  carries the ``DenyOnLimit`` flag; otherwise the job is accepted and **pends**
+  until it fits. This matches Slurm, where ``DenyOnLimit`` applies to QOS and
+  association limits alike, so a permissive QOS (``DenyOnLimit`` off) pends an
+  association TRES breach instead of rejecting it. A job that resolves to **no
+  QOS** is treated as ``DenyOnLimit`` on, so a request that can never fit is
+  rejected rather than pending forever.
+- **Running-count limits** (``maxjobs``, ``maxjobsperuser``) never reject at
+  submit. They count only **running** jobs, so the submit is always accepted and
+  the job **pends** once the running cap is reached.
+
+When the submit gate rejects a job, the denial carries the canonical Slurm
+reason code alongside a human-readable sentence. The codes the gate can emit
+are: ``AssocMaxSubmitJobLimit``, ``AssocGrpSubmitJobsLimit``,
+``AssocMaxWallDurationPerJobLimit``, ``QOSMaxSubmitJobPerUserLimit``,
+``MaxSubmitJobsPerAccount``, ``QOSGrpSubmitJobsLimit``,
+``QOSMaxWallDurationPerJobLimit``, and the QOS per-job TRES codes
+(e.g. ``QOSMaxCpuPerJobLimit``, ``QOSMaxNodePerJobLimit``, ``QOSMaxMemoryPerJob``,
+``QOSMaxGRESPerJob``). Running-count reasons (``AssocMaxJobsLimit``,
+``QOSMaxJobsPerUserLimit``) never appear at submit; they surface as pending
+reasons instead.
 
 Set ``DenyOnLimit`` through the QOS ``flags`` key:
 
@@ -578,9 +605,11 @@ Limits resolve in two layers:
   ``grptres``, ``maxwall``) and the association's QOS allow-list together gate
   whether a submit is accepted.
 - **QOS limits.** The limits on the job's resolved QOS layer on top of the
-  association limits. Where a QOS limit is defined, it takes precedence over the
-  association's corresponding limit — matching Slurm's rule that QOS limits
-  override association limits.
+  association limits. Both sets are enforced: the submit gate checks the
+  association's submit-count and per-job wall limits first, then the QOS limits,
+  and rejects on the first breach it finds. A job must satisfy both the
+  association and the QOS to be accepted, so a denial may carry an ``Assoc*``
+  reason even when a QOS limit also applies.
 
 Associations are managed via ``add user`` and inspected via ``sacctmgr show
 user`` (see `Managing users`_).

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1275,6 +1275,8 @@ message CreateAccountRequest {
   optional string organization = 3;
   optional string parent_account = 4;
   optional double fairshare_weight = 5;
+  // Unset preserves the stored value; the INFINITE sentinel (4294967295) clears
+  // to no-limit; any other value (including a literal 0) is stored as-is.
   optional uint32 max_running_jobs = 6;
   optional string grp_tres = 7;
 }
@@ -1300,8 +1302,11 @@ message AccountInfo {
 }
 
 // Add or modify a user-account association (proto3 presence: unset = leave
-// unchanged on modify, set = write; `add` sets every field). The limit/QOS
-// fields below are nullable and clear to NULL when set empty/0; admin_level is
+// unchanged on modify, set = write; `add` sets every field). For the numeric
+// limit fields below: unset preserves the stored value, the INFINITE sentinel
+// (4294967295) clears to no-limit (SQL NULL), and any other value (including a
+// literal 0, which means "block all") is stored as-is. Text limit fields
+// (max_tres_*, grp_tres) clear to NULL when set empty. admin_level is
 // non-nullable, storing the literal sent (unset keeps it, 'none' on create).
 message AddUserRequest {
   string user = 1;
@@ -1311,8 +1316,8 @@ message AddUserRequest {
   // Default QOS for this user's association with `account`. Unset preserves
   // the stored default; explicit empty clears it.
   optional string default_qos = 5;
-  // Association-level resource limits for `user` within `account`. Unset
-  // preserves the stored limit; an explicit 0/empty clears it (no limit).
+  // Association-level resource limits for `user` within `account`. See the
+  // message-level comment for the unset/INFINITE/literal sentinel semantics.
   optional uint32 max_running_jobs = 6;
   optional uint32 max_submit_jobs = 7;
   optional string max_tres_per_job = 8;
@@ -1322,6 +1327,8 @@ message AddUserRequest {
   // stored allow-list; explicit empty clears it back to unrestricted.
   // default_qos must be a member when both are set in the same request.
   optional string allowed_qos = 11;
+  // Max submitted (pending + running) jobs across all users in the account.
+  optional uint32 grp_submit_jobs = 12;
 }
 
 message RemoveUserRequest {
@@ -1345,12 +1352,24 @@ message UserInfo {
   string default_account = 4;
   string default_qos = 5;
   string allowed_qos = 6;
+  // Per-association limits (read-back of what `sacctmgr add/modify user` set).
+  // Numeric fields use the INFINITE sentinel (4294967295) for "no limit"; a
+  // literal 0 means "block all". Text fields are empty when unset.
+  uint32 max_running_jobs = 7;
+  uint32 max_submit_jobs = 8;
+  uint32 grp_submit_jobs = 9;
+  uint32 max_wall_minutes = 10;
+  string max_tres_per_job = 11;
+  string grp_tres = 12;
 }
 
 // Add or modify a QOS (proto3 presence: unset = leave unchanged on modify, set =
-// write; `add` sets every field). Empty/0 clears the nullable limits
-// (max_*_per_user, *_wall_minutes, max_tres_*, grp_tres) to NULL; description,
-// preempt_mode, priority, and usage_factor store their literal value (0 is real).
+// write; `add` sets every field). For the numeric limit fields: unset preserves
+// the stored value, the INFINITE sentinel (4294967295) clears to no-limit (SQL
+// NULL), and any other value (including a literal 0, which means "block all") is
+// stored as-is. Text limits (max_tres_*, grp_tres) clear to NULL when set empty.
+// description, preempt_mode, priority, and usage_factor store their literal
+// value (0 is real).
 message CreateQosRequest {
   string name = 1;
   optional string description = 2;
@@ -1375,6 +1394,13 @@ message CreateQosRequest {
   // Set to true to clear preempt_exempt_time back to NULL (inherit from
   // partition / global default). Takes precedence over preempt_exempt_time.
   bool clear_preempt_exempt_time = 15;
+  // Max submitted (pending + running) jobs per account within this QOS.
+  optional uint32 max_submit_jobs_per_account = 16;
+  // Max submitted (pending + running) jobs across all users in this QOS.
+  optional uint32 grp_submit_jobs = 17;
+  // Comma-separated QOS flags. Recognized: DenyOnLimit. Unset preserves the
+  // stored flags; explicit empty clears them.
+  optional string flags = 18;
 }
 
 message DeleteQosRequest {
@@ -1403,6 +1429,9 @@ message QosInfo {
   // Comma-separated QOS names this QOS may preempt (empty = none allowed).
   string preempt = 13;
   optional uint32 preempt_exempt_time = 14;  // absent = unset (inherits partition/global); 0 = no exemption
+  uint32 max_submit_jobs_per_account = 16;
+  uint32 grp_submit_jobs = 17;
+  string flags = 18;
 }
 
 // ============================================================

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1266,9 +1266,11 @@ message ReportJobStatusRequest {
 // ============================================================
 
 // Add or modify an account (proto3 presence: unset = leave unchanged on modify,
-// set = write; `add` sets every field). Empty/0 clears parent_account, grp_tres,
-// and max_running_jobs to NULL; description, organization, and fairshare_weight
-// store their literal value (0 is a real weight, not a clear).
+// set = write; `add` sets every field). Empty string clears the text fields
+// parent_account and grp_tres to NULL. max_running_jobs follows the sentinel
+// rule on its field (INFINITE clears, a literal 0 is stored). description,
+// organization, and fairshare_weight store their literal value (0 is a real
+// weight, not a clear).
 message CreateAccountRequest {
   string name = 1;
   optional string description = 2;


### PR DESCRIPTION
Implements SPUR-191: validate QOS and association limits at job submit time, so unsatisfiable requests are rejected up front instead of pending forever (or being silently ignored).

## What this adds
- Submit-time limit gate (`enforce_submit_limits`), mirroring Slurm's `acct_policy_validate`:
  - Submit-count families (association `MaxSubmitJobs`/`GrpSubmitJobs`, QOS per-user/per-account/grp) deny unconditionally.
  - Association per-job wall denies unconditionally.
  - Stand-alone TRES/wall breaches deny only under the governing QOS's `DenyOnLimit`. A job with no QOS is treated as `DenyOnLimit`-on, so an unsatisfiable request is rejected rather than pending indefinitely.
- Human-readable denial messages that carry the exact Slurm reason code in parentheses, e.g. `you have reached the maximum submitted jobs for your association (AssocMaxSubmitJobLimit)`. `squeue`-facing reason codes are unchanged for scrapers.
- Read-back of association limits via `sacctmgr show user` (`MaxJobs`, `MaxSubmit`, `GrpSubmit`, `MaxWall`, `MaxTRES`, `GrpTRES`), closing the prior write-only gap.

## Breaking change
Limit values now follow Slurm sentinel semantics: unset = no limit, `-1` clears a limit, and `0` means **block all**. This flips the prior Spur meaning of `0` (was "no limit"). Scripts or configs that set `0` to mean unlimited must switch to `-1`.

Because binaries ship together, this is safe within a release. During a mixed-version window (old CLI against a new controller, or vice versa) unset limits can be misread, so upgrade the CLI and controller together.

## Reason codes
- Per-account submit uses Slurm's canonical `MaxSubmitJobsPerAccount` (previously the non-canonical `QOSMaxSubmitJobPerAccountLimit`).
- New codes `AssocGrpSubmitJobsLimit` and `QOSGrpSubmitJobsLimit`.

## Proto
Append-only, presence-aware (`optional`) fields on `AddUserRequest`, `UserInfo`, `CreateQosRequest`, and `QosInfo`. No tag renumbering, removal, or retyping; `package slurm;` unchanged.

## Docs
`docs/admin-guide/accounting.rst`: limit-value conventions (unset/`-1`/`0`), the new fields (`maxsubmitjobsperaccount`, `grpsubmit`, `DenyOnLimit`, `grpwall`), a "how limits are enforced at submit" section, corrected `modify` partial-patch semantics (omitted fields are preserved, not reset), and the new `show user` columns.

## Testing
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`: no warnings.
- `cargo test --locked`: 2965 tests pass, 0 failures.
- Bare-metal 4-node cluster smoke matrix, 49/49: core scheduling, interactive (`srun`/`salloc`/`sattach`), and the full QOS/association enforcement matrix including sentinel semantics and every denial reason code. Verified twice on a freshly reset cluster.

## Follow-ups (not in scope)
- Submit-count TOCTOU under concurrent submits (bounded over-admission; the count read and the persist are not atomic).
- When an association and a QOS submit-count limit both trip, report the QOS reason (Slurm gives QOS precedence); today the association reason wins. Deny/allow outcome is identical.
- Render `MaxWall` as `d-hh:mm:ss` instead of raw minutes.
- Define per-account submit counting for account-less jobs.