### PR TITLE
fix(security): enforce caller identity on job-mutation and agent RPCs

### DIFF
--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -331,6 +331,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 spur_proto::proto::UpdateJobRequest {
                     job_id,
                     hold: Some(true),
+                    user: crate::interactive::current_user()?,
                     ..Default::default()
                 },
             )
@@ -342,6 +343,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 spur_proto::proto::UpdateJobRequest {
                     job_id,
                     hold: Some(false),
+                    user: crate::interactive::current_user()?,
                     ..Default::default()
                 },
             )
@@ -1283,6 +1285,7 @@ async fn parse_and_update(controller: &str, params: &[String]) -> Result<()> {
             account,
             comment,
             qos,
+            user: crate::interactive::current_user()?,
             ..Default::default()
         },
     )

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -760,6 +760,7 @@ async fn dispatch_step(
             step_id,
             label: args.label,
             mpi: step_mpi.to_string(),
+            user: params.user.to_string(),
         })
         .await
         .context("RunStep dispatch failed")?

--- a/crates/spur-core/src/auth.rs
+++ b/crates/spur-core/src/auth.rs
@@ -29,6 +29,13 @@ pub enum AuthError {
     UnknownUser(String),
 }
 
+/// Subject under which the controller signs the credentials it presents to node agents.
+///
+/// An agent that verifies a credential carrying this subject knows the caller is the control plane,
+/// not an end user, and gates controller-only RPCs on it. Kept here so the controller (which mints
+/// the credential) and the agent (which checks it) cannot drift apart on the value.
+pub const CONTROLLER_SUBJECT: &str = "spurctld";
+
 /// Resolve a username to its UNIX credentials through NSS.
 ///
 /// The controller derives uid/gid from the *authenticated* username rather than accepting them from
@@ -92,6 +99,14 @@ impl Identity {
         }
     }
 
+    /// Whether this identity is the cluster controller (its credential's subject).
+    ///
+    /// Node agents use this to gate controller-only RPCs: a job launch or cancel must arrive from
+    /// the control plane, which allocates and accounts for it, not straight from a user's token.
+    pub fn is_controller(&self) -> bool {
+        self.user == CONTROLLER_SUBJECT
+    }
+
     /// Check if this identity can perform admin operations.
     pub fn require_admin(&self) -> Result<(), AuthError> {
         if self.is_admin {
@@ -105,14 +120,21 @@ impl Identity {
     }
 }
 
-/// Check that `user` is allowed to perform `action` on a job owned by `owner`.
+/// Check that a caller is allowed to perform `action` on a job owned by `owner`.
 ///
-/// Allows the owner, root, or an empty `user` (daemon calls and clients
-/// predating the identity field). Jobs with an empty owner are restricted to
-/// root only, since they run as root and granting access to any caller would
-/// be a privilege escalation.
-pub fn check_job_owner(user: &str, owner: &str, action: &str) -> Result<(), AuthError> {
-    if user.is_empty() || user == "root" || user == owner {
+/// Access is granted to the job's owner and to an explicitly identified internal/daemon caller
+/// (`is_internal` — the controller, or a verified admin). There is deliberately no bypass for an
+/// empty `user` or a literal `"root"` string: an internal caller must be named by `is_internal`,
+/// which the caller derives from a *verified* identity and never infers from a wire-supplied string
+/// an attacker can set. An empty `user` therefore matches no owner and is denied unless
+/// `is_internal`, so a job that runs as root (empty owner) stays reachable only by internal callers.
+pub fn check_job_owner(
+    user: &str,
+    is_internal: bool,
+    owner: &str,
+    action: &str,
+) -> Result<(), AuthError> {
+    if is_internal || (!user.is_empty() && user == owner) {
         return Ok(());
     }
     Err(AuthError::NotJobOwner {
@@ -315,15 +337,30 @@ mod tests {
     }
 
     #[test]
-    fn test_check_job_owner_allows_owner_root_and_daemon() {
-        assert!(check_job_owner("alice", "alice", "exec").is_ok());
-        assert!(check_job_owner("root", "alice", "exec").is_ok());
-        assert!(check_job_owner("", "alice", "exec").is_ok());
+    fn test_check_job_owner_allows_owner_and_internal() {
+        // The owner reaches their own job; an explicitly internal caller reaches any job.
+        assert!(check_job_owner("alice", false, "alice", "exec").is_ok());
+        assert!(check_job_owner("", true, "alice", "exec").is_ok());
+        assert!(check_job_owner("spurctld", true, "alice", "exec").is_ok());
+    }
+
+    /// The empty-user and literal-"root" bypasses are gone: only `is_internal` grants a non-owner,
+    /// and it is never inferred from the (attacker-controllable) `user` string.
+    #[test]
+    fn test_check_job_owner_no_empty_or_root_string_bypass() {
+        assert!(
+            check_job_owner("", false, "alice", "exec").is_err(),
+            "an empty user must not be treated as a daemon caller"
+        );
+        assert!(
+            check_job_owner("root", false, "alice", "exec").is_err(),
+            "a literal \"root\" username must not bypass the ownership check"
+        );
     }
 
     #[test]
     fn test_check_job_owner_rejects_other_user() {
-        let err = check_job_owner("bob", "alice", "exec").expect_err("bob must be denied");
+        let err = check_job_owner("bob", false, "alice", "exec").expect_err("bob must be denied");
         assert!(matches!(err, AuthError::NotJobOwner { .. }));
         assert_eq!(
             err.to_string(),
@@ -332,29 +369,50 @@ mod tests {
         );
     }
 
-    /// Jobs with an empty owner run as root, so only root and daemon (empty
-    /// user) are allowed. A regular user must be denied.
+    /// Jobs with an empty owner run as root, so only an internal caller is allowed — a named user is
+    /// denied, and an empty user no longer slips through as a daemon.
     #[test]
-    fn test_check_job_owner_empty_owner_restricts_to_root() {
-        assert!(check_job_owner("root", "", "exec").is_ok());
-        assert!(check_job_owner("", "", "exec").is_ok());
+    fn test_check_job_owner_empty_owner_restricts_to_internal() {
+        assert!(check_job_owner("", true, "", "exec").is_ok());
         assert!(
-            check_job_owner("alice", "", "exec").is_err(),
+            check_job_owner("", false, "", "exec").is_err(),
+            "an empty non-internal caller must not match an empty owner"
+        );
+        assert!(
+            check_job_owner("alice", false, "", "exec").is_err(),
             "empty-owner jobs run as root; granting access is a privilege escalation"
         );
     }
 
     /// A non-empty placeholder owner matches no caller, so it restricts the job
-    /// to root. Asserted so that introducing such a placeholder cannot silently
-    /// lock users out of their own jobs.
+    /// to internal callers. Asserted so that introducing such a placeholder
+    /// cannot silently lock users out of their own jobs.
     #[test]
-    fn test_check_job_owner_placeholder_owner_restricts_to_root() {
-        assert!(check_job_owner("root", "k8s", "exec").is_ok());
+    fn test_check_job_owner_placeholder_owner_restricts_to_internal() {
+        assert!(check_job_owner("", true, "k8s", "exec").is_ok());
         assert!(
-            check_job_owner("alice", "k8s", "exec").is_err(),
+            check_job_owner("alice", false, "k8s", "exec").is_err(),
             "a placeholder owner denies every named user; record the real \
              submitter or leave the owner empty instead"
         );
+    }
+
+    #[test]
+    fn test_is_controller_only_matches_the_controller_subject() {
+        let controller = Identity {
+            user: CONTROLLER_SUBJECT.into(),
+            uid: 0,
+            gid: 0,
+            is_admin: true,
+        };
+        assert!(controller.is_controller());
+        let user = Identity {
+            user: "alice".into(),
+            uid: 1000,
+            gid: 1000,
+            is_admin: false,
+        };
+        assert!(!user.is_controller());
     }
 
     #[test]

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -28,8 +28,9 @@ use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 /// enough to tolerate clock skew between the controller and a node.
 const CREDENTIAL_TTL_SECS: u64 = 300;
 
-/// Subject the agent sees for controller-issued credentials.
-const CONTROLLER_SUBJECT: &str = "spurctld";
+/// Subject the agent sees for controller-issued credentials. Shared with the agent (which gates
+/// controller-only RPCs on it) via `spur_core::auth` so the two cannot drift apart.
+use spur_core::auth::CONTROLLER_SUBJECT;
 
 /// An agent channel that presents the controller's credential.
 pub type AgentChannel = InterceptedService<Channel, ControllerCredential>;

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2593,6 +2593,45 @@ impl ClusterManager {
             None => None,
         };
 
+        // Re-validate placement, account and wall-time against the resulting spec
+        // before mutating, exactly as submit_job does. An owner editing a job's
+        // partition/account/time_limit must still satisfy the same partition ACLs,
+        // account associations and MaxTime limits — otherwise a post-submit rewrite
+        // would slip a job onto nodes or into an account the user is not entitled to
+        // (the QOS arm above already re-validates for the same reason). Reject before
+        // mutating so a failed edit leaves the job untouched.
+        {
+            let partitions = self.partitions.read().clone();
+            let config = self.config();
+            let candidate = {
+                let jobs = self.jobs.read();
+                let job = jobs
+                    .get(&job_id)
+                    .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
+                let mut spec = job.spec.clone();
+                if let Some(tl) = time_limit {
+                    spec.time_limit = Some(tl);
+                }
+                if let Some(part) = partition.as_ref() {
+                    spec.partition = Some(part.clone());
+                }
+                if let Some(acct) = account.as_ref() {
+                    spec.account = Some(acct.clone());
+                }
+                if let Some(q) = qos.as_ref() {
+                    spec.qos = Some(q.clone());
+                }
+                spec
+            };
+            validate_user_account(&candidate, &self.association_cache)?;
+            self.validate_partition(&candidate, &partitions)?;
+            validate_partition_time_limit(
+                &candidate,
+                config.scheduler.enforce_part_limits,
+                &partitions,
+            )?;
+        }
+
         if let Some(p) = priority {
             let old = self
                 .jobs

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1190,9 +1190,14 @@ impl ClusterManager {
     }
 
     /// Check that `user` is allowed to perform `action` on a job owned by `owner`.
-    /// Delegates to [`spur_core::auth::check_job_owner`]; see there for the bypass rules.
+    ///
+    /// These are control-plane paths where `user` has already been bound to the verified identity
+    /// (or is a daemon-internal call that leaves it empty). An empty `user` is the daemon caller and
+    /// a literal `"root"` is the admin override, so both are treated as internal here; the raw
+    /// [`spur_core::auth::check_job_owner`] no longer infers that itself.
     fn check_job_owner(user: &str, owner: &str, action: &str) -> anyhow::Result<()> {
-        spur_core::auth::check_job_owner(user, owner, action).map_err(Into::into)
+        let is_internal = user.is_empty() || user == "root";
+        spur_core::auth::check_job_owner(user, is_internal, owner, action).map_err(Into::into)
     }
 
     /// Cancel a job. The requesting `user` must be the job owner, root, or

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1234,6 +1234,7 @@ impl ClusterManager {
         &self,
         job_id: JobId,
         user: &str,
+        caller_is_admin: bool,
         hold: bool,
     ) -> anyhow::Result<RequeueOutcome> {
         let (targets, is_array) = {
@@ -1258,7 +1259,7 @@ impl ClusterManager {
         // user sees exactly why (not owner, interactive, already pending, ...).
         if !is_array {
             let id = targets[0];
-            let (requeued, killed) = self.requeue_one_job(id, user, hold)?;
+            let (requeued, killed) = self.requeue_one_job(id, user, caller_is_admin, hold)?;
             return Ok(if requeued {
                 RequeueOutcome {
                     requeued: 1,
@@ -1281,7 +1282,7 @@ impl ClusterManager {
         let total = targets.len();
         let mut outcome = RequeueOutcome::default();
         for id in targets {
-            match self.requeue_one_job(id, user, hold) {
+            match self.requeue_one_job(id, user, caller_is_admin, hold) {
                 Ok((true, killed)) => {
                     outcome.requeued += 1;
                     outcome.killed.extend(killed);
@@ -1310,6 +1311,7 @@ impl ClusterManager {
         &self,
         job_id: JobId,
         user: &str,
+        caller_is_admin: bool,
         hold: bool,
     ) -> anyhow::Result<(bool, Option<Job>)> {
         let snapshot = {
@@ -1317,7 +1319,8 @@ impl ClusterManager {
             let job = jobs
                 .get(&job_id)
                 .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
-            Self::check_job_owner(user, &job.spec.user, "requeue")?;
+            spur_core::auth::check_job_owner(user, caller_is_admin, &job.spec.user, "requeue")
+                .map_err(anyhow::Error::from)?;
             // Interactive/srun allocations have no batch script to re-run.
             if job.spec.interactive || job.spec.srun_job || job.spec.pty {
                 anyhow::bail!("job {} is interactive and cannot be requeued", job_id);
@@ -10273,7 +10276,9 @@ mod tests {
         let job_id = run_job_on(&cm, "requeue-me", "worker1");
         assert_eq!(cm.node_metrics().alloc_cpus, 2);
 
-        let outcome = cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        let outcome = cm
+            .requeue_job_by_user(job_id, "testuser", false, false)
+            .unwrap();
         assert_eq!(
             outcome.killed.len(),
             1,
@@ -10314,7 +10319,9 @@ mod tests {
         cm.suspend_job(job_id, "testuser").unwrap();
         settle(&cm, job_id, JobState::Suspended);
 
-        let outcome = cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        let outcome = cm
+            .requeue_job_by_user(job_id, "testuser", false, false)
+            .unwrap();
         assert_eq!(outcome.killed.len(), 1);
         settle(&cm, job_id, JobState::Pending);
 
@@ -10335,7 +10342,9 @@ mod tests {
         settle(&cm, job_id, JobState::Completed);
 
         // An already-terminal job has no live processes to kill.
-        let outcome = cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        let outcome = cm
+            .requeue_job_by_user(job_id, "testuser", false, false)
+            .unwrap();
         assert!(
             outcome.killed.is_empty(),
             "terminal job needs no agent kill"
@@ -10368,7 +10377,8 @@ mod tests {
             cm.complete_job(job_id, -1, state).unwrap();
             settle(&cm, job_id, state);
 
-            cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+            cm.requeue_job_by_user(job_id, "testuser", false, false)
+                .unwrap();
             settle(&cm, job_id, JobState::Pending);
             assert_eq!(cm.get_job(job_id).unwrap().user_requeue_count, 1);
         }
@@ -10394,7 +10404,7 @@ mod tests {
 
         // Requeuing already-terminal A must not free its slice a second time, or
         // B's accounting on the shared node would be corrupted.
-        cm.requeue_job_by_user(a, "testuser", false).unwrap();
+        cm.requeue_job_by_user(a, "testuser", false, false).unwrap();
         settle(&cm, a, JobState::Pending);
         assert_eq!(
             cm.node_metrics().alloc_cpus,
@@ -10441,7 +10451,8 @@ mod tests {
         register_node(&cm, "worker1", 8, 16000);
 
         let job_id = run_job_on(&cm, "requeue-hold", "worker1");
-        cm.requeue_job_by_user(job_id, "testuser", true).unwrap();
+        cm.requeue_job_by_user(job_id, "testuser", false, true)
+            .unwrap();
         settle(&cm, job_id, JobState::Pending);
 
         let job = cm.get_job(job_id).unwrap();
@@ -10474,7 +10485,7 @@ mod tests {
             apply(&mut spec);
             let job_id = submit_and_wait(&cm, spec);
             let err = cm
-                .requeue_job_by_user(job_id, "testuser", false)
+                .requeue_job_by_user(job_id, "testuser", false, false)
                 .expect_err("interactive jobs cannot be requeued");
             assert!(err.to_string().contains("interactive"), "{name}: {err}");
         }
@@ -10487,7 +10498,8 @@ mod tests {
         register_node(&cm, "worker1", 8, 16000);
 
         let job_id = run_job_on(&cm, "hold-release", "worker1");
-        cm.requeue_job_by_user(job_id, "testuser", true).unwrap();
+        cm.requeue_job_by_user(job_id, "testuser", false, true)
+            .unwrap();
         settle(&cm, job_id, JobState::Pending);
         assert!(cm
             .get_job(job_id)
@@ -10528,7 +10540,8 @@ mod tests {
         .unwrap();
         settle(&cm, job_id, JobState::Running);
 
-        cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        cm.requeue_job_by_user(job_id, "testuser", false, false)
+            .unwrap();
         settle(&cm, job_id, JobState::Pending);
         assert_eq!(
             cm.get_job(job_id).unwrap().spec.begin_time,
@@ -10547,7 +10560,8 @@ mod tests {
         let job_id = run_job_on(&cm, "epoch", "worker1");
         assert_eq!(cm.get_job(job_id).unwrap().run_attempt, 1);
 
-        cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+        cm.requeue_job_by_user(job_id, "testuser", false, false)
+            .unwrap();
         settle(&cm, job_id, JobState::Pending);
 
         // Re-dispatch bumps the epoch to 2 (requeue must not have reset it).
@@ -10576,7 +10590,7 @@ mod tests {
         let job_id = submit_and_wait(&cm, basic_spec("pending"));
 
         let err = cm
-            .requeue_job_by_user(job_id, "testuser", false)
+            .requeue_job_by_user(job_id, "testuser", false, false)
             .expect_err("a pending job cannot be requeued");
         assert!(err.to_string().contains("already pending"), "got: {err}");
     }
@@ -10589,14 +10603,14 @@ mod tests {
         let job_id = run_job_on(&cm, "owned-by-testuser", "worker1");
 
         let err = cm
-            .requeue_job_by_user(job_id, "bob", false)
-            .expect_err("a non-owner non-root user must be denied");
+            .requeue_job_by_user(job_id, "bob", false, false)
+            .expect_err("a non-owner non-admin must be denied");
         assert!(
             err.downcast_ref::<spur_core::auth::AuthError>().is_some(),
             "got: {err}"
         );
-        // root may requeue any job.
-        cm.requeue_job_by_user(job_id, "root", false).unwrap();
+        // an admin may requeue any job.
+        cm.requeue_job_by_user(job_id, "root", true, false).unwrap();
         settle(&cm, job_id, JobState::Pending);
     }
 
@@ -10639,7 +10653,9 @@ mod tests {
         }
 
         // Requeuing the bare array-parent id fans out to every task.
-        let outcome = cm.requeue_job_by_user(parent, "testuser", false).unwrap();
+        let outcome = cm
+            .requeue_job_by_user(parent, "testuser", false, false)
+            .unwrap();
         assert_eq!(outcome.requeued, task_ids.len() as u32);
         assert!(outcome.skipped.is_empty());
         for &id in &task_ids {
@@ -10667,7 +10683,7 @@ mod tests {
         });
 
         let err = cm
-            .requeue_job_by_user(parent, "testuser", false)
+            .requeue_job_by_user(parent, "testuser", false, false)
             .expect_err("all-pending array requeue must error");
         assert!(err.to_string().contains("no tasks of array"), "got: {err}");
     }
@@ -10687,7 +10703,7 @@ mod tests {
         settle(&cm, job_id, JobState::Completing);
 
         let err = cm
-            .requeue_job_by_user(job_id, "testuser", false)
+            .requeue_job_by_user(job_id, "testuser", false, false)
             .expect_err("a completing job cannot be requeued");
         assert!(err.to_string().contains("completing"), "got: {err}");
     }
@@ -10728,7 +10744,9 @@ mod tests {
         .unwrap();
         settle(&cm, task_ids[0], JobState::Running);
 
-        let outcome = cm.requeue_job_by_user(parent, "testuser", false).unwrap();
+        let outcome = cm
+            .requeue_job_by_user(parent, "testuser", false, false)
+            .unwrap();
         assert_eq!(outcome.requeued, 1, "only the running task is requeued");
         assert_eq!(
             outcome.skipped.len(),
@@ -10792,7 +10810,8 @@ mod tests {
                 .unwrap();
                 settle(&cm, job_id, JobState::Running);
             }
-            cm.requeue_job_by_user(job_id, "testuser", false).unwrap();
+            cm.requeue_job_by_user(job_id, "testuser", false, false)
+                .unwrap();
             settle(&cm, job_id, JobState::Pending);
             let job = cm.get_job(job_id).unwrap();
             assert_eq!(job.user_requeue_count, n + 1);

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2631,7 +2631,7 @@ impl ClusterManager {
                 }
                 spec
             };
-            validate_user_account(&candidate, &self.association_cache)?;
+            validate_user_account(&candidate, &self.association_cache, &config.accounting)?;
             self.validate_partition(&candidate, &partitions)?;
             validate_partition_time_limit(
                 &candidate,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -958,7 +958,7 @@ impl SlurmController for ControllerService {
             .ok_or_else(|| Status::not_found(format!("job {} not found", req.job_id)))?;
         spur_core::auth::check_job_owner(
             &req.user,
-            req.user == "root",
+            self.caller_is_admin(__identity.as_ref()),
             &job.spec.user,
             "send keepalive for",
         )
@@ -1068,15 +1068,16 @@ impl SlurmController for ControllerService {
         // Reject a caller who does not own the target job before any mutation —
         // including the hold/release branch below. Mirrors cancel_job / exec_in_job:
         // update touches placement, account and time limit, so it must be gated the
-        // same way. An empty/root caller (unauthenticated permissive/disabled, or
-        // the internal control plane) is treated as internal, as at the attach path.
+        // same way. `is_internal` is a verified admin only — derived from the
+        // verified identity, never the wire `user` string; an unauthenticated
+        // non-owner is still denied, ownership checked against the claimed user.
         let job = self
             .cluster
             .get_job(req.job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", req.job_id)))?;
         spur_core::auth::check_job_owner(
             &req.user,
-            req.user.is_empty() || req.user == "root",
+            self.caller_is_admin(__identity.as_ref()),
             &job.spec.user,
             "modify",
         )
@@ -1956,7 +1957,7 @@ impl SlurmController for ControllerService {
 
         spur_core::auth::check_job_owner(
             &req.user,
-            req.user.is_empty() || req.user == "root",
+            self.caller_is_admin(__identity.as_ref()),
             &job.spec.user,
             "attach to",
         )
@@ -2480,7 +2481,7 @@ impl SlurmController for ControllerService {
 
         spur_core::auth::check_job_owner(
             &req.user,
-            req.user.is_empty() || req.user == "root",
+            self.caller_is_admin(__identity.as_ref()),
             &job.spec.user,
             "exec into",
         )
@@ -2553,7 +2554,7 @@ impl SlurmController for ControllerService {
         // caller must own the target job — same gate as create_job_step / exec_in_job.
         spur_core::auth::check_job_owner(
             &req.user,
-            req.user.is_empty() || req.user == "root",
+            self.caller_is_admin(__identity.as_ref()),
             &job.spec.user,
             "run a step in",
         )
@@ -5729,6 +5730,40 @@ mod tests {
             None,
             "a denied update must not mutate the job"
         );
+    }
+
+    // `is_internal` is derived from the verified identity (an admin), not the wire `user` string, so
+    // (a) an admin whose username is not literally "root" is still treated as internal, and (b) an
+    // unauthenticated caller cannot bypass ownership by claiming user = "root".
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_job_admin_override_uses_verified_identity_not_wire_root() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        // A verified admin whose name is not "root" may modify another user's job.
+        let mut admin_req = Request::new(UpdateJobRequest {
+            job_id,
+            comment: Some("by-admin".into()),
+            ..Default::default()
+        });
+        admin_req.extensions_mut().insert(viewer("carol", true));
+        assert!(
+            svc.update_job(admin_req).await.is_ok(),
+            "a verified admin (non-root) must be able to modify any job"
+        );
+
+        // An unauthenticated caller cannot spoof admin by putting user = "root" on the wire.
+        let err = svc
+            .update_job(Request::new(UpdateJobRequest {
+                job_id,
+                comment: Some("spoof".into()),
+                user: "root".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("claiming root without a credential must not bypass ownership");
+        assert_eq!(err.code(), Code::PermissionDenied);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1144,10 +1144,13 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let caller_is_admin = self.caller_is_admin(__identity.as_ref());
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
         let outcome = self
             .cluster
-            .requeue_job_by_user(req.job_id, &req.user, req.hold)
+            .requeue_job_by_user(req.job_id, &req.user, caller_is_admin, req.hold)
             .map_err(cluster_err_to_precondition_status)?;
 
         // Kill the old processes for jobs that were Running/Suspended; the
@@ -5238,6 +5241,59 @@ mod tests {
             .into_inner();
         assert_eq!(resp.requeued, 1);
         assert!(resp.skipped.is_empty());
+    }
+
+    // An authenticated non-admin cannot requeue another user's job by setting user="root" on
+    // the wire. authoritative_user overwrites the field before the owner check.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn requeue_job_rejects_spoofed_root_from_authenticated_non_admin() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        let mut req = Request::new(RequeueJobRequest {
+            job_id,
+            user: "root".into(), // spoof admin on the wire
+            hold: false,
+        });
+        req.extensions_mut().insert(viewer("mallory", false));
+
+        let err = svc
+            .requeue_job(req)
+            .await
+            .expect_err("a spoofed root claim must not bypass the ownership check");
+        assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    // A verified admin (whose username is not literally "root") can requeue any job.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn requeue_job_admin_override_uses_verified_identity_not_wire_root() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        // A verified admin (name != "root") may requeue another user's job.
+        let mut admin_req = Request::new(RequeueJobRequest {
+            job_id,
+            hold: false,
+            ..Default::default()
+        });
+        admin_req.extensions_mut().insert(viewer("carol", true));
+        assert!(
+            svc.requeue_job(admin_req).await.is_ok(),
+            "a verified admin (non-root) must be able to requeue any job"
+        );
+
+        // An unauthenticated caller cannot claim admin by putting user="root" on the wire.
+        let err = svc
+            .requeue_job(Request::new(RequeueJobRequest {
+                job_id,
+                user: "root".into(),
+                hold: false,
+            }))
+            .await
+            .expect_err("claiming root without a credential must not bypass ownership");
+        assert_eq!(err.code(), Code::PermissionDenied);
     }
 
     // A step must NOT be created when the target node is allocated but unregistered: address

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -956,8 +956,13 @@ impl SlurmController for ControllerService {
             .cluster
             .get_job(req.job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", req.job_id)))?;
-        spur_core::auth::check_job_owner(&req.user, &job.spec.user, "send keepalive for")
-            .map_err(|e| Status::permission_denied(e.to_string()))?;
+        spur_core::auth::check_job_owner(
+            &req.user,
+            req.user == "root",
+            &job.spec.user,
+            "send keepalive for",
+        )
+        .map_err(|e| Status::permission_denied(e.to_string()))?;
 
         // Only interactive allocations are reaped, so only they need tracking.
         if !(job.spec.interactive || job.spec.srun_job) {
@@ -1063,14 +1068,19 @@ impl SlurmController for ControllerService {
         // Reject a caller who does not own the target job before any mutation —
         // including the hold/release branch below. Mirrors cancel_job / exec_in_job:
         // update touches placement, account and time limit, so it must be gated the
-        // same way. An empty/root user (unauthenticated permissive/disabled) is
-        // treated as authorized by check_job_owner.
+        // same way. An empty/root caller (unauthenticated permissive/disabled, or
+        // the internal control plane) is treated as internal, as at the attach path.
         let job = self
             .cluster
             .get_job(req.job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", req.job_id)))?;
-        spur_core::auth::check_job_owner(&req.user, &job.spec.user, "modify")
-            .map_err(|e| Status::permission_denied(e.to_string()))?;
+        spur_core::auth::check_job_owner(
+            &req.user,
+            req.user.is_empty() || req.user == "root",
+            &job.spec.user,
+            "modify",
+        )
+        .map_err(|e| Status::permission_denied(e.to_string()))?;
 
         // Handle hold/release via priority
         if let Some(hold) = req.hold {
@@ -1944,8 +1954,13 @@ impl SlurmController for ControllerService {
             .get_job(job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))?;
 
-        spur_core::auth::check_job_owner(&req.user, &job.spec.user, "attach to")
-            .map_err(|e| Status::permission_denied(e.to_string()))?;
+        spur_core::auth::check_job_owner(
+            &req.user,
+            req.user.is_empty() || req.user == "root",
+            &job.spec.user,
+            "attach to",
+        )
+        .map_err(|e| Status::permission_denied(e.to_string()))?;
 
         if job.state != spur_core::job::JobState::Running {
             return Err(Status::failed_precondition(format!(
@@ -2463,8 +2478,13 @@ impl SlurmController for ControllerService {
             .get_job(job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))?;
 
-        spur_core::auth::check_job_owner(&req.user, &job.spec.user, "exec into")
-            .map_err(|e| Status::permission_denied(e.to_string()))?;
+        spur_core::auth::check_job_owner(
+            &req.user,
+            req.user.is_empty() || req.user == "root",
+            &job.spec.user,
+            "exec into",
+        )
+        .map_err(|e| Status::permission_denied(e.to_string()))?;
 
         if job.state != spur_core::job::JobState::Running {
             return Err(Status::failed_precondition(format!(
@@ -2531,8 +2551,13 @@ impl SlurmController for ControllerService {
 
         // A step executes arbitrary commands on the job's allocated nodes, so the
         // caller must own the target job — same gate as create_job_step / exec_in_job.
-        spur_core::auth::check_job_owner(&req.user, &job.spec.user, "run a step in")
-            .map_err(|e| Status::permission_denied(e.to_string()))?;
+        spur_core::auth::check_job_owner(
+            &req.user,
+            req.user.is_empty() || req.user == "root",
+            &job.spec.user,
+            "run a step in",
+        )
+        .map_err(|e| Status::permission_denied(e.to_string()))?;
 
         if job.allocated_nodes.is_empty() {
             return Err(Status::failed_precondition(format!(

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1055,8 +1055,22 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let caller_is_privileged = self.caller_is_privileged(Self::verified_identity(&request));
+        let __identity = Self::verified_identity(&request).cloned();
+        let caller_is_privileged = self.caller_is_privileged(__identity.as_ref());
         let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
+
+        // Reject a caller who does not own the target job before any mutation —
+        // including the hold/release branch below. Mirrors cancel_job / exec_in_job:
+        // update touches placement, account and time limit, so it must be gated the
+        // same way. An empty/root user (unauthenticated permissive/disabled) is
+        // treated as authorized by check_job_owner.
+        let job = self
+            .cluster
+            .get_job(req.job_id)
+            .ok_or_else(|| Status::not_found(format!("job {} not found", req.job_id)))?;
+        spur_core::auth::check_job_owner(&req.user, &job.spec.user, "modify")
+            .map_err(|e| Status::permission_denied(e.to_string()))?;
 
         // Handle hold/release via priority
         if let Some(hold) = req.hold {
@@ -2505,13 +2519,20 @@ impl SlurmController for ControllerService {
             return client.run_step(fwd).await;
         }
 
-        let req = request.into_inner();
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
         let job_id = req.job_id;
 
         let job = self
             .cluster
             .get_job(job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))?;
+
+        // A step executes arbitrary commands on the job's allocated nodes, so the
+        // caller must own the target job — same gate as create_job_step / exec_in_job.
+        spur_core::auth::check_job_owner(&req.user, &job.spec.user, "run a step in")
+            .map_err(|e| Status::permission_denied(e.to_string()))?;
 
         if job.allocated_nodes.is_empty() {
             return Err(Status::failed_precondition(format!(
@@ -5603,6 +5624,106 @@ mod tests {
             .expect("the owner must be allowed to attach");
 
         assert_eq!(resp.into_inner().node_addr, "127.0.0.1:6818");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_job_denies_non_owner() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        let err = svc
+            .update_job(Request::new(UpdateJobRequest {
+                job_id,
+                comment: Some("owned".into()),
+                user: "rsikande".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("a non-owner must not modify another user's job");
+
+        assert_eq!(err.code(), Code::PermissionDenied);
+        assert_eq!(
+            svc.cluster.get_job(job_id).unwrap().spec.comment,
+            None,
+            "a denied update must not mutate the job"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_job_allows_owner() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        svc.update_job(Request::new(UpdateJobRequest {
+            job_id,
+            comment: Some("reviewed".into()),
+            user: "ubuntu".into(),
+            ..Default::default()
+        }))
+        .await
+        .expect("the owner must be allowed to modify their job");
+
+        assert_eq!(
+            svc.cluster.get_job(job_id).unwrap().spec.comment,
+            Some("reviewed".into())
+        );
+    }
+
+    /// The owner check must key off the *authenticated* identity, not the
+    /// wire-asserted `user`: a caller cannot spoof the owner's name to slip past
+    /// the gate. `authoritative_user` overwrites the field before the check.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_job_rejects_spoofed_owner_when_authenticated() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        let mut req = Request::new(UpdateJobRequest {
+            job_id,
+            comment: Some("owned".into()),
+            user: "ubuntu".into(), // spoof the owner's name on the wire
+            ..Default::default()
+        });
+        req.extensions_mut().insert(spur_core::auth::Identity {
+            user: "rsikande".into(),
+            uid: 1001,
+            gid: 1001,
+            is_admin: false,
+        });
+
+        let err = svc
+            .update_job(req)
+            .await
+            .expect_err("a spoofed owner name must not bypass the ownership check");
+
+        assert_eq!(err.code(), Code::PermissionDenied);
+        assert_eq!(
+            svc.cluster.get_job(job_id).unwrap().spec.comment,
+            None,
+            "a denied update must not mutate the job"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_step_denies_non_owner() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        let err = svc
+            .run_step(Request::new(RunStepRequest {
+                job_id,
+                command: vec!["id".into()],
+                step_id: 0,
+                user: "rsikande".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("a non-owner must not run a step in another user's allocation");
+
+        assert_eq!(err.code(), Code::PermissionDenied);
     }
 
     async fn assign_ha_control_plane(svc: &ControllerService) {

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1054,8 +1054,17 @@ impl SlurmAgent for AgentService {
         &self,
         request: Request<LaunchJobRequest>,
     ) -> Result<Response<LaunchJobResponse>, Status> {
+        Self::require_controller(&request)?;
         let req = request.into_inner();
         let job_id = req.job_id;
+        // A launch names the node the controller scheduled it onto. If it does not name this host it
+        // was aimed at the wrong agent — refuse rather than run another node's allocation here.
+        if !req.target_node.is_empty() && !self.agent_owns_node(&req.target_node) {
+            return Err(Status::failed_precondition(format!(
+                "launch targeted node '{}' but this agent serves '{}'",
+                req.target_node, self.reporter.hostname
+            )));
+        }
         let peer_nodes = req.peer_nodes;
         let task_offset = req.task_offset;
         // Per-task array identity is controller-assigned on the launch request,
@@ -1664,6 +1673,7 @@ impl SlurmAgent for AgentService {
         &self,
         request: Request<AgentCancelJobRequest>,
     ) -> Result<Response<()>, Status> {
+        Self::require_controller(&request)?;
         let req = request.into_inner();
         let job_id = req.job_id;
 
@@ -1694,6 +1704,7 @@ impl SlurmAgent for AgentService {
         &self,
         request: Request<CancelStepRequest>,
     ) -> Result<Response<()>, Status> {
+        Self::require_controller(&request)?;
         let req = request.into_inner();
         let step_key = (req.job_id, req.step_id);
         let signal = if req.signal > 0 {
@@ -1721,6 +1732,7 @@ impl SlurmAgent for AgentService {
         &self,
         request: Request<AgentSuspendJobRequest>,
     ) -> Result<Response<()>, Status> {
+        Self::require_controller(&request)?;
         let req = request.into_inner();
         self.suspend_signal(req.job_id, req.resume).await;
         Ok(Response::new(()))
@@ -1743,9 +1755,10 @@ impl SlurmAgent for AgentService {
         &self,
         request: Request<ExecInJobRequest>,
     ) -> Result<Response<ExecInJobResponse>, Status> {
+        let identity = Self::verified_identity(&request).cloned();
         let req = request.into_inner();
 
-        self.check_job_access(req.job_id, &req.user, "exec into")
+        self.check_job_access(req.job_id, identity.as_ref(), &req.user, "exec into")
             .await?;
 
         let entry = self.job_entry(req.job_id).await?;
@@ -1906,6 +1919,7 @@ impl SlurmAgent for AgentService {
         &self,
         request: Request<RunCommandRequest>,
     ) -> Result<Response<RunCommandResponse>, Status> {
+        Self::require_controller(&request)?;
         let req = request.into_inner();
         if req.command.is_empty() {
             return Err(Status::invalid_argument("no command specified"));
@@ -2267,10 +2281,11 @@ impl SlurmAgent for AgentService {
         &self,
         request: Request<StreamJobOutputRequest>,
     ) -> Result<Response<Self::StreamJobOutputStream>, Status> {
+        let identity = Self::verified_identity(&request).cloned();
         let req = request.into_inner();
         let job_id = req.job_id;
 
-        self.check_job_access(job_id, &req.user, "read output of")
+        self.check_job_access(job_id, identity.as_ref(), &req.user, "read output of")
             .await?;
 
         // No retry on a miss, same as run_command: a Running job has been
@@ -2364,6 +2379,7 @@ impl SlurmAgent for AgentService {
     ) -> Result<Response<Self::InteractiveSessionStream>, Status> {
         use crate::pty::WindowSize as PtyWinSize;
 
+        let identity = Self::verified_identity(&request).cloned();
         let mut inbound = request.into_inner();
 
         let first = inbound
@@ -2381,7 +2397,7 @@ impl SlurmAgent for AgentService {
             }
         };
 
-        self.check_job_access(init.job_id, &init.user, "attach to")
+        self.check_job_access(init.job_id, identity.as_ref(), &init.user, "attach to")
             .await?;
 
         let entry = self.job_entry(init.job_id).await?;
@@ -2484,6 +2500,7 @@ impl SlurmAgent for AgentService {
         &self,
         request: Request<CreateK0sJoinTokenRequest>,
     ) -> Result<Response<CreateK0sJoinTokenResponse>, Status> {
+        Self::require_controller(&request)?;
         let req = request.into_inner();
         match self
             .k0s
@@ -2539,9 +2556,12 @@ impl SlurmAgent for AgentService {
         &self,
         request: Request<GetKubeconfigRequest>,
     ) -> Result<Response<GetKubeconfigResponse>, Status> {
+        Self::require_controller(&request)?;
         let req = request.into_inner();
         // Empty user -> cluster-admin kubeconfig; set -> a scoped kubeconfig (SA + bound token in the
-        // user's account namespace).
+        // user's account namespace). The controller already gates admin kubeconfig behind
+        // `is_k0s_admin` + `allow_admin_kubeconfig`; requiring the controller here keeps that from
+        // being sidestepped by dialing the agent directly.
         let result = if req.user.is_empty() {
             self.k0s.admin_kubeconfig().await
         } else {
@@ -2840,18 +2860,76 @@ impl AgentService {
         });
     }
 
-    /// Gate `user` for `action` on job `job_id`, per
-    /// [`spur_core::auth::check_job_owner`].
+    /// The verified identity for this request, if the auth layer authenticated one.
     ///
-    /// Enforced here as well as on the controller because `sattach` and the
-    /// output stream dial the agent's port directly.
-    async fn check_job_access(&self, job_id: u32, user: &str, action: &str) -> Result<(), Status> {
+    /// `None` means the caller presented no credential — allowed only under `permissive`/`disabled`,
+    /// where the pre-auth behavior is preserved (`required` never reaches a handler unauthenticated,
+    /// the auth layer rejects first). Only [`crate::auth_middleware`] inserts this, so its presence
+    /// always means "verified".
+    fn verified_identity<T>(request: &Request<T>) -> Option<&spur_core::auth::Identity> {
+        request.extensions().get::<spur_core::auth::Identity>()
+    }
+
+    /// Refuse a controller-only RPC unless the verified caller is the cluster controller.
+    ///
+    /// These RPCs (launch/run/cancel/suspend, kubeconfig, join-token) drive work and secrets that
+    /// only the control plane may request; a valid *user* token — which verifies identically to the
+    /// controller's under the shared cluster key — must not reach them by dialing the agent directly.
+    /// An unauthenticated caller is tolerated only under `permissive`/`disabled` (there is no
+    /// identity to check), matching the rest of the agent's no-auth behavior.
+    fn require_controller<T>(request: &Request<T>) -> Result<(), Status> {
+        match Self::verified_identity(request) {
+            Some(id) if id.is_controller() => Ok(()),
+            Some(id) => Err(Status::permission_denied(format!(
+                "this RPC is reachable only by the cluster controller; caller '{}' is not the \
+                 controller — route the request through spurctld",
+                id.user
+            ))),
+            None => Ok(()),
+        }
+    }
+
+    /// Whether `node` names this agent's own host.
+    ///
+    /// A launch carries the node the controller scheduled it onto; if it does not name this host the
+    /// request was misrouted (or aimed straight at the wrong node's agent) and must not run here.
+    /// Accepts either the reporter's node name or the OS hostname to tolerate short/long-name skew.
+    fn agent_owns_node(&self, node: &str) -> bool {
+        if node == self.reporter.hostname {
+            return true;
+        }
+        hostname::get()
+            .map(|h| h.to_string_lossy() == node)
+            .unwrap_or(false)
+    }
+
+    /// Gate a user-facing attach/exec/stream on job `job_id` for `action`.
+    ///
+    /// The caller is the *verified* identity, not a wire-supplied `user`: the owner reaches their own
+    /// job, an admin (or the controller) reaches any job, and everyone else is refused. With no
+    /// verified identity (`permissive`/`disabled` and no credential) the asserted `user` is trusted
+    /// as a plain, non-privileged principal — never as an internal caller — so an empty or `"root"`
+    /// string can no longer stand in for one.
+    ///
+    /// Enforced here as well as on the controller because `sattach` and the output stream dial the
+    /// agent's port directly.
+    async fn check_job_access(
+        &self,
+        job_id: u32,
+        identity: Option<&spur_core::auth::Identity>,
+        asserted_user: &str,
+        action: &str,
+    ) -> Result<(), Status> {
         let jobs = self.running.lock().await;
         let tracked = jobs
             .get(&job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not running on this node", job_id)))?;
 
-        spur_core::auth::check_job_owner(user, &tracked.user, action)
+        let (user, is_internal) = match identity {
+            Some(id) => (id.user.as_str(), id.is_admin),
+            None => (asserted_user, false),
+        };
+        spur_core::auth::check_job_owner(user, is_internal, &tracked.user, action)
             .map_err(|e| Status::permission_denied(e.to_string()))
     }
 
@@ -3855,6 +3933,24 @@ mod tests {
         assert_ne!(code, Some(tonic::Code::PermissionDenied));
     }
 
+    fn user_identity(name: &str) -> spur_core::auth::Identity {
+        spur_core::auth::Identity {
+            user: name.into(),
+            uid: 1000,
+            gid: 1000,
+            is_admin: false,
+        }
+    }
+
+    fn controller_identity() -> spur_core::auth::Identity {
+        spur_core::auth::Identity {
+            user: spur_core::auth::CONTROLLER_SUBJECT.into(),
+            uid: 0,
+            gid: 0,
+            is_admin: true,
+        }
+    }
+
     /// `interactive_session` (the `sattach` and `srun --pty` path) gates on
     /// `check_job_access`, but its handler consumes a gRPC stream that cannot be
     /// built in-process, so the gate is exercised directly here.
@@ -3869,27 +3965,47 @@ mod tests {
         svc.insert_test_job(46, TrackedJob::dummy(std::process::id()))
             .await;
 
-        svc.check_job_access(46, "testuser", "attach to")
+        // Verified owner and a verified admin (the controller mints an admin credential) are allowed.
+        svc.check_job_access(46, Some(&user_identity("testuser")), "", "attach to")
             .await
             .expect("the owner must be allowed to attach");
-        svc.check_job_access(46, "root", "attach to")
+        svc.check_job_access(46, Some(&controller_identity()), "", "attach to")
             .await
-            .expect("root is an admin override");
+            .expect("an admin/controller is an override");
 
+        // A verified non-owner is refused even if it claims the owner's name on the wire — the
+        // verified identity wins over the asserted `user`.
         let err = svc
-            .check_job_access(46, "intruder", "attach to")
+            .check_job_access(
+                46,
+                Some(&user_identity("intruder")),
+                "testuser",
+                "attach to",
+            )
             .await
             .expect_err("a non-owner must not attach to another user's job");
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
 
+        // With no verified identity (permissive/disabled) the asserted user is trusted only as a
+        // plain principal: the owner's name clears, another user's does not.
+        svc.check_job_access(46, None, "testuser", "attach to")
+            .await
+            .expect("the asserted owner clears under permissive");
+        let err = svc
+            .check_job_access(46, None, "intruder", "attach to")
+            .await
+            .expect_err("an asserted non-owner must be denied");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
         let missing = svc
-            .check_job_access(999, "testuser", "attach to")
+            .check_job_access(999, Some(&user_identity("testuser")), "", "attach to")
             .await
             .expect_err("an untracked job must report not-found");
         assert_eq!(missing.code(), tonic::Code::NotFound);
     }
 
-    /// An empty-owner job runs as root, so non-root callers must be denied.
+    /// An empty-owner job runs as root, so only an internal caller (a verified admin/controller) is
+    /// allowed — an empty or `"root"` string no longer stands in for one.
     #[tokio::test]
     async fn check_job_access_denies_non_root_on_empty_owner() {
         let svc = AgentService::new(
@@ -3902,19 +4018,105 @@ mod tests {
         job.user = String::new();
         svc.insert_test_job(47, job).await;
 
-        let err = svc
-            .check_job_access(47, "alice", "attach to")
+        // A verified admin/controller reaches the root-owned job.
+        svc.check_job_access(47, Some(&controller_identity()), "", "attach to")
             .await
-            .expect_err("empty-owner jobs run as root; non-root must be denied");
+            .expect("an admin/controller must reach a root-owned job");
+
+        // A verified non-admin user must not.
+        let err = svc
+            .check_job_access(47, Some(&user_identity("alice")), "", "attach to")
+            .await
+            .expect_err("empty-owner jobs run as root; a named user must be denied");
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
 
-        svc.check_job_access(47, "root", "attach to")
-            .await
-            .expect("root must always be allowed");
+        // The removed bypass: an empty or literal-"root" asserted user (no verified identity) is now
+        // rejected instead of silently authorized.
+        for forged in ["", "root"] {
+            let err = svc
+                .check_job_access(47, None, forged, "attach to")
+                .await
+                .expect_err("empty/root string must not bypass the ownership check");
+            assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        }
+    }
 
-        svc.check_job_access(47, "", "attach to")
+    /// The controller gate on the controller-only RPCs: a verified user token is refused, the
+    /// controller's own credential passes, and an unauthenticated caller is left to the permissive
+    /// path (no identity to check).
+    #[test]
+    fn require_controller_admits_only_the_controller() {
+        let mut user_req = Request::new(());
+        user_req.extensions_mut().insert(user_identity("attacker"));
+        let err = AgentService::require_controller(&user_req)
+            .expect_err("a plain user credential must not drive a controller-only RPC");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let mut ctl_req = Request::new(());
+        ctl_req.extensions_mut().insert(controller_identity());
+        AgentService::require_controller(&ctl_req)
+            .expect("the controller's own credential must pass");
+
+        let anon_req = Request::new(());
+        AgentService::require_controller(&anon_req)
+            .expect("no credential is tolerated (permissive/disabled)");
+    }
+
+    /// End-to-end: a verified *user* identity in the request extensions cannot cancel a job through
+    /// the agent — the controller-only gate refuses it before any signal is sent.
+    #[tokio::test]
+    async fn cancel_job_rejects_a_non_controller_caller() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        svc.insert_test_job(48, TrackedJob::dummy(std::process::id()))
+            .await;
+
+        let mut req = Request::new(AgentCancelJobRequest {
+            job_id: 48,
+            signal: 9,
+        });
+        req.extensions_mut().insert(user_identity("attacker"));
+        let err = svc
+            .cancel_job(req)
             .await
-            .expect("daemon (empty user) must always be allowed");
+            .expect_err("a user token must not cancel jobs by dialing the agent directly");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    /// A launch aimed at another node's name must be refused: the agent only runs allocations
+    /// scheduled onto its own host.
+    #[tokio::test]
+    async fn launch_job_rejects_a_foreign_target_node() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let err = svc
+            .launch_job(Request::new(LaunchJobRequest {
+                job_id: 7,
+                target_node: "some-other-node".into(),
+                spec: Some(JobSpec {
+                    uid: 1000,
+                    name: "j".into(),
+                    script: "#!/bin/bash\ntrue\n".into(),
+                    num_tasks: 1,
+                    num_nodes: 1,
+                    cpus_per_task: 1,
+                    work_dir: std::env::temp_dir().to_string_lossy().into_owned(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("a launch targeting another node must be refused");
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
     }
 
     #[tokio::test]

--- a/crates/spurd/src/auth_middleware.rs
+++ b/crates/spurd/src/auth_middleware.rs
@@ -16,6 +16,11 @@
 //!
 //! The ruling itself is `spur_core::auth::authenticate_bearer`, shared with the controller so the
 //! two daemons cannot drift apart on a security decision.
+//!
+//! On success the verified [`spur_core::auth::Identity`] is inserted into the request extensions so
+//! handlers can gate on *who* the caller is — the controller's subject for controller-only RPCs, or
+//! the tracked job owner for user-facing ones. Only this layer inserts an `Identity`, so a handler
+//! that finds one knows it was verified here.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -92,7 +97,7 @@ where
         self.inner.poll_ready(cx).map_err(Into::into)
     }
 
-    fn call(&mut self, req: Request<B>) -> Self::Future {
+    fn call(&mut self, mut req: Request<B>) -> Self::Future {
         let header = req
             .headers()
             .get(http::header::AUTHORIZATION)
@@ -100,9 +105,13 @@ where
             .map(str::to_owned);
 
         match decide(&self.config, header.as_deref()) {
-            // The agent does not act *as* the caller — it runs what the controller allocated — so
-            // the identity is not carried into handlers; verifying the credential is the point.
-            BearerOutcome::Authenticated(_) => {}
+            // Carry the verified identity into the handlers so they can enforce caller scope: the
+            // controller's subject for controller-only RPCs, and the tracked job owner for
+            // user-facing ones. Verifying the credential is necessary but not sufficient — a valid
+            // *user* token must not be able to drive a controller-only RPC.
+            BearerOutcome::Authenticated(identity) => {
+                req.extensions_mut().insert(*identity);
+            }
             BearerOutcome::Anonymous => {
                 if self.config.mode == AuthMode::Permissive {
                     warn!(

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -556,7 +556,7 @@ message UpdateJobRequest {
   optional bool hold = 6;
   optional string comment = 7;
   optional string qos = 8;
-  string user = 9;   // For authorization (owner or root required).
+  string user = 9;   // Requesting user; verified identity must own the job; the controller/admin credential overrides
 }
 
 message RequeueJobRequest {
@@ -882,7 +882,7 @@ message RunStepRequest {
   uint32 step_id = 7;  // Step id from CreateJobStep, for recording completion
   bool label = 8;      // Prefix output lines with [rank] (srun -l)
   string mpi = 9;      // Step MPI type; when empty, inherit job.spec.mpi
-  string user = 10;    // For authorization (owner or root required).
+  string user = 10;    // Requesting user; verified identity must own the job; the controller/admin credential overrides
 }
 
 message RunStepResponse {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -859,7 +859,7 @@ message NodeResourcesResponse {
 message ExecInJobRequest {
   uint32 job_id = 1;
   repeated string command = 2;  // Command to exec inside the container
-  string user = 3;              // Requesting user; must own the job (empty/root bypasses)
+  string user = 3;              // Requesting user; verified identity must own the job; the controller/admin credential overrides
 }
 
 message ExecInJobResponse {
@@ -1141,7 +1141,7 @@ message CancelStepRequest {
 message StreamJobOutputRequest {
   uint32 job_id = 1;
   string stream = 2;  // "stdout" or "stderr"
-  string user = 3;    // Requesting user; must own the job (empty/root bypasses)
+  string user = 3;    // Requesting user; verified identity must own the job; the controller/admin credential overrides
 }
 
 message StreamJobOutputChunk {
@@ -1166,7 +1166,7 @@ message InitSession {
   WindowSize winsize = 5;    // Initial terminal dimensions
   repeated string argv = 6;  // Command to run (empty = default shell)
   map<string, string> env = 7;
-  string user = 8;           // Requesting user; must own the job (empty/root bypasses)
+  string user = 8;           // Requesting user; verified identity must own the job; the controller/admin credential overrides
 }
 
 message InteractiveInput {
@@ -1512,7 +1512,7 @@ message CreateJobStepRequest {
   bool pty = 6;               // Allocate a PTY for the step
   WindowSize winsize = 7;     // Initial terminal dimensions
   string node = 8;            // Target node (-w); empty = first allocated node
-  string user = 9;            // Requesting user; must own the job (empty/root bypasses)
+  string user = 9;            // Requesting user; verified identity must own the job; the controller/admin credential overrides
 }
 
 message CreateJobStepResponse {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -556,6 +556,7 @@ message UpdateJobRequest {
   optional bool hold = 6;
   optional string comment = 7;
   optional string qos = 8;
+  string user = 9;   // For authorization (owner or root required).
 }
 
 message RequeueJobRequest {
@@ -881,6 +882,7 @@ message RunStepRequest {
   uint32 step_id = 7;  // Step id from CreateJobStep, for recording completion
   bool label = 8;      // Prefix output lines with [rank] (srun -l)
   string mpi = 9;      // Step MPI type; when empty, inherit job.spec.mpi
+  string user = 10;    // For authorization (owner or root required).
 }
 
 message RunStepResponse {


### PR DESCRIPTION
Hardening, as **two stacked commits** (the second assumes the first has landed). These two were combined because they both change `check_job_owner` and would otherwise conflict.

## Commit 1 — enforce job ownership on `update_job` / `run_step`

These RPCs mutated/executed against a target job with no owner check (their protos carried no caller), enabling cross-tenant placement/account rewrite, arbitrary command execution on the victim's nodes, and remote kill via `TimeLimit`.

- Adds a `user` field to `UpdateJobRequest`/`RunStepRequest` (regenerated via the `spur-proto` build).
- Both handlers bind the caller via `authoritative_user`, then enforce `check_job_owner` against `job.spec.user` **before** any mutation/dispatch (including the hold/release branch).
- `Cluster::update_job` re-runs `validate_user_account`/`validate_partition`/`validate_partition_time_limit` against the candidate spec before writing — so a post-submit partition/account/time rewrite still satisfies the same ACLs; a rejection leaves the job untouched.
- CLI callers send the caller username so the gate holds under permissive/disabled too.

## Commit 2 — scope the agent (spurd) gRPC surface to the verified caller

The agent verified a credential then discarded the identity, so its handlers couldn't check it.

- Carry the verified identity into agent handlers; require the controller's subject for controller-only RPCs (`LaunchJob`, `RunCommand`, `CancelJob`, `CancelStep`, `SuspendJob`, `GetKubeconfig`, `CreateK0sJoinToken`); validate a launch's `target_node` against the agent's own host.
- User-facing RPCs (`ExecInJob`, `StreamJobOutput`, `InteractiveSession`) compare the **verified** identity to the tracked owner.
- Removes the empty/`"root"` bypass in `check_job_owner`: an internal caller is now named explicitly by an `is_internal` flag derived from a verified identity, never inferred from a wire string. Commit 2 migrates commit 1's two new call sites to this signature.

## Tests

Owner-vs-non-owner on `update_job`/`run_step` (non-owner denied, owner allowed, wire-spoofed owner rejected once authenticated), plus the agent-surface controller-subject and owner-scope tests.

## Verification / deferred

- `spurctld` + `spur-proto` + `spur-core`: fmt/clippy/tests green locally. `spurd` (Linux-only deps) and `spur-cli` (pre-existing macOS `getgroups` gate) verify on CI.
- Deferred: submit-time `spec.reservation` validation (reservation-escape vector); `update_job`'s validation-rejection gRPC codes are `internal` rather than `invalid_argument` (the security property holds; the code is imprecise).

Part of the multi-tenancy authorization hardening (epic #665).