### PR TITLE
fix(spur-core): use checked arithmetic in time parsers to prevent overflow

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1625,7 +1625,7 @@ fn parse_slurm_time_minutes(s: &str) -> Option<u32> {
     if let Some((days, rest)) = s.split_once('-') {
         let days: u32 = days.parse().ok()?;
         let hms = parse_hms(rest)?;
-        return Some(days * 24 * 60 + hms);
+        return days.checked_mul(24 * 60)?.checked_add(hms);
     }
 
     // hours:minutes:seconds or hours:minutes or just minutes
@@ -1635,7 +1635,7 @@ fn parse_slurm_time_minutes(s: &str) -> Option<u32> {
         2 => {
             let h: u32 = parts[0].parse().ok()?;
             let m: u32 = parts[1].parse().ok()?;
-            Some(h * 60 + m)
+            h.checked_mul(60)?.checked_add(m)
         }
         3 => parse_hms(s),
         _ => None,
@@ -1659,7 +1659,9 @@ fn parse_slurm_time_seconds(s: &str) -> Option<u64> {
     // days-hours:minutes:seconds
     if let Some((days, rest)) = s.split_once('-') {
         let days: u64 = days.parse().ok()?;
-        return Some(days * 86400 + parse_hms_seconds(rest)?);
+        return days
+            .checked_mul(86400)?
+            .checked_add(parse_hms_seconds(rest)?);
     }
 
     let parts: Vec<&str> = s.split(':').collect();
@@ -1667,20 +1669,22 @@ fn parse_slurm_time_seconds(s: &str) -> Option<u64> {
         1 => {
             // Just minutes → convert to seconds
             let mins: u64 = parts[0].parse().ok()?;
-            Some(mins * 60)
+            mins.checked_mul(60)
         }
         2 => {
             // HH:MM → hours and minutes (no seconds)
             let h: u64 = parts[0].parse().ok()?;
             let m: u64 = parts[1].parse().ok()?;
-            Some(h * 3600 + m * 60)
+            h.checked_mul(3600)?.checked_add(m.checked_mul(60)?)
         }
         3 => {
             // HH:MM:SS
             let h: u64 = parts[0].parse().ok()?;
             let m: u64 = parts[1].parse().ok()?;
             let sec: u64 = parts[2].parse().ok()?;
-            Some(h * 3600 + m * 60 + sec)
+            h.checked_mul(3600)?
+                .checked_add(m.checked_mul(60)?)?
+                .checked_add(sec)
         }
         _ => None,
     }
@@ -1726,13 +1730,15 @@ fn parse_hms_seconds(s: &str) -> Option<u64> {
         2 => {
             let h: u64 = parts[0].parse().ok()?;
             let m: u64 = parts[1].parse().ok()?;
-            Some(h * 3600 + m * 60)
+            h.checked_mul(3600)?.checked_add(m.checked_mul(60)?)
         }
         3 => {
             let h: u64 = parts[0].parse().ok()?;
             let m: u64 = parts[1].parse().ok()?;
             let sec: u64 = parts[2].parse().ok()?;
-            Some(h * 3600 + m * 60 + sec)
+            h.checked_mul(3600)?
+                .checked_add(m.checked_mul(60)?)?
+                .checked_add(sec)
         }
         _ => None,
     }
@@ -1750,7 +1756,10 @@ fn parse_hms(s: &str) -> Option<u32> {
     } else {
         0
     };
-    Some(h * 60 + m + if s > 0 { 1 } else { 0 }) // Round up seconds
+    // Round up seconds
+    h.checked_mul(60)?
+        .checked_add(m)?
+        .checked_add(if s > 0 { 1 } else { 0 })
 }
 
 /// Format minutes as D-HH:MM:SS or HH:MM:SS.
@@ -2279,6 +2288,31 @@ memory_mb = 1024000
         // Slurm grammar unchanged.
         assert_eq!(parse_time_seconds("60"), Some(3600));
         assert_eq!(parse_time_seconds("00:00:30"), Some(30));
+    }
+
+    #[test]
+    fn parse_time_rejects_overflowing_slurm_durations() {
+        // u32 minutes overflow: 2982617 days * 1440 is u32::MAX + 1185.
+        assert_eq!(parse_time_minutes("2982617-00:00:00"), None);
+        // Overflow on the `+ hms`, not the multiply: 2982616 days leaves only
+        // 255 minutes of headroom and "05:00:00" is 300.
+        assert_eq!(parse_time_minutes("2982616-05:00:00"), None);
+        // HH:MM arm.
+        assert_eq!(parse_time_minutes("71582789:00"), None);
+        // u64 seconds overflow.
+        assert_eq!(parse_time_seconds("213503982334602-00:00:00"), None);
+        // The largest non-overflowing value is still accepted unchanged.
+        assert_eq!(parse_time_minutes("2982616-00:00:00"), Some(4_294_967_040));
+    }
+
+    #[test]
+    fn parse_partition_time_rejects_overflowing_duration() {
+        // validate() promises a bad partition time fails loudly rather than
+        // silently enforcing a different cap.
+        assert!(matches!(
+            parse_partition_time("partitions.gpu.max_time", "2982617-00:00:00"),
+            Err(ConfigError::InvalidValue { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #678

## Problem

Four time-parsing helpers in `config.rs` multiplied and added user-supplied
values with unchecked arithmetic. `parse_suffix_duration_seconds`, sitting
directly between them in the same file, already uses `checked_mul`/`checked_add`
throughout — the Slurm-grammar path just never got the same treatment.

The result is profile-dependent, and the release behavior is the worse of the two.
Starting `spurctld` with a partition whose `max_time = "2982617-00:00:00"`:

- **Debug:** `panicked at crates/spur-core/src/config.rs:1628:21: attempt to
  multiply with overflow`, exit 101.
- **Release:** the controller starts and becomes leader, and `spur show partition`
  reports `MaxTime=19:44:00`. 2982617 × 1440 wraps to 1184 minutes, so an operator
  who asked for ~8000 years silently gets a 19-hour cap, with nothing logged.

This defeats two invariants the code states in its own doc comments. The first is
on `parse_partition_time`: "a typo like `"1 hour"` fails loudly instead of
collapsing to UNLIMITED" — an overflowing value fails neither loudly nor to
UNLIMITED, it collapses to an arbitrary shorter limit. The second is the
round-up rule in `parse_hms`, which can round a wrapped value down instead.

The parsers are reachable from operator config, from the create/update partition
RPC and `scontrol update PartitionName=… MaxTime=…`, from the REST job-submit
handler, and from `--time` on `sbatch`/`srun`/`salloc`, so the input is not
exclusively trusted.

## Fix

Every affected arm already returns `Option`, so this is mechanical: each `*`
becomes `.checked_mul(..)?` and each `+` becomes `.checked_add(..)`, and overflow
falls out as `None` — the same signal a malformed string already produces. No new
error variant and no policy decision needed, since `parse_partition_time` already
converts `None` into `ConfigError::InvalidValue`.

Covered functions:

- `parse_slurm_time_minutes` — `D-HH:MM:SS` and `HH:MM` arms
- `parse_slurm_time_seconds` — days, bare-minutes, `HH:MM`, and `HH:MM:SS` arms
- `parse_hms_seconds` — both arms
- `parse_hms` — the seconds round-up expression

## Tests

- `parse_time_rejects_overflowing_slurm_durations` — covers overflow on the
  multiply (`2982617-00:00:00`), on the add (`2982616-05:00:00`, where 2982616
  days leaves 255 minutes of headroom and `05:00:00` needs 300), the `HH:MM` arm
  (`71582789:00`), and the u64 seconds path (`213503982334602-00:00:00`). It also
  asserts the largest non-overflowing value, `2982616-00:00:00`, still returns
  `Some(4_294_967_040)`, so nothing valid was narrowed.
- `parse_partition_time_rejects_overflowing_duration` — confirms the loud-failure
  contract now holds for overflow, not just for typos.

Verified end-to-end as well: after the fix, both debug and release print
`Error: invalid value for partitions.gpu.max_time: 2982617-00:00:00` and exit 1.

## Verification

Ubuntu 24.04, pinned 1.95.0 toolchain, `RUSTFLAGS="-D warnings"`, on `main`
@ `54f3763b`:

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — zero warnings
- `cargo build --all-targets --locked` — clean, `Cargo.lock` unchanged
- `cargo test --locked` — 33 test binaries green (spur-core 539, spurctld 839,
  spurd 238), 0 failures

## Notes for review

- I deliberately did **not** add a sanity ceiling (something like "no more than N
  years"). Rejecting only what cannot be represented is the smaller, more
  obviously-correct change, and a ceiling is a policy call that belongs to you. Say
  the word if you'd like one and I'll add it here.
- `parse_time_minutes`'s suffixed-duration fallback (`90m`, `2d12h`) was already
  overflow-safe and is untouched; this only brings the Slurm-grammar path up to the
  same standard.