### PR TITLE
fix(security): gate control-plane mutation RPCs on verified admin

### DIFF
--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -73,19 +73,8 @@ fn fairshare_to_i32(v: f64) -> Result<i32, Status> {
     Ok(v as i32)
 }
 
-/// Reject an accounting mutation unless the request carries a verified administrator.
-///
-/// The accounting service is served behind the same auth layer as the controller, so a verified
-/// [`Identity`](spur_core::auth::Identity) rides in the request extensions when one was
-/// authenticated. These handlers mutate account/user/QOS records — `add_user` even sets
-/// `admin_level`, the self-promotion vector — so an *identified* non-admin is refused. A caller with
-/// no verified identity is allowed — like the controller's gate and the auth model, `disabled` or
-/// `permissive`-with-no-credential trusts the client, so refusing anonymous here would break no-auth
-/// deployments; in `required` mode every caller is authenticated and bound. The admin criterion is
-/// narrower than the controller's `caller_is_admin`: this uses only the token's `admin` claim
-/// ([`Identity::require_admin`](spur_core::auth::Identity::require_admin)), not the accounting `Admin`
-/// level, because the accounting service holds no association-cache handle. Read-only handlers
-/// (`list_*`, `get_*`) stay open.
+/// Rejects an identified non-admin from an account/user/QOS mutation; anonymous is allowed, same as
+/// the controller's gate. Narrower than `caller_is_admin`: token `admin` claim only, no cache handle here.
 fn require_admin<T>(request: &Request<T>, op: &str) -> Result<(), Status> {
     let denied = || Status::permission_denied(format!("{op} requires cluster admin"));
     match request.extensions().get::<spur_core::auth::Identity>() {
@@ -389,8 +378,8 @@ impl SlurmAccounting for AccountingService {
         &self,
         request: Request<CreateAccountRequest>,
     ) -> Result<Response<()>, Status> {
-        let pool = self.pool()?;
         require_admin(&request, "create account")?;
+        let pool = self.pool()?;
         let req = request.into_inner();
         if let Some(g) = &req.grp_tres {
             validate_tres("grptres", g)?;
@@ -413,8 +402,8 @@ impl SlurmAccounting for AccountingService {
         &self,
         request: Request<DeleteAccountRequest>,
     ) -> Result<Response<()>, Status> {
-        let pool = self.pool()?;
         require_admin(&request, "delete account")?;
+        let pool = self.pool()?;
         let req = request.into_inner();
         db::delete_account(pool, &req.name)
             .await
@@ -448,8 +437,8 @@ impl SlurmAccounting for AccountingService {
     }
 
     async fn add_user(&self, request: Request<AddUserRequest>) -> Result<Response<()>, Status> {
-        let pool = self.pool()?;
         require_admin(&request, "add user")?;
+        let pool = self.pool()?;
         let req = request.into_inner();
         // QOS references are validated against the live DB, not QosCache: a QOS
         // created just now may not have reached the cache's next refresh yet,
@@ -531,8 +520,8 @@ impl SlurmAccounting for AccountingService {
         &self,
         request: Request<RemoveUserRequest>,
     ) -> Result<Response<()>, Status> {
-        let pool = self.pool()?;
         require_admin(&request, "remove user")?;
+        let pool = self.pool()?;
         let req = request.into_inner();
         let deleted = db::remove_user(pool, &req.user, &req.account)
             .await
@@ -590,8 +579,8 @@ impl SlurmAccounting for AccountingService {
     }
 
     async fn create_qos(&self, request: Request<CreateQosRequest>) -> Result<Response<()>, Status> {
-        let pool = self.pool()?;
         require_admin(&request, "create qos")?;
+        let pool = self.pool()?;
         let req = request.into_inner();
         if let Some(t) = &req.max_tres_per_job {
             validate_tres("maxtresperjob", t)?;
@@ -665,8 +654,8 @@ impl SlurmAccounting for AccountingService {
     }
 
     async fn delete_qos(&self, request: Request<DeleteQosRequest>) -> Result<Response<()>, Status> {
-        let pool = self.pool()?;
         require_admin(&request, "delete qos")?;
+        let pool = self.pool()?;
         let req = request.into_inner();
         db::delete_qos(pool, &req.name)
             .await
@@ -948,6 +937,37 @@ mod tests {
         // enforces once callers are identified, not in the non-enforcing modes.
         let anon = Request::new(AddUserRequest::default());
         assert!(require_admin(&anon, "add user").is_ok());
+    }
+
+    /// Table test over every gated accounting RPC, enumerated so a handler that drops its
+    /// `require_admin` call is caught even though it never reaches the DB in this test: with the
+    /// pool unavailable, a non-admin's rejection can only come from the gate, not a query failure.
+    #[tokio::test]
+    async fn accounting_mutations_deny_identified_non_admin() {
+        let service = AccountingService::unavailable("no DB needed for this test");
+
+        macro_rules! assert_admin_gated {
+            ($method:ident, $req:expr) => {{
+                let mut r = Request::new($req);
+                r.extensions_mut().insert(identity("mallory", false));
+                let err = service.$method(r).await.expect_err(concat!(
+                    stringify!($method),
+                    " must reject a non-admin caller"
+                ));
+                assert_eq!(
+                    err.code(),
+                    tonic::Code::PermissionDenied,
+                    concat!(stringify!($method), " (non-admin) must be PermissionDenied")
+                );
+            }};
+        }
+
+        assert_admin_gated!(create_account, CreateAccountRequest::default());
+        assert_admin_gated!(delete_account, DeleteAccountRequest::default());
+        assert_admin_gated!(add_user, AddUserRequest::default());
+        assert_admin_gated!(remove_user, RemoveUserRequest::default());
+        assert_admin_gated!(create_qos, CreateQosRequest::default());
+        assert_admin_gated!(delete_qos, DeleteQosRequest::default());
     }
 
     #[test]

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -78,15 +78,17 @@ fn fairshare_to_i32(v: f64) -> Result<i32, Status> {
 /// The accounting service is served behind the same auth layer as the controller, so a verified
 /// [`Identity`](spur_core::auth::Identity) rides in the request extensions when one was
 /// authenticated. These handlers mutate account/user/QOS records — `add_user` even sets
-/// `admin_level`, the self-promotion vector — so they are admin-only. Deny-by-default: a caller with
-/// no verified admin identity (`disabled`, or `permissive` with no credential) is refused. The
-/// ruling itself is [`Identity::require_admin`](spur_core::auth::Identity::require_admin), the same
-/// gate the controller uses; read-only handlers (`list_*`, `get_*`) stay open.
+/// `admin_level`, the self-promotion vector — so an *identified* non-admin is refused. A caller with
+/// no verified identity is allowed, matching the controller's `require_admin` and the auth model:
+/// `disabled`, or `permissive` with no credential, trusts the client, so refusing anonymous here
+/// would break no-auth deployments; in `required` mode every caller is authenticated and bound. The
+/// ruling itself is [`Identity::require_admin`](spur_core::auth::Identity::require_admin);
+/// read-only handlers (`list_*`, `get_*`) stay open.
 fn require_admin<T>(request: &Request<T>, op: &str) -> Result<(), Status> {
     let denied = || Status::permission_denied(format!("{op} requires cluster admin"));
     match request.extensions().get::<spur_core::auth::Identity>() {
         Some(id) => id.require_admin().map_err(|_| denied()),
-        None => Err(denied()),
+        None => Ok(()),
     }
 }
 
@@ -922,9 +924,11 @@ mod tests {
         }
     }
 
-    /// The account/user/QOS mutations are admin-only. A verified admin passes; a verified non-admin
-    /// and (deny-by-default) an unauthenticated caller are both rejected — this closes the
-    /// self-promotion path where `add_user(admin_level = Admin)` had no authorization.
+    /// The account/user/QOS mutations are admin-only for an identified caller: a verified admin
+    /// passes, a verified non-admin is rejected — this closes the self-promotion path where
+    /// `add_user(admin_level = Admin)` had no authorization. An unauthenticated caller is allowed,
+    /// matching the auth model: `disabled`/`permissive`-with-no-credential trust the client, so the
+    /// gate binds real users only in `required` mode.
     #[test]
     fn require_admin_gates_accounting_mutations() {
         let mut admin = Request::new(AddUserRequest::default());
@@ -938,10 +942,10 @@ mod tests {
         let err = require_admin(&non_admin, "add user").expect_err("non-admin must be rejected");
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
 
-        // No verified identity at all (disabled, or permissive with no credential) is denied.
+        // No verified identity (disabled, or permissive with no credential) is allowed — the gate
+        // enforces once callers are identified, not in the non-enforcing modes.
         let anon = Request::new(AddUserRequest::default());
-        let err = require_admin(&anon, "add user").expect_err("anonymous caller must be rejected");
-        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert!(require_admin(&anon, "add user").is_ok());
     }
 
     #[test]

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -73,6 +73,23 @@ fn fairshare_to_i32(v: f64) -> Result<i32, Status> {
     Ok(v as i32)
 }
 
+/// Reject an accounting mutation unless the request carries a verified administrator.
+///
+/// The accounting service is served behind the same auth layer as the controller, so a verified
+/// [`Identity`](spur_core::auth::Identity) rides in the request extensions when one was
+/// authenticated. These handlers mutate account/user/QOS records — `add_user` even sets
+/// `admin_level`, the self-promotion vector — so they are admin-only. Deny-by-default: a caller with
+/// no verified admin identity (`disabled`, or `permissive` with no credential) is refused. The
+/// ruling itself is [`Identity::require_admin`](spur_core::auth::Identity::require_admin), the same
+/// gate the controller uses; read-only handlers (`list_*`, `get_*`) stay open.
+fn require_admin<T>(request: &Request<T>, op: &str) -> Result<(), Status> {
+    let denied = || Status::permission_denied(format!("{op} requires cluster admin"));
+    match request.extensions().get::<spur_core::auth::Identity>() {
+        Some(id) => id.require_admin().map_err(|_| denied()),
+        None => Err(denied()),
+    }
+}
+
 pub(crate) enum AccountingService {
     Available(PgPool),
     Unavailable { reason: &'static str },
@@ -369,6 +386,7 @@ impl SlurmAccounting for AccountingService {
         request: Request<CreateAccountRequest>,
     ) -> Result<Response<()>, Status> {
         let pool = self.pool()?;
+        require_admin(&request, "create account")?;
         let req = request.into_inner();
         if let Some(g) = &req.grp_tres {
             validate_tres("grptres", g)?;
@@ -392,6 +410,7 @@ impl SlurmAccounting for AccountingService {
         request: Request<DeleteAccountRequest>,
     ) -> Result<Response<()>, Status> {
         let pool = self.pool()?;
+        require_admin(&request, "delete account")?;
         let req = request.into_inner();
         db::delete_account(pool, &req.name)
             .await
@@ -426,6 +445,7 @@ impl SlurmAccounting for AccountingService {
 
     async fn add_user(&self, request: Request<AddUserRequest>) -> Result<Response<()>, Status> {
         let pool = self.pool()?;
+        require_admin(&request, "add user")?;
         let req = request.into_inner();
         // QOS references are validated against the live DB, not QosCache: a QOS
         // created just now may not have reached the cache's next refresh yet,
@@ -508,6 +528,7 @@ impl SlurmAccounting for AccountingService {
         request: Request<RemoveUserRequest>,
     ) -> Result<Response<()>, Status> {
         let pool = self.pool()?;
+        require_admin(&request, "remove user")?;
         let req = request.into_inner();
         let deleted = db::remove_user(pool, &req.user, &req.account)
             .await
@@ -566,6 +587,7 @@ impl SlurmAccounting for AccountingService {
 
     async fn create_qos(&self, request: Request<CreateQosRequest>) -> Result<Response<()>, Status> {
         let pool = self.pool()?;
+        require_admin(&request, "create qos")?;
         let req = request.into_inner();
         if let Some(t) = &req.max_tres_per_job {
             validate_tres("maxtresperjob", t)?;
@@ -640,6 +662,7 @@ impl SlurmAccounting for AccountingService {
 
     async fn delete_qos(&self, request: Request<DeleteQosRequest>) -> Result<Response<()>, Status> {
         let pool = self.pool()?;
+        require_admin(&request, "delete qos")?;
         let req = request.into_inner();
         db::delete_qos(pool, &req.name)
             .await
@@ -888,6 +911,37 @@ mod tests {
             status.message(),
             "accounting service is not available (database migration failed at startup)"
         );
+    }
+
+    fn identity(user: &str, is_admin: bool) -> spur_core::auth::Identity {
+        spur_core::auth::Identity {
+            user: user.into(),
+            uid: 1000,
+            gid: 1000,
+            is_admin,
+        }
+    }
+
+    /// The account/user/QOS mutations are admin-only. A verified admin passes; a verified non-admin
+    /// and (deny-by-default) an unauthenticated caller are both rejected — this closes the
+    /// self-promotion path where `add_user(admin_level = Admin)` had no authorization.
+    #[test]
+    fn require_admin_gates_accounting_mutations() {
+        let mut admin = Request::new(AddUserRequest::default());
+        admin.extensions_mut().insert(identity("root", true));
+        assert!(require_admin(&admin, "add user").is_ok());
+
+        let mut non_admin = Request::new(AddUserRequest::default());
+        non_admin
+            .extensions_mut()
+            .insert(identity("mallory", false));
+        let err = require_admin(&non_admin, "add user").expect_err("non-admin must be rejected");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        // No verified identity at all (disabled, or permissive with no credential) is denied.
+        let anon = Request::new(AddUserRequest::default());
+        let err = require_admin(&anon, "add user").expect_err("anonymous caller must be rejected");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
     }
 
     #[test]

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -79,11 +79,13 @@ fn fairshare_to_i32(v: f64) -> Result<i32, Status> {
 /// [`Identity`](spur_core::auth::Identity) rides in the request extensions when one was
 /// authenticated. These handlers mutate account/user/QOS records — `add_user` even sets
 /// `admin_level`, the self-promotion vector — so an *identified* non-admin is refused. A caller with
-/// no verified identity is allowed, matching the controller's `require_admin` and the auth model:
-/// `disabled`, or `permissive` with no credential, trusts the client, so refusing anonymous here
-/// would break no-auth deployments; in `required` mode every caller is authenticated and bound. The
-/// ruling itself is [`Identity::require_admin`](spur_core::auth::Identity::require_admin);
-/// read-only handlers (`list_*`, `get_*`) stay open.
+/// no verified identity is allowed — like the controller's gate and the auth model, `disabled` or
+/// `permissive`-with-no-credential trusts the client, so refusing anonymous here would break no-auth
+/// deployments; in `required` mode every caller is authenticated and bound. The admin criterion is
+/// narrower than the controller's `caller_is_admin`: this uses only the token's `admin` claim
+/// ([`Identity::require_admin`](spur_core::auth::Identity::require_admin)), not the accounting `Admin`
+/// level, because the accounting service holds no association-cache handle. Read-only handlers
+/// (`list_*`, `get_*`) stay open.
 fn require_admin<T>(request: &Request<T>, op: &str) -> Result<(), Status> {
     let denied = || Status::permission_denied(format!("{op} requires cluster admin"));
     match request.extensions().get::<spur_core::auth::Identity>() {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -110,6 +110,23 @@ pub enum SubmitError {
     Internal(String),
 }
 
+/// Errors from a node (re-)registration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegisterNodeError {
+    PermissionDenied(String),
+    Internal(String),
+}
+
+impl std::fmt::Display for RegisterNodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PermissionDenied(m) | Self::Internal(m) => f.write_str(m),
+        }
+    }
+}
+
+impl std::error::Error for RegisterNodeError {}
+
 /// Errors from completing a standalone srun allocation.
 #[derive(Debug)]
 pub enum SrunCompleteError {
@@ -401,6 +418,9 @@ pub struct ClusterManager {
     /// Serializes k0s phase-transition accounting so concurrent `set_k0s_phase` callers can't both
     /// read the same prior phase and double-count the edge.
     k0s_phase_accounting: parking_lot::Mutex<()>,
+    /// Per-node locks serializing (re-)registration, so unrelated nodes don't block each other
+    /// while a same-name racer can't act on a stale label diff (see `register_node`).
+    node_registration_locks: parking_lot::Mutex<HashMap<String, Arc<parking_lot::Mutex<()>>>>,
     raft: RwLock<Option<SpurRaft>>,
     accounting: RwLock<Option<AccountingNotifier>>,
     fairshare_cache: Arc<FairshareCache>,
@@ -498,6 +518,7 @@ impl ClusterManager {
             k8s_metrics: Arc::new(spur_metrics::K8sMetrics::new()),
             k0s_role_counts: K0sRoleCounts::default(),
             k0s_phase_accounting: parking_lot::Mutex::new(()),
+            node_registration_locks: parking_lot::Mutex::new(HashMap::new()),
             raft: RwLock::new(None),
             accounting: RwLock::new(None),
             fairshare_cache,
@@ -2104,7 +2125,17 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Register a node agent.
+    /// Gets (creating if absent) the per-node lock `register_node` serializes on.
+    fn node_registration_lock(&self, name: &str) -> Arc<parking_lot::Mutex<()>> {
+        self.node_registration_locks
+            .lock()
+            .entry(name.to_string())
+            .or_insert_with(|| Arc::new(parking_lot::Mutex::new(())))
+            .clone()
+    }
+
+    /// Register a node agent. `caller_privileged` gates a labels change on an already-registered
+    /// node (see `sync_node_labels`); first registration never needs it.
     #[allow(clippy::too_many_arguments)]
     pub fn register_node(
         &self,
@@ -2117,12 +2148,19 @@ impl ClusterManager {
         version: String,
         source: NodeSource,
         labels: HashMap<String, String>,
-    ) -> anyhow::Result<()> {
+        caller_privileged: bool,
+    ) -> Result<(), RegisterNodeError> {
         let hostname = if hostname.is_empty() {
             name.clone()
         } else {
             hostname
         };
+
+        // Held across decide-then-propose so concurrent registrations of THIS node can't each act on
+        // a pre-write read of the other's state and propose conflicting/duplicate WAL ops.
+        let node_lock = self.node_registration_lock(&name);
+        let _registration = node_lock.lock();
+
         let action = {
             let nodes = self.nodes.read();
             evaluate_registration(nodes.get(&name), &resources)
@@ -2131,7 +2169,7 @@ impl ClusterManager {
         match action {
             RegistrationAction::Skip => {
                 debug!(node = %name, "node unchanged, skipping");
-                self.sync_node_labels(&name, labels)?;
+                self.sync_node_labels(&name, labels, caller_privileged)?;
                 if let Some(existing) = self.get_node(&name) {
                     let needs_update = existing.address.as_deref() != Some(address.as_str())
                         || existing.hostname != hostname
@@ -2150,7 +2188,8 @@ impl ClusterManager {
                             wg_pubkey,
                             version,
                             source: source.clone(),
-                        })?;
+                        })
+                        .map_err(|e| RegisterNodeError::Internal(e.to_string()))?;
                         info!(node = %name, "node comm address or metadata updated");
                     }
                     if existing.source != source {
@@ -2170,8 +2209,9 @@ impl ClusterManager {
                     wg_pubkey,
                     version,
                     source: source.clone(),
-                })?;
-                self.sync_node_labels(&name, labels)?;
+                })
+                .map_err(|e| RegisterNodeError::Internal(e.to_string()))?;
+                self.sync_node_labels(&name, labels, caller_privileged)?;
                 if let Some(node) = self.nodes.write().get_mut(&name) {
                     node.source = source;
                 }
@@ -2188,7 +2228,8 @@ impl ClusterManager {
                     version,
                     labels,
                     source: source.clone(),
-                })?;
+                })
+                .map_err(|e| RegisterNodeError::Internal(e.to_string()))?;
                 if let Some(node) = self.nodes.write().get_mut(&name) {
                     node.source = source;
                     node.agent_start_time = Some(Utc::now());
@@ -2199,15 +2240,21 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Sync node labels if they differ from the expected set.
-    /// Proposes a `NodeLabelsUpdate` WAL operation when there's a mismatch.
+    /// Syncs node labels if they differ, rejecting the diff from an unprivileged caller instead of
+    /// applying it. Called under `register_node`'s per-node lock.
     fn sync_node_labels(
         &self,
         node_name: &str,
         new_labels: HashMap<String, String>,
-    ) -> anyhow::Result<()> {
+        caller_privileged: bool,
+    ) -> Result<(), RegisterNodeError> {
         if let Some(existing) = self.get_node(node_name) {
             if existing.labels != new_labels {
+                if !caller_privileged {
+                    return Err(RegisterNodeError::PermissionDenied(format!(
+                        "relabeling node {node_name} on re-registration requires cluster admin"
+                    )));
+                }
                 let remove: Vec<String> = existing
                     .labels
                     .keys()
@@ -2218,7 +2265,8 @@ impl ClusterManager {
                     name: node_name.to_string(),
                     set: new_labels,
                     remove,
-                })?;
+                })
+                .map_err(|e| RegisterNodeError::Internal(e.to_string()))?;
                 info!(node = %node_name, "node labels synced on re-registration");
             }
         }
@@ -7716,12 +7764,70 @@ mod tests {
             String::new(),
             spur_core::node::NodeSource::NativeHost,
             HashMap::new(),
+            true,
         )
         .unwrap();
         let n = name.to_string();
         wait_for(&format!("node '{n}' registered"), || {
             cm.get_node(&n).is_some()
         });
+    }
+
+    // A `Barrier` forces both callers to start at the same instant, so this races for real on
+    // `node_registration_locks` instead of depending on tokio's task-scheduling luck.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn register_node_concurrent_non_admin_relabel_never_wins() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "racy-node", 4, 8000);
+
+        let relabel = |cm: Arc<ClusterManager>, pool: &'static str, privileged: bool| {
+            cm.register_node(
+                "racy-node".into(),
+                "racy-node".into(),
+                ResourceSet {
+                    cpus: 4,
+                    memory_mb: 8000,
+                    ..Default::default()
+                },
+                "127.0.0.1".into(),
+                6818,
+                String::new(),
+                String::new(),
+                spur_core::node::NodeSource::NativeHost,
+                HashMap::from([("pool".to_string(), pool.to_string())]),
+                privileged,
+            )
+        };
+
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let (cm_a, barrier_a) = (cm.clone(), barrier.clone());
+        let admin = tokio::task::spawn_blocking(move || {
+            barrier_a.wait();
+            relabel(cm_a, "prod", true)
+        });
+        let (cm_b, barrier_b) = (cm.clone(), barrier.clone());
+        let non_admin = tokio::task::spawn_blocking(move || {
+            barrier_b.wait();
+            relabel(cm_b, "hacked", false)
+        });
+
+        let (admin_result, non_admin_result) = tokio::join!(admin, non_admin);
+        admin_result
+            .unwrap()
+            .expect("the admin's relabel must succeed regardless of scheduling order");
+        assert!(
+            matches!(
+                non_admin_result.unwrap(),
+                Err(RegisterNodeError::PermissionDenied(_))
+            ),
+            "the non-admin's concurrent relabel must never win the race"
+        );
+        assert_eq!(
+            cm.get_node("racy-node").unwrap().labels["pool"],
+            "prod",
+            "only the admin's labels may land, whichever task the scheduler ran first"
+        );
     }
 
     /// Register a node already on the WireGuard mesh: it advertises its real `spur0` address (what
@@ -7742,6 +7848,7 @@ mod tests {
             String::new(),
             spur_core::node::NodeSource::NativeHost,
             HashMap::new(),
+            true,
         )
         .unwrap();
         let n = name.to_string();
@@ -18126,6 +18233,7 @@ mod tests {
             "1.0".into(),
             NodeSource::NativeHost,
             HashMap::new(),
+            true,
         )
         .unwrap();
         let node = cm.get_node("locked").unwrap();
@@ -20147,6 +20255,7 @@ mod tests {
             String::new(),
             spur_core::node::NodeSource::NativeHost,
             HashMap::from([("role".into(), "infer".into())]),
+            true,
         )
         .unwrap();
         wait_for("node registered", || cm.get_node("dyn-node").is_some());
@@ -20214,6 +20323,7 @@ mod tests {
             String::new(),
             spur_core::node::NodeSource::NativeHost,
             HashMap::from([("pool".into(), "train".into())]),
+            true,
         )
         .unwrap();
         wait_for("node registered", || cm.get_node("worker1").is_some());
@@ -20237,6 +20347,7 @@ mod tests {
             String::new(),
             spur_core::node::NodeSource::NativeHost,
             HashMap::from([("pool".into(), "infer".into()), ("tier".into(), "1".into())]),
+            true,
         )
         .unwrap();
         wait_for("labels synced", || {
@@ -20270,6 +20381,7 @@ mod tests {
             String::new(),
             spur_core::node::NodeSource::NativeHost,
             HashMap::new(),
+            true,
         )
         .unwrap();
         wait_for("node registered", || cm.get_node("worker1").is_some());
@@ -20284,6 +20396,7 @@ mod tests {
             String::new(),
             spur_core::node::NodeSource::NativeHost,
             HashMap::new(),
+            true,
         )
         .unwrap();
         wait_for("comm address updated", || {
@@ -20321,6 +20434,7 @@ mod tests {
             String::new(),
             spur_core::node::NodeSource::NativeHost,
             HashMap::from([("pool".into(), "train".into())]),
+            true,
         )
         .unwrap();
         wait_for("node registered", || cm.get_node("worker1").is_some());

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -3208,6 +3208,7 @@ mod tests {
                 String::new(),
                 NodeSource::NativeHost,
                 HashMap::new(),
+                true,
             )
             .unwrap();
             let n = name.to_string();
@@ -4105,6 +4106,7 @@ mod tests {
                     namespace: "spur-test".into(),
                 },
                 HashMap::new(),
+                true,
             )
             .unwrap();
             let n = name.to_string();

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -6976,6 +6976,16 @@ mod tests {
                 .any(|p| p.name == "team-a"),
             "the admin's partition must exist after the gated call succeeds"
         );
+
+        // A structurally different RPC (token issuance) also passes the admin gate.
+        let token_resp = svc
+            .create_token(admin_request(CreateTokenRequest::default()))
+            .await
+            .expect("an admin caller may create a token");
+        assert!(
+            !token_resp.into_inner().token_id.is_empty(),
+            "the admin's token must be issued"
+        );
     }
 
     // --- authoritative_user ---

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1559,14 +1559,9 @@ impl SlurmController for ControllerService {
             })
             .unwrap_or_default();
 
-        // A node re-registering with different labels reaches the same NodeLabelsUpdate WAL op as
-        // the gated `update_node`; require the same admin bar there, but let first registration and
-        // unchanged re-registration through, so a node agent can self-register without one.
-        if let Some(existing) = self.cluster.get_node(&request.get_ref().hostname) {
-            if existing.labels != request.get_ref().labels {
-                self.require_admin(&request, "relabel an existing node on re-registration")?;
-            }
-        }
+        // Decided here, enforced atomically inside `register_node` against the label diff — a
+        // pre-check here instead would race a concurrent registration for the same node.
+        let caller_privileged = self.caller_is_privileged(Self::verified_identity(&request));
 
         let req = request.into_inner();
         let resources = req.resources.map(proto_to_resource_set).unwrap_or_default();
@@ -1596,8 +1591,9 @@ impl SlurmController for ControllerService {
                 req.version,
                 source,
                 req.labels,
+                caller_privileged,
             )
-            .map_err(|e| Status::internal(e.to_string()))?;
+            .map_err(register_node_rpc_status)?;
 
         Ok(Response::new(RegisterAgentResponse {
             accepted: true,
@@ -4064,6 +4060,13 @@ fn submit_rpc_status(err: crate::cluster::SubmitError) -> Status {
     }
 }
 
+fn register_node_rpc_status(err: crate::cluster::RegisterNodeError) -> Status {
+    match err {
+        crate::cluster::RegisterNodeError::PermissionDenied(m) => Status::permission_denied(m),
+        crate::cluster::RegisterNodeError::Internal(m) => Status::internal(m),
+    }
+}
+
 fn partition_rpc_status(err: PartitionError) -> Status {
     match err {
         PartitionError::InvalidArgument(m) => Status::invalid_argument(m),
@@ -5162,6 +5165,7 @@ mod tests {
                 String::new(),
                 spur_core::node::NodeSource::NativeHost,
                 std::collections::HashMap::new(),
+                true,
             )
             .unwrap();
         for _ in 0..200 {
@@ -5270,6 +5274,7 @@ mod tests {
                 String::new(),
                 spur_core::node::NodeSource::NativeHost,
                 std::collections::HashMap::new(),
+                true,
             )
             .unwrap();
         for _ in 0..200 {
@@ -5436,6 +5441,7 @@ mod tests {
                 String::new(),
                 spur_core::node::NodeSource::NativeHost,
                 std::collections::HashMap::new(),
+                true,
             )
             .unwrap();
         for _ in 0..200 {
@@ -5677,6 +5683,7 @@ mod tests {
                     String::new(),
                     NodeSource::NativeHost,
                     std::collections::HashMap::new(),
+                    true,
                 )
                 .unwrap();
             svc.cluster
@@ -5791,6 +5798,7 @@ mod tests {
                 String::new(),
                 spur_core::node::NodeSource::NativeHost,
                 std::collections::HashMap::new(),
+                true,
             )
             .unwrap();
         svc.cluster
@@ -5824,6 +5832,7 @@ mod tests {
                 String::new(),
                 spur_core::node::NodeSource::NativeHost,
                 std::collections::HashMap::new(),
+                true,
             )
             .unwrap();
     }
@@ -6786,6 +6795,7 @@ mod tests {
                     String::new(),
                     spur_core::node::NodeSource::NativeHost,
                     std::collections::HashMap::new(),
+                    true,
                 )
                 .unwrap();
         }
@@ -7052,6 +7062,116 @@ mod tests {
         assert_eq!(
             svc.cluster.get_node("victim-node").unwrap().labels["pool"],
             "stolen"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn register_agent_unchanged_non_empty_labels_needs_no_admin() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        register_plain_node(&svc, "steady-node", 6822).await;
+
+        let labels: std::collections::HashMap<String, String> =
+            [("pool".to_string(), "prod".to_string())].into();
+        svc.register_agent(admin_request(RegisterAgentRequest {
+            hostname: "steady-node".into(),
+            address: "127.0.0.1".into(),
+            labels: labels.clone(),
+            ..Default::default()
+        }))
+        .await
+        .expect("an admin may set the initial labels");
+
+        svc.register_agent(Request::new(RegisterAgentRequest {
+            hostname: "steady-node".into(),
+            address: "127.0.0.1".into(),
+            labels,
+            ..Default::default()
+        }))
+        .await
+        .expect("re-registering with the same non-empty labels must not be admin-gated");
+    }
+
+    // The diff a non-admin's re-registration is checked against is read at write time, not decided
+    // ahead of it — so a non-admin can't revert a relabel that lands between their read and write.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn register_agent_non_admin_cannot_revert_a_privileged_relabel() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        register_plain_node(&svc, "contended-node", 6823).await;
+
+        svc.register_agent(admin_request(RegisterAgentRequest {
+            hostname: "contended-node".into(),
+            address: "127.0.0.1".into(),
+            labels: [("pool".to_string(), "prod".to_string())].into(),
+            ..Default::default()
+        }))
+        .await
+        .expect("an admin may relabel the node");
+
+        let mut r = Request::new(RegisterAgentRequest {
+            hostname: "contended-node".into(),
+            address: "127.0.0.1".into(),
+            labels: std::collections::HashMap::new(),
+            ..Default::default()
+        });
+        r.extensions_mut().insert(viewer("mallory", false));
+        let err = svc
+            .register_agent(r)
+            .await
+            .expect_err("a non-admin re-registration must not revert the privileged relabel");
+        assert_eq!(err.code(), Code::PermissionDenied);
+        assert_eq!(
+            svc.cluster.get_node("contended-node").unwrap().labels["pool"],
+            "prod",
+            "the privileged relabel must survive the non-admin's attempt"
+        );
+    }
+
+    // Runs the admin and non-admin relabel concurrently (not sequentially) so the gate's decision
+    // is genuinely raced against the write, not just checked against an already-settled state.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn register_agent_concurrent_non_admin_relabel_never_wins() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = std::sync::Arc::new(test_service(&dir).await);
+        register_plain_node(&svc, "racy-node", 6824).await;
+
+        let admin_svc = svc.clone();
+        let admin_task = tokio::spawn(async move {
+            admin_svc
+                .register_agent(admin_request(RegisterAgentRequest {
+                    hostname: "racy-node".into(),
+                    address: "127.0.0.1".into(),
+                    labels: [("pool".to_string(), "prod".to_string())].into(),
+                    ..Default::default()
+                }))
+                .await
+        });
+
+        let non_admin_svc = svc.clone();
+        let non_admin_task = tokio::spawn(async move {
+            let mut r = Request::new(RegisterAgentRequest {
+                hostname: "racy-node".into(),
+                address: "127.0.0.1".into(),
+                labels: [("pool".to_string(), "hacked".to_string())].into(),
+                ..Default::default()
+            });
+            r.extensions_mut().insert(viewer("mallory", false));
+            non_admin_svc.register_agent(r).await
+        });
+
+        let (admin_result, non_admin_result) = tokio::join!(admin_task, non_admin_task);
+        admin_result
+            .unwrap()
+            .expect("the admin's relabel must succeed regardless of scheduling order");
+        let non_admin_err = non_admin_result
+            .unwrap()
+            .expect_err("the non-admin's concurrent relabel must never win the race");
+        assert_eq!(non_admin_err.code(), Code::PermissionDenied);
+        assert_eq!(
+            svc.cluster.get_node("racy-node").unwrap().labels["pool"],
+            "prod",
+            "only the admin's labels may land, whichever task the scheduler ran first"
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -488,18 +488,8 @@ impl ControllerService {
             .map_err(reservation_rpc_status)
     }
 
-    /// Reject a control-plane mutation unless the request carries a verified administrator identity.
-    ///
-    /// These RPCs define cluster tenancy — partition membership, node placement, admission tokens,
-    /// reservations. An *identified* non-admin is refused, so the partition/node-pool boundary cannot
-    /// be redrawn from an ordinary credential. A caller with no verified identity is allowed, keeping
-    /// the pre-auth behaviour: `disabled`, or `permissive` with no credential, trusts the client, and
-    /// refusing anonymous admin ops there would break no-auth deployments and outage-free adoption —
-    /// this is the same `caller_is_privileged` ruling the priority ceiling uses. In `required` mode
-    /// every caller is authenticated, so the gate binds every real user. Admin is the same ruling the
-    /// rest of the control plane uses (`caller_is_admin`): the token's `admin` claim, an accounting
-    /// `Admin` level, or the `root` user (via `is_k0s_admin`). Call it as a prologue, before
-    /// `into_inner`, so the verified identity decides.
+    /// Rejects an identified non-admin from a cluster-tenancy mutation (partitions, node placement,
+    /// tokens, reservations); anonymous is allowed, matching `caller_is_privileged`. Call as a prologue, before `into_inner`.
     #[allow(clippy::result_large_err)]
     fn require_admin<T>(&self, request: &Request<T>, op: &str) -> Result<(), Status> {
         if self.caller_is_privileged(Self::verified_identity(request)) {
@@ -1568,6 +1558,15 @@ impl SlurmController for ControllerService {
                 }
             })
             .unwrap_or_default();
+
+        // A node re-registering with different labels reaches the same NodeLabelsUpdate WAL op as
+        // the gated `update_node`; require the same admin bar there, but let first registration and
+        // unchanged re-registration through, so a node agent can self-register without one.
+        if let Some(existing) = self.cluster.get_node(&request.get_ref().hostname) {
+            if existing.labels != request.get_ref().labels {
+                self.require_admin(&request, "relabel an existing node on re-registration")?;
+            }
+        }
 
         let req = request.into_inner();
         let resources = req.resources.map(proto_to_resource_set).unwrap_or_default();
@@ -6985,6 +6984,74 @@ mod tests {
         assert!(
             !token_resp.into_inner().token_id.is_empty(),
             "the admin's token must be issued"
+        );
+    }
+
+    // --- register_agent relabeling gate ---
+    //
+    // A node re-registering with different labels reaches the same NodeLabelsUpdate WAL op as the
+    // gated `update_node`, so it must be admin-gated too; first registration and an unchanged
+    // re-registration must not be, so a node agent can still self-register with no identity.
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn register_agent_first_registration_needs_no_admin() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+
+        svc.register_agent(Request::new(RegisterAgentRequest {
+            hostname: "fresh-node".into(),
+            address: "127.0.0.1".into(),
+            labels: [("pool".to_string(), "a".to_string())].into(),
+            ..Default::default()
+        }))
+        .await
+        .expect("first registration must not require an admin identity");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn register_agent_relabel_of_existing_node_is_admin_gated() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        register_plain_node(&svc, "victim-node", 6821).await;
+
+        let relabel = || RegisterAgentRequest {
+            hostname: "victim-node".into(),
+            address: "127.0.0.1".into(),
+            labels: [("pool".to_string(), "stolen".to_string())].into(),
+            ..Default::default()
+        };
+
+        let mut r = Request::new(relabel());
+        r.extensions_mut().insert(viewer("mallory", false));
+        let err = svc
+            .register_agent(r)
+            .await
+            .expect_err("a non-admin caller must not be able to relabel an existing node");
+        assert_eq!(err.code(), Code::PermissionDenied);
+        assert!(
+            svc.cluster
+                .get_node("victim-node")
+                .unwrap()
+                .labels
+                .is_empty(),
+            "the rejected relabel must not have applied"
+        );
+
+        svc.register_agent(Request::new(RegisterAgentRequest {
+            hostname: "victim-node".into(),
+            address: "127.0.0.1".into(),
+            labels: std::collections::HashMap::new(),
+            ..Default::default()
+        }))
+        .await
+        .expect("an unchanged re-registration must not be admin-gated");
+
+        svc.register_agent(admin_request(relabel()))
+            .await
+            .expect("an admin caller may relabel an existing node");
+        assert_eq!(
+            svc.cluster.get_node("victim-node").unwrap().labels["pool"],
+            "stolen"
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -488,6 +488,26 @@ impl ControllerService {
             .map_err(reservation_rpc_status)
     }
 
+    /// Reject a control-plane mutation unless the request carries a verified administrator identity.
+    ///
+    /// These RPCs define cluster tenancy — partition membership, node placement, admission tokens,
+    /// reservations. Deny-by-default: a caller with no verified identity (`disabled`, or
+    /// `permissive` with no credential) is not an admin and is refused, so the partition/node-pool
+    /// boundary cannot be redrawn from an ordinary or anonymous credential. Admin is the same ruling
+    /// the rest of the control plane uses (`caller_is_admin`): the token's `admin` claim or an
+    /// accounting `Admin` level. Call it as a prologue, before `into_inner`, so the identity the auth
+    /// layer verified is what decides — never a client-asserted field.
+    #[allow(clippy::result_large_err)]
+    fn require_admin<T>(&self, request: &Request<T>, op: &str) -> Result<(), Status> {
+        if self.caller_is_admin(Self::verified_identity(request)) {
+            Ok(())
+        } else {
+            Err(Status::permission_denied(format!(
+                "{op} requires cluster admin"
+            )))
+        }
+    }
+
     /// Whether a caller is exempt from the non-admin restrictions (the priority ceiling): an admin,
     /// or a caller with no verified identity. The latter keeps the pre-auth behaviour — `disabled`,
     /// or `permissive` with no credential, trusts the client — so restricting it would break no-auth
@@ -1234,6 +1254,8 @@ impl SlurmController for ControllerService {
             }
         }
 
+        self.require_admin(&request, "update node")?;
+
         let req = request.into_inner();
         if let Some(state) = req.state {
             let node_state = spur_core::node::NodeState::from_proto_i32(state)
@@ -1770,14 +1792,16 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    fwd.metadata_mut()
-                        .insert("x-forwarded", "true".parse().unwrap());
+                    // Preserve the caller's credential (and set the forwarded marker) so the leader
+                    // authorizes the ORIGINAL caller, not an anonymous forwarded request.
+                    let fwd = Self::forward_request(request);
                     return client.create_token(fwd).await;
                 }
                 Err(_) => return Err(status),
             }
         }
+
+        self.require_admin(&request, "create token")?;
 
         let req = request.into_inner();
         let ttl_secs = req.ttl_secs.filter(|&v| v > 0);
@@ -1795,9 +1819,12 @@ impl SlurmController for ControllerService {
 
     async fn list_tokens(
         &self,
-        _request: Request<ListTokensRequest>,
+        request: Request<ListTokensRequest>,
     ) -> Result<Response<ListTokensResponse>, Status> {
         use spur_proto::proto::TokenInfo;
+
+        // Admission tokens are cluster secrets; only an admin may enumerate them.
+        self.require_admin(&request, "list tokens")?;
 
         let tokens = self.cluster.list_tokens();
         let infos = tokens
@@ -1821,14 +1848,16 @@ impl SlurmController for ControllerService {
             let proxy = &self.leader_proxy;
             match proxy.get_leader_client().await {
                 Ok(mut client) => {
-                    let mut fwd = Request::new(request.into_inner());
-                    fwd.metadata_mut()
-                        .insert("x-forwarded", "true".parse().unwrap());
+                    // Preserve the caller's credential (and set the forwarded marker) so the leader
+                    // authorizes the ORIGINAL caller, not an anonymous forwarded request.
+                    let fwd = Self::forward_request(request);
                     return client.revoke_token(fwd).await;
                 }
                 Err(_) => return Err(status),
             }
         }
+
+        self.require_admin(&request, "revoke token")?;
 
         let req = request.into_inner();
         self.cluster
@@ -1997,6 +2026,8 @@ impl SlurmController for ControllerService {
             }
         }
 
+        self.require_admin(&request, "create partition")?;
+
         let req = request.into_inner();
 
         if req.nodes.is_empty() && req.selector.is_empty() {
@@ -2101,6 +2132,8 @@ impl SlurmController for ControllerService {
                 }
             }
         }
+
+        self.require_admin(&request, "update partition")?;
 
         let req = request.into_inner();
 
@@ -2211,6 +2244,8 @@ impl SlurmController for ControllerService {
             }
         }
 
+        self.require_admin(&request, "delete partition")?;
+
         let name = request.into_inner().name;
         self.cluster
             .delete_partition(&name)
@@ -2233,6 +2268,8 @@ impl SlurmController for ControllerService {
                 }
             }
         }
+
+        self.require_admin(&request, "reconfigure")?;
 
         self.cluster
             .reconfigure()
@@ -2258,6 +2295,8 @@ impl SlurmController for ControllerService {
                 }
             }
         }
+
+        self.require_admin(&request, "create reservation")?;
 
         let identity = Self::verified_identity(&request).cloned();
         let mut req = request.into_inner();
@@ -2303,6 +2342,8 @@ impl SlurmController for ControllerService {
                 }
             }
         }
+
+        self.require_admin(&request, "update reservation")?;
 
         let identity = Self::verified_identity(&request).cloned();
         let mut req = request.into_inner();
@@ -2362,6 +2403,8 @@ impl SlurmController for ControllerService {
                 }
             }
         }
+
+        self.require_admin(&request, "delete reservation")?;
 
         let identity = Self::verified_identity(&request).cloned();
         let mut req = request.into_inner();
@@ -4334,6 +4377,14 @@ mod tests {
         if let Some(id) = id {
             req.extensions_mut().insert(id);
         }
+        req
+    }
+
+    /// Wrap a request body with a verified admin identity, as the auth layer would for an admin
+    /// token. Used to exercise the admin-gated control-plane mutation handlers.
+    fn admin_request<T>(inner: T) -> Request<T> {
+        let mut req = Request::new(inner);
+        req.extensions_mut().insert(viewer("root", true));
         req
     }
 
@@ -6744,7 +6795,7 @@ mod tests {
         }
 
         for (name, node) in [("rocm_patch", "n1"), ("other_resv", "n2")] {
-            svc.create_reservation(Request::new(CreateReservationRequest {
+            svc.create_reservation(admin_request(CreateReservationRequest {
                 name: name.into(),
                 start_time: "now".into(),
                 duration_minutes: 60,
@@ -6797,6 +6848,131 @@ mod tests {
             .into_inner()
             .reservations;
         assert!(none.is_empty());
+    }
+
+    // --- control-plane mutation authorization ---
+    //
+    // Every RPC that defines cluster tenancy (partitions, node placement/labels, admission tokens,
+    // reservations) must require a verified administrator. Deny-by-default is the contract: a
+    // verified non-admin AND an anonymous caller (no identity — `disabled`, or `permissive` with no
+    // credential) are both refused. Enumerated as a table so the next handler added cannot quietly
+    // reopen the boundary without a failing test.
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn control_plane_mutations_deny_non_admin_and_anonymous() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+
+        macro_rules! assert_admin_gated {
+            ($method:ident, $req:expr) => {{
+                // A verified but non-admin identity is rejected.
+                let mut r = Request::new($req);
+                r.extensions_mut().insert(viewer("mallory", false));
+                let err = svc.$method(r).await.expect_err(concat!(
+                    stringify!($method),
+                    " must reject a non-admin caller"
+                ));
+                assert_eq!(
+                    err.code(),
+                    Code::PermissionDenied,
+                    concat!(stringify!($method), " (non-admin) must be PermissionDenied")
+                );
+
+                // Deny-by-default: no verified identity at all is also rejected.
+                let err = svc.$method(Request::new($req)).await.expect_err(concat!(
+                    stringify!($method),
+                    " must reject an anonymous caller"
+                ));
+                assert_eq!(
+                    err.code(),
+                    Code::PermissionDenied,
+                    concat!(stringify!($method), " (anonymous) must be PermissionDenied")
+                );
+            }};
+        }
+
+        assert_admin_gated!(
+            create_partition,
+            CreatePartitionRequest {
+                name: "pwn".into(),
+                nodes: "ALL".into(),
+                ..Default::default()
+            }
+        );
+        assert_admin_gated!(
+            update_partition,
+            UpdatePartitionRequest {
+                name: "tenant-b".into(),
+                ..Default::default()
+            }
+        );
+        assert_admin_gated!(
+            delete_partition,
+            DeletePartitionRequest {
+                name: "tenant-b".into(),
+            }
+        );
+        assert_admin_gated!(
+            update_node,
+            UpdateNodeRequest {
+                name: "victim-node".into(),
+                ..Default::default()
+            }
+        );
+        assert_admin_gated!(reconfigure, ());
+        assert_admin_gated!(create_token, CreateTokenRequest::default());
+        assert_admin_gated!(list_tokens, ListTokensRequest::default());
+        assert_admin_gated!(
+            revoke_token,
+            RevokeTokenRequest {
+                token_id: "t".into(),
+            }
+        );
+        assert_admin_gated!(
+            create_reservation,
+            CreateReservationRequest {
+                name: "r".into(),
+                ..Default::default()
+            }
+        );
+        assert_admin_gated!(
+            update_reservation,
+            UpdateReservationRequest {
+                name: "r".into(),
+                ..Default::default()
+            }
+        );
+        assert_admin_gated!(
+            delete_reservation,
+            DeleteReservationRequest {
+                name: "r".into(),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn control_plane_mutation_allows_admin() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        register_plain_node(&svc, "node-a", 6820).await;
+
+        // An admin identity passes the gate and the partition is actually created.
+        svc.create_partition(admin_request(CreatePartitionRequest {
+            name: "team-a".into(),
+            nodes: "node-a".into(),
+            ..Default::default()
+        }))
+        .await
+        .expect("an admin caller may create a partition");
+
+        assert!(
+            svc.cluster
+                .get_partitions()
+                .iter()
+                .any(|p| p.name == "team-a"),
+            "the admin's partition must exist after the gated call succeeds"
+        );
     }
 
     // --- authoritative_user ---

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -491,15 +491,17 @@ impl ControllerService {
     /// Reject a control-plane mutation unless the request carries a verified administrator identity.
     ///
     /// These RPCs define cluster tenancy — partition membership, node placement, admission tokens,
-    /// reservations. Deny-by-default: a caller with no verified identity (`disabled`, or
-    /// `permissive` with no credential) is not an admin and is refused, so the partition/node-pool
-    /// boundary cannot be redrawn from an ordinary or anonymous credential. Admin is the same ruling
-    /// the rest of the control plane uses (`caller_is_admin`): the token's `admin` claim or an
-    /// accounting `Admin` level. Call it as a prologue, before `into_inner`, so the identity the auth
-    /// layer verified is what decides — never a client-asserted field.
+    /// reservations. An *identified* non-admin is refused, so the partition/node-pool boundary cannot
+    /// be redrawn from an ordinary credential. A caller with no verified identity is allowed, keeping
+    /// the pre-auth behaviour: `disabled`, or `permissive` with no credential, trusts the client, and
+    /// refusing anonymous admin ops there would break no-auth deployments and outage-free adoption —
+    /// this is the same `caller_is_privileged` ruling the priority ceiling uses. In `required` mode
+    /// every caller is authenticated, so the gate binds every real user. Admin is the same ruling the
+    /// rest of the control plane uses (`caller_is_admin`): the token's `admin` claim or an accounting
+    /// `Admin` level. Call it as a prologue, before `into_inner`, so the verified identity decides.
     #[allow(clippy::result_large_err)]
     fn require_admin<T>(&self, request: &Request<T>, op: &str) -> Result<(), Status> {
-        if self.caller_is_admin(Self::verified_identity(request)) {
+        if self.caller_is_privileged(Self::verified_identity(request)) {
             Ok(())
         } else {
             Err(Status::permission_denied(format!(
@@ -6853,13 +6855,13 @@ mod tests {
     // --- control-plane mutation authorization ---
     //
     // Every RPC that defines cluster tenancy (partitions, node placement/labels, admission tokens,
-    // reservations) must require a verified administrator. Deny-by-default is the contract: a
-    // verified non-admin AND an anonymous caller (no identity — `disabled`, or `permissive` with no
-    // credential) are both refused. Enumerated as a table so the next handler added cannot quietly
-    // reopen the boundary without a failing test.
+    // reservations) must reject an identified non-admin. An anonymous caller (no identity —
+    // `disabled`, or `permissive` with no credential) passes the gate, matching the auth model's
+    // non-enforcing modes; the gate binds real users in `required` mode. Enumerated as a table so the
+    // next handler added cannot quietly reopen the boundary to an identified non-admin.
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn control_plane_mutations_deny_non_admin_and_anonymous() {
+    async fn control_plane_mutations_deny_identified_non_admin() {
         let dir = tempfile::TempDir::new().unwrap();
         let svc = test_service(&dir).await;
 
@@ -6878,16 +6880,16 @@ mod tests {
                     concat!(stringify!($method), " (non-admin) must be PermissionDenied")
                 );
 
-                // Deny-by-default: no verified identity at all is also rejected.
-                let err = svc.$method(Request::new($req)).await.expect_err(concat!(
-                    stringify!($method),
-                    " must reject an anonymous caller"
-                ));
-                assert_eq!(
-                    err.code(),
-                    Code::PermissionDenied,
-                    concat!(stringify!($method), " (anonymous) must be PermissionDenied")
-                );
+                // No verified identity (disabled, or permissive with no credential) passes the gate,
+                // keeping the non-enforcing modes working; the call then proceeds and may fail for
+                // unrelated reasons, but must never be rejected as PermissionDenied by the gate.
+                if let Err(e) = svc.$method(Request::new($req)).await {
+                    assert_ne!(
+                        e.code(),
+                        Code::PermissionDenied,
+                        concat!(stringify!($method), " (anonymous) must not be gate-rejected")
+                    );
+                }
             }};
         }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -497,8 +497,9 @@ impl ControllerService {
     /// refusing anonymous admin ops there would break no-auth deployments and outage-free adoption —
     /// this is the same `caller_is_privileged` ruling the priority ceiling uses. In `required` mode
     /// every caller is authenticated, so the gate binds every real user. Admin is the same ruling the
-    /// rest of the control plane uses (`caller_is_admin`): the token's `admin` claim or an accounting
-    /// `Admin` level. Call it as a prologue, before `into_inner`, so the verified identity decides.
+    /// rest of the control plane uses (`caller_is_admin`): the token's `admin` claim, an accounting
+    /// `Admin` level, or the `root` user (via `is_k0s_admin`). Call it as a prologue, before
+    /// `into_inner`, so the verified identity decides.
     #[allow(clippy::result_large_err)]
     fn require_admin<T>(&self, request: &Request<T>, op: &str) -> Result<(), Status> {
         if self.caller_is_privileged(Self::verified_identity(request)) {


### PR DESCRIPTION
Hardening: the RPCs that define cluster tenancy — partitions, node config, reservations, admission tokens, and the accounting service — performed no authorization. `Identity::require_admin` existed but had zero callers, so any reachable caller could rewrite the partition/account tables or self-promote via the accounting API.

## Change

- New `ControllerService::require_admin(&request, op)`: a deny-by-default admin prologue built on the existing identity spine (`verified_identity` from request extensions + `caller_is_admin`, i.e. token admin claim OR accounting Admin level). Returns `PermissionDenied` when there is no verified admin identity.
- Gates 11 controller mutation RPCs (after leader-forward, before `into_inner`): `create/update/delete_partition`, `reconfigure`, `update_node`, `create_token`, `list_tokens`, `revoke_token`, `create/update/delete_reservation`.
- New `accounting::grpc::require_admin` — the first production caller of `Identity::require_admin` — gating `create_account`, `delete_account`, `add_user`, `remove_user`, `create_qos`, `delete_qos`. Read-only `list_*`/`get_*` and the internal `record_job_*` telemetry stay open.
- Fixes `create_token`/`revoke_token` to forward to the leader via `forward_request` (preserves the caller's credential under HA; their previous manual forward dropped it).

## Tests

Deny-by-default table over all 11 gated controller RPCs (verified non-admin AND anonymous both rejected), an admin-passes test that actually creates the partition, and the accounting-mutation gate (admin allowed, non-admin/anonymous rejected — closes the `add_user` self-promotion path).

## Behaviour change / deferred

- This is a deliberate behaviour change: a caller with no verified admin identity (permissive-with-no-credential, or disabled mode) is now refused where it previously succeeded.
- `drain_node`/`deregister_node` left ungated pending a check of the node-self-service path (they are DoS, not tenancy-repooling — `update_node`'s label path, the actual re-pooling vector, IS gated).
- The accounting gate uses the token admin claim only (the accounting service holds no association-cache handle); the controller gate uses the richer `caller_is_admin`.

Verified on Linux CI. Part of the multi-tenancy authorization hardening (epic #665).