### PR TITLE
feat(spurctld): QOS preemption hierarchy and minimum exempt time

### DIFF
--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -216,6 +216,20 @@ fn parse_i32(key: &str, val: &str) -> Result<i32> {
         .map_err(|_| anyhow::anyhow!("invalid value for {key}=: '{val}'"))
 }
 
+/// Parse an unsigned integer field, failing loudly rather than silently
+/// defaulting so a typo never quietly changes a limit on a partial `modify`.
+fn parse_u32(key: &str, val: &str) -> Result<u32> {
+    val.parse()
+        .map_err(|_| anyhow::anyhow!("invalid value for {key}=: '{val}'"))
+}
+
+/// Return true when a key=value pair explicitly opts in to a boolean action
+/// (value is "1", "yes", or "true", case-insensitive). Bare keys (no `=value`)
+/// never match because `parse_params` maps them to an empty string.
+fn is_truthy(val: &str) -> bool {
+    matches!(val.to_lowercase().as_str(), "1" | "yes" | "true")
+}
+
 /// Look up a field by its accepted aliases in priority order, returning the key
 /// the caller actually wrote alongside its value. Parsers use the returned key
 /// so an invalid-value error names the exact parameter the user passed (e.g.
@@ -488,7 +502,8 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                     grp_wall_minutes: Some(grp_wall),
                     preempt_exempt_time: p
                         .get("preemptexempttime")
-                        .and_then(|v| v.parse::<u32>().ok()),
+                        .map(|v| parse_u32("preemptexempttime", v))
+                        .transpose()?,
                     clear_preempt_exempt_time: false,
                 })
                 .await
@@ -655,8 +670,12 @@ fn build_modify_qos_request(
             .transpose()?,
         preempt_exempt_time: p
             .get("preemptexempttime")
-            .and_then(|v| v.parse::<u32>().ok()),
-        clear_preempt_exempt_time: p.contains_key("clearpreemptexempttime"),
+            .map(|v| parse_u32("preemptexempttime", v))
+            .transpose()?,
+        clear_preempt_exempt_time: p
+            .get("clearpreemptexempttime")
+            .map(|v| is_truthy(v))
+            .unwrap_or(false),
     })
 }
 
@@ -1004,7 +1023,7 @@ fn resolve_qos_field(q: &QosInfo, spec: char) -> String {
         'p' => q.priority.to_string(),
         'P' => q.preempt_mode.clone(),
         'Q' => q.preempt.clone(),
-        'E' => blank_if_zero(q.preempt_exempt_time),
+        'E' => q.preempt_exempt_time.map(blank_if_zero).unwrap_or_default(),
         'U' => format!("{}", q.usage_factor),
         'G' => q.grp_tres.clone(),
         'T' => q.max_tres_per_job.clone(),
@@ -1835,6 +1854,87 @@ mod tests {
         assert!(
             !header.contains("MaxJobs"),
             "default should omit MaxJobs: {header}"
+        );
+    }
+
+    // --- parse_u32 / is_truthy ---
+
+    #[test]
+    fn parse_u32_accepts_valid_integer() {
+        assert_eq!(parse_u32("preemptexempttime", "120").unwrap(), 120);
+        assert_eq!(parse_u32("preemptexempttime", "0").unwrap(), 0);
+    }
+
+    #[test]
+    fn parse_u32_rejects_non_integer() {
+        let err = parse_u32("preemptexempttime", "abc").unwrap_err();
+        assert!(
+            err.to_string().contains("preemptexempttime"),
+            "error names the field: {err}"
+        );
+        assert!(
+            err.to_string().contains("abc"),
+            "error names the bad value: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_u32_rejects_negative() {
+        assert!(parse_u32("preemptexempttime", "-1").is_err());
+    }
+
+    #[test]
+    fn is_truthy_accepts_canonical_values() {
+        for v in &["1", "yes", "YES", "true", "True", "TRUE"] {
+            assert!(is_truthy(v), "{v} should be truthy");
+        }
+    }
+
+    #[test]
+    fn is_truthy_rejects_other_values() {
+        for v in &["0", "no", "false", "", "maybe"] {
+            assert!(!is_truthy(v), "{v} should not be truthy");
+        }
+    }
+
+    // --- clearpreemptexempttime must require explicit value ---
+
+    #[test]
+    fn clear_preempt_exempt_time_requires_truthy_value() {
+        // A bare key (parse_params maps it to "") must NOT trigger the clear.
+        let p: std::collections::HashMap<String, String> = [
+            ("name".into(), "q".into()),
+            ("clearpreemptexempttime".into(), "".into()),
+        ]
+        .into_iter()
+        .collect();
+        let req = build_modify_qos_request(&p).unwrap();
+        assert!(!req.clear_preempt_exempt_time, "bare key must not clear");
+    }
+
+    #[test]
+    fn clear_preempt_exempt_time_fires_on_explicit_one() {
+        let p: std::collections::HashMap<String, String> = [
+            ("name".into(), "q".into()),
+            ("clearpreemptexempttime".into(), "1".into()),
+        ]
+        .into_iter()
+        .collect();
+        let req = build_modify_qos_request(&p).unwrap();
+        assert!(req.clear_preempt_exempt_time);
+    }
+
+    #[test]
+    fn preempt_exempt_time_bad_value_errors() {
+        let p: std::collections::HashMap<String, String> = [
+            ("name".into(), "q".into()),
+            ("preemptexempttime".into(), "not-a-number".into()),
+        ]
+        .into_iter()
+        .collect();
+        assert!(
+            build_modify_qos_request(&p).is_err(),
+            "malformed preemptexempttime should error"
         );
     }
 }

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -118,6 +118,7 @@ const QOS_KEYS: &[&str] = &[
     "preemptmode",
     "preempt",
     "preemptexempttime",
+    "clearpreemptexempttime",
     "usagefactor",
     "maxjobsperuser",
     "maxjobspu",
@@ -488,6 +489,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                     preempt_exempt_time: p
                         .get("preemptexempttime")
                         .and_then(|v| v.parse::<u32>().ok()),
+                    clear_preempt_exempt_time: false,
                 })
                 .await
                 .context("CreateQos RPC failed")?;
@@ -654,6 +656,7 @@ fn build_modify_qos_request(
         preempt_exempt_time: p
             .get("preemptexempttime")
             .and_then(|v| v.parse::<u32>().ok()),
+        clear_preempt_exempt_time: p.contains_key("clearpreemptexempttime"),
     })
 }
 

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -116,6 +116,8 @@ const QOS_KEYS: &[&str] = &[
     "description",
     "priority",
     "preemptmode",
+    "preempt",
+    "preemptexempttime",
     "usagefactor",
     "maxjobsperuser",
     "maxjobspu",
@@ -469,6 +471,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                     description: Some(desc),
                     priority: Some(priority),
                     preempt_mode: Some(preempt.clone()),
+                    preempt: p.get("preempt").cloned(),
                     usage_factor: Some(usage_factor),
                     max_jobs_per_user: Some(max_jobs),
                     max_wall_minutes: Some(max_wall),
@@ -482,6 +485,9 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                     max_tres_per_user: Some(p.get("maxtresperuser").cloned().unwrap_or_default()),
                     grp_tres: Some(p.get("grptres").cloned().unwrap_or_default()),
                     grp_wall_minutes: Some(grp_wall),
+                    preempt_exempt_time: p
+                        .get("preemptexempttime")
+                        .and_then(|v| v.parse::<u32>().ok()),
                 })
                 .await
                 .context("CreateQos RPC failed")?;
@@ -622,6 +628,7 @@ fn build_modify_qos_request(
             .map(|v| parse_i32("priority", v))
             .transpose()?,
         preempt_mode: p.get("preemptmode").cloned(),
+        preempt: p.get("preempt").cloned(),
         usage_factor: p
             .get("usagefactor")
             .map(|v| parse_f64("usagefactor", v))
@@ -644,6 +651,9 @@ fn build_modify_qos_request(
             .get("grpwall")
             .map(|v| parse_wall_limit("grpwall", v))
             .transpose()?,
+        preempt_exempt_time: p
+            .get("preemptexempttime")
+            .and_then(|v| v.parse::<u32>().ok()),
     })
 }
 
@@ -949,7 +959,9 @@ fn qos_header(spec: char) -> &'static str {
         'N' => "Name",
         'D' => "Descr",
         'p' => "Priority",
-        'P' => "Preempt",
+        'P' => "PreemptMode",
+        'Q' => "Preempt",
+        'E' => "PreemptExemptTime",
         'U' => "UsageFactor",
         'G' => "GrpTRES",
         'T' => "MaxTRES",
@@ -967,7 +979,9 @@ fn qos_field_spec(name: &str) -> Option<char> {
         "name" => Some('N'),
         "description" | "descr" => Some('D'),
         "priority" | "prio" => Some('p'),
-        "preempt" | "preemptmode" => Some('P'),
+        "preemptmode" => Some('P'),
+        "preempt" => Some('Q'),
+        "preemptexempttime" => Some('E'),
         "usagefactor" => Some('U'),
         "grptres" => Some('G'),
         "maxtres" | "maxtrespj" | "maxtresperjob" => Some('T'),
@@ -986,6 +1000,8 @@ fn resolve_qos_field(q: &QosInfo, spec: char) -> String {
         'D' => q.description.clone(),
         'p' => q.priority.to_string(),
         'P' => q.preempt_mode.clone(),
+        'Q' => q.preempt.clone(),
+        'E' => blank_if_zero(q.preempt_exempt_time),
         'U' => format!("{}", q.usage_factor),
         'G' => q.grp_tres.clone(),
         'T' => q.max_tres_per_job.clone(),

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -147,6 +147,10 @@ pub enum ScontrolCommand {
         /// Preemption mode: OFF (default), CANCEL, REQUEUE, SUSPEND
         #[arg(long, default_value = "OFF")]
         preempt_mode: String,
+        /// Minimum seconds a job must run before it is eligible for preemption
+        /// (0 = immediately preemptable; omit to use the global default)
+        #[arg(long)]
+        preempt_exempt_time: Option<u32>,
     },
     /// Update a partition
     #[command(name = "update-partition")]
@@ -221,9 +225,13 @@ pub enum ScontrolCommand {
         #[arg(long)]
         preempt_mode: Option<String>,
         /// Minimum seconds a job must have been running before it is eligible for
-        /// preemption (0 = defer to global default)
+        /// preemption. 0 is a valid value (immediately preemptable).
         #[arg(long)]
         preempt_exempt_time: Option<u32>,
+        /// Clear the partition's preempt_exempt_time override, reverting to the
+        /// global scheduler.preempt_exempt_time default.
+        #[arg(long)]
+        clear_preempt_exempt_time: bool,
     },
     /// Delete a partition
     #[command(name = "delete-partition")]
@@ -391,6 +399,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             allow_qos,
             priority_tier,
             preempt_mode,
+            preempt_exempt_time,
         } => {
             create_partition(
                 &args.controller,
@@ -410,6 +419,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 &allow_qos,
                 priority_tier,
                 &preempt_mode,
+                preempt_exempt_time,
             )
             .await
         }
@@ -438,6 +448,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             priority_tier,
             preempt_mode,
             preempt_exempt_time,
+            clear_preempt_exempt_time,
         } => {
             let selector_map = match selector {
                 Some(ref s) => parse_selector(s)?,
@@ -468,6 +479,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 priority_tier,
                 preempt_mode,
                 preempt_exempt_time,
+                clear_preempt_exempt_time,
             };
             update_partition(&args.controller, req).await
         }
@@ -995,6 +1007,7 @@ async fn parse_and_create_partition(controller: &str, params: &[String]) -> Resu
     let mut deny_qos = String::new();
     let mut priority_tier: u32 = 1;
     let mut preempt_mode = "OFF".to_string();
+    let mut preempt_exempt_time: Option<u32> = None;
 
     for param in params {
         if let Some((key, value)) = param.split_once('=') {
@@ -1014,6 +1027,7 @@ async fn parse_and_create_partition(controller: &str, params: &[String]) -> Resu
                 "denyqos" => deny_qos = value.into(),
                 "prioritytier" | "priorityjobfactor" => priority_tier = value.parse().unwrap_or(1),
                 "preemptmode" => preempt_mode = value.to_uppercase(),
+                "preemptexempttime" => preempt_exempt_time = value.parse().ok(),
                 // silently ignore Slurm-only keys that don't map to spur fields
                 "allocnodes" | "hidden" | "rootonly" | "reqresv" | "oversubscribe"
                 | "overtimelimit" | "gracetime" | "disablerootjobs" | "exclusiveuser"
@@ -1046,6 +1060,7 @@ async fn parse_and_create_partition(controller: &str, params: &[String]) -> Resu
         &allow_qos,
         priority_tier,
         &preempt_mode,
+        preempt_exempt_time,
     )
     .await?;
 
@@ -1319,6 +1334,7 @@ async fn parse_and_update_partition(controller: &str, params: &[String]) -> Resu
     let mut priority_tier: Option<u32> = None;
     let mut preempt_mode: Option<String> = None;
     let mut preempt_exempt_time: Option<u32> = None;
+    let mut clear_preempt_exempt_time = false;
 
     for param in params {
         if let Some((key, value)) = param.split_once('=') {
@@ -1348,6 +1364,11 @@ async fn parse_and_update_partition(controller: &str, params: &[String]) -> Resu
                 "prioritytier" | "priorityjobfactor" => priority_tier = value.parse().ok(),
                 "preemptmode" => preempt_mode = Some(value.to_uppercase()),
                 "preemptexempttime" => preempt_exempt_time = value.parse().ok(),
+                "clearpreemptexempttime" => {
+                    clear_preempt_exempt_time = value.eq_ignore_ascii_case("yes")
+                        || value == "1"
+                        || value.eq_ignore_ascii_case("true");
+                }
                 // silently ignore Slurm-only keys
                 "allocnodes" | "hidden" | "rootonly" | "reqresv" | "oversubscribe"
                 | "overtimelimit" | "gracetime" | "disablerootjobs" | "exclusiveuser"
@@ -1388,6 +1409,7 @@ async fn parse_and_update_partition(controller: &str, params: &[String]) -> Resu
         priority_tier,
         preempt_mode,
         preempt_exempt_time,
+        clear_preempt_exempt_time,
     };
 
     update_partition(controller, req).await
@@ -1464,6 +1486,7 @@ async fn create_partition(
     allow_qos: &str,
     priority_tier: u32,
     preempt_mode: &str,
+    preempt_exempt_time: Option<u32>,
 ) -> Result<()> {
     let channel = crate::authclient::connect(controller)
         .await
@@ -1488,6 +1511,7 @@ async fn create_partition(
             allow_qos: split_csv(allow_qos),
             priority_tier,
             preempt_mode: preempt_mode.to_string(),
+            preempt_exempt_time,
         })
         .await
         .context("failed to create partition")?;

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -220,6 +220,10 @@ pub enum ScontrolCommand {
         /// New preemption mode: OFF, CANCEL, REQUEUE, SUSPEND
         #[arg(long)]
         preempt_mode: Option<String>,
+        /// Minimum seconds a job must have been running before it is eligible for
+        /// preemption (0 = defer to global default)
+        #[arg(long)]
+        preempt_exempt_time: Option<u32>,
     },
     /// Delete a partition
     #[command(name = "delete-partition")]
@@ -433,6 +437,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             set_allow_qos,
             priority_tier,
             preempt_mode,
+            preempt_exempt_time,
         } => {
             let selector_map = match selector {
                 Some(ref s) => parse_selector(s)?,
@@ -462,6 +467,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 set_allow_qos,
                 priority_tier,
                 preempt_mode,
+                preempt_exempt_time,
             };
             update_partition(&args.controller, req).await
         }
@@ -723,11 +729,15 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                         part.max_nodes.to_string()
                     },
                 );
-                println!(
+                print!(
                     "   PreemptMode={} PriorityTier={}",
                     part.preempt_mode.to_uppercase(),
                     part.priority_tier
                 );
+                if part.preempt_exempt_time > 0 {
+                    print!(" PreemptExemptTime={}", part.preempt_exempt_time);
+                }
+                println!();
                 println!();
             }
         }
@@ -1308,6 +1318,7 @@ async fn parse_and_update_partition(controller: &str, params: &[String]) -> Resu
     let mut allow_qos: Option<String> = None;
     let mut priority_tier: Option<u32> = None;
     let mut preempt_mode: Option<String> = None;
+    let mut preempt_exempt_time: Option<u32> = None;
 
     for param in params {
         if let Some((key, value)) = param.split_once('=') {
@@ -1336,6 +1347,7 @@ async fn parse_and_update_partition(controller: &str, params: &[String]) -> Resu
                 "allowqos" => allow_qos = Some(value.into()),
                 "prioritytier" | "priorityjobfactor" => priority_tier = value.parse().ok(),
                 "preemptmode" => preempt_mode = Some(value.to_uppercase()),
+                "preemptexempttime" => preempt_exempt_time = value.parse().ok(),
                 // silently ignore Slurm-only keys
                 "allocnodes" | "hidden" | "rootonly" | "reqresv" | "oversubscribe"
                 | "overtimelimit" | "gracetime" | "disablerootjobs" | "exclusiveuser"
@@ -1375,6 +1387,7 @@ async fn parse_and_update_partition(controller: &str, params: &[String]) -> Resu
         allow_qos: allow_qos.as_deref().map(split_csv).unwrap_or_default(),
         priority_tier,
         preempt_mode,
+        preempt_exempt_time,
     };
 
     update_partition(controller, req).await

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -746,8 +746,10 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                     part.preempt_mode.to_uppercase(),
                     part.priority_tier
                 );
-                if part.preempt_exempt_time > 0 {
-                    print!(" PreemptExemptTime={}", part.preempt_exempt_time);
+                if let Some(t) = part.preempt_exempt_time {
+                    if t > 0 {
+                        print!(" PreemptExemptTime={t}");
+                    }
                 }
                 println!();
                 println!();
@@ -1027,7 +1029,11 @@ async fn parse_and_create_partition(controller: &str, params: &[String]) -> Resu
                 "denyqos" => deny_qos = value.into(),
                 "prioritytier" | "priorityjobfactor" => priority_tier = value.parse().unwrap_or(1),
                 "preemptmode" => preempt_mode = value.to_uppercase(),
-                "preemptexempttime" => preempt_exempt_time = value.parse().ok(),
+                "preemptexempttime" => {
+                    preempt_exempt_time = Some(value.parse::<u32>().map_err(|_| {
+                        anyhow::anyhow!("invalid value for PreemptExemptTime=: '{value}'")
+                    })?);
+                }
                 // silently ignore Slurm-only keys that don't map to spur fields
                 "allocnodes" | "hidden" | "rootonly" | "reqresv" | "oversubscribe"
                 | "overtimelimit" | "gracetime" | "disablerootjobs" | "exclusiveuser"
@@ -1363,7 +1369,11 @@ async fn parse_and_update_partition(controller: &str, params: &[String]) -> Resu
                 "allowqos" => allow_qos = Some(value.into()),
                 "prioritytier" | "priorityjobfactor" => priority_tier = value.parse().ok(),
                 "preemptmode" => preempt_mode = Some(value.to_uppercase()),
-                "preemptexempttime" => preempt_exempt_time = value.parse().ok(),
+                "preemptexempttime" => {
+                    preempt_exempt_time = Some(value.parse::<u32>().map_err(|_| {
+                        anyhow::anyhow!("invalid value for PreemptExemptTime=: '{value}'")
+                    })?);
+                }
                 "clearpreemptexempttime" => {
                     clear_preempt_exempt_time = value.eq_ignore_ascii_case("yes")
                         || value == "1"

--- a/crates/spur-core/src/accounting.rs
+++ b/crates/spur-core/src/accounting.rs
@@ -147,6 +147,12 @@ pub struct Qos {
     /// Usage factor — multiplier for fair-share usage accounting.
     /// 0.0 = don't charge, 1.0 = normal, 2.0 = double charge.
     pub usage_factor: f64,
+    /// QOS names that jobs in this QOS are allowed to preempt. Only enforced
+    /// when `scheduler.preempt_type = qos_priority`. Empty means this QOS may
+    /// not preempt any other QOS under that mode. Mirrors Slurm's `Preempt=`
+    /// field on a QOS.
+    #[serde(default)]
+    pub preempt: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -181,6 +187,12 @@ pub struct QosLimits {
     pub grp_tres: Option<TresRecord>,
     pub max_wall_minutes: Option<u32>,
     pub grp_wall_minutes: Option<u32>,
+    /// Per-QOS override for the minimum seconds a job must have been running
+    /// before it is eligible for preemption. Overrides the partition value,
+    /// which in turn overrides the cluster-wide `preempt_exempt_time`. `None`
+    /// defers to the next level.
+    #[serde(default)]
+    pub preempt_exempt_time: Option<u32>,
 }
 
 impl Default for Account {
@@ -205,6 +217,7 @@ impl Default for Qos {
             preempt_mode: QosPreemptMode::Off,
             limits: QosLimits::default(),
             usage_factor: 1.0,
+            preempt: Vec::new(),
         }
     }
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use thiserror::Error;
 
-use crate::partition::{Partition, PartitionState, PreemptMode};
+use crate::partition::{Partition, PartitionState, PreemptMode, PreemptType};
 
 #[derive(Debug, Error)]
 pub enum ConfigError {
@@ -566,6 +566,19 @@ pub struct SchedulerConfig {
     /// operator-only. Raise it to grant users a band above the baseline.
     #[serde(default = "default_max_user_priority")]
     pub max_user_priority: u32,
+    /// Controls which jobs are eligible to preempt which. `None` (default)
+    /// enforces no cross-QOS restrictions — any job with sufficient priority gap
+    /// may preempt any other. `QosPriority` requires the pending job's QOS to
+    /// list the running job's QOS in its `preempt` allow-list. Mirrors Slurm's
+    /// `PreemptType`.
+    #[serde(default)]
+    pub preempt_type: PreemptType,
+    /// Cluster-wide minimum number of seconds a job must have been running before
+    /// it becomes eligible for preemption. Can be overridden per-partition and
+    /// per-QOS. `0` (default) means immediately eligible. Mirrors Slurm's
+    /// `PreemptExemptTime`.
+    #[serde(default)]
+    pub preempt_exempt_time: u32,
 }
 
 /// How often an interactive client (`salloc`/`srun`) pings the controller to
@@ -605,6 +618,8 @@ impl Default for SchedulerConfig {
             resv_overrun_minutes: 0,
             inactive_limit_secs: 0,
             max_user_priority: default_max_user_priority(),
+            preempt_type: PreemptType::None,
+            preempt_exempt_time: 0,
         }
     }
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -715,6 +715,11 @@ pub struct PartitionConfig {
     pub priority_tier: u32,
     #[serde(default)]
     pub preempt_mode: String,
+    /// Minimum seconds a job must have been running before it is eligible for
+    /// preemption from this partition. Overrides the cluster-wide default.
+    /// `None` defers to `scheduler.preempt_exempt_time`.
+    #[serde(default)]
+    pub preempt_exempt_time: Option<u32>,
 }
 
 fn default_partition_state() -> String {
@@ -1597,6 +1602,7 @@ impl SlurmConfig {
                     "suspend" => PreemptMode::Suspend,
                     _ => PreemptMode::Off,
                 },
+                preempt_exempt_time: pc.preempt_exempt_time,
                 ..Default::default()
             })
             .collect()

--- a/crates/spur-core/src/partition.rs
+++ b/crates/spur-core/src/partition.rs
@@ -37,6 +37,11 @@ pub struct Partition {
     /// Scheduling
     pub preempt_mode: PreemptMode,
     pub priority_tier: u32,
+    /// Partition-level override for the minimum seconds a job must have been
+    /// running before it is eligible for preemption. `None` defers to the
+    /// cluster-wide `preempt_exempt_time` in `SchedulerConfig`.
+    #[serde(default)]
+    pub preempt_exempt_time: Option<u32>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -62,6 +67,18 @@ impl std::fmt::Display for PartitionState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.display())
     }
+}
+
+/// Controls cross-QOS preemption eligibility. Mirrors Slurm's `PreemptType`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum PreemptType {
+    /// No QOS-level restrictions — eligibility is determined solely by priority
+    /// gap, partition mode, and reservation tier (existing behaviour).
+    #[default]
+    None,
+    /// A pending job may only preempt a running job when the pending job's QOS
+    /// lists the running job's QOS in its `preempt` allow-list.
+    QosPriority,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -138,6 +155,7 @@ impl Default for Partition {
             deny_qos: Vec::new(),
             preempt_mode: PreemptMode::Off,
             priority_tier: 1,
+            preempt_exempt_time: None,
         }
     }
 }

--- a/crates/spur-core/src/partition.rs
+++ b/crates/spur-core/src/partition.rs
@@ -71,6 +71,7 @@ impl std::fmt::Display for PartitionState {
 
 /// Controls cross-QOS preemption eligibility. Mirrors Slurm's `PreemptType`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
 pub enum PreemptType {
     /// No QOS-level restrictions — eligibility is determined solely by priority
     /// gap, partition mode, and reservation tier (existing behaviour).

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -253,6 +253,8 @@ pub enum WalOperation {
         priority_tier: Option<u32>,
         preempt_mode: Option<String>,
         is_default: Option<bool>,
+        #[serde(default)]
+        preempt_exempt_time: Option<Option<u32>>,
     },
     PartitionDelete {
         name: String,

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -91,6 +91,7 @@ CREATE TABLE IF NOT EXISTS qos (
     description     TEXT NOT NULL DEFAULT '',
     priority        INTEGER NOT NULL DEFAULT 0,
     preempt_mode    TEXT NOT NULL DEFAULT 'off',
+    preempt         TEXT NOT NULL DEFAULT '',
     usage_factor    REAL NOT NULL DEFAULT 1.0,
     max_jobs_per_user INTEGER,
     max_submit_per_user INTEGER,
@@ -99,6 +100,7 @@ CREATE TABLE IF NOT EXISTS qos (
     grp_tres        TEXT,
     max_wall_min    INTEGER,
     grp_wall_min    INTEGER,
+    preempt_exempt_time INTEGER,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
@@ -144,6 +146,8 @@ ALTER TABLE associations ADD COLUMN IF NOT EXISTS default_qos TEXT;
 ALTER TABLE associations ADD COLUMN IF NOT EXISTS allowed_qos TEXT;
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS grp_wall_min INTEGER;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS grp_tres TEXT;
+ALTER TABLE qos ADD COLUMN IF NOT EXISTS preempt TEXT NOT NULL DEFAULT '';
+ALTER TABLE qos ADD COLUMN IF NOT EXISTS preempt_exempt_time INTEGER;
 
 -- users.default_account is the single source of truth for a user's default
 -- account (the scheduler reads it via the association cache). associations
@@ -975,6 +979,8 @@ pub struct QosUpdate<'a> {
     pub description: Option<&'a str>,
     pub priority: Option<i32>,
     pub preempt_mode: Option<&'a str>,
+    /// Comma-separated QOS names; `Some("")` clears the list.
+    pub preempt: Option<&'a str>,
     pub usage_factor: Option<f64>,
     pub max_jobs_per_user: Option<Option<i32>>,
     pub max_wall_min: Option<Option<i32>>,
@@ -983,6 +989,7 @@ pub struct QosUpdate<'a> {
     pub max_tres_per_user: Option<Option<&'a str>>,
     pub grp_tres: Option<Option<&'a str>>,
     pub grp_wall_min: Option<Option<i32>>,
+    pub preempt_exempt_time: Option<Option<i32>>,
 }
 
 /// Create or update a QOS, writing only the fields set in `u`. `modify` sends
@@ -1023,6 +1030,12 @@ pub async fn upsert_qos<'a>(pool: &PgPool, name: &'a str, u: QosUpdate<'a>) -> a
     }
     if let Some(v) = u.grp_wall_min {
         updates.push(("grp_wall_min", SqlVal::NullInt(v)));
+    }
+    if let Some(v) = u.preempt {
+        updates.push(("preempt", SqlVal::Text(v)));
+    }
+    if let Some(v) = u.preempt_exempt_time {
+        updates.push(("preempt_exempt_time", SqlVal::NullInt(v)));
     }
     upsert_row(pool, UpsertTable::Qos, &keys, &updates).await
 }
@@ -1069,7 +1082,7 @@ pub async fn missing_qos(pool: &PgPool, names: &[&str]) -> anyhow::Result<Vec<St
 /// List all QOS.
 pub async fn list_qos(pool: &PgPool) -> anyhow::Result<Vec<QosRecord>> {
     let rows = sqlx::query(
-        "SELECT name, description, priority, preempt_mode, usage_factor, max_jobs_per_user, max_wall_min, max_tres_per_job, max_submit_per_user, max_tres_per_user, grp_tres, grp_wall_min FROM qos ORDER BY name"
+        "SELECT name, description, priority, preempt_mode, preempt, usage_factor, max_jobs_per_user, max_wall_min, max_tres_per_job, max_submit_per_user, max_tres_per_user, grp_tres, grp_wall_min, preempt_exempt_time FROM qos ORDER BY name"
     ).fetch_all(pool).await?;
 
     Ok(rows
@@ -1079,6 +1092,7 @@ pub async fn list_qos(pool: &PgPool) -> anyhow::Result<Vec<QosRecord>> {
             description: r.get("description"),
             priority: r.get("priority"),
             preempt_mode: r.get("preempt_mode"),
+            preempt: r.get::<Option<String>, _>("preempt").unwrap_or_default(),
             // Column is REAL (f32) in the schema; widen to the struct's f64.
             usage_factor: r.get::<f32, _>("usage_factor") as f64,
             max_jobs_per_user: r.get("max_jobs_per_user"),
@@ -1088,6 +1102,7 @@ pub async fn list_qos(pool: &PgPool) -> anyhow::Result<Vec<QosRecord>> {
             max_tres_per_user: r.get("max_tres_per_user"),
             grp_tres: r.get("grp_tres"),
             grp_wall_min: r.get("grp_wall_min"),
+            preempt_exempt_time: r.get("preempt_exempt_time"),
         })
         .collect())
 }
@@ -1098,6 +1113,8 @@ pub struct QosRecord {
     pub description: String,
     pub priority: i32,
     pub preempt_mode: String,
+    /// Comma-separated QOS names this QOS may preempt; empty string = none.
+    pub preempt: String,
     pub usage_factor: f64,
     pub max_jobs_per_user: Option<i32>,
     pub max_wall_min: Option<i32>,
@@ -1106,6 +1123,7 @@ pub struct QosRecord {
     pub max_tres_per_user: Option<String>,
     pub grp_tres: Option<String>,
     pub grp_wall_min: Option<i32>,
+    pub preempt_exempt_time: Option<i32>,
 }
 
 #[cfg(test)]
@@ -1400,6 +1418,7 @@ mod job_history_tests {
                 description: Some("d"),
                 priority: Some(5),
                 preempt_mode: Some("cluster"),
+                preempt: None,
                 usage_factor: Some(1.5),
                 max_jobs_per_user: Some(Some(3)),
                 max_wall_min: Some(Some(60)),
@@ -1408,6 +1427,7 @@ mod job_history_tests {
                 max_tres_per_user: Some(Some("cpu=16")),
                 grp_tres: Some(Some("cpu=64")),
                 grp_wall_min: Some(Some(120)),
+                preempt_exempt_time: None,
             },
         )
         .await?;

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -548,6 +548,7 @@ impl SlurmAccounting for AccountingService {
             description: req.description.as_deref(),
             priority: req.priority,
             preempt_mode: req.preempt_mode.as_deref(),
+            preempt: req.preempt.as_deref(),
             usage_factor: req.usage_factor,
             max_jobs_per_user: nullable_limit(req.max_jobs_per_user, "max_jobs_per_user")?,
             max_wall_min: nullable_limit(req.max_wall_minutes, "max_wall_minutes")?,
@@ -559,6 +560,9 @@ impl SlurmAccounting for AccountingService {
             max_tres_per_user: nullable_str(&req.max_tres_per_user),
             grp_tres: nullable_str(&req.grp_tres),
             grp_wall_min: nullable_limit(req.grp_wall_minutes, "grp_wall_minutes")?,
+            preempt_exempt_time: req
+                .preempt_exempt_time
+                .map(|v| if v == 0 { None } else { Some(v as i32) }),
         };
         db::upsert_qos(pool, &req.name, update)
             .await
@@ -591,6 +595,7 @@ impl SlurmAccounting for AccountingService {
                 description: r.description,
                 priority: r.priority,
                 preempt_mode: r.preempt_mode,
+                preempt: r.preempt,
                 usage_factor: r.usage_factor,
                 max_jobs_per_user: r.max_jobs_per_user.unwrap_or(0) as u32,
                 max_wall_minutes: r.max_wall_min.unwrap_or(0) as u32,
@@ -599,6 +604,7 @@ impl SlurmAccounting for AccountingService {
                 max_tres_per_user: r.max_tres_per_user.unwrap_or_default(),
                 grp_tres: r.grp_tres.unwrap_or_default(),
                 grp_wall_minutes: r.grp_wall_min.unwrap_or(0) as u32,
+                preempt_exempt_time: r.preempt_exempt_time.unwrap_or(0) as u32,
             })
             .collect();
 

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -560,9 +560,11 @@ impl SlurmAccounting for AccountingService {
             max_tres_per_user: nullable_str(&req.max_tres_per_user),
             grp_tres: nullable_str(&req.grp_tres),
             grp_wall_min: nullable_limit(req.grp_wall_minutes, "grp_wall_minutes")?,
-            preempt_exempt_time: req
-                .preempt_exempt_time
-                .map(|v| if v == 0 { None } else { Some(v as i32) }),
+            preempt_exempt_time: if req.clear_preempt_exempt_time {
+                Some(None)
+            } else {
+                req.preempt_exempt_time.map(|v| Some(v as i32))
+            },
         };
         db::upsert_qos(pool, &req.name, update)
             .await

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -544,11 +544,34 @@ impl SlurmAccounting for AccountingService {
         if let Some(t) = &req.grp_tres {
             validate_tres("grptres", t)?;
         }
+        // Validate that every QOS name in the preempt allow-list exists before
+        // writing — a typo here becomes silent dead config that could retroactively
+        // grant preempt rights if a QOS with that name is created later.
+        let preempt_normalized: Option<String> = match req.preempt.as_deref() {
+            None | Some("") => req.preempt.clone(),
+            Some(list) => {
+                let names: Vec<&str> = list
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                let missing = db::missing_qos(pool, &names)
+                    .await
+                    .map_err(|e| Status::internal(e.to_string()))?;
+                if let Some(name) = missing.first() {
+                    return Err(Status::not_found(format!(
+                        "QOS '{name}' does not exist (in preempt allow-list)"
+                    )));
+                }
+                Some(names.join(","))
+            }
+        };
+
         let update = db::QosUpdate {
             description: req.description.as_deref(),
             priority: req.priority,
             preempt_mode: req.preempt_mode.as_deref(),
-            preempt: req.preempt.as_deref(),
+            preempt: preempt_normalized.as_deref(),
             usage_factor: req.usage_factor,
             max_jobs_per_user: nullable_limit(req.max_jobs_per_user, "max_jobs_per_user")?,
             max_wall_min: nullable_limit(req.max_wall_minutes, "max_wall_minutes")?,
@@ -606,7 +629,7 @@ impl SlurmAccounting for AccountingService {
                 max_tres_per_user: r.max_tres_per_user.unwrap_or_default(),
                 grp_tres: r.grp_tres.unwrap_or_default(),
                 grp_wall_minutes: r.grp_wall_min.unwrap_or(0) as u32,
-                preempt_exempt_time: r.preempt_exempt_time.unwrap_or(0) as u32,
+                preempt_exempt_time: r.preempt_exempt_time.map(|v| v as u32),
             })
             .collect();
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3558,6 +3558,7 @@ impl ClusterManager {
         allow_qos: Option<Vec<String>>,
         priority_tier: Option<u32>,
         preempt_mode: Option<String>,
+        preempt_exempt_time: Option<Option<u32>>,
     ) -> Result<(), PartitionError> {
         if !self.partitions.read().iter().any(|p| p.name == name) {
             return Err(PartitionError::not_found(format!(
@@ -3614,6 +3615,7 @@ impl ClusterManager {
             priority_tier,
             preempt_mode,
             is_default,
+            preempt_exempt_time,
         })
         .map_err(|e| PartitionError::raft(e.to_string()))?;
         Ok(())
@@ -3735,6 +3737,7 @@ impl ClusterManager {
                 priority_tier: Some(part.priority_tier),
                 preempt_mode: Some(preempt_str.to_string()),
                 is_default: Some(part.is_default),
+                preempt_exempt_time: Some(part.preempt_exempt_time),
             })
             .map_err(|e| anyhow::anyhow!("reconfigure: update {}: {e}", part.name))?;
         }
@@ -5533,6 +5536,7 @@ impl ClusterManager {
                 priority_tier,
                 preempt_mode,
                 is_default,
+                preempt_exempt_time,
             } => {
                 {
                     let mut partitions = self.partitions.write();
@@ -5592,6 +5596,9 @@ impl ClusterManager {
                         }
                         if let Some(def) = is_default {
                             part.is_default = *def;
+                        }
+                        if let Some(et) = preempt_exempt_time {
+                            part.preempt_exempt_time = *et;
                         }
                         info!(name, "partition updated");
                     } else {
@@ -12712,7 +12719,7 @@ mod tests {
         let high_job = cm.get_job(high_id).unwrap();
         let partitions = cm.get_partitions();
 
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job]).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job], &cm.config().scheduler).await;
         assert_eq!(cm.get_job(low_id).unwrap().state, JobState::Running);
     }
 
@@ -12746,7 +12753,7 @@ mod tests {
         let high_job = cm.get_job(high_id).unwrap();
         let partitions = cm.get_partitions();
 
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job]).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job], &cm.config().scheduler).await;
         assert_eq!(cm.get_job(low_id).unwrap().state, JobState::Running);
     }
 
@@ -12787,7 +12794,7 @@ mod tests {
         let pending = cm.pending_jobs();
         let pending_refs: Vec<&Job> = pending.iter().collect();
         let partitions = cm.get_partitions();
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler).await;
 
         settle(&cm, low_id, JobState::Cancelled);
     }
@@ -12845,7 +12852,7 @@ mod tests {
              for preemption to fire"
         );
 
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler).await;
 
         settle(&cm, burst_id, JobState::Cancelled);
         assert_eq!(
@@ -12900,7 +12907,7 @@ mod tests {
         let pending = cm.pending_jobs();
         let pending_refs: Vec<&Job> = pending.iter().collect();
         let partitions = cm.get_partitions();
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler).await;
 
         // burst job must still be running — equal explicit priorities, no preemption.
         let burst_job = cm.get_job(burst_id).unwrap();
@@ -12985,7 +12992,7 @@ mod tests {
         let high_job = cm.get_job(high_id).unwrap();
         let partitions = cm.get_partitions();
 
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job]).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job], &cm.config().scheduler).await;
 
         // Suspended, not Cancelled: proves the QoS override reached the real
         // preemption action, not just the pure job_preempt_mode() decision.
@@ -19923,6 +19930,7 @@ mod tests {
             priority_tier: None,
             preempt_mode: None,
             is_default: None,
+            preempt_exempt_time: None,
         });
 
         let gpu = cm
@@ -20045,6 +20053,7 @@ mod tests {
             priority_tier: None,
             preempt_mode: None,
             is_default: None,
+            preempt_exempt_time: None,
         });
 
         assert_eq!(
@@ -20089,6 +20098,7 @@ mod tests {
             priority_tier: None,
             preempt_mode: None,
             is_default: Some(true),
+            preempt_exempt_time: None,
         });
 
         let parts = cm.get_partitions();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3737,7 +3737,9 @@ impl ClusterManager {
                 priority_tier: Some(part.priority_tier),
                 preempt_mode: Some(preempt_str.to_string()),
                 is_default: Some(part.is_default),
-                preempt_exempt_time: Some(part.preempt_exempt_time),
+                // Only push a WAL change when TOML explicitly sets the field;
+                // absent means "leave whatever the runtime WAL already has".
+                preempt_exempt_time: part.preempt_exempt_time.map(Some),
             })
             .map_err(|e| anyhow::anyhow!("reconfigure: update {}: {e}", part.name))?;
         }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -12852,7 +12852,9 @@ mod tests {
         let partitions = cm.get_partitions();
 
         let burst_job = cm.get_job(burst_id).unwrap();
-        let burst_effective = cm.current_effective_priority(&burst_job, &partitions);
+        let burst_qos = cm.resolve_qos(&burst_job);
+        let burst_effective =
+            cm.current_effective_priority_with_qos(&burst_job, &burst_qos, &partitions);
         let primus_effective = pending_refs[0].priority;
         assert!(
             primus_effective >= burst_effective * 2,

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -12852,9 +12852,7 @@ mod tests {
         let partitions = cm.get_partitions();
 
         let burst_job = cm.get_job(burst_id).unwrap();
-        let burst_qos = cm.resolve_qos(&burst_job);
-        let burst_effective =
-            cm.current_effective_priority_with_qos(&burst_job, &burst_qos, &partitions);
+        let burst_effective = cm.current_effective_priority(&burst_job, &partitions);
         let primus_effective = pending_refs[0].priority;
         assert!(
             primus_effective >= burst_effective * 2,

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -6982,6 +6982,7 @@ mod tests {
                 allow_qos: Vec::new(),
                 priority_tier: 1,
                 preempt_mode: String::new(),
+            preempt_exempt_time: None,
             }],
             nodes: Vec::new(),
             network: Default::default(),
@@ -7587,6 +7588,7 @@ mod tests {
             allow_qos: Vec::new(),
             priority_tier: 1,
             preempt_mode: String::new(),
+            preempt_exempt_time: None,
         });
         config.hooks.job_submit = Some(write_hook_script(&dir, r#"echo '{"partition":"small"}'"#));
         let cm = test_cluster_with_config(&dir, config).await;
@@ -7764,6 +7766,7 @@ mod tests {
             allow_qos: Vec::new(),
             priority_tier: 1,
             preempt_mode: String::new(),
+            preempt_exempt_time: None,
         });
         config.hooks.job_submit_lua = Some(write_lua_script(
             &dir,
@@ -12915,6 +12918,155 @@ mod tests {
             burst_job.state,
             JobState::Running,
             "burst job must keep running when both jobs have identical explicit --priority"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn qos_preempt_hierarchy_blocks_preemption_when_not_in_allow_list() {
+        // With preempt_type = qos_priority, a pending job may only preempt a
+        // running job when the pending job's QOS lists the running QOS in its
+        // `preempt` allow-list. Here "high" does NOT list "low", so even though
+        // "high" has a priority gap > 2x, preemption must be blocked.
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.partitions[0].preempt_mode = "cancel".into();
+        config.scheduler.preempt_type = spur_core::partition::PreemptType::QosPriority;
+        let cm = test_cluster_with_config(&dir, config).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.qos_cache().insert(Qos {
+            name: "low".into(),
+            priority: 100,
+            ..Default::default()
+        });
+        cm.qos_cache().insert(Qos {
+            name: "high".into(),
+            priority: 10000,
+            preempt: vec![],   // empty = not allowed to preempt anything
+            ..Default::default()
+        });
+
+        let mut low = basic_spec("low");
+        low.qos = Some("low".into());
+        let low_id = submit_and_wait(&cm, low);
+        let res = scalar_alloc(2, 4000);
+        cm.start_job(
+            low_id,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res),
+        )
+        .unwrap();
+        settle(&cm, low_id, JobState::Running);
+
+        let mut high = basic_spec("high");
+        high.qos = Some("high".into());
+        submit_and_wait(&cm, high);
+
+        let pending = cm.pending_jobs();
+        let pending_refs: Vec<&Job> = pending.iter().collect();
+        let partitions = cm.get_partitions();
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler).await;
+
+        // low job must still be running — "high" QOS is not allowed to preempt "low"
+        assert_eq!(
+            cm.get_job(low_id).unwrap().state,
+            JobState::Running,
+            "preemption must be blocked when pending QOS allow-list does not include running QOS"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn qos_preempt_hierarchy_allows_preemption_when_in_allow_list() {
+        // With preempt_type = qos_priority and "high" explicitly listing "low"
+        // in its preempt allow-list, the preemption must fire.
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.partitions[0].preempt_mode = "cancel".into();
+        config.scheduler.preempt_type = spur_core::partition::PreemptType::QosPriority;
+        let cm = test_cluster_with_config(&dir, config).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.qos_cache().insert(Qos {
+            name: "low".into(),
+            priority: 100,
+            ..Default::default()
+        });
+        cm.qos_cache().insert(Qos {
+            name: "high".into(),
+            priority: 10000,
+            preempt: vec!["low".into()],
+            ..Default::default()
+        });
+
+        let mut low = basic_spec("low");
+        low.qos = Some("low".into());
+        let low_id = submit_and_wait(&cm, low);
+        let res = scalar_alloc(2, 4000);
+        cm.start_job(
+            low_id,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res),
+        )
+        .unwrap();
+        settle(&cm, low_id, JobState::Running);
+
+        let mut high = basic_spec("high");
+        high.qos = Some("high".into());
+        submit_and_wait(&cm, high);
+
+        let pending = cm.pending_jobs();
+        let pending_refs: Vec<&Job> = pending.iter().collect();
+        let partitions = cm.get_partitions();
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler).await;
+
+        settle(&cm, low_id, JobState::Cancelled);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_exempt_time_protects_recently_started_job() {
+        // A job that started less than preempt_exempt_time seconds ago must not
+        // be preempted even when the priority gap is large enough.
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.partitions[0].preempt_mode = "cancel".into();
+        // Set a very large exempt window so a job started "just now" is always protected.
+        config.scheduler.preempt_exempt_time = 3600;
+        let cm = test_cluster_with_config(&dir, config).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        let mut low = basic_spec("low");
+        low.priority = Some(100);
+        let low_id = submit_and_wait(&cm, low);
+        let res = scalar_alloc(2, 4000);
+        cm.start_job(
+            low_id,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res),
+        )
+        .unwrap();
+        settle(&cm, low_id, JobState::Running);
+
+        // Confirm the job has a start_time (required for exempt check to fire).
+        let low_job = cm.get_job(low_id).unwrap();
+        assert!(low_job.start_time.is_some(), "running job must have a start_time");
+
+        let mut high = basic_spec("high");
+        high.priority = Some(10_000);
+        submit_and_wait(&cm, high);
+
+        let pending = cm.pending_jobs();
+        let pending_refs: Vec<&Job> = pending.iter().collect();
+        let partitions = cm.get_partitions();
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler).await;
+
+        // low job must still be running — it was started moments ago and is within the exempt window
+        assert_eq!(
+            cm.get_job(low_id).unwrap().state,
+            JobState::Running,
+            "job started within preempt_exempt_time window must not be preempted"
         );
     }
 
@@ -18791,6 +18943,7 @@ mod tests {
                 allow_qos: Vec::new(),
                 priority_tier: 1,
                 preempt_mode: String::new(),
+            preempt_exempt_time: None,
             },
             spur_core::config::PartitionConfig {
                 name: "train".into(),
@@ -18809,6 +18962,7 @@ mod tests {
                 allow_qos: Vec::new(),
                 priority_tier: 1,
                 preempt_mode: String::new(),
+            preempt_exempt_time: None,
             },
         ];
         let cm = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
@@ -18868,6 +19022,7 @@ mod tests {
             allow_qos: Vec::new(),
             priority_tier: 1,
             preempt_mode: String::new(),
+            preempt_exempt_time: None,
         }];
         let cm = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
         let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cm.clone())

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -6982,7 +6982,7 @@ mod tests {
                 allow_qos: Vec::new(),
                 priority_tier: 1,
                 preempt_mode: String::new(),
-            preempt_exempt_time: None,
+                preempt_exempt_time: None,
             }],
             nodes: Vec::new(),
             network: Default::default(),
@@ -12722,7 +12722,8 @@ mod tests {
         let high_job = cm.get_job(high_id).unwrap();
         let partitions = cm.get_partitions();
 
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job], &cm.config().scheduler).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job], &cm.config().scheduler)
+            .await;
         assert_eq!(cm.get_job(low_id).unwrap().state, JobState::Running);
     }
 
@@ -12756,7 +12757,8 @@ mod tests {
         let high_job = cm.get_job(high_id).unwrap();
         let partitions = cm.get_partitions();
 
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job], &cm.config().scheduler).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job], &cm.config().scheduler)
+            .await;
         assert_eq!(cm.get_job(low_id).unwrap().state, JobState::Running);
     }
 
@@ -12797,7 +12799,8 @@ mod tests {
         let pending = cm.pending_jobs();
         let pending_refs: Vec<&Job> = pending.iter().collect();
         let partitions = cm.get_partitions();
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler)
+            .await;
 
         settle(&cm, low_id, JobState::Cancelled);
     }
@@ -12855,7 +12858,8 @@ mod tests {
              for preemption to fire"
         );
 
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler)
+            .await;
 
         settle(&cm, burst_id, JobState::Cancelled);
         assert_eq!(
@@ -12910,7 +12914,8 @@ mod tests {
         let pending = cm.pending_jobs();
         let pending_refs: Vec<&Job> = pending.iter().collect();
         let partitions = cm.get_partitions();
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler)
+            .await;
 
         // burst job must still be running — equal explicit priorities, no preemption.
         let burst_job = cm.get_job(burst_id).unwrap();
@@ -12942,7 +12947,7 @@ mod tests {
         cm.qos_cache().insert(Qos {
             name: "high".into(),
             priority: 10000,
-            preempt: vec![],   // empty = not allowed to preempt anything
+            preempt: vec![], // empty = not allowed to preempt anything
             ..Default::default()
         });
 
@@ -12966,7 +12971,8 @@ mod tests {
         let pending = cm.pending_jobs();
         let pending_refs: Vec<&Job> = pending.iter().collect();
         let partitions = cm.get_partitions();
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler)
+            .await;
 
         // low job must still be running — "high" QOS is not allowed to preempt "low"
         assert_eq!(
@@ -13019,7 +13025,8 @@ mod tests {
         let pending = cm.pending_jobs();
         let pending_refs: Vec<&Job> = pending.iter().collect();
         let partitions = cm.get_partitions();
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler)
+            .await;
 
         settle(&cm, low_id, JobState::Cancelled);
     }
@@ -13051,7 +13058,10 @@ mod tests {
 
         // Confirm the job has a start_time (required for exempt check to fire).
         let low_job = cm.get_job(low_id).unwrap();
-        assert!(low_job.start_time.is_some(), "running job must have a start_time");
+        assert!(
+            low_job.start_time.is_some(),
+            "running job must have a start_time"
+        );
 
         let mut high = basic_spec("high");
         high.priority = Some(10_000);
@@ -13060,7 +13070,8 @@ mod tests {
         let pending = cm.pending_jobs();
         let pending_refs: Vec<&Job> = pending.iter().collect();
         let partitions = cm.get_partitions();
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler)
+            .await;
 
         // low job must still be running — it was started moments ago and is within the exempt window
         assert_eq!(
@@ -13144,7 +13155,8 @@ mod tests {
         let high_job = cm.get_job(high_id).unwrap();
         let partitions = cm.get_partitions();
 
-        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job], &cm.config().scheduler).await;
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job], &cm.config().scheduler)
+            .await;
 
         // Suspended, not Cancelled: proves the QoS override reached the real
         // preemption action, not just the pure job_preempt_mode() decision.
@@ -18943,7 +18955,7 @@ mod tests {
                 allow_qos: Vec::new(),
                 priority_tier: 1,
                 preempt_mode: String::new(),
-            preempt_exempt_time: None,
+                preempt_exempt_time: None,
             },
             spur_core::config::PartitionConfig {
                 name: "train".into(),
@@ -18962,7 +18974,7 @@ mod tests {
                 allow_qos: Vec::new(),
                 priority_tier: 1,
                 preempt_mode: String::new(),
-            preempt_exempt_time: None,
+                preempt_exempt_time: None,
             },
         ];
         let cm = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -123,6 +123,13 @@ fn qos_from_record(r: crate::accounting::db::QosRecord) -> Qos {
         description: r.description,
         priority: r.priority,
         preempt_mode: r.preempt_mode.parse::<QosPreemptMode>().unwrap_or_default(),
+        preempt: r
+            .preempt
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect(),
         limits: QosLimits {
             max_jobs_per_user: opt_u32(r.max_jobs_per_user),
             max_submit_jobs_per_user: opt_u32(r.max_submit_per_user),
@@ -131,6 +138,7 @@ fn qos_from_record(r: crate::accounting::db::QosRecord) -> Qos {
             grp_tres: opt_tres(r.grp_tres),
             max_wall_minutes: opt_u32(r.max_wall_min),
             grp_wall_minutes: opt_u32(r.grp_wall_min),
+            preempt_exempt_time: r.preempt_exempt_time.map(|v| v as u32),
         },
         usage_factor: r.usage_factor,
     }
@@ -146,11 +154,7 @@ mod tests {
     fn make_qos(name: &str) -> Qos {
         Qos {
             name: name.into(),
-            description: String::new(),
-            priority: 0,
-            preempt_mode: QosPreemptMode::default(),
-            limits: QosLimits::default(),
-            usage_factor: 1.0,
+            ..Default::default()
         }
     }
 
@@ -227,6 +231,7 @@ mod tests {
             description: "High priority QoS".into(),
             priority: 100,
             preempt_mode: "cancel".into(),
+            preempt: String::new(),
             usage_factor: 2.0,
             max_jobs_per_user: Some(10),
             max_wall_min: Some(60),
@@ -235,6 +240,7 @@ mod tests {
             max_tres_per_user: Some("cpu=64".into()),
             grp_tres: Some("gpu=8".into()),
             grp_wall_min: Some(120),
+            preempt_exempt_time: None,
         };
 
         let qos = qos_from_record(record);
@@ -275,6 +281,7 @@ mod tests {
             description: String::new(),
             priority: 0,
             preempt_mode: "off".into(),
+            preempt: String::new(),
             usage_factor: 1.0,
             max_jobs_per_user: Some(0),
             max_wall_min: None,
@@ -283,6 +290,7 @@ mod tests {
             max_tres_per_user: None,
             grp_tres: None,
             grp_wall_min: Some(0),
+            preempt_exempt_time: None,
         };
 
         let qos = qos_from_record(record);

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -430,6 +430,7 @@ fn default_config() -> spur_core::config::SlurmConfig {
             allow_qos: Vec::new(),
             priority_tier: 1,
             preempt_mode: String::new(),
+            preempt_exempt_time: None,
         }],
         nodes: Vec::new(),
         network: Default::default(),

--- a/crates/spurctld/src/metrics_server.rs
+++ b/crates/spurctld/src/metrics_server.rs
@@ -176,6 +176,7 @@ mod tests {
                 allow_qos: Vec::new(),
                 priority_tier: 1,
                 preempt_mode: String::new(),
+                preempt_exempt_time: None,
             }],
             nodes: Vec::new(),
             network: Default::default(),

--- a/crates/spurctld/src/rpc_middleware.rs
+++ b/crates/spurctld/src/rpc_middleware.rs
@@ -186,6 +186,7 @@ mod tests {
                     allow_qos: Vec::new(),
                     priority_tier: 1,
                     preempt_mode: String::new(),
+                    preempt_exempt_time: None,
                 }],
                 nodes: Vec::new(),
                 network: Default::default(),

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -203,7 +203,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 // "no suitable nodes at all".
                 cluster.update_pending_reasons(&unscheduled, &cluster_state);
 
-                try_preempt(&cluster, &partitions, &unscheduled).await;
+                try_preempt(&cluster, &partitions, &unscheduled, &cluster.config().scheduler).await;
 
                 // Federation: forward still-unschedulable jobs to peer clusters.
                 if !cluster.config().federation.clusters.is_empty() {
@@ -534,16 +534,33 @@ fn job_preempt_mode(
         .unwrap_or(PreemptMode::Off)
 }
 
+/// Effective preempt-exempt seconds for a running job: QOS > partition > global.
+fn effective_exempt_secs(
+    job: &spur_core::job::Job,
+    partitions: &[spur_core::partition::Partition],
+    qos: &spur_core::accounting::Qos,
+    sched: &spur_core::config::SchedulerConfig,
+) -> u32 {
+    if let Some(t) = qos.limits.preempt_exempt_time {
+        return t;
+    }
+    spur_core::partition::matched_partitions(job.spec.partition.as_deref(), partitions)
+        .into_iter()
+        .find_map(|p| p.preempt_exempt_time)
+        .unwrap_or(sched.preempt_exempt_time)
+}
+
 /// Preempt lower-priority running jobs per their partition PreemptMode
 /// (Off jobs are never preempted).
 pub(crate) async fn try_preempt(
     cluster: &Arc<ClusterManager>,
     partitions: &[spur_core::partition::Partition],
     unscheduled: &[&spur_core::job::Job],
+    sched: &spur_core::config::SchedulerConfig,
 ) {
     use crate::cluster::PreemptOutcome;
     use spur_core::job::JobState;
-    use spur_core::partition::{Partition, PreemptMode};
+    use spur_core::partition::{Partition, PreemptMode, PreemptType};
     use spur_core::reservation::job_runs_in_active_reservation;
 
     let now = chrono::Utc::now();
@@ -578,6 +595,14 @@ pub(crate) async fn try_preempt(
         .collect();
     running.sort_by_key(|j| running_priority[&j.job_id]);
 
+    // Pending job's QOS is resolved once per pending job; used for the
+    // QosPriority hierarchy check.
+    let pending_qos_map: std::collections::HashMap<spur_core::job::JobId, spur_core::accounting::Qos> =
+        unscheduled
+            .iter()
+            .map(|j| (j.job_id, cluster.resolve_qos(j)))
+            .collect();
+
     for pending in unscheduled {
         let Some(pending_part) = partition_for(pending) else {
             continue;
@@ -586,6 +611,7 @@ pub(crate) async fn try_preempt(
             continue;
         }
         let pending_tier = pending_part.priority_tier;
+        let pending_qos = &pending_qos_map[&pending.job_id];
 
         for candidate in &running {
             let candidate_priority = running_priority[&candidate.job_id];
@@ -606,7 +632,26 @@ pub(crate) async fn try_preempt(
                 }
             }
 
-            let mode = job_preempt_mode(candidate, partitions, &running_qos[&candidate.job_id]);
+            // QOS hierarchy: pending job may only preempt candidate when the
+            // pending QOS explicitly lists the candidate's QOS in its allow-list.
+            let candidate_qos = &running_qos[&candidate.job_id];
+            if sched.preempt_type == PreemptType::QosPriority
+                && !pending_qos.preempt.contains(&candidate_qos.name)
+            {
+                continue;
+            }
+
+            // Exempt time: skip candidates that haven't been running long enough.
+            let exempt_secs = effective_exempt_secs(candidate, partitions, candidate_qos, sched);
+            if exempt_secs > 0 {
+                let started_at = candidate.start_time.unwrap_or(now);
+                let running_for = (now - started_at).num_seconds().max(0) as u32;
+                if running_for < exempt_secs {
+                    continue;
+                }
+            }
+
+            let mode = job_preempt_mode(candidate, partitions, candidate_qos);
             if mode == PreemptMode::Off {
                 continue;
             }
@@ -2519,6 +2564,113 @@ mod tests {
 
     fn no_qos_override() -> spur_core::accounting::Qos {
         qos_with_mode(spur_core::accounting::QosPreemptMode::Off)
+    }
+
+    fn sched_config_default() -> spur_core::config::SchedulerConfig {
+        spur_core::config::SchedulerConfig::default()
+    }
+
+    fn sched_config_with_exempt(secs: u32) -> spur_core::config::SchedulerConfig {
+        spur_core::config::SchedulerConfig {
+            preempt_exempt_time: secs,
+            ..Default::default()
+        }
+    }
+
+    fn partition_with_exempt(name: &str, secs: u32) -> spur_core::partition::Partition {
+        spur_core::partition::Partition {
+            name: name.into(),
+            preempt_exempt_time: Some(secs),
+            ..Default::default()
+        }
+    }
+
+    fn qos_with_exempt(secs: u32) -> spur_core::accounting::Qos {
+        spur_core::accounting::Qos {
+            limits: spur_core::accounting::QosLimits {
+                preempt_exempt_time: Some(secs),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn qos_with_preempt_list(names: &[&str]) -> spur_core::accounting::Qos {
+        spur_core::accounting::Qos {
+            preempt: names.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn effective_exempt_secs_falls_back_to_global() {
+        let job = job_in_partitions("gpu");
+        let parts = vec![partition_with_mode("gpu", spur_core::partition::PreemptMode::Cancel)];
+        let qos = no_qos_override();
+        let sched = sched_config_with_exempt(120);
+        assert_eq!(effective_exempt_secs(&job, &parts, &qos, &sched), 120);
+    }
+
+    #[test]
+    fn effective_exempt_secs_partition_overrides_global() {
+        let job = job_in_partitions("gpu");
+        let parts = vec![partition_with_exempt("gpu", 60)];
+        let qos = no_qos_override();
+        let sched = sched_config_with_exempt(300);
+        assert_eq!(effective_exempt_secs(&job, &parts, &qos, &sched), 60);
+    }
+
+    #[test]
+    fn effective_exempt_secs_qos_overrides_partition_and_global() {
+        let job = job_in_partitions("gpu");
+        let parts = vec![partition_with_exempt("gpu", 60)];
+        let qos = qos_with_exempt(10);
+        let sched = sched_config_with_exempt(300);
+        assert_eq!(effective_exempt_secs(&job, &parts, &qos, &sched), 10);
+    }
+
+    #[test]
+    fn effective_exempt_secs_zero_global_and_no_overrides_is_zero() {
+        let job = job_in_partitions("gpu");
+        let parts = vec![partition_with_mode("gpu", spur_core::partition::PreemptMode::Cancel)];
+        let qos = no_qos_override();
+        let sched = sched_config_default();
+        assert_eq!(effective_exempt_secs(&job, &parts, &qos, &sched), 0);
+    }
+
+    #[test]
+    fn qos_preempt_allow_list_permits_listed_qos() {
+        use spur_core::partition::PreemptType;
+        let pending_qos = qos_with_preempt_list(&["low", "batch"]);
+        let candidate_qos = spur_core::accounting::Qos {
+            name: "low".into(),
+            ..Default::default()
+        };
+        // Simulate the allow-list check from try_preempt.
+        let permitted = pending_qos.preempt.contains(&candidate_qos.name);
+        assert!(permitted);
+    }
+
+    #[test]
+    fn qos_preempt_allow_list_blocks_unlisted_qos() {
+        let pending_qos = qos_with_preempt_list(&["low"]);
+        let candidate_qos = spur_core::accounting::Qos {
+            name: "medium".into(),
+            ..Default::default()
+        };
+        let permitted = pending_qos.preempt.contains(&candidate_qos.name);
+        assert!(!permitted);
+    }
+
+    #[test]
+    fn qos_preempt_empty_allow_list_blocks_all() {
+        let pending_qos = qos_with_preempt_list(&[]);
+        let candidate_qos = spur_core::accounting::Qos {
+            name: "low".into(),
+            ..Default::default()
+        };
+        let permitted = pending_qos.preempt.contains(&candidate_qos.name);
+        assert!(!permitted);
     }
 
     #[test]

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -535,6 +535,9 @@ fn job_preempt_mode(
 }
 
 /// Effective preempt-exempt seconds for a running job: QOS > partition > global.
+/// When the job spans multiple partitions, the maximum partition override wins
+/// (most protective), consistent with how `job_preempt_mode` uses the most
+/// aggressive mode across partitions.
 fn effective_exempt_secs(
     job: &spur_core::job::Job,
     partitions: &[spur_core::partition::Partition],
@@ -546,7 +549,8 @@ fn effective_exempt_secs(
     }
     spur_core::partition::matched_partitions(job.spec.partition.as_deref(), partitions)
         .into_iter()
-        .find_map(|p| p.preempt_exempt_time)
+        .filter_map(|p| p.preempt_exempt_time)
+        .max()
         .unwrap_or(sched.preempt_exempt_time)
 }
 
@@ -642,12 +646,15 @@ pub(crate) async fn try_preempt(
             }
 
             // Exempt time: skip candidates that haven't been running long enough.
+            // A missing start_time is treated as immediately preemptable — we
+            // can't know when it started, so we don't grant extra protection.
             let exempt_secs = effective_exempt_secs(candidate, partitions, candidate_qos, sched);
             if exempt_secs > 0 {
-                let started_at = candidate.start_time.unwrap_or(now);
-                let running_for = (now - started_at).num_seconds().max(0) as u32;
-                if running_for < exempt_secs {
-                    continue;
+                if let Some(started_at) = candidate.start_time {
+                    let running_for = (now - started_at).num_seconds().max(0) as u32;
+                    if running_for < exempt_secs {
+                        continue;
+                    }
                 }
             }
 
@@ -3108,6 +3115,7 @@ mod tests {
                     deny_qos: Vec::new(),
                     priority_tier: 1,
                     preempt_mode: String::new(),
+                    preempt_exempt_time: None,
                 }],
                 nodes: Vec::new(),
                 network: Default::default(),

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -2661,7 +2661,6 @@ mod tests {
 
     #[test]
     fn qos_preempt_allow_list_permits_listed_qos() {
-        use spur_core::partition::PreemptType;
         let pending_qos = qos_with_preempt_list(&["low", "batch"]);
         let candidate_qos = spur_core::accounting::Qos {
             name: "low".into(),

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -203,7 +203,13 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 // "no suitable nodes at all".
                 cluster.update_pending_reasons(&unscheduled, &cluster_state);
 
-                try_preempt(&cluster, &partitions, &unscheduled, &cluster.config().scheduler).await;
+                try_preempt(
+                    &cluster,
+                    &partitions,
+                    &unscheduled,
+                    &cluster.config().scheduler,
+                )
+                .await;
 
                 // Federation: forward still-unschedulable jobs to peer clusters.
                 if !cluster.config().federation.clusters.is_empty() {
@@ -601,11 +607,13 @@ pub(crate) async fn try_preempt(
 
     // Pending job's QOS is resolved once per pending job; used for the
     // QosPriority hierarchy check.
-    let pending_qos_map: std::collections::HashMap<spur_core::job::JobId, spur_core::accounting::Qos> =
-        unscheduled
-            .iter()
-            .map(|j| (j.job_id, cluster.resolve_qos(j)))
-            .collect();
+    let pending_qos_map: std::collections::HashMap<
+        spur_core::job::JobId,
+        spur_core::accounting::Qos,
+    > = unscheduled
+        .iter()
+        .map(|j| (j.job_id, cluster.resolve_qos(j)))
+        .collect();
 
     for pending in unscheduled {
         let Some(pending_part) = partition_for(pending) else {
@@ -2612,7 +2620,10 @@ mod tests {
     #[test]
     fn effective_exempt_secs_falls_back_to_global() {
         let job = job_in_partitions("gpu");
-        let parts = vec![partition_with_mode("gpu", spur_core::partition::PreemptMode::Cancel)];
+        let parts = vec![partition_with_mode(
+            "gpu",
+            spur_core::partition::PreemptMode::Cancel,
+        )];
         let qos = no_qos_override();
         let sched = sched_config_with_exempt(120);
         assert_eq!(effective_exempt_secs(&job, &parts, &qos, &sched), 120);
@@ -2639,7 +2650,10 @@ mod tests {
     #[test]
     fn effective_exempt_secs_zero_global_and_no_overrides_is_zero() {
         let job = job_in_partitions("gpu");
-        let parts = vec![partition_with_mode("gpu", spur_core::partition::PreemptMode::Cancel)];
+        let parts = vec![partition_with_mode(
+            "gpu",
+            spur_core::partition::PreemptMode::Cancel,
+        )];
         let qos = no_qos_override();
         let sched = sched_config_default();
         assert_eq!(effective_exempt_secs(&job, &parts, &qos, &sched), 0);

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1990,6 +1990,7 @@ impl SlurmController for ControllerService {
             allow_qos: req.allow_qos,
             priority_tier: req.priority_tier,
             preempt_mode,
+            preempt_exempt_time: req.preempt_exempt_time,
             ..Default::default()
         };
 
@@ -2098,7 +2099,11 @@ impl SlurmController for ControllerService {
                 allow_qos,
                 req.priority_tier,
                 preempt_mode,
-                req.preempt_exempt_time.map(|v| if v == 0 { None } else { Some(v) }),
+                if req.clear_preempt_exempt_time {
+                    Some(None)
+                } else {
+                    req.preempt_exempt_time.map(Some)
+                },
             )
             .map_err(partition_rpc_status)?;
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2098,6 +2098,7 @@ impl SlurmController for ControllerService {
                 allow_qos,
                 req.priority_tier,
                 preempt_mode,
+                req.preempt_exempt_time.map(|v| if v == 0 { None } else { Some(v) }),
             )
             .map_err(partition_rpc_status)?;
 
@@ -3742,6 +3743,7 @@ fn partition_to_proto(part: &spur_core::partition::Partition) -> PartitionInfo {
         deny_qos: part.deny_qos.join(","),
         preempt_mode: format!("{:?}", part.preempt_mode),
         priority_tier: part.priority_tier,
+        preempt_exempt_time: part.preempt_exempt_time.unwrap_or(0),
     }
 }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -3748,7 +3748,7 @@ fn partition_to_proto(part: &spur_core::partition::Partition) -> PartitionInfo {
         deny_qos: part.deny_qos.join(","),
         preempt_mode: format!("{:?}", part.preempt_mode),
         priority_tier: part.priority_tier,
-        preempt_exempt_time: part.preempt_exempt_time.unwrap_or(0),
+        preempt_exempt_time: part.preempt_exempt_time,
     }
 }
 

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -374,6 +374,22 @@ QOS keys
        A job from a higher-``priority`` QOS can preempt a running job from a
        lower-``priority`` QOS when its effective priority exceeds twice the
        victim's.
+   * - ``preempt``
+     - ``""`` (no restriction)
+     - Comma-separated list of QOS names that jobs in this QOS are allowed to
+       preempt. Only enforced when ``scheduler.preempt_type = "qos_priority"``
+       (see :doc:`configuration`). An empty value means this QOS may not preempt
+       any other QOS under that mode. Example: ``preempt=low,batch`` allows jobs
+       in this QOS to preempt ``low`` and ``batch`` jobs. To clear the list at
+       runtime: ``sacctmgr modify qos name=<name> set clearpreemptexempttime``.
+   * - ``preemptexempttime``
+     - ``0`` (inherit partition / global)
+     - Per-QOS override for the minimum seconds a job must have been running
+       before it is eligible for preemption. Overrides the partition-level
+       ``preempt_exempt_time`` and the global ``scheduler.preempt_exempt_time``
+       (see :doc:`configuration`). ``0`` means immediately preemptable (no
+       exemption). To revert to inheriting from the partition or global default:
+       ``sacctmgr modify qos name=<name> set clearpreemptexempttime``.
    * - ``usagefactor``
      - ``1.0``
      - Multiplier applied to usage charged under this QOS.
@@ -398,6 +414,70 @@ QOS keys
    * - ``grpwall``
      - ``0`` (no limit)
      - Aggregate wall-clock time across all jobs under this QOS.
+
+QOS preemption hierarchy
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, Spur's preemption eligibility is based purely on the numeric
+priority gap: any job with an effective priority more than 2× the running
+job's may preempt it (subject to the partition's ``preempt_mode`` gate).
+
+To restrict which QOS tiers may preempt which, enable the QOS preemption
+hierarchy in ``spur.conf``:
+
+.. code-block:: toml
+
+   [scheduler]
+   preempt_type = "qos_priority"
+
+With ``preempt_type = "qos_priority"``, a job may only preempt a running job
+when the pending job's QOS lists the running job's QOS name in its ``preempt``
+allow-list. An empty allow-list means the QOS may not preempt anything.
+
+**Example: two-tier system**
+
+.. code-block:: bash
+
+   # "burst" pool — high-throughput, low-priority, immediately preemptable.
+   sacctmgr add qos name=burst priority=100 preemptmode=cancel
+
+   # "priority" pool — reserved capacity; may preempt burst jobs only.
+   sacctmgr add qos name=priority priority=10000 preempt=burst
+
+   # "reserved" pool — guaranteed; cannot be preempted by anyone,
+   # and cannot preempt anyone (no preemptmode, no preempt list).
+   sacctmgr add qos name=reserved priority=50000
+
+With this setup:
+
+- A ``priority`` job preempts ``burst`` jobs when the priority gap is large enough.
+- A ``priority`` job cannot preempt ``reserved`` jobs (``reserved`` is not in
+  ``priority``'s allow-list).
+- A ``burst`` job never preempts anyone (empty allow-list).
+- ``reserved`` jobs are never preempted (``preemptmode=off`` is the default).
+
+**Minimum exempt time**
+
+To protect recently-started jobs from being immediately evicted, set
+``preempt_exempt_time`` at the global, partition, or QOS level. Resolution
+order: QOS > partition > global.
+
+.. code-block:: bash
+
+   # Global: no job can be preempted in its first 5 minutes.
+   # (Set in spur.conf: scheduler.preempt_exempt_time = 300)
+
+   # Per-QOS: burst jobs are protected for 2 minutes regardless of global.
+   sacctmgr modify qos name=burst set preemptexempttime=120
+
+   # Per-partition via scontrol (runtime, no restart needed):
+   scontrol update-partition PartitionName=gpu PreemptExemptTime=600
+
+   # Clear a per-QOS override (revert to partition/global):
+   sacctmgr modify qos name=burst set clearpreemptexempttime
+
+   # Clear a per-partition override (revert to global):
+   scontrol update-partition --name=gpu --clear-preempt-exempt-time
 
 How a job's QOS is resolved
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -380,16 +380,16 @@ QOS keys
        preempt. Only enforced when ``scheduler.preempt_type = "qos_priority"``
        (see :doc:`configuration`). An empty value means this QOS may not preempt
        any other QOS under that mode. Example: ``preempt=low,batch`` allows jobs
-       in this QOS to preempt ``low`` and ``batch`` jobs. To clear the list at
-       runtime: ``sacctmgr modify qos name=<name> set clearpreemptexempttime``.
+       in this QOS to preempt ``low`` and ``batch`` jobs. To clear the list:
+       ``sacctmgr modify qos name=<name> set preempt=`` (empty value).
    * - ``preemptexempttime``
-     - ``0`` (inherit partition / global)
+     - unset (inherits partition / global)
      - Per-QOS override for the minimum seconds a job must have been running
        before it is eligible for preemption. Overrides the partition-level
        ``preempt_exempt_time`` and the global ``scheduler.preempt_exempt_time``
        (see :doc:`configuration`). ``0`` means immediately preemptable (no
        exemption). To revert to inheriting from the partition or global default:
-       ``sacctmgr modify qos name=<name> set clearpreemptexempttime``.
+       ``sacctmgr modify qos name=<name> set clearpreemptexempttime=1``.
    * - ``usagefactor``
      - ``1.0``
      - Multiplier applied to usage charged under this QOS.
@@ -471,13 +471,13 @@ order: QOS > partition > global.
    sacctmgr modify qos name=burst set preemptexempttime=120
 
    # Per-partition via scontrol (runtime, no restart needed):
-   scontrol update-partition PartitionName=gpu PreemptExemptTime=600
+   scontrol update PartitionName=gpu PreemptExemptTime=600
 
    # Clear a per-QOS override (revert to partition/global):
-   sacctmgr modify qos name=burst set clearpreemptexempttime
+   sacctmgr modify qos name=burst set clearpreemptexempttime=1
 
    # Clear a per-partition override (revert to global):
-   scontrol update-partition --name=gpu --clear-preempt-exempt-time
+   scontrol update PartitionName=gpu ClearPreemptExemptTime=yes
 
 How a job's QOS is resolved
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -410,6 +410,28 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
      - Live
      - Grace minutes after a reservation ends before its still-running jobs are
        cancelled.
+   * - ``preempt_type``
+     - string
+     - ``"none"``
+     - Live
+     - Controls cross-QOS preemption eligibility. ``"none"`` (default) applies no
+       QOS-level restrictions — any job with a sufficient priority gap may preempt
+       any other. ``"qos_priority"`` enforces the per-QOS ``preempt`` allow-list:
+       a pending job may only preempt a running job when the pending job's QOS
+       explicitly lists the running job's QOS name in its ``preempt`` field. An
+       empty allow-list means the QOS may not preempt anything. Mirrors Slurm's
+       ``PreemptType=preempt/qos``. See :doc:`accounting` for the QOS
+       ``preempt`` field.
+   * - ``preempt_exempt_time``
+     - integer
+     - ``0``
+     - Live
+     - Cluster-wide minimum number of seconds a job must have been running before
+       it becomes eligible for preemption. ``0`` (default) means a job is
+       immediately eligible. Can be overridden per-partition (``preempt_exempt_time``
+       in ``[[partitions]]``) and per-QOS (``preemptexempttime`` via
+       ``sacctmgr``); the most specific value wins (QOS > partition > global).
+       Mirrors Slurm's ``PreemptExemptTime``.
 
 ``[auth]``
 ----------
@@ -536,6 +558,16 @@ jobs is skipped rather than deleted (see :ref:`reload-scope`).
      - string
      - ``"off"``
      - Preemption mode: ``cancel``, ``requeue``, ``suspend``; anything else is off.
+   * - ``preempt_exempt_time``
+     - integer or null
+     - ``null`` (inherit global)
+     - Per-partition override for the minimum seconds a job must have been running
+       before it is eligible for preemption. Overrides ``scheduler.preempt_exempt_time``
+       for jobs in this partition. Can be further overridden per-job by the QOS's
+       ``preemptexempttime`` field. Can also be set at runtime without restart via
+       ``scontrol update-partition PartitionName=<name> PreemptExemptTime=<secs>``
+       or ``scontrol update-partition --name=<name> --preempt-exempt-time=<secs>``;
+       use ``--clear-preempt-exempt-time`` to revert to the global default.
 
 ``[[nodes]]``
 -------------

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -565,9 +565,9 @@ jobs is skipped rather than deleted (see :ref:`reload-scope`).
        before it is eligible for preemption. Overrides ``scheduler.preempt_exempt_time``
        for jobs in this partition. Can be further overridden per-job by the QOS's
        ``preemptexempttime`` field. Can also be set at runtime without restart via
-       ``scontrol update-partition PartitionName=<name> PreemptExemptTime=<secs>``
-       or ``scontrol update-partition --name=<name> --preempt-exempt-time=<secs>``;
-       use ``--clear-preempt-exempt-time`` to revert to the global default.
+       ``scontrol update PartitionName=<name> PreemptExemptTime=<secs>``;
+       use ``scontrol update PartitionName=<name> ClearPreemptExemptTime=yes``
+       to revert to the global default.
 
 ``[[nodes]]``
 -------------

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -296,7 +296,7 @@ message PartitionInfo {
 
   string preempt_mode = 40;
   uint32 priority_tier = 41;
-  uint32 preempt_exempt_time = 44;   // 0 = defer to partition/global default
+  uint32 preempt_exempt_time = 44;   // 0 = no exemption; absent/unset = defer to global default
 }
 
 // ============================================================
@@ -1368,7 +1368,13 @@ message CreateQosRequest {
   // Only enforced when scheduler.preempt_type = qos_priority.
   // Empty string clears the list. Absent = no change on update.
   optional string preempt = 13;
-  optional uint32 preempt_exempt_time = 14;  // seconds; 0 = defer to partition/global
+  // Minimum seconds a job must run before eligible for preemption.
+  // 0 is a valid value meaning "immediately preemptable" (no exemption).
+  // Absent = no change on update.
+  optional uint32 preempt_exempt_time = 14;
+  // Set to true to clear preempt_exempt_time back to NULL (inherit from
+  // partition / global default). Takes precedence over preempt_exempt_time.
+  bool clear_preempt_exempt_time = 15;
 }
 
 message DeleteQosRequest {
@@ -1457,6 +1463,9 @@ message CreatePartitionRequest {
   repeated string deny_accounts = 14;
   repeated string deny_qos = 15;
   repeated string allow_qos = 16;
+  // Minimum seconds a job must run before it is eligible for preemption.
+  // 0 = no exemption (immediately preemptable). Absent = use global default.
+  optional uint32 preempt_exempt_time = 17;
 }
 
 message UpdatePartitionRequest {
@@ -1477,7 +1486,13 @@ message UpdatePartitionRequest {
   bool set_allow_groups = 14;
   optional uint32 priority_tier = 15;
   optional string preempt_mode = 16;
-  optional uint32 preempt_exempt_time = 24;  // seconds; 0 = defer to global default
+  // Minimum seconds a job must run before eligible for preemption.
+  // 0 is a valid value meaning "immediately preemptable" (no exemption).
+  // Absent = no change.
+  optional uint32 preempt_exempt_time = 24;
+  // Set to true to clear preempt_exempt_time back to NULL (inherit from global
+  // default). Takes precedence over preempt_exempt_time.
+  bool clear_preempt_exempt_time = 25;
   repeated string deny_accounts = 17;
   bool set_deny_accounts = 18;
   repeated string deny_qos = 19;

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -296,7 +296,7 @@ message PartitionInfo {
 
   string preempt_mode = 40;
   uint32 priority_tier = 41;
-  uint32 preempt_exempt_time = 44;   // 0 = no exemption; absent/unset = defer to global default
+  optional uint32 preempt_exempt_time = 44;   // absent = unset (inherits global default); 0 = no exemption
 }
 
 // ============================================================
@@ -1402,7 +1402,7 @@ message QosInfo {
   uint32 grp_wall_minutes = 12;
   // Comma-separated QOS names this QOS may preempt (empty = none allowed).
   string preempt = 13;
-  uint32 preempt_exempt_time = 14;  // 0 = defer to partition/global default
+  optional uint32 preempt_exempt_time = 14;  // absent = unset (inherits partition/global); 0 = no exemption
 }
 
 // ============================================================

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -296,6 +296,7 @@ message PartitionInfo {
 
   string preempt_mode = 40;
   uint32 priority_tier = 41;
+  uint32 preempt_exempt_time = 44;   // 0 = defer to partition/global default
 }
 
 // ============================================================
@@ -1363,6 +1364,11 @@ message CreateQosRequest {
   optional string max_tres_per_user = 10;
   optional string grp_tres = 11;
   optional uint32 grp_wall_minutes = 12;
+  // Comma-separated list of QOS names this QOS is allowed to preempt.
+  // Only enforced when scheduler.preempt_type = qos_priority.
+  // Empty string clears the list. Absent = no change on update.
+  optional string preempt = 13;
+  optional uint32 preempt_exempt_time = 14;  // seconds; 0 = defer to partition/global
 }
 
 message DeleteQosRequest {
@@ -1388,6 +1394,9 @@ message QosInfo {
   string max_tres_per_user = 10;
   string grp_tres = 11;
   uint32 grp_wall_minutes = 12;
+  // Comma-separated QOS names this QOS may preempt (empty = none allowed).
+  string preempt = 13;
+  uint32 preempt_exempt_time = 14;  // 0 = defer to partition/global default
 }
 
 // ============================================================
@@ -1468,6 +1477,7 @@ message UpdatePartitionRequest {
   bool set_allow_groups = 14;
   optional uint32 priority_tier = 15;
   optional string preempt_mode = 16;
+  optional uint32 preempt_exempt_time = 24;  // seconds; 0 = defer to global default
   repeated string deny_accounts = 17;
   bool set_deny_accounts = 18;
   repeated string deny_qos = 19;

--- a/tests/native_host/e2e/test_preemption_qos_hierarchy.py
+++ b/tests/native_host/e2e/test_preemption_qos_hierarchy.py
@@ -294,12 +294,8 @@ class TestReconfigurePreservesExemptTime:
         c.scontrol("reconfigure")
         time.sleep(3)  # let the controller apply the reload
 
-        # The override must survive: it was set at runtime, not from TOML.
-        # In Spur, a live scontrol update writes a WAL entry; reconfigure
-        # sends its own WAL update from the TOML values. After this fix,
-        # the reconfigure WAL entry carries preempt_exempt_time=None (no change)
-        # for partitions whose TOML does not have the field set, so the
-        # runtime value is preserved.
+        # reconfigure must not clobber a runtime-set override when the TOML
+        # partition entry does not specify preempt_exempt_time.
         out_after = c.scontrol("show", "partition", "default")
         assert "PreemptExemptTime=120" in out_after, (
             f"preempt_exempt_time was wiped by reconfigure:\nbefore: {out}\nafter: {out_after}"

--- a/tests/native_host/e2e/test_preemption_qos_hierarchy.py
+++ b/tests/native_host/e2e/test_preemption_qos_hierarchy.py
@@ -92,7 +92,7 @@ class TestQosPreemptHierarchyBlocked:
 
             # low job must still be running — high-hier has an empty
             # preempt allow-list so it cannot preempt low-hier.
-            state = c.scontrol(["show", "job", str(low_id)])
+            state = c.scontrol("show", "job", str(low_id))
             assert "JobState=RUNNING" in state, (
                 "low job must remain RUNNING when pending QOS allow-list is empty"
             )
@@ -214,7 +214,7 @@ class TestPreemptExemptTime:
             )
             low_id = parse_job_id(low_out)
             assert low_id is not None, f"submit failed:\n{low_out}"
-            wait_job_state(c, low_id, "R", timeout=30)
+            wait_job_state(c, low_id, "R", timeout=60)
 
             # Submit the high-priority job immediately after low starts.
             high_script = c.write_file(
@@ -227,13 +227,11 @@ class TestPreemptExemptTime:
             high_id = parse_job_id(high_out)
             assert high_id is not None, f"submit failed:\n{high_out}"
             # Force high's priority above the 2× threshold.
-            c.scontrol(
-                ["update", f"JobId={high_id}", "Priority=1000000"]
-            )
+            c.scontrol("update", f"JobId={high_id}", "Priority=1000000")
 
             # Within the exempt window: low must still be running.
             time.sleep(self.SAFE_WAIT_SECS)
-            state = c.scontrol(["show", "job", str(low_id)])
+            state = c.scontrol("show", "job", str(low_id))
             assert "JobState=RUNNING" in state, (
                 f"low job must be protected within the {self.EXEMPT_SECS}s "
                 f"exempt window (checked after {self.SAFE_WAIT_SECS}s)"
@@ -275,19 +273,17 @@ class TestReconfigurePreservesExemptTime:
     def test_reconfigure_preserves_partition_exempt_time(self, cluster):
         c = cluster
 
-        # Set a per-partition exempt time via scontrol at runtime.
-        c.scontrol(
-            ["update-partition", "--name=default", "--preempt-exempt-time=120"]
-        )
+        # Set a per-partition exempt time via scontrol inline syntax.
+        c.scontrol("update", "PartitionName=default", "PreemptExemptTime=120")
 
         # Confirm it's visible in scontrol show partition.
-        out = c.scontrol(["show", "partition", "default"])
+        out = c.scontrol("show", "partition", "default")
         assert "PreemptExemptTime=120" in out, (
             f"preempt_exempt_time not set after scontrol update: {out}"
         )
 
         # Trigger a reconfigure.
-        c.scontrol(["reconfigure"])
+        c.scontrol("reconfigure")
         time.sleep(3)  # let the controller apply the reload
 
         # The override must survive: it was set at runtime, not from TOML.
@@ -296,7 +292,7 @@ class TestReconfigurePreservesExemptTime:
         # the reconfigure WAL entry carries preempt_exempt_time=None (no change)
         # for partitions whose TOML does not have the field set, so the
         # runtime value is preserved.
-        out_after = c.scontrol(["show", "partition", "default"])
+        out_after = c.scontrol("show", "partition", "default")
         assert "PreemptExemptTime=120" in out_after, (
             f"preempt_exempt_time was wiped by reconfigure:\nbefore: {out}\nafter: {out_after}"
         )

--- a/tests/native_host/e2e/test_preemption_qos_hierarchy.py
+++ b/tests/native_host/e2e/test_preemption_qos_hierarchy.py
@@ -29,6 +29,10 @@ import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
 
+# Merged into every cluster_config_overrides fixture so that jobs submitted
+# by the root user (the typical CI / developer case) are not rejected by spurd.
+_AUTH_ALLOW_ROOT = {"auth": {"plugin": "none", "allow_root_jobs": True}}
+
 
 class TestQosPreemptHierarchyBlocked:
     """With preempt_type=qos_priority, a high-priority job whose QOS has an
@@ -52,6 +56,7 @@ class TestQosPreemptHierarchyBlocked:
             "scheduler": {
                 "preempt_type": "qos_priority",
             },
+            **_AUTH_ALLOW_ROOT,
         }
 
     def test_preemption_blocked_when_qos_not_in_allow_list(self, accounting_cluster):
@@ -123,6 +128,7 @@ class TestQosPreemptHierarchyAllowed:
             "scheduler": {
                 "preempt_type": "qos_priority",
             },
+            **_AUTH_ALLOW_ROOT,
         }
 
     def test_preemption_fires_when_qos_in_allow_list(self, accounting_cluster):
@@ -197,6 +203,7 @@ class TestPreemptExemptTime:
             "scheduler": {
                 "preempt_exempt_time": self.EXEMPT_SECS,
             },
+            **_AUTH_ALLOW_ROOT,
         }
 
     def test_exempt_window_protects_then_expires(self, cluster):
@@ -268,6 +275,7 @@ class TestReconfigurePreservesExemptTime:
                     # No preempt_exempt_time in TOML — starts at None (inherit global=0).
                 }
             ],
+            **_AUTH_ALLOW_ROOT,
         }
 
     def test_reconfigure_preserves_partition_exempt_time(self, cluster):

--- a/tests/native_host/e2e/test_preemption_qos_hierarchy.py
+++ b/tests/native_host/e2e/test_preemption_qos_hierarchy.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+E2E tests for the QOS preemption hierarchy and preempt_exempt_time features.
+
+Covers four scenarios:
+
+1. preempt_type=qos_priority blocks preemption when the pending job's QOS
+   allow-list does not include the running job's QOS.
+
+2. preempt_type=qos_priority allows preemption when the pending job's QOS
+   allow-list explicitly includes the running job's QOS.
+
+3. preempt_exempt_time protects a recently-started job from preemption for
+   a configurable window (wall-clock test with a short window).
+
+4. scontrol reconfigure preserves a per-partition preempt_exempt_time that
+   was set via scontrol update-partition, confirming the fix for the
+   reconfigure-wipe bug.
+
+Tests 1 and 2 require Postgres (accounting_cluster fixture, skips when Docker
+is unavailable). Tests 3 and 4 only need the base cluster fixture.
+"""
+
+import time
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+
+class TestQosPreemptHierarchyBlocked:
+    """With preempt_type=qos_priority, a high-priority job whose QOS has an
+    empty preempt allow-list must NOT preempt a running job, even with a
+    priority gap well above 2×."""
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {
+            "partitions": [
+                {
+                    "name": "default",
+                    "state": "UP",
+                    "default": True,
+                    "nodes": "ALL",
+                    "max_time": "24:00:00",
+                    "default_time": "10:00",
+                    "preempt_mode": "cancel",
+                }
+            ],
+            "scheduler": {
+                "preempt_type": "qos_priority",
+            },
+        }
+
+    def test_preemption_blocked_when_qos_not_in_allow_list(self, accounting_cluster):
+        c = accounting_cluster
+        node0 = c.node_names[0]
+
+        # "low" QOS: lower priority. "high" QOS: much higher priority but
+        # with an empty preempt allow-list — it is not allowed to preempt
+        # any other QOS under qos_priority mode.
+        c.sacctmgr(["add", "qos", "name=low-hier", "priority=100", "preemptmode=cancel"])
+        c.sacctmgr(["add", "qos", "name=high-hier", "priority=100000"])
+        # No "preempt=..." set on high-hier => allow-list is empty.
+        time.sleep(15)  # wait past QoS cache refresh floor
+
+        low_id = None
+        try:
+            low_script = c.write_file(
+                "hier-blocked-low.sh", "#!/bin/bash\nsleep 600\n"
+            )
+            low_out = c.sbatch(
+                ["-J", "hier-low", "-N", "1", f"--nodelist={node0}",
+                 "--exclusive", "-q", "low-hier", low_script]
+            )
+            low_id = parse_job_id(low_out)
+            assert low_id is not None, f"submit failed:\n{low_out}"
+            wait_job_state(c, low_id, "R", timeout=30)
+
+            high_script = c.write_file(
+                "hier-blocked-high.sh", "#!/bin/bash\nsleep 2\n"
+            )
+            c.sbatch(
+                ["-J", "hier-high", "-N", "1", f"--nodelist={node0}",
+                 "--exclusive", "-q", "high-hier", high_script]
+            )
+
+            # Give the scheduler several cycles to attempt preemption.
+            time.sleep(10)
+
+            # low job must still be running — high-hier has an empty
+            # preempt allow-list so it cannot preempt low-hier.
+            state = c.scontrol(["show", "job", str(low_id)])
+            assert "JobState=RUNNING" in state, (
+                "low job must remain RUNNING when pending QOS allow-list is empty"
+            )
+        finally:
+            if low_id is not None:
+                c.cli_allow_fail(["scancel", str(low_id)])
+            c.cli_allow_fail(["scancel", "--name=hier-high"])
+
+
+class TestQosPreemptHierarchyAllowed:
+    """With preempt_type=qos_priority, a high-priority job whose QOS explicitly
+    lists the running job's QOS in its preempt allow-list MUST preempt."""
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {
+            "partitions": [
+                {
+                    "name": "default",
+                    "state": "UP",
+                    "default": True,
+                    "nodes": "ALL",
+                    "max_time": "24:00:00",
+                    "default_time": "10:00",
+                    "preempt_mode": "cancel",
+                }
+            ],
+            "scheduler": {
+                "preempt_type": "qos_priority",
+            },
+        }
+
+    def test_preemption_fires_when_qos_in_allow_list(self, accounting_cluster):
+        c = accounting_cluster
+        node0 = c.node_names[0]
+
+        c.sacctmgr(["add", "qos", "name=low-allow", "priority=100", "preemptmode=cancel"])
+        # "high-allow" explicitly lists "low-allow" in its preempt allow-list.
+        c.sacctmgr(
+            ["add", "qos", "name=high-allow", "priority=100000",
+             "preempt=low-allow"]
+        )
+        time.sleep(15)
+
+        low_id = None
+        try:
+            low_script = c.write_file(
+                "hier-allow-low.sh", "#!/bin/bash\nsleep 600\n"
+            )
+            low_out = c.sbatch(
+                ["-J", "allow-low", "-N", "1", f"--nodelist={node0}",
+                 "--exclusive", "-q", "low-allow", low_script]
+            )
+            low_id = parse_job_id(low_out)
+            assert low_id is not None, f"submit failed:\n{low_out}"
+            wait_job_state(c, low_id, "R", timeout=30)
+
+            high_script = c.write_file(
+                "hier-allow-high.sh", "#!/bin/bash\nsleep 2\n"
+            )
+            high_out = c.sbatch(
+                ["-J", "allow-high", "-N", "1", f"--nodelist={node0}",
+                 "--exclusive", "-q", "high-allow", high_script]
+            )
+            high_id = parse_job_id(high_out)
+            assert high_id is not None, f"submit failed:\n{high_out}"
+
+            # low must be preempted (cancelled) and high must complete.
+            wait_job_state(c, low_id, "CA", timeout=30)
+            high_state = wait_job(c, high_id, timeout=30)
+            assert high_state == "CD", (
+                f"high-allow job did not complete: {high_state}"
+            )
+        finally:
+            if low_id is not None:
+                c.cli_allow_fail(["scancel", str(low_id)])
+
+
+class TestPreemptExemptTime:
+    """preempt_exempt_time protects a recently-started job for the configured
+    window, then stops protecting it once the window has elapsed."""
+
+    # Use a short exempt window so the test doesn't take forever.
+    EXEMPT_SECS = 20
+    SAFE_WAIT_SECS = 8   # comfortably inside the window
+    AFTER_WINDOW_WAIT = EXEMPT_SECS + 10  # comfortably past the window
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {
+            "partitions": [
+                {
+                    "name": "default",
+                    "state": "UP",
+                    "default": True,
+                    "nodes": "ALL",
+                    "max_time": "24:00:00",
+                    "default_time": "10:00",
+                    "preempt_mode": "cancel",
+                }
+            ],
+            "scheduler": {
+                "preempt_exempt_time": self.EXEMPT_SECS,
+            },
+        }
+
+    def test_exempt_window_protects_then_expires(self, cluster):
+        c = cluster
+        node0 = c.node_names[0]
+
+        low_id = None
+        try:
+            low_script = c.write_file(
+                "exempt-low.sh", "#!/bin/bash\nsleep 600\n"
+            )
+            low_out = c.sbatch(
+                ["-J", "exempt-low", "-N", "1", f"--nodelist={node0}",
+                 "--exclusive", low_script]
+            )
+            low_id = parse_job_id(low_out)
+            assert low_id is not None, f"submit failed:\n{low_out}"
+            wait_job_state(c, low_id, "R", timeout=30)
+
+            # Submit the high-priority job immediately after low starts.
+            high_script = c.write_file(
+                "exempt-high.sh", "#!/bin/bash\nsleep 2\n"
+            )
+            high_out = c.sbatch(
+                ["-J", "exempt-high", "-N", "1", f"--nodelist={node0}",
+                 "--exclusive", high_script]
+            )
+            high_id = parse_job_id(high_out)
+            assert high_id is not None, f"submit failed:\n{high_out}"
+            # Force high's priority above the 2× threshold.
+            c.scontrol(
+                ["update", f"JobId={high_id}", "Priority=1000000"]
+            )
+
+            # Within the exempt window: low must still be running.
+            time.sleep(self.SAFE_WAIT_SECS)
+            state = c.scontrol(["show", "job", str(low_id)])
+            assert "JobState=RUNNING" in state, (
+                f"low job must be protected within the {self.EXEMPT_SECS}s "
+                f"exempt window (checked after {self.SAFE_WAIT_SECS}s)"
+            )
+
+            # After the window expires, preemption must fire.
+            time.sleep(self.AFTER_WINDOW_WAIT)
+            wait_job_state(c, low_id, "CA", timeout=30)
+            high_state = wait_job(c, high_id, timeout=30)
+            assert high_state == "CD", (
+                f"high-priority job did not complete after exempt window: {high_state}"
+            )
+        finally:
+            if low_id is not None:
+                c.cli_allow_fail(["scancel", str(low_id)])
+
+
+class TestReconfigurePreservesExemptTime:
+    """scontrol reconfigure must not wipe a per-partition preempt_exempt_time
+    override that was set live via scontrol update-partition."""
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {
+            "partitions": [
+                {
+                    "name": "default",
+                    "state": "UP",
+                    "default": True,
+                    "nodes": "ALL",
+                    "max_time": "24:00:00",
+                    "default_time": "10:00",
+                    "preempt_mode": "cancel",
+                    # No preempt_exempt_time in TOML — starts at None (inherit global=0).
+                }
+            ],
+        }
+
+    def test_reconfigure_preserves_partition_exempt_time(self, cluster):
+        c = cluster
+
+        # Set a per-partition exempt time via scontrol at runtime.
+        c.scontrol(
+            ["update-partition", "--name=default", "--preempt-exempt-time=120"]
+        )
+
+        # Confirm it's visible in scontrol show partition.
+        out = c.scontrol(["show", "partition", "default"])
+        assert "PreemptExemptTime=120" in out, (
+            f"preempt_exempt_time not set after scontrol update: {out}"
+        )
+
+        # Trigger a reconfigure.
+        c.scontrol(["reconfigure"])
+        time.sleep(3)  # let the controller apply the reload
+
+        # The override must survive: it was set at runtime, not from TOML.
+        # In Spur, a live scontrol update writes a WAL entry; reconfigure
+        # sends its own WAL update from the TOML values. After this fix,
+        # the reconfigure WAL entry carries preempt_exempt_time=None (no change)
+        # for partitions whose TOML does not have the field set, so the
+        # runtime value is preserved.
+        out_after = c.scontrol(["show", "partition", "default"])
+        assert "PreemptExemptTime=120" in out_after, (
+            f"preempt_exempt_time was wiped by reconfigure:\nbefore: {out}\nafter: {out_after}"
+        )


### PR DESCRIPTION
## Context

Spur's preemption was missing two controls that Slurm provides, causing a practical problem: a team's QOS quota provides no runtime guarantee — a higher-priority job from any other pool can displace running work that is well within its allocated quota. This PR closes both gaps.

**What Spur already matched Slurm on (unchanged):**
- `preempt_mode` (`cancel`, `requeue`, `suspend`, `off`) — per partition, with QOS override
- Partition `priority_tier` — lower-tier partitions are protected from equal/lower-tier preemption
- Named reservation protection — jobs inside an active time-windowed reservation are shielded

## What this adds

### [1] QOS preemption hierarchy (`PreemptType=preempt/qos`)

Previously, any job with 2× higher effective priority could preempt any other job regardless of which QOS or pool it belonged to. There was no way to say "tier A may preempt tier B but not tier C."

This PR adds:
- `scheduler.preempt_type = "qos_priority"` in `spur.conf` — enables the hierarchy
- `preempt = <comma-separated QOS names>` field on each QOS — the allow-list of tiers this QOS may preempt
- When enabled, `try_preempt` enforces: a pending job may only preempt a running job when the pending job's QOS explicitly lists the running job's QOS in its `preempt` allow-list. An empty allow-list means the QOS may not preempt anything.

```bash
# Example two-tier setup
sacctmgr add qos name=burst  priority=100   preemptmode=cancel
sacctmgr add qos name=priority priority=10000 preempt=burst
# "priority" can preempt "burst"; "burst" cannot preempt anyone;
# "reserved" (no preempt list) cannot be preempted by either.
```

### [2] Minimum guaranteed running time (`PreemptExemptTime`)

Previously, a newly-started job was immediately eligible for preemption — no grace window.

This PR adds `preempt_exempt_time` at three levels (most specific wins: QOS > partition > global):
- Global: `scheduler.preempt_exempt_time = <seconds>` in `spur.conf`
- Per partition: `preempt_exempt_time` in `[[partitions]]`, or via `scontrol update PartitionName=<name> PreemptExemptTime=<secs>`
- Per QOS: `preemptexempttime=<secs>` via `sacctmgr`; use `clearpreemptexempttime` to revert to inheriting

## Approach

Both controls are implemented as additional filters in `try_preempt` in `scheduler_loop.rs`, layered on top of the existing priority-gap, node-overlap, and reservation-tier checks. Both default to the existing behavior (`preempt_type = "none"`, `preempt_exempt_time = 0`), so this is fully backward-compatible for existing clusters.

Key design choices:
- `preempt_type` and the global `preempt_exempt_time` live in `[scheduler]` (TOML, live-reloadable)
- Per-partition `preempt_exempt_time` lives in `[[partitions]]` and is also settable at runtime via `scontrol update`. It survives `scontrol reconfigure` when not specified in TOML (the WAL entry is skipped, leaving the runtime value intact).
- `preempt_exempt_time = 0` is a valid explicit value meaning "immediately preemptable"; to revert a QOS/partition to inheriting the global default, use `clearpreemptexempttime` / `--clear-preempt-exempt-time`.
- `start_time = None` on a running job (should not happen, but defensively handled) is treated as immediately preemptable rather than infinitely protected.
- For multi-partition jobs, the maximum partition-level `preempt_exempt_time` is used (most protective, consistent with how `preempt_mode` picks the most aggressive mode).

The implementation is wired end-to-end: DB schema (with `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` migrations) → limits cache → gRPC → proto → `scontrol` / `sacctmgr`.

## Testing

`cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean  
`cargo test --locked` — all pass

Unit tests added in `scheduler_loop.rs`:
- `effective_exempt_secs` resolution (QOS > partition > global, multi-partition max)
- QOS allow-list permit/block/empty cases

Integration tests added in `cluster.rs` (full `ClusterManager` + `try_preempt`):
- `qos_preempt_hierarchy_blocks_preemption_when_not_in_allow_list`
- `qos_preempt_hierarchy_allows_preemption_when_in_allow_list`
- `preempt_exempt_time_protects_recently_started_job`

E2e tests added in `tests/native_host/e2e/test_preemption_qos_hierarchy.py`:
- `TestQosPreemptHierarchyBlocked` — with `preempt_type=qos_priority` and empty allow-list, preemption is blocked even with 1000× priority gap
- `TestQosPreemptHierarchyAllowed` — with `"low-allow"` in the allow-list, preemption fires and the low job is cancelled
- `TestPreemptExemptTime` — 20s exempt window: job survives inside it, preemption fires after it expires
- `TestReconfigurePreservesExemptTime` — runtime `scontrol update` exempt time survives `scontrol reconfigure` (regression for the reconfigure-wipe bug) — **passes** on `shrey-dev`

Note: `TestPreemptExemptTime` and the two accounting tests require a host where `spurd` can dispatch jobs (cgroup/namespace permissions); they could not be run on the available test host due to a pre-existing environment issue unrelated to this PR (same `JobLaunchFailure` on unmodified `test_preemption.py`).

## Docs

- `docs/admin-guide/configuration.rst`: `preempt_type` and `preempt_exempt_time` added to `[scheduler]` and `[[partitions]]` tables
- `docs/admin-guide/accounting.rst`: `preempt` and `preemptexempttime` added to QOS keys table; new "QOS preemption hierarchy" subsection with two-tier worked example

## Proto

New fields use new tag numbers (no renumbering). New WAL field uses `#[serde(default)]`. All DB columns added with `IF NOT EXISTS`. Backward-compatible.