### PR TITLE
fix(spur-core): cap hostlist expansion size to prevent controller OOM

### DIFF
--- a/crates/spur-core/src/hostlist.rs
+++ b/crates/spur-core/src/hostlist.rs
@@ -665,6 +665,16 @@ mod tests {
     }
 
     #[test]
+    fn expand_rejects_recursive_overshoot_past_cap() {
+        // A comma-list suffix pushes per element without consulting the pre-loop
+        // bound, so the running total steps past the cap instead of being
+        // rejected in advance. Exercises the incremental backstop, which the
+        // nested-range case above never reaches.
+        let err = expand("rack[0-999999]-node[1,2]").unwrap_err();
+        assert!(matches!(err, HostlistError::TooLarge { .. }));
+    }
+
+    #[test]
     fn count_rejects_oversized_range() {
         assert!(count("node[0-18446744073709551615]").is_err());
     }

--- a/crates/spur-core/src/hostlist.rs
+++ b/crates/spur-core/src/hostlist.rs
@@ -3,6 +3,8 @@
 
 use thiserror::Error;
 
+pub const MAX_HOSTLIST_SIZE: usize = 1_000_000;
+
 /// Errors from hostlist parsing.
 #[derive(Debug, Error)]
 pub enum HostlistError {
@@ -10,6 +12,8 @@ pub enum HostlistError {
     InvalidPattern(String),
     #[error("invalid range: {0}")]
     InvalidRange(String),
+    #[error("hostlist too large: {count} hosts exceeds maximum {max}")]
+    TooLarge { count: u64, max: usize },
 }
 
 /// Expand a Slurm hostlist pattern into individual hostnames.
@@ -314,12 +318,30 @@ fn expand_single(pattern: &str, results: &mut Vec<String>) -> Result<(), Hostlis
                     return Err(HostlistError::InvalidRange(format!("{} > {}", start, end)));
                 }
 
+                // Bound element count BEFORE materializing. Saturating so the count
+                // arithmetic itself can't overflow on a u64::MAX range.
+                let range_count = (end - start).saturating_add(1);
+                if (results.len() as u64).saturating_add(range_count) > MAX_HOSTLIST_SIZE as u64 {
+                    return Err(HostlistError::TooLarge {
+                        count: (results.len() as u64).saturating_add(range_count),
+                        max: MAX_HOSTLIST_SIZE,
+                    });
+                }
+
                 for i in start..=end {
                     let name = format!("{}{:0>width$}{}", prefix, i, suffix, width = width);
                     if suffix.contains('[') {
                         expand_single(&name, results)?;
                     } else {
                         results.push(name);
+                    }
+                    // Incremental backstop: nested products like rack[0-9999]-node[0-9999]
+                    // can exceed the cap even when each single range is under it.
+                    if results.len() > MAX_HOSTLIST_SIZE {
+                        return Err(HostlistError::TooLarge {
+                            count: results.len() as u64,
+                            max: MAX_HOSTLIST_SIZE,
+                        });
                     }
                 }
             } else {
@@ -622,5 +644,28 @@ mod tests {
     #[test]
     fn recursive_suffix_bracket_order_rejected() {
         assert!(expand("node[1-2]a]b[3-4]").is_err());
+    }
+
+    #[test]
+    fn expand_rejects_oversized_range() {
+        let err = expand("node[0-18446744073709551615]").unwrap_err();
+        assert!(matches!(err, HostlistError::TooLarge { .. }));
+    }
+
+    #[test]
+    fn expand_allows_cap_boundary() {
+        let hosts = expand("node[0-999999]").unwrap();
+        assert_eq!(hosts.len(), 1_000_000);
+    }
+
+    #[test]
+    fn expand_rejects_nested_product_over_cap() {
+        let err = expand("rack[0-9999]-node[0-9999]").unwrap_err();
+        assert!(matches!(err, HostlistError::TooLarge { .. }));
+    }
+
+    #[test]
+    fn count_rejects_oversized_range() {
+        assert!(count("node[0-18446744073709551615]").is_err());
     }
 }


### PR DESCRIPTION
Closes #677

## Problem

`hostlist::expand()` parsed bracket-range endpoints as `u64` and materialized one
`String` per element with no limit on the resulting count. A 28-byte pattern —
`node[0-18446744073709551615]` — requests ~1.8e19 allocations, so `results` grows
until the kernel OOM-kills the process.

This is reachable from untrusted input on three paths, the first of which is a
read-only RPC that is unauthenticated under the default `auth.mode`:

- `get_nodes` (`spurctld/src/server.rs`) expands the caller-supplied `nodelist`
  filter — reached via `sinfo -n '<pattern>'` and `scontrol show node <pattern>`.
  One such query takes down the whole control plane.
- `NodePlacement::new` (`spur-sched/src/node_match.rs`) expands a pending job's
  `--nodelist` and `--exclude` every scheduling cycle. Because the spec is
  persisted in the Raft log, a single `sbatch -w '<pattern>'` re-triggers the
  expansion on every tick and every controller restart.
- `remove_nodes` (admin-gated, so lowest impact).

Size was the only property `hostlist.rs` never validated — unmatched `[`,
reversed ranges, `]`-before-`[` (#639), and stray `]` before a comma (#643) are
all already rejected.

## Fix

Mirrors the approach #646 took for `parse_array_spec` in the adjacent `array.rs`:

- Add `MAX_HOSTLIST_SIZE` (1,000,000) and a `HostlistError::TooLarge` variant.
- Bound the element count arithmetically in `expand_single` **before** anything is
  materialized. The bound uses `(end - start).saturating_add(1)` — this is
  load-bearing rather than stylistic, since a plain `end - start + 1` overflows on
  exactly the `u64::MAX` input the guard exists to reject.
- Keep an incremental check inside the push loop so nested products such as
  `rack[0-9999]-node[0-9999]` are bounded by the cap overall rather than per range.
  `results.len()` is the natural accumulator since it is already threaded through
  the recursion.

Peak memory is now bounded by the cap (~52 bytes/host, so ~52 MB) regardless of
input, and an over-cap pattern gets the same clean `HostlistError` treatment every
other malformed pattern already receives.

## Tests

Four regression tests added to `hostlist.rs`:

- `expand_rejects_oversized_range` — `node[0-18446744073709551615]` returns
  `Err(TooLarge)` promptly (guards the RPC DoS).
- `expand_allows_cap_boundary` — `node[0-999999]` still yields 1,000,000 hosts.
- `expand_rejects_nested_product_over_cap` — `rack[0-9999]-node[0-9999]` is bounded
  overall, not per range.
- `count_rejects_oversized_range` — `count()` is covered too, since it delegates to
  `expand()`.

Existing valid patterns are unchanged, including the `#639` and `#643` cases.

## Verification

Run locally on Ubuntu 24.04 with the pinned 1.95.0 toolchain and
`RUSTFLAGS="-D warnings"`, rebased onto `main` @ `54f3763b`:

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — zero warnings
- `cargo build --all-targets --locked` — clean, `Cargo.lock` unchanged
- `cargo test --locked` — all green (spur-core 541, spurctld 839, spurd 238), 0 failures

## Notes for review

- **`MAX_HOSTLIST_SIZE = 1_000_000` is a policy choice I'd like maintainers to
  confirm.** It is generous next to the largest real clusters while capping peak
  memory around 52 MB. Matching `MAX_ARRAY_SIZE` (100,000) would be tighter and
  more consistent — either is defensible, happy to change it.
- `TooLarge { count: u64, max: usize }` uses `u64` for `count` where `array.rs`
  uses `usize`. This is deliberate: the saturating range count is computed in `u64`
  before any narrowing, so the error can faithfully report a value above `usize`
  range on the pathological input.
- Out of scope but worth flagging: `expand_hostlist_or_split`
  (`spur-sched/src/node_match.rs`) falls back to a plain comma-split when `expand`
  returns `Err`, so an over-cap `--nodelist` becomes one literal name that matches
  nothing. That is safe and keeps the RPC responsive, but the job then silently
  never matches a node. Validating the nodelist at `submit_job` would give the user
  a clean rejection and close the persistent re-expansion variant at the door — happy
  to do that as a follow-up if you'd like.