### PR TITLE
fix(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## What this fixes

`h2 0.4.15` accepts and queues empty HTTP/2 DATA frames without limit ([RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258), [GHSA-q83h-524g-xf6h](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h)). A peer can drive unbounded memory growth in any process serving HTTP/2.

This is not only a CI gate failure. `h2` reaches `spurctld` through both `axum` (REST) and `tonic` (gRPC), so a deployed controller is exposed on its listening ports:

```
h2 v0.4.15
├── hyper v1.10.1
│   ├── axum v0.8.9
│   │   ├── spurctld v0.8.0
│   │   └── tonic v0.14.6
```

The advisory landed between `main`'s last green CI run and now, so the `deny` gate is currently red on every open PR regardless of its contents.

## Approach

The `h2` entry is pinned in place, giving a two-line lockfile diff (version plus checksum) and no manifest change — the fix is entirely within semver.

I did not use `cargo update -p h2`. On the toolchain this repo pins (`1.95.0`), that command also re-resolves five `windows-sys` dependents from `0.61.2` down to `0.52.0`. Those crates are Windows-only and irrelevant to a Linux scheduler, but a downgrade is not something a security bump should be smuggling in, so the hand-pinned entry keeps the diff reviewable.

That churn is worth a separate look: it reproduces with the pinned toolchain, which suggests the committed `Cargo.lock` was last written by a newer cargo than `rust-toolchain.toml` pins. Not addressed here.

## Trade-offs

Editing `Cargo.lock` directly is normally worth avoiding. It is safe in this case because `h2 0.4.16` did not change its own dependency list, so the file stays internally consistent — confirmed by `cargo metadata --locked` and by the full suite building under `--locked`.

## Testing

- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok` (was `advisories FAILED` on this advisory before the bump)
- `cargo tree --locked -i h2` — resolves to `h2 v0.4.16`
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — no warnings
- `cargo test --locked` — 2953 tests pass, no failures
