### PR TITLE
fix(spurd): start container jobs from the image's config.Env

### DIFF
--- a/crates/spur-cli/src/image.rs
+++ b/crates/spur-cli/src/image.rs
@@ -246,6 +246,21 @@ fn extract_docker_save_tar(tar_data: &[u8], rootfs: &str) -> Result<()> {
                 .with_context(|| format!("failed to extract layer {}", layer_file))?;
         }
 
+        // Record the image config so container jobs can start from its config.Env.
+        // Best effort: an archive without a readable config still imports.
+        if let Some(config_file) = manifest
+            .first()
+            .and_then(|entry| entry.get("Config"))
+            .and_then(|config| config.as_str())
+        {
+            let recorded = resolve_docker_save_file(&archive_root, config_file)
+                .and_then(|path| std::fs::read(path).with_context(|| format!("read {config_file}")))
+                .and_then(|config_json| spur_net::oci::record_image_config(dest, &config_json));
+            if let Err(e) = recorded {
+                eprintln!("warning: image environment not captured from {config_file}: {e:#}");
+            }
+        }
+
         Ok(())
     })();
 

--- a/crates/spur-net/src/oci.rs
+++ b/crates/spur-net/src/oci.rs
@@ -15,6 +15,7 @@
 //! 5. Extract layers in order to build rootfs
 //! 6. Pack rootfs into squashfs via mksquashfs
 
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -44,7 +45,15 @@ struct TokenResponse {
 struct Manifest {
     #[serde(default)]
     layers: Vec<LayerDescriptor>,
+    /// Image config blob, which carries `config.Env`.
+    #[serde(default)]
+    config: Option<ConfigDescriptor>,
     // v1 compat: some registries return "fsLayers" instead
+}
+
+#[derive(Deserialize)]
+struct ConfigDescriptor {
+    digest: String,
 }
 
 #[derive(Deserialize)]
@@ -354,6 +363,26 @@ async fn pull_and_extract(
         let media_type = &manifest.layers[i].media_type;
         extract_layer(data, Some(media_type), rootfs_dir)
             .with_context(|| format!("failed to extract layer {}", i + 1))?;
+    }
+
+    // Best effort: a registry that will not serve the config blob still yields
+    // a usable image, and jobs using it fall back to the host environment.
+    match manifest.config.as_ref() {
+        Some(config) => {
+            if let Err(e) = fetch_and_record_config(
+                &client,
+                image_ref,
+                &registry_url,
+                &config.digest,
+                token.as_deref(),
+                rootfs_dir,
+            )
+            .await
+            {
+                warn!(error = %e, digest = %config.digest, "image environment not captured");
+            }
+        }
+        None => debug!("manifest has no config descriptor; image environment not captured"),
     }
 
     Ok(())
@@ -721,12 +750,261 @@ pub fn sanitize_name(name: &str) -> String {
     name.replace("docker://", "").replace(['/', ':'], "+")
 }
 
+/// Where an image's OCI config is recorded inside the rootfs, so the node agent
+/// can seed container jobs with the environment the image ships.
+pub const IMAGE_CONFIG_PATH: &str = "etc/spur/image-config.json";
+
+/// Variables that accumulate instead of replacing: the image's entries come
+/// first so its executables and libraries stay reachable, and the job's are
+/// appended so host additions still apply.
+const UNIONED_VARS: [&str; 2] = ["PATH", "LD_LIBRARY_PATH"];
+
+/// Cap on the recorded config a job launch will read. `--container-image`
+/// accepts an arbitrary squashfs path, so this file is user-supplied content
+/// and the node agent reads it as root.
+const MAX_IMAGE_CONFIG_BYTES: u64 = 1 << 20;
+
+/// Resolve the recorded-config path inside `rootfs`, refusing to traverse a
+/// symlink. The rootfs is unpacked from an image spur does not control, so an
+/// image shipping `etc` as a symlink would otherwise redirect the write out of
+/// the tree at import, and the read out of the tree at launch.
+fn image_config_path(rootfs: &Path) -> anyhow::Result<PathBuf> {
+    let mut path = rootfs.to_path_buf();
+    for component in Path::new(IMAGE_CONFIG_PATH).iter() {
+        path.push(component);
+        if path
+            .symlink_metadata()
+            .is_ok_and(|m| m.file_type().is_symlink())
+        {
+            bail!("{} is a symlink", path.display());
+        }
+    }
+    Ok(path)
+}
+
+/// Record an image's OCI config inside the rootfs, before it is packed into
+/// squashfs, for `container_base_env` to read back at launch.
+pub fn record_image_config(rootfs: &Path, config_json: &[u8]) -> anyhow::Result<()> {
+    serde_json::from_slice::<serde_json::Value>(config_json)
+        .context("invalid image config JSON")?;
+    let dest = image_config_path(rootfs)?;
+    let dir = dest.parent().expect("IMAGE_CONFIG_PATH is not the root");
+    std::fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
+    std::fs::write(&dest, config_json).with_context(|| format!("write {}", dest.display()))
+}
+
+/// Base environment for a container job: the image's own `config.Env` with the
+/// job environment layered on top, as `docker run` would apply it.
+///
+/// `PATH` and `LD_LIBRARY_PATH` are unioned, image entries first, rather than
+/// replaced. That is what keeps executables shipped in the image resolvable
+/// when the job exports a host `PATH`, which it does by default under
+/// `--export ALL`.
+///
+/// Images imported before spur recorded the config have nothing to read, so the
+/// job environment is returned unchanged and they keep behaving as they did.
+pub fn container_base_env(
+    rootfs: &Path,
+    job_env: HashMap<String, String>,
+) -> HashMap<String, String> {
+    let Ok(path) = image_config_path(rootfs) else {
+        return job_env;
+    };
+    // Opening a FIFO blocks until a writer appears, which would stall the
+    // launch, so read the path only when it is a regular file.
+    if !path
+        .symlink_metadata()
+        .is_ok_and(|m| m.file_type().is_file())
+    {
+        return job_env;
+    }
+    let Ok(file) = std::fs::File::open(&path) else {
+        return job_env;
+    };
+    let mut config_json = Vec::new();
+    if file
+        .take(MAX_IMAGE_CONFIG_BYTES)
+        .read_to_end(&mut config_json)
+        .is_err()
+    {
+        return job_env;
+    }
+    let Ok(config) = serde_json::from_slice::<serde_json::Value>(&config_json) else {
+        return job_env;
+    };
+
+    let mut env: HashMap<String, String> = config
+        .get("config")
+        .and_then(|config| config.get("Env"))
+        .and_then(|env| env.as_array())
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| entry.as_str()?.split_once('='))
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    for (key, value) in job_env {
+        let value = match env.get(&key) {
+            Some(image_value) if UNIONED_VARS.contains(&key.as_str()) => {
+                union_paths(image_value, &value)
+            }
+            _ => value,
+        };
+        env.insert(key, value);
+    }
+    env
+}
+
+/// Join two `PATH`-style lists, keeping the order of `first` and dropping
+/// duplicate and empty entries.
+fn union_paths(first: &str, second: &str) -> String {
+    let mut entries: Vec<&str> = Vec::new();
+    for entry in first.split(':').chain(second.split(':')) {
+        if !entry.is_empty() && !entries.contains(&entry) {
+            entries.push(entry);
+        }
+    }
+    entries.join(":")
+}
+
+/// Download the image config blob and record it inside the rootfs.
+async fn fetch_and_record_config(
+    client: &reqwest::Client,
+    image_ref: &ImageRef,
+    registry_url: &str,
+    digest: &str,
+    token: Option<&str>,
+    rootfs_dir: &Path,
+) -> anyhow::Result<()> {
+    let url = format!(
+        "{}/v2/{}/blobs/{}",
+        registry_url, image_ref.repository, digest
+    );
+    let mut req = client.get(&url);
+    if let Some(token) = token {
+        req = req.header(AUTHORIZATION, format!("Bearer {}", token));
+    }
+
+    let resp = req.send().await.context("failed to download config blob")?;
+    if !resp.status().is_success() {
+        bail!("registry returned {} for config blob", resp.status());
+    }
+    let config_json = resp.bytes().await.context("failed to read config blob")?;
+    record_image_config(rootfs_dir, &config_json)
+}
+
 #[cfg(test)]
 mod tests {
     use base64::{engine::general_purpose::STANDARD, Engine as _};
     use flate2::{write::GzEncoder, Compression};
 
     use super::*;
+
+    fn image_config(env: &[&str]) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({ "config": { "Env": env } })).unwrap()
+    }
+
+    #[test]
+    fn image_env_seeds_the_container_and_search_paths_are_unioned() {
+        let rootfs = tempfile::tempdir().unwrap();
+        record_image_config(
+            rootfs.path(),
+            &image_config(&[
+                "PATH=/opt/venv/bin:/usr/bin",
+                "LD_LIBRARY_PATH=/opt/rocm/lib",
+                "IMG_MARKER=from_image",
+            ]),
+        )
+        .unwrap();
+        let job_env: HashMap<String, String> = [
+            ("PATH", "/usr/bin:/host/only"),
+            ("LD_LIBRARY_PATH", "/host/lib"),
+            ("IMG_MARKER", "from_job"),
+        ]
+        .iter()
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect();
+
+        let env = container_base_env(rootfs.path(), job_env);
+
+        // Image entries first, host entries appended, no duplicate /usr/bin.
+        assert_eq!(env["PATH"], "/opt/venv/bin:/usr/bin:/host/only");
+        assert_eq!(env["LD_LIBRARY_PATH"], "/opt/rocm/lib:/host/lib");
+        // Everything else: the job's value replaces the image's.
+        assert_eq!(env["IMG_MARKER"], "from_job");
+    }
+
+    #[test]
+    fn oversized_recorded_config_is_not_read_into_memory() {
+        let rootfs = tempfile::tempdir().unwrap();
+        let dest = rootfs.path().join(IMAGE_CONFIG_PATH);
+        std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        // A string value that runs past the cap: the capped read cannot parse,
+        // so the job environment stands rather than the whole file being loaded.
+        let mut oversized = br#"{"config":{"Env":["PATH="#.to_vec();
+        oversized.resize(MAX_IMAGE_CONFIG_BYTES as usize + 4096, b'x');
+        oversized.extend_from_slice(br#""]}}"#);
+        std::fs::write(&dest, &oversized).unwrap();
+        let job_env: HashMap<String, String> =
+            std::iter::once(("PATH".to_string(), "/usr/bin".to_string())).collect();
+
+        assert_eq!(container_base_env(rootfs.path(), job_env.clone()), job_env);
+    }
+
+    #[test]
+    fn symlinked_path_component_is_refused_in_both_directions() {
+        let rootfs = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), rootfs.path().join("etc")).unwrap();
+
+        // An image shipping etc as a symlink must not redirect the write out of
+        // the rootfs at import...
+        assert!(record_image_config(rootfs.path(), &image_config(&["A=1"])).is_err());
+        assert!(!outside.path().join("spur/image-config.json").exists());
+
+        // ...nor the read at launch.
+        let job_env: HashMap<String, String> =
+            std::iter::once(("PATH".to_string(), "/usr/bin".to_string())).collect();
+        assert_eq!(container_base_env(rootfs.path(), job_env.clone()), job_env);
+    }
+
+    #[test]
+    fn a_fifo_at_the_config_path_cannot_stall_a_launch() {
+        let rootfs = tempfile::tempdir().unwrap();
+        let dest = rootfs.path().join(IMAGE_CONFIG_PATH);
+        std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        assert!(std::process::Command::new("mkfifo")
+            .arg(&dest)
+            .status()
+            .unwrap()
+            .success());
+        let job_env: HashMap<String, String> =
+            std::iter::once(("PATH".to_string(), "/usr/bin".to_string())).collect();
+
+        // Opening a FIFO blocks until a writer appears, so a regression here
+        // hangs the launch: fail on a timeout rather than hang with it.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let path = rootfs.path().to_path_buf();
+        let sent = job_env.clone();
+        std::thread::spawn(move || tx.send(container_base_env(&path, sent)));
+        let env = rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("container_base_env blocked on a FIFO");
+
+        assert_eq!(env, job_env);
+    }
+
+    #[test]
+    fn image_without_recorded_config_keeps_job_env() {
+        let rootfs = tempfile::tempdir().unwrap();
+        let job_env: HashMap<String, String> =
+            std::iter::once(("PATH".to_string(), "/usr/bin".to_string())).collect();
+
+        assert_eq!(container_base_env(rootfs.path(), job_env.clone()), job_env);
+    }
 
     fn tar_layer(path: &str, contents: &[u8]) -> Vec<u8> {
         let mut data = Vec::new();

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1436,7 +1436,9 @@ async fn launch_container_job(
     // Snapshot everything the child needs (must not reference async state after fork)
     let config = &ctn.config;
     let rootfs = ctn.rootfs.clone();
-    let env_snapshot = env.clone();
+    // The image's own config.Env is the base environment, as with docker run;
+    // the job environment layers on top of it.
+    let env_snapshot = spur_net::oci::container_base_env(&rootfs, env.clone());
     let container_env = config.container_env.clone();
     let entrypoint = config.entrypoint.clone();
 

--- a/docs/user-guide/running-containers.rst
+++ b/docs/user-guide/running-containers.rst
@@ -83,6 +83,35 @@ An interactive shell in a container with your home directory mounted:
 
    srun --container-image ubuntu:22.04 --container-mount-home bash
 
+Environment Inside the Container
+--------------------------------
+
+A container job starts from the image's own environment — the ``config.Env`` that
+``docker run`` would apply — and layers the job's environment on top of it. Spur
+records the image config at ``spur image import`` time, so images imported by an
+older Spur have nothing recorded and keep starting from the job environment
+alone; re-import them to pick up their environment.
+
+Later entries win:
+
+1. the image's ``config.Env``
+2. the job environment (``--export``, which defaults to ``ALL``)
+3. ``--container-env KEY=VAL``
+4. admin ``environ.d`` files and hook variables
+
+``PATH`` and ``LD_LIBRARY_PATH`` are the exception: instead of being replaced,
+the image's entries and the job's are joined, image first, so that the programs
+and libraries shipped in the image stay reachable while additions from the
+submitting host still apply. An explicit ``--container-env PATH=...`` replaces
+the result outright.
+
+This is what lets an image's own tooling run without spelling out its paths:
+
+.. code-block:: bash
+
+   # torchrun lives on the image's PATH (/opt/venv/bin), not the host's
+   sbatch --container-image registry.example.com/pytorch:latest train.sh
+
 Exec Into a Running Container Job
 ---------------------------------
 

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -194,6 +194,20 @@ class SpurCluster:
     waits for the cluster to become ready, and tears everything down.
     """
 
+    # Payload carried by build_imported_container_image(): a directory that
+    # exists only inside the image, so a bare command name resolves there
+    # only when the image's own PATH reaches the container.
+    IMAGE_ONLY_BIN_DIR = "/opt/img/bin"
+    IMAGE_PAYLOAD = "img-payload"
+    IMAGE_PAYLOAD_MARKER = "IMAGE_PAYLOAD_OK"
+
+    # Real public image pulled by pull_container_image(). Its config.Env holds
+    # PATH (first entry below), LANG and PYTHON_VERSION, none of which the job
+    # environment supplies. Pinned so those expectations stay true.
+    TEST_IMAGE = "docker.io/library/python:3.11-slim"
+    TEST_IMAGE_REGISTRY = "registry-1.docker.io"
+    TEST_IMAGE_PATH_HEAD = "/usr/local/bin"
+
     def __init__(self, nodes: list[SshNode], remote_dir: str, bin_dir: str):
         self.nodes = nodes
         self.node_names: list[str] = []
@@ -893,15 +907,12 @@ class SpurCluster:
                     f"(apt install squashfs-tools)"
                 )
 
-    def build_container_image(self, tmp_path: Path) -> str:
+    def _build_test_rootfs(self, rootfs: Path, extra: str = "") -> None:
         """
-        Build a minimal squashfs container image locally, ship to all nodes.
-        Returns the remote path to the .sqsh file.
+        Populate *rootfs* locally with a minimal userland: host binaries plus
+        the libraries ldd reports for them. *extra* is shell appended to the
+        build script, run with $R pointing at the rootfs.
         """
-        remote_path = f"{self.remote_dir}/test-container.sqsh"
-        rootfs = tmp_path / "rootfs"
-        local_img = tmp_path / "test-container.sqsh"
-
         build_script = f"""set -e
 R='{rootfs}'
 mkdir -p "$R/bin" "$R/usr/bin" "$R/lib" "$R/lib64" \
@@ -930,19 +941,107 @@ done
 for f in /etc/passwd /etc/group /etc/nsswitch.conf; do
   [ -f "$f" ] && cp "$f" "$R/etc/"
 done
-mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
+{extra}
 """
         result = subprocess.run(
             ["sh", "-c", build_script],
             capture_output=True, text=True,
         )
         if result.returncode != 0:
-            raise RuntimeError(f"mksquashfs failed: {result.stderr}")
+            raise RuntimeError(f"rootfs build failed: {result.stderr}")
+
+    def build_container_image(self, tmp_path: Path) -> str:
+        """
+        Build a minimal squashfs container image locally, ship to all nodes.
+        Returns the remote path to the .sqsh file.
+        """
+        remote_path = f"{self.remote_dir}/test-container.sqsh"
+        rootfs = tmp_path / "rootfs"
+        local_img = tmp_path / "test-container.sqsh"
+        self._build_test_rootfs(
+            rootfs,
+            extra=f"""mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1""",
+        )
 
         for node in self.nodes:
             node.upload(str(local_img), remote_path)
 
         return remote_path
+
+    def build_imported_container_image(
+        self,
+        tmp_path: Path,
+        image_env: list[str],
+        tag: str = "spur-e2e-imgenv:test",
+    ) -> str:
+        """
+        Build an image through the real `spur image import` path, so the image
+        config recorded at import time is on the rootfs when a job launches.
+        *image_env* becomes the image's config.Env.
+
+        The rootfs carries a payload binary under IMAGE_ONLY_BIN_DIR, a
+        directory that exists nowhere on the host, so it is reachable only if
+        the image's own PATH survives into the container. It is a copy of a
+        real ELF rather than a shebang script, so the job's execve resolves a
+        binary the way `torchrun` from a venv image would.
+
+        Skips the test when docker or mksquashfs is unusable on node 0, where
+        both the docker build and the import run. Returns the remote .sqsh.
+        """
+        node = self.nodes[0]
+        # `docker info` (not `command -v docker`) so an unreachable daemon socket skips.
+        if node.exec_allow_fail("docker info >/dev/null 2>&1 && echo ok").strip() != "ok":
+            pytest.skip("docker not usable on node 0; cannot run `spur image import`")
+
+        rootfs = tmp_path / "import-rootfs"
+        local_tar = tmp_path / "import-rootfs.tar.gz"
+        payload = f"{self.IMAGE_ONLY_BIN_DIR}/{self.IMAGE_PAYLOAD}"
+        self._build_test_rootfs(rootfs, extra=f"""
+mkdir -p "$R{self.IMAGE_ONLY_BIN_DIR}"
+cp "$R/usr/bin/echo" "$R{payload}"
+tar -C "$R" -czf '{local_tar}' .
+""")
+
+        remote_tar = f"{self.remote_dir}/import-rootfs.tar.gz"
+        node.upload(str(local_tar), remote_tar)
+
+        # docker mints the config.Env; `spur image import` is what records it.
+        changes = " ".join(f"--change {shlex.quote('ENV ' + v)}" for v in image_env)
+        node.exec_allow_fail(f"docker rmi -f {shlex.quote(tag)}")
+        node.exec(f"docker import {changes} '{remote_tar}' {shlex.quote(tag)}")
+        return self.import_container_image(f"dockerd://{tag}", "dockerd")
+
+    def pull_container_image(self) -> str:
+        """
+        Import TEST_IMAGE straight from its registry, so the pull path rather
+        than `docker save` is what records the config. Skips when the registry
+        is unreachable. Returns the remote .sqsh path on node 0.
+        """
+        probe = self.nodes[0].exec_allow_fail(
+            f"getent hosts {self.TEST_IMAGE_REGISTRY} >/dev/null && echo ok"
+        )
+        if "ok" not in probe:
+            pytest.skip(f"{self.TEST_IMAGE_REGISTRY} unreachable from node 0")
+        return self.import_container_image(self.TEST_IMAGE, "registry")
+
+    def import_container_image(self, uri: str, slug: str) -> str:
+        """
+        Run the real `spur image import` on node 0. Each import gets its own
+        image directory, so the .sqsh it produced is the only one there and
+        this does not have to reproduce spur's image naming rules.
+        """
+        node = self.nodes[0]
+        if "ok" not in node.exec_allow_fail("command -v mksquashfs >/dev/null && echo ok"):
+            pytest.skip("mksquashfs not found on node 0 (apt install squashfs-tools)")
+        image_dir = f"{self.remote_dir}/images/{slug}"
+        node.exec(f"mkdir -p '{image_dir}'")
+        node.exec(
+            f"SPUR_IMAGE_DIR='{image_dir}' '{self.bin_dir}/spur' image import {shlex.quote(uri)}"
+        )
+        images = node.exec(f"ls '{image_dir}'/*.sqsh").split()
+        if len(images) != 1:
+            raise RuntimeError(f"expected one imported image under {image_dir}, got {images}")
+        return images[0]
 
     # --- Internal helpers ---
 

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -1029,6 +1029,9 @@ tar -C "$R" -czf '{local_tar}' .
         Run the real `spur image import` on node 0. Each import gets its own
         image directory, so the .sqsh it produced is the only one there and
         this does not have to reproduce spur's image naming rules.
+
+        Unlike build_container_image, the result lands on node 0 alone, so a
+        job using it has to be pinned there with `-w`.
         """
         node = self.nodes[0]
         if "ok" not in node.exec_allow_fail("command -v mksquashfs >/dev/null && echo ok"):

--- a/tests/native_host/e2e/test_container.py
+++ b/tests/native_host/e2e/test_container.py
@@ -37,6 +37,34 @@ def multi_container_cluster(multi_node_cluster, tmp_path):
     return multi_node_cluster
 
 
+@pytest.fixture
+def imported_image_cluster(cluster, tmp_path):
+    """
+    Single-node cluster whose image went through `spur image import`, so the
+    image config recorded at import time is present when a job launches.
+    """
+    cluster.container_preflight()
+    cluster.container_image = cluster.build_imported_container_image(
+        tmp_path,
+        image_env=[
+            f"PATH={cluster.IMAGE_ONLY_BIN_DIR}:/usr/bin",
+            "IMAGE_MARKER=from-image",
+        ],
+    )
+    return cluster
+
+
+@pytest.fixture
+def registry_image_cluster(cluster):
+    """
+    Single-node cluster running a real public image pulled from its registry,
+    so the config recorded by the pull path is what seeds the container.
+    """
+    cluster.container_preflight()
+    cluster.container_image = cluster.pull_container_image()
+    return cluster
+
+
 class TestContainerSingleNode:
     def test_container_launch_and_exit(self, container_cluster):
         cluster = container_cluster
@@ -200,6 +228,114 @@ class TestContainerSingleNode:
             f"bind mount test failed (1=content wrong, 2=ro not enforced), "
             f"state={state}\n{diag}"
         )
+
+    def test_container_starts_from_image_env(self, imported_image_cluster):
+        """A binary on the image's own PATH must be runnable, host PATH kept."""
+        cluster = imported_image_cluster
+        img = cluster.container_image
+        out_path = f"{cluster.remote_dir}/c10-image-env.out"
+        script = cluster.write_file(
+            "c10-image-env.sh",
+            "#!/bin/bash\n"
+            f"{cluster.IMAGE_PAYLOAD} {cluster.IMAGE_PAYLOAD_MARKER} || exit 1\n"
+            'echo "CONTAINER_PATH=$PATH"\n'
+            'echo "MARKER=$IMAGE_MARKER"\n',
+        )
+        sb = cluster.sbatch([
+            "-J", "c10-image-env", "-N", "1", "-o", out_path,
+            f"--container-image={img}", script,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=120)
+        output = cluster.read_output_all_nodes(out_path)
+        diag = cluster.debug_job(job_id)
+        assert state in ("CD", "GONE"), (
+            f"job running the image's own binary must complete, got {state}\n"
+            f"{diag}\noutput:\n{output}"
+        )
+        assert cluster.IMAGE_PAYLOAD_MARKER in output, (
+            f"{cluster.IMAGE_PAYLOAD} is only on the image's PATH and must "
+            f"still resolve\noutput:\n{output}"
+        )
+        assert f"CONTAINER_PATH={cluster.IMAGE_ONLY_BIN_DIR}:" in output, (
+            f"image PATH entries must come first\noutput:\n{output}"
+        )
+        assert f"{cluster.bin_dir}" in output, (
+            f"job PATH entries must still be appended\noutput:\n{output}"
+        )
+        assert "MARKER=from-image" in output, (
+            f"non-PATH image variables must reach the container\noutput:\n{output}"
+        )
+
+    def test_container_without_image_config_keeps_job_env(self, container_cluster):
+        """An image with no recorded config must run on the job env, unchanged."""
+        cluster = container_cluster
+        img = cluster.container_image
+        out_path = f"{cluster.remote_dir}/c11-no-image-config.out"
+        script = cluster.write_file(
+            "c11-no-image-config.sh",
+            "#!/bin/bash\n"
+            "[ -e /etc/spur/image-config.json ] && exit 1\n"
+            'echo "CONTAINER_PATH=$PATH"\n'
+            "echo NO_IMAGE_CONFIG_OK\n",
+        )
+        sb = cluster.sbatch([
+            "-J", "c11-no-cfg", "-N", "1", "-o", out_path,
+            f"--container-image={img}", script,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=60)
+        output = cluster.read_output_all_nodes(out_path)
+        diag = cluster.debug_job(job_id)
+        assert state in ("CD", "GONE"), (
+            f"image without a recorded config must still run (1=config present), "
+            f"got {state}\n{diag}\noutput:\n{output}"
+        )
+        assert "NO_IMAGE_CONFIG_OK" in output, f"job did not run:\n{output}"
+        assert f"CONTAINER_PATH={cluster.bin_dir}:" in output, (
+            f"job PATH must pass through untouched\noutput:\n{output}"
+        )
+
+    def test_container_starts_from_pulled_image_env(self, registry_image_cluster):
+        """A real registry image must run on its own config.Env."""
+        cluster = registry_image_cluster
+        img = cluster.container_image
+        out_path = f"{cluster.remote_dir}/c12-pulled-image.out"
+        script = cluster.write_file(
+            "c12-pulled-image.sh",
+            "#!/bin/bash\n"
+            "python3 -c 'print(\"PULLED_IMAGE_OK\")' || exit 1\n"
+            'echo "CONTAINER_PATH=$PATH"\n'
+            'echo "PY=$PYTHON_VERSION"\n',
+        )
+        sb = cluster.sbatch([
+            "-J", "c12-pulled", "-N", "1", "-o", out_path,
+            f"--container-image={img}", script,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=120)
+        output = cluster.read_output_all_nodes(out_path)
+        diag = cluster.debug_job(job_id)
+        assert state in ("CD", "GONE"), (
+            f"job in a pulled image must complete, got {state}\n{diag}\noutput:\n{output}"
+        )
+        assert "PULLED_IMAGE_OK" in output, f"the image's python did not run:\n{output}"
+        assert f"CONTAINER_PATH={cluster.TEST_IMAGE_PATH_HEAD}:" in output, (
+            f"the image's PATH must come first\noutput:\n{output}"
+        )
+        assert cluster.bin_dir in output, (
+            f"job PATH entries must still be appended\noutput:\n{output}"
+        )
+        # Set only in the image config, so it is empty without the fix. LANG is
+        # not usable here: the image sets it too, but the job environment has its
+        # own and job values win for everything except the search paths.
+        assert "PY=3.11" in output, f"PYTHON_VERSION must reach the job\noutput:\n{output}"
 
 
 class TestContainerMultiNode:

--- a/tests/native_host/e2e/test_container.py
+++ b/tests/native_host/e2e/test_container.py
@@ -241,9 +241,10 @@ class TestContainerSingleNode:
             'echo "CONTAINER_PATH=$PATH"\n'
             'echo "MARKER=$IMAGE_MARKER"\n',
         )
+        # The import ran on node 0, so the .sqsh exists only there.
         sb = cluster.sbatch([
-            "-J", "c10-image-env", "-N", "1", "-o", out_path,
-            f"--container-image={img}", script,
+            "-J", "c10-image-env", "-N", "1", "-w", cluster.node_names[0],
+            "-o", out_path, f"--container-image={img}", script,
         ])
         job_id = parse_job_id(sb)
         assert job_id is not None
@@ -312,9 +313,10 @@ class TestContainerSingleNode:
             'echo "CONTAINER_PATH=$PATH"\n'
             'echo "PY=$PYTHON_VERSION"\n',
         )
+        # The import ran on node 0, so the .sqsh exists only there.
         sb = cluster.sbatch([
-            "-J", "c12-pulled", "-N", "1", "-o", out_path,
-            f"--container-image={img}", script,
+            "-J", "c12-pulled", "-N", "1", "-w", cluster.node_names[0],
+            "-o", out_path, f"--container-image={img}", script,
         ])
         job_id = parse_job_id(sb)
         assert job_id is not None


### PR DESCRIPTION
Closes #649.

## What

Container jobs ran with the submitting host's environment instead of the
image's. `spur image import` discarded the OCI config blob on both the
`docker save` and registry paths, and `launch_container_job` built the child
environment from the job environment alone, so `execve` replaced everything the
image had set. Programs installed on the image's own `PATH` — `torchrun` under
`/opt/venv/bin` in `rocm/pytorch` — were unresolvable and `LD_LIBRARY_PATH` for
ROCm/RCCL was lost, while `docker run` on the same image works.

## Approach

Import records the image config into the rootfs at `etc/spur/image-config.json`
before mksquashfs, from the `docker save` archive and from the registry blob.
Launch reads it back and uses `config.Env` as the base environment.

Precedence, low to high: image `config.Env` → job environment (`--export`,
default `ALL`) → `--container-env` → `environ.d` and hook variables. `PATH` and
`LD_LIBRARY_PATH` are unioned with the image's entries first instead of being
replaced, so tools shipped in the image resolve while host additions still
apply; an explicit `--container-env PATH=...` still replaces outright.

The whole config blob is recorded, not just `Env`, so `Entrypoint`, `Cmd`, and
`WorkingDir` are available for a follow-up that makes `--container-entrypoint`
do what the docs already describe. Nothing reads them yet.

## Trade-offs

- Images imported by an earlier version record nothing and keep today's
  behaviour until re-imported. No flag day.
- After re-import, `PATH` ordering changes: a tool present both in the image's
  venv and in `/usr/bin` now resolves to the image's, matching `docker run`.
  That is the point of the fix, but it is a visible change.
- With `--export NONE`, or an `--export` list omitting `HOME`, an image that
  sets `HOME` in `config.Env` now supplies it; under the default `--export ALL`
  the submitter's value wins. This matches `docker run`, but I am happy to
  filter `HOME`/`USER` out of the image environment if reviewers prefer.
- The rootfs is content spur does not control, since `--container-image` accepts
  an arbitrary squashfs path. The recorded config is therefore read only through
  non-symlinked path components, only when it is a regular file, and only up to
  1 MiB; without those guards a crafted image could redirect the write out of
  the rootfs at import or stall a launch on a FIFO.
- #649 cites #149/#151 as a live workaround for this root cause. That code was
  superseded by #154, which moved both root and rootless launches onto
  `container_init` + `pivot_root`; the root cause itself still stands.

## Testing

- `cargo test` (2983 tests, 34 suites), `cargo fmt --check`, `clippy
  --all-targets` (0 warnings), SPDX headers, and the docs image (`sphinx -W`,
  pyspelling, markdownlint) all pass.
- Five unit tests in `spur-net::oci`: union and override, no recorded config,
  oversized config, symlinked path component, and a FIFO at the config path
  (guarded by a channel timeout so a regression fails rather than hangs).
- End to end on a single-node cluster: image imported by the previous binary
  (unchanged), by this one (`torchrun` runs, `PATH` image-first, image variables
  present, host variables still pass through), `--container-env` override,
  non-container job, registry import path, named containers, `--export NONE`,
  and a hostile squashfs with a FIFO at the sidecar path (job runs, node stays
  responsive).