### PR TITLE
fix(security): harden the k8s operator plane tenancy boundary

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -260,3 +260,4 @@ PDB
 unioned
 ANDed
 ServiceAccount
+reconciler

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3747,6 +3747,7 @@ dependencies = [
  "clap",
  "futures-util",
  "hostname",
+ "http",
  "k8s-openapi",
  "kube",
  "prost-types",
@@ -3759,6 +3760,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/spur-k8s/Cargo.toml
+++ b/crates/spur-k8s/Cargo.toml
@@ -21,6 +21,8 @@ k8s-openapi = { workspace = true }
 schemars = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
+tower = { workspace = true }
+http = "1"
 prost-types = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -91,11 +91,21 @@ impl VirtualAgent {
                     .map_err(|_| Status::unavailable("k8s API timeout"))?
                     .map_err(|e| Status::internal(e.to_string()))?;
 
-                list.items.into_iter().next().ok_or_else(|| {
-                    Status::not_found(format!(
+                // Fail closed on ambiguity: a label is not unique in Kubernetes, so if more than one
+                // SpurJob carries this job-id, silently taking the first could launch pods into the
+                // wrong namespace. Zero is a not-yet-visible race (retried); two or more is a real
+                // conflict that must not be guessed.
+                let mut items = list.items.into_iter();
+                match (items.next(), items.next()) {
+                    (None, _) => Err(Status::not_found(format!(
                         "spur.amd.com/job-id={job_id} label not yet visible"
-                    ))
-                })
+                    ))),
+                    (Some(job), None) => Ok(job),
+                    (Some(_), Some(_)) => Err(Status::failed_precondition(format!(
+                        "multiple SpurJobs carry spur.amd.com/job-id={job_id}; refusing to guess \
+                         which one to launch"
+                    ))),
+                }
             })
             .retry(
                 ExponentialBuilder::default()

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -24,6 +24,49 @@ use spur_proto::proto::*;
 
 const NS_LOOKUP_BUDGET: Duration = Duration::from_secs(5);
 
+/// The placement facts the agent reads off a job's SpurJob before creating pods: which namespace it
+/// belongs to, and which nodes the controller recorded as its allocation.
+struct ResolvedJob {
+    namespace: String,
+    /// `status.assignedNodes` — the controller's recorded allocation, projected onto the CRD. Empty
+    /// until the operator's job controller has patched it (see [`validate_target_node`]).
+    assigned_nodes: Vec<String>,
+}
+
+/// Refuse a launch that pins a node the controller did not allocate to this job.
+///
+/// `target_node` becomes the pod's `spec.nodeName`, which bypasses the scheduler; honoring one
+/// outside the job's recorded allocation would let a caller place work on another tenant's node.
+/// The allocation is `status.assignedNodes`, projected from the controller. When it is not yet
+/// visible the pin cannot be checked, so it is allowed but logged — a legitimate launch can race
+/// the status projection; closing that residual window needs an authoritative controller lookup
+/// (deferred, see the advisory remediation).
+fn validate_target_node(
+    target_node: &str,
+    assigned_nodes: &[String],
+    job_id: u32,
+) -> Result<(), Status> {
+    if target_node.is_empty() {
+        return Ok(());
+    }
+    if assigned_nodes.is_empty() {
+        warn!(
+            job_id,
+            target_node,
+            "launch pins a node before the job's allocation is visible; placement not validated"
+        );
+        return Ok(());
+    }
+    if assigned_nodes.iter().any(|n| n == target_node) {
+        Ok(())
+    } else {
+        Err(Status::permission_denied(format!(
+            "target node '{target_node}' is not in job {job_id}'s allocation {assigned_nodes:?}: \
+             refusing to place a pod outside the recorded allocation"
+        )))
+    }
+}
+
 /// Virtual SlurmAgent that creates K8s Pods instead of fork/exec.
 pub struct VirtualAgent {
     client: Client,
@@ -34,9 +77,9 @@ impl VirtualAgent {
         Self { client }
     }
 
-    /// Look up the namespace of the SpurJob labeled `spur.amd.com/job-id=<id>`.
+    /// Look up the SpurJob labeled `spur.amd.com/job-id=<id>` and return its placement facts.
     /// Fails loudly if not found so pods are never placed in the wrong namespace.
-    async fn resolve_namespace(&self, job_id: u32) -> Result<String, Status> {
+    async fn resolve_job(&self, job_id: u32) -> Result<ResolvedJob, Status> {
         let api: Api<SpurJob> = Api::all(self.client.clone());
         let lp = ListParams::default().labels(&format!("spur.amd.com/job-id={}", job_id));
 
@@ -48,15 +91,11 @@ impl VirtualAgent {
                     .map_err(|_| Status::unavailable("k8s API timeout"))?
                     .map_err(|e| Status::internal(e.to_string()))?;
 
-                list.items
-                    .into_iter()
-                    .next()
-                    .and_then(|j| j.metadata.namespace)
-                    .ok_or_else(|| {
-                        Status::not_found(format!(
-                            "spur.amd.com/job-id={job_id} label not yet visible"
-                        ))
-                    })
+                list.items.into_iter().next().ok_or_else(|| {
+                    Status::not_found(format!(
+                        "spur.amd.com/job-id={job_id} label not yet visible"
+                    ))
+                })
             })
             .retry(
                 ExponentialBuilder::default()
@@ -70,14 +109,32 @@ impl VirtualAgent {
         )
         .await;
 
-        match result {
-            Ok(Ok(ns)) => Ok(ns),
-            Ok(Err(status)) => Err(status),
-            Err(_elapsed) => Err(Status::deadline_exceeded(format!(
-                "namespace lookup for spur.amd.com/job-id={job_id} timed out after {}s",
-                NS_LOOKUP_BUDGET.as_secs()
-            ))),
-        }
+        let job = match result {
+            Ok(Ok(job)) => job,
+            Ok(Err(status)) => return Err(status),
+            Err(_elapsed) => {
+                return Err(Status::deadline_exceeded(format!(
+                    "namespace lookup for spur.amd.com/job-id={job_id} timed out after {}s",
+                    NS_LOOKUP_BUDGET.as_secs()
+                )))
+            }
+        };
+
+        let namespace = job.metadata.namespace.ok_or_else(|| {
+            Status::not_found(format!(
+                "SpurJob for spur.amd.com/job-id={job_id} has no namespace"
+            ))
+        })?;
+        let assigned_nodes = job.status.map(|s| s.assigned_nodes).unwrap_or_default();
+        Ok(ResolvedJob {
+            namespace,
+            assigned_nodes,
+        })
+    }
+
+    /// Look up the namespace of the SpurJob labeled `spur.amd.com/job-id=<id>`.
+    async fn resolve_namespace(&self, job_id: u32) -> Result<String, Status> {
+        Ok(self.resolve_job(job_id).await?.namespace)
     }
 }
 
@@ -94,8 +151,13 @@ impl SlurmAgent for VirtualAgent {
     ) -> Result<Response<LaunchJobResponse>, Status> {
         let req = request.into_inner();
         let job_id = req.job_id;
-        let ns = self.resolve_namespace(job_id).await?;
+        let job = self.resolve_job(job_id).await?;
+        let ns = job.namespace;
         let target_node = req.target_node.clone();
+        // `target_node` becomes the pod's spec.nodeName (scheduler-bypassing). Refuse to pin a node
+        // the controller did not allocate to this job so a caller can't place work on another
+        // tenant's node.
+        validate_target_node(&target_node, &job.assigned_nodes, job_id)?;
         let peer_nodes = &req.peer_nodes;
         let num_peers = peer_nodes.len();
 
@@ -945,6 +1007,34 @@ pub fn gpu_request_to_gres(count: u32, gpu_type: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- validate_target_node ---
+
+    #[test]
+    fn target_node_in_allocation_is_allowed() {
+        let alloc = vec!["gpu-a-01".to_string(), "gpu-a-02".to_string()];
+        assert!(validate_target_node("gpu-a-02", &alloc, 7).is_ok());
+    }
+
+    #[test]
+    fn target_node_outside_allocation_is_rejected() {
+        // The core hardening: a caller pinning another tenant's node is refused.
+        let alloc = vec!["gpu-a-01".to_string()];
+        let err = validate_target_node("gpu-b-07", &alloc, 7).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[test]
+    fn empty_target_node_is_allowed() {
+        // No pin: the scheduler (or a peer node) places the pod; nothing to validate.
+        assert!(validate_target_node("", &["gpu-a-01".to_string()], 7).is_ok());
+    }
+
+    #[test]
+    fn target_node_allowed_when_allocation_not_yet_visible() {
+        // Races the status projection: allowed but (in the real path) logged.
+        assert!(validate_target_node("gpu-a-01", &[], 7).is_ok());
+    }
 
     // --- gpu_request_to_gres ---
 

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -33,14 +33,9 @@ struct ResolvedJob {
     assigned_nodes: Vec<String>,
 }
 
-/// Refuse a launch that pins a node the controller did not allocate to this job.
-///
-/// `target_node` becomes the pod's `spec.nodeName`, which bypasses the scheduler; honoring one
-/// outside the job's recorded allocation would let a caller place work on another tenant's node.
-/// The allocation is `status.assignedNodes`, projected from the controller. When it is not yet
-/// visible the pin cannot be checked, so it is allowed but logged — a legitimate launch can race
-/// the status projection; closing that residual window needs an authoritative controller lookup
-/// (deferred, see the advisory remediation).
+/// Refuses a `target_node` (which bypasses the scheduler) outside the job's allocation. Before the
+/// allocation is projected — the normal state for any not-yet-scheduled job, not a brief race — the
+/// pin is allowed but logged, unvalidated.
 fn validate_target_node(
     target_node: &str,
     assigned_nodes: &[String],
@@ -91,10 +86,8 @@ impl VirtualAgent {
                     .map_err(|_| Status::unavailable("k8s API timeout"))?
                     .map_err(|e| Status::internal(e.to_string()))?;
 
-                // Fail closed on ambiguity: a label is not unique in Kubernetes, so if more than one
-                // SpurJob carries this job-id, silently taking the first could launch pods into the
-                // wrong namespace. Zero is a not-yet-visible race (retried); two or more is a real
-                // conflict that must not be guessed.
+                // Fail closed on ambiguity: a non-unique label could match >1 SpurJob. Zero is a
+                // not-yet-visible race (retried); >1 is a real conflict, never guessed.
                 let mut items = list.items.into_iter();
                 match (items.next(), items.next()) {
                     (None, _) => Err(Status::not_found(format!(

--- a/crates/spur-k8s/src/auth_middleware.rs
+++ b/crates/spur-k8s/src/auth_middleware.rs
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tower middleware that authenticates callers of the operator's virtual-agent gRPC surface.
+//!
+//! The operator's agent port is the registered agent address for every k8s-managed node and holds a
+//! cluster-wide pod-create privilege. Without this layer, anything that can reach the port can ask
+//! the operator to create a pod — stepping around the controller's authentication entirely. The
+//! layer verifies that a request carries a credential signed with the cluster's `[auth] jwt_key`,
+//! which the controller attaches to every agent call.
+//!
+//! This mirrors spurd's `AgentAuthLayer`; the shared ruling lives in
+//! `spur_core::auth::authenticate_bearer` so the operator, spurd, and spurctld cannot drift apart on
+//! a security decision. spurd's copy is in a binary crate and cannot be imported, hence the small
+//! duplication here.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use http::{Request, Response};
+use tower::{Layer, Service};
+use tracing::warn;
+
+use spur_core::auth::BearerOutcome;
+use spur_core::config::AuthMode;
+
+#[derive(Clone)]
+pub struct AgentAuthLayer {
+    inner: Arc<AgentAuthConfig>,
+}
+
+struct AgentAuthConfig {
+    mode: AuthMode,
+    jwt_key: Vec<u8>,
+}
+
+impl AgentAuthLayer {
+    pub fn new(mode: AuthMode, jwt_key: &str) -> Self {
+        Self {
+            inner: Arc::new(AgentAuthConfig {
+                mode,
+                jwt_key: jwt_key.as_bytes().to_vec(),
+            }),
+        }
+    }
+}
+
+impl<S> Layer<S> for AgentAuthLayer {
+    type Service = AgentAuthMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AgentAuthMiddleware {
+            inner,
+            config: self.inner.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AgentAuthMiddleware<S> {
+    inner: S,
+    config: Arc<AgentAuthConfig>,
+}
+
+fn decide(config: &AgentAuthConfig, header: Option<&str>) -> BearerOutcome {
+    spur_core::auth::authenticate_bearer(
+        config.mode,
+        &config.jwt_key,
+        header,
+        "the k8s operator only accepts agent calls carrying the cluster credential",
+    )
+}
+
+impl<S, B> Service<Request<B>> for AgentAuthMiddleware<S>
+where
+    S: Service<Request<B>, Response = Response<tonic::body::Body>> + Clone + Send + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Future: Send + 'static,
+    B: Send + 'static,
+{
+    type Response = Response<tonic::body::Body>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let header = req
+            .headers()
+            .get(http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+
+        match decide(&self.config, header.as_deref()) {
+            // The operator does not act *as* the caller — it creates what the controller allocated —
+            // so the identity is not carried into handlers; verifying the credential is the point.
+            BearerOutcome::Authenticated(_) => {}
+            BearerOutcome::Anonymous => {
+                if self.config.mode == AuthMode::Permissive {
+                    warn!(
+                        path = %req.uri().path(),
+                        "unauthenticated operator agent request accepted (auth.mode = permissive): \
+                         any peer that can reach this port can ask the operator to create a pod"
+                    );
+                }
+            }
+            BearerOutcome::Reject(msg) => {
+                let resp = tonic::Status::unauthenticated(msg).into_http();
+                return Box::pin(async move { Ok(resp) });
+            }
+        }
+
+        let mut inner = self.inner.clone();
+        Box::pin(async move { inner.call(req).await.map_err(Into::into) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spur_core::auth::generate_token;
+
+    fn cfg(mode: AuthMode, key: &str) -> AgentAuthConfig {
+        AgentAuthConfig {
+            mode,
+            jwt_key: key.as_bytes().to_vec(),
+        }
+    }
+
+    fn controller_token(key: &str) -> String {
+        generate_token("spurctld", 0, true, key.as_bytes(), 300).unwrap()
+    }
+
+    #[test]
+    fn required_refuses_an_uncredentialed_caller() {
+        assert!(matches!(
+            decide(&cfg(AuthMode::Required, "k"), None),
+            BearerOutcome::Reject(_)
+        ));
+    }
+
+    #[test]
+    fn permissive_still_accepts_an_uncredentialed_caller() {
+        // Migration window: controllers start presenting a credential before agents demand one.
+        assert!(matches!(
+            decide(&cfg(AuthMode::Permissive, "k"), None),
+            BearerOutcome::Anonymous
+        ));
+    }
+
+    #[test]
+    fn a_controller_credential_is_accepted() {
+        let header = format!("Bearer {}", controller_token("cluster-key"));
+        assert!(matches!(
+            decide(&cfg(AuthMode::Required, "cluster-key"), Some(&header)),
+            BearerOutcome::Authenticated(_)
+        ));
+    }
+
+    #[test]
+    fn a_credential_signed_with_another_key_is_refused_even_in_permissive() {
+        let forged = format!("Bearer {}", controller_token("attacker-key"));
+        assert!(matches!(
+            decide(&cfg(AuthMode::Permissive, "cluster-key"), Some(&forged)),
+            BearerOutcome::Reject(_)
+        ));
+    }
+}

--- a/crates/spur-k8s/src/auth_middleware.rs
+++ b/crates/spur-k8s/src/auth_middleware.rs
@@ -1,18 +1,8 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Tower middleware that authenticates callers of the operator's virtual-agent gRPC surface.
-//!
-//! The operator's agent port is the registered agent address for every k8s-managed node and holds a
-//! cluster-wide pod-create privilege. Without this layer, anything that can reach the port can ask
-//! the operator to create a pod — stepping around the controller's authentication entirely. The
-//! layer verifies that a request carries a credential signed with the cluster's `[auth] jwt_key`,
-//! which the controller attaches to every agent call.
-//!
-//! This mirrors spurd's `AgentAuthLayer`; the shared ruling lives in
-//! `spur_core::auth::authenticate_bearer` so the operator, spurd, and spurctld cannot drift apart on
-//! a security decision. spurd's copy is in a binary crate and cannot be imported, hence the small
-//! duplication here.
+//! Authenticates callers of the operator's cluster-wide-pod-create agent surface via the shared
+//! `spur_core::auth::authenticate_bearer` (mirrors spurd's `AgentAuthLayer`, duplicated since spurd is a binary crate).
 
 use std::future::Future;
 use std::pin::Pin;
@@ -169,5 +159,45 @@ mod tests {
             decide(&cfg(AuthMode::Permissive, "cluster-key"), Some(&forged)),
             BearerOutcome::Reject(_)
         ));
+    }
+
+    // Exercises the real `Layer`/`Service` wiring (not just `decide()`), so a misplaced or
+    // no-op `.layer(...)` call in main.rs would fail this rather than only the unit tests above.
+    #[derive(Clone)]
+    struct StubInner;
+
+    impl Service<Request<()>> for StubInner {
+        type Response = Response<tonic::body::Body>;
+        type Error = Box<dyn std::error::Error + Send + Sync>;
+        type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: Request<()>) -> Self::Future {
+            std::future::ready(Ok(Response::new(tonic::body::Body::default())))
+        }
+    }
+
+    #[tokio::test]
+    async fn required_mode_rejects_an_uncredentialed_call_through_the_real_layer() {
+        let mut svc = AgentAuthLayer::new(AuthMode::Required, "k").layer(StubInner);
+        let resp = svc.call(Request::new(())).await.unwrap();
+        assert_eq!(resp.headers().get("grpc-status").unwrap(), "16");
+    }
+
+    #[tokio::test]
+    async fn required_mode_forwards_a_valid_credential_through_the_real_layer() {
+        let mut svc = AgentAuthLayer::new(AuthMode::Required, "cluster-key").layer(StubInner);
+        let req = Request::builder()
+            .header(
+                http::header::AUTHORIZATION,
+                format!("Bearer {}", controller_token("cluster-key")),
+            )
+            .body(())
+            .unwrap();
+        let resp = svc.call(req).await.unwrap();
+        assert!(resp.headers().get("grpc-status").is_none());
     }
 }

--- a/crates/spur-k8s/src/main.rs
+++ b/crates/spur-k8s/src/main.rs
@@ -229,6 +229,12 @@ async fn main() -> anyhow::Result<()> {
         spur_core::config::AuthMode::Required => {
             info!("operator agent requires a cluster credential on every RPC")
         }
+        spur_core::config::AuthMode::Permissive if jwt_key.is_empty() => tracing::warn!(
+            "operator agent is permissive but has no --jwt-key / SPUR_JWT_KEY: uncredentialed calls \
+             are allowed, but a controller that DOES present a credential is REJECTED (no key to \
+             verify it against). Set the key so presented credentials verify, then move to \
+             --auth-mode required."
+        ),
         spur_core::config::AuthMode::Permissive => tracing::warn!(
             "operator agent accepts uncredentialed RPCs (auth.mode = permissive): any peer that can \
              reach this port can ask the operator to create a pod. Set --auth-mode required once \

--- a/crates/spur-k8s/src/main.rs
+++ b/crates/spur-k8s/src/main.rs
@@ -56,9 +56,8 @@ struct Args {
     #[arg(long, default_value = "[::]:8080")]
     health_addr: String,
 
-    /// How strictly the virtual-agent gRPC surface authenticates callers: "disabled", "permissive"
-    /// (verify a credential when presented, else log and allow — the migration default), or
-    /// "required" (reject every uncredentialed call). Mirrors the cluster `[auth] mode`.
+    /// Agent-surface auth strictness: "disabled", "permissive" (default; verify if presented, else
+    /// allow), or "required" (reject uncredentialed calls). Mirrors the cluster `[auth] mode`.
     #[arg(long, default_value = "permissive")]
     auth_mode: String,
 

--- a/crates/spur-k8s/src/main.rs
+++ b/crates/spur-k8s/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod agent;
+mod auth_middleware;
 mod crd;
 mod health;
 mod heartbeat;
@@ -55,9 +56,34 @@ struct Args {
     #[arg(long, default_value = "[::]:8080")]
     health_addr: String,
 
+    /// How strictly the virtual-agent gRPC surface authenticates callers: "disabled", "permissive"
+    /// (verify a credential when presented, else log and allow — the migration default), or
+    /// "required" (reject every uncredentialed call). Mirrors the cluster `[auth] mode`.
+    #[arg(long, default_value = "permissive")]
+    auth_mode: String,
+
+    /// Cluster JWT signing key (`[auth] jwt_key`) the operator's agent surface verifies credentials
+    /// against. Required when `--auth-mode required`.
+    #[arg(long, env = "SPUR_JWT_KEY")]
+    jwt_key: Option<String>,
+
     /// Log level
     #[arg(long, default_value = "info")]
     log_level: String,
+}
+
+/// Parse the `--auth-mode` flag into an [`AuthMode`], failing loudly on an unknown value rather than
+/// silently downgrading the agent surface to a weaker mode.
+fn parse_auth_mode(s: &str) -> anyhow::Result<spur_core::config::AuthMode> {
+    use spur_core::config::AuthMode;
+    match s {
+        "disabled" => Ok(AuthMode::Disabled),
+        "permissive" => Ok(AuthMode::Permissive),
+        "required" => Ok(AuthMode::Required),
+        other => anyhow::bail!(
+            "invalid --auth-mode {other:?}: expected \"disabled\", \"permissive\", or \"required\""
+        ),
+    }
 }
 
 #[derive(Subcommand)]
@@ -191,11 +217,35 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
+    // Authenticate callers of the virtual-agent surface: this port carries a cluster-wide
+    // pod-create privilege, so reaching it must not be enough to ask the operator to run work.
+    let auth_mode = parse_auth_mode(&args.auth_mode)?;
+    let jwt_key = args.jwt_key.clone().unwrap_or_default();
+    match auth_mode {
+        spur_core::config::AuthMode::Required if jwt_key.is_empty() => anyhow::bail!(
+            "--auth-mode required but no --jwt-key / SPUR_JWT_KEY is set: the operator agent could \
+             never verify a credential and would refuse every launch"
+        ),
+        spur_core::config::AuthMode::Required => {
+            info!("operator agent requires a cluster credential on every RPC")
+        }
+        spur_core::config::AuthMode::Permissive => tracing::warn!(
+            "operator agent accepts uncredentialed RPCs (auth.mode = permissive): any peer that can \
+             reach this port can ask the operator to create a pod. Set --auth-mode required once \
+             the controller presents a credential."
+        ),
+        spur_core::config::AuthMode::Disabled => tracing::warn!(
+            "operator agent does NOT authenticate callers (auth.mode = disabled): treat this port \
+             as an administrative boundary."
+        ),
+    }
+
     // Start virtual agent gRPC server
     let virtual_agent = agent::VirtualAgent::new(client);
     info!(%listen_addr, "virtual agent gRPC server listening");
 
     tonic::transport::Server::builder()
+        .layer(auth_middleware::AgentAuthLayer::new(auth_mode, &jwt_key))
         .add_service(spur_proto::agent_server(virtual_agent))
         .serve(listen_addr)
         .await?;

--- a/crates/spur-k8s/src/quota.rs
+++ b/crates/spur-k8s/src/quota.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Projects a SPUR account's allocation into the native Kubernetes objects that ENFORCE it:
-//! a Namespace (tenancy), a ResourceQuota (hard caps from the account's `grp_tres` allocation),
-//! a LimitRange (default requests so unset-request pods can't dodge the quota), and RBAC (a Role
-//! and a RoleBinding to the account's members). Pure — no I/O — so the whole mapping is unit-tested
-//! here; the quota controller applies what these return and drift-corrects.
+//! a Namespace (tenancy, labeled for PodSecurity Admission so its pods can't run privileged or
+//! mount the host), a ResourceQuota (hard caps on requests AND limits from the account's `grp_tres`
+//! allocation — closed to zero pods when the account has no allocation), a LimitRange (default
+//! requests and limits so unset pods can't dodge the caps), and RBAC (a Role and a RoleBinding to
+//! the account's members). Pure — no I/O — so the whole mapping is unit-tested here; the quota
+//! controller applies what these return and drift-corrects.
 
 use std::collections::BTreeMap;
 
@@ -25,6 +27,13 @@ pub use spur_core::quota_names::{account_namespace, user_service_account};
 /// The controller finds + drift-corrects its objects by this label and it encodes the
 /// "SPUR-managed" contract (an admin hand-edit is reverted).
 pub const MANAGED_BY: &str = "spur-quota";
+
+/// PodSecurity Admission level enforced on every account namespace. `baseline` forbids the pod
+/// features that break the node-side tenancy boundary (privileged containers, host namespaces,
+/// hostPath mounts of the node filesystem). Without it a namespace admits `privileged: true` +
+/// `hostPath: /` pods that reach root on the node. `baseline` is the compatible floor; `restricted`
+/// is the stronger target but rejects many ordinary workloads, so it is left to operator opt-in.
+const POD_SECURITY_LEVEL: &str = "baseline";
 
 /// Name of the (single) ResourceQuota / LimitRange / Role per account namespace.
 const QUOTA_NAME: &str = "spur-account-quota";
@@ -59,6 +68,18 @@ fn managed_labels(account: &str) -> BTreeMap<String, String> {
     ])
 }
 
+/// PodSecurity Admission mode labels (enforce + warn + audit) at [`POD_SECURITY_LEVEL`]. These live
+/// only on the Namespace — the admission controller keys off namespace labels — so they are added on
+/// top of `managed_labels` in [`namespace`], not stamped on every managed object.
+fn pod_security_labels() -> [(String, String); 3] {
+    ["enforce", "warn", "audit"].map(|mode| {
+        (
+            format!("pod-security.kubernetes.io/{mode}"),
+            POD_SECURITY_LEVEL.to_string(),
+        )
+    })
+}
+
 fn meta(name: &str, namespace: Option<&str>, account: &str) -> ObjectMeta {
     ObjectMeta {
         name: Some(name.to_string()),
@@ -69,34 +90,51 @@ fn meta(name: &str, namespace: Option<&str>, account: &str) -> ObjectMeta {
 }
 
 /// Map the account allocation to ResourceQuota `hard` entries. CPU (cores) and memory (MB) are
-/// capped on `requests.*`; GPUs go on `requests.amd.com/gpu` (an extended resource). A dimension
-/// left at 0 is omitted (uncapped). Node/Energy/Billing have no pod-level quota analog.
+/// capped on both `requests.*` and `limits.*`; GPUs go on `requests.amd.com/gpu` (an extended
+/// resource — limits must equal requests, so it is quota'd on requests only). A CPU/memory/GPU
+/// dimension left at 0 is omitted (uncapped in that dimension). Node/Energy/Billing have no
+/// pod-level quota analog.
 ///
-/// Only `requests.*` is capped, never `limits.*`: a `limits.cpu`/`limits.memory` quota key forces
-/// every pod to declare a limit (or inherit a LimitRange default), so unset-limit pods would fail
-/// admission. `limit_range` supplies only a default *request*, matching this requests-only cap.
+/// `limits.*` is capped as well as `requests.*` so a pod cannot request a tiny amount (counting
+/// little against the quota) yet burst far past the account's allocation. Capping `limits.*` makes
+/// a container that names no limit fail admission, so [`limit_range`] supplies a default *limit*
+/// (alongside the default request) to fill one in.
+///
+/// An account with no cpu/memory/gpu allocation gets a *closed* quota (`pods: 0`), not an empty
+/// one: an empty `hard` map is an uncapped namespace, which would let an unallocated account
+/// consume the cluster. It fails closed — zero pods — until the account is given an allocation.
 pub fn quota_hard(grp_tres: &TresRecord) -> BTreeMap<String, Quantity> {
     let mut hard = BTreeMap::new();
     let cpu = grp_tres.get(TresType::Cpu);
     if cpu > 0 {
         hard.insert("requests.cpu".into(), Quantity(cpu.to_string()));
+        hard.insert("limits.cpu".into(), Quantity(cpu.to_string()));
     }
     let mem_mb = grp_tres.get(TresType::Memory);
     if mem_mb > 0 {
         // TRES mem is base-10 MB; `M` (not `Mi`) keeps the quota equal to the allocation.
         hard.insert("requests.memory".into(), Quantity(format!("{mem_mb}M")));
+        hard.insert("limits.memory".into(), Quantity(format!("{mem_mb}M")));
     }
     let gpu = grp_tres.get(TresType::Gpu);
     if gpu > 0 {
         hard.insert("requests.amd.com/gpu".into(), Quantity(gpu.to_string()));
     }
+    if hard.is_empty() {
+        hard.insert("pods".into(), Quantity("0".into()));
+    }
     hard
 }
 
-/// The account's Namespace.
+/// The account's Namespace, labeled for PodSecurity Admission (the node-side half of tenancy): the
+/// account's own pods cannot run privileged, share host namespaces, or mount the host filesystem.
 pub fn namespace(account: &str) -> Namespace {
+    let mut meta = meta(&account_namespace(account), None, account);
+    if let Some(labels) = meta.labels.as_mut() {
+        labels.extend(pod_security_labels());
+    }
     Namespace {
-        metadata: meta(&account_namespace(account), None, account),
+        metadata: meta,
         ..Default::default()
     }
 }
@@ -114,13 +152,14 @@ pub fn resource_quota(aq: &AccountQuota) -> ResourceQuota {
     }
 }
 
-/// A LimitRange giving every container a default *request*, so a pod that omits requests still
-/// counts against the ResourceQuota (otherwise unset-request pods dodge the cap). Deliberately no
-/// default *limit*: forcing an arbitrary small limit would reject ordinary larger pods that omit
-/// limits — the account's ResourceQuota is what actually bounds usage.
+/// A LimitRange giving every container a default *request* (so a pod that omits requests still
+/// counts against the ResourceQuota) and a default *limit* (so a pod that omits limits still admits
+/// under the `limits.*` cap that [`quota_hard`] now sets). The default limit equals the default
+/// request, so an unset-limit container is admitted as a small Guaranteed-QoS pod; a container that
+/// needs more declares its own limit, bounded by the account's ResourceQuota.
 pub fn limit_range(account: &str) -> LimitRange {
     let ns = account_namespace(account);
-    let default_request = BTreeMap::from([
+    let defaults = BTreeMap::from([
         ("cpu".to_string(), Quantity("100m".into())),
         ("memory".to_string(), Quantity("128M".into())),
     ]);
@@ -129,7 +168,8 @@ pub fn limit_range(account: &str) -> LimitRange {
         spec: Some(LimitRangeSpec {
             limits: vec![LimitRangeItem {
                 type_: "Container".to_string(),
-                default_request: Some(default_request),
+                default_request: Some(defaults.clone()),
+                default: Some(defaults),
                 ..Default::default()
             }],
         }),
@@ -226,9 +266,11 @@ mod tests {
         assert_eq!(h["requests.cpu"].0, "16");
         assert_eq!(h["requests.memory"].0, "32768M");
         assert_eq!(h["requests.amd.com/gpu"].0, "8");
-        // Never cap limits.* — that would reject pods that omit limits.
-        assert!(!h.contains_key("limits.cpu"));
-        assert!(!h.contains_key("limits.memory"));
+        // limits.* are capped alongside requests so a pod can't burst past the allocation.
+        assert_eq!(h["limits.cpu"].0, "16");
+        assert_eq!(h["limits.memory"].0, "32768M");
+        // Not a closed quota when an allocation exists.
+        assert!(!h.contains_key("pods"));
     }
 
     #[test]
@@ -237,12 +279,34 @@ mod tests {
         let h = quota_hard(&tres(0, 0, 4));
         assert!(!h.contains_key("requests.cpu"));
         assert!(!h.contains_key("requests.memory"));
+        assert!(!h.contains_key("limits.cpu"));
         assert_eq!(h["requests.amd.com/gpu"].0, "4");
-        // Node/Energy/Billing never map even when set.
+        // GPU is an extended resource: quota'd on requests only, never limits.
+        assert!(!h.contains_key("limits.amd.com/gpu"));
+        assert!(!h.contains_key("pods"));
+    }
+
+    #[test]
+    fn quota_hard_is_closed_when_no_cpu_mem_gpu_allocation() {
+        // No mapped allocation must NOT yield an empty (uncapped) quota — it fails closed.
+        assert_eq!(quota_hard(&tres(0, 0, 0))["pods"].0, "0");
+        // Node/Energy/Billing don't map, so an account with only those is still closed.
         let mut t = TresRecord::new();
         t.set(TresType::Node, 3);
         t.set(TresType::Billing, 100);
-        assert!(quota_hard(&t).is_empty());
+        assert_eq!(quota_hard(&t)["pods"].0, "0");
+    }
+
+    #[test]
+    fn namespace_carries_pod_security_admission_labels() {
+        let ns = namespace("physics");
+        let labels = ns.metadata.labels.unwrap();
+        assert_eq!(labels["pod-security.kubernetes.io/enforce"], "baseline");
+        assert_eq!(labels["pod-security.kubernetes.io/warn"], "baseline");
+        assert_eq!(labels["pod-security.kubernetes.io/audit"], "baseline");
+        // The SPUR-managed contract labels are still present.
+        assert_eq!(labels["app.kubernetes.io/managed-by"], MANAGED_BY);
+        assert_eq!(labels["spur.amd.com/account"], "physics");
     }
 
     #[test]
@@ -283,13 +347,15 @@ mod tests {
     }
 
     #[test]
-    fn limit_range_defaults_requests_so_pods_count_against_quota() {
+    fn limit_range_defaults_requests_and_limits() {
         let lr = limit_range("physics");
         let item = &lr.spec.unwrap().limits[0];
         assert_eq!(item.type_, "Container");
         assert_eq!(item.default_request.as_ref().unwrap()["cpu"].0, "100m");
         assert_eq!(item.default_request.as_ref().unwrap()["memory"].0, "128M");
-        // No default limit: it would reject ordinary pods that omit limits.
-        assert!(item.default.is_none());
+        // A default limit is required now that quota_hard caps limits.*, so unset-limit
+        // containers still admit instead of being rejected.
+        assert_eq!(item.default.as_ref().unwrap()["cpu"].0, "100m");
+        assert_eq!(item.default.as_ref().unwrap()["memory"].0, "128M");
     }
 }

--- a/crates/spur-k8s/src/quota.rs
+++ b/crates/spur-k8s/src/quota.rs
@@ -1,13 +1,8 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Projects a SPUR account's allocation into the native Kubernetes objects that ENFORCE it:
-//! a Namespace (tenancy, labeled for PodSecurity Admission so its pods can't run privileged or
-//! mount the host), a ResourceQuota (hard caps on requests AND limits from the account's `grp_tres`
-//! allocation — closed to zero pods when the account has no allocation), a LimitRange (default
-//! requests and limits so unset pods can't dodge the caps), and RBAC (a Role and a RoleBinding to
-//! the account's members). Pure — no I/O — so the whole mapping is unit-tested here; the quota
-//! controller applies what these return and drift-corrects.
+//! Projects a SPUR account's allocation into the Kubernetes objects that ENFORCE it: a PSA-labeled
+//! Namespace, a ResourceQuota/LimitRange, and RBAC. Pure — the quota controller applies these and drift-corrects.
 
 use std::collections::BTreeMap;
 
@@ -28,11 +23,8 @@ pub use spur_core::quota_names::{account_namespace, user_service_account};
 /// "SPUR-managed" contract (an admin hand-edit is reverted).
 pub const MANAGED_BY: &str = "spur-quota";
 
-/// PodSecurity Admission level enforced on every account namespace. `baseline` forbids the pod
-/// features that break the node-side tenancy boundary (privileged containers, host namespaces,
-/// hostPath mounts of the node filesystem). Without it a namespace admits `privileged: true` +
-/// `hostPath: /` pods that reach root on the node. `baseline` is the compatible floor; `restricted`
-/// is the stronger target but rejects many ordinary workloads, so it is left to operator opt-in.
+/// PodSecurity Admission level for account namespaces. `baseline` blocks privileged/host-namespace/
+/// hostPath pods; `restricted` is stronger but rejects ordinary workloads, so it's left to opt-in.
 const POD_SECURITY_LEVEL: &str = "baseline";
 
 /// Name of the (single) ResourceQuota / LimitRange / Role per account namespace.
@@ -47,8 +39,8 @@ const BINDING_NAME: &str = "spur-account-members";
 pub struct AccountQuota {
     /// SPUR account name (e.g. "physics").
     pub account: String,
-    /// The account's resource allocation. Only Cpu/Memory/Gpu map to a ResourceQuota; a 0/unset
-    /// dimension is left uncapped (a 0 cap would block every pod).
+    /// The account's resource allocation. Only Cpu/Memory/Gpu map to a ResourceQuota; an all-zero
+    /// allocation closes the namespace to zero pods instead of leaving it uncapped.
     pub grp_tres: TresRecord,
     /// Users associated with the account. Each becomes a RoleBinding subject via their per-namespace
     /// ServiceAccount (minted by `spur k8s kubeconfig --user`).
@@ -89,20 +81,8 @@ fn meta(name: &str, namespace: Option<&str>, account: &str) -> ObjectMeta {
     }
 }
 
-/// Map the account allocation to ResourceQuota `hard` entries. CPU (cores) and memory (MB) are
-/// capped on both `requests.*` and `limits.*`; GPUs go on `requests.amd.com/gpu` (an extended
-/// resource — limits must equal requests, so it is quota'd on requests only). A CPU/memory/GPU
-/// dimension left at 0 is omitted (uncapped in that dimension). Node/Energy/Billing have no
-/// pod-level quota analog.
-///
-/// `limits.*` is capped as well as `requests.*` so a pod cannot request a tiny amount (counting
-/// little against the quota) yet burst far past the account's allocation. Capping `limits.*` makes
-/// a container that names no limit fail admission, so [`limit_range`] supplies a default *limit*
-/// (alongside the default request) to fill one in.
-///
-/// An account with no cpu/memory/gpu allocation gets a *closed* quota (`pods: 0`), not an empty
-/// one: an empty `hard` map is an uncapped namespace, which would let an unallocated account
-/// consume the cluster. It fails closed — zero pods — until the account is given an allocation.
+/// Maps `grp_tres` to ResourceQuota `hard`: cpu/memory cap both `requests.*` and `limits.*` (GPU is
+/// requests-only); an all-zero allocation closes to `pods: 0` rather than an uncapped `hard` map.
 pub fn quota_hard(grp_tres: &TresRecord) -> BTreeMap<String, Quantity> {
     let mut hard = BTreeMap::new();
     let cpu = grp_tres.get(TresType::Cpu);
@@ -152,11 +132,8 @@ pub fn resource_quota(aq: &AccountQuota) -> ResourceQuota {
     }
 }
 
-/// A LimitRange giving every container a default *request* (so a pod that omits requests still
-/// counts against the ResourceQuota) and a default *limit* (so a pod that omits limits still admits
-/// under the `limits.*` cap that [`quota_hard`] now sets). The default limit equals the default
-/// request, so an unset-limit container is admitted as a small Guaranteed-QoS pod; a container that
-/// needs more declares its own limit, bounded by the account's ResourceQuota.
+/// Defaults every container's request AND limit (equal values, Guaranteed QoS) so an unset-limit
+/// container still admits under [`quota_hard`]'s `limits.*` cap instead of failing.
 pub fn limit_range(account: &str) -> LimitRange {
     let ns = account_namespace(account);
     let defaults = BTreeMap::from([

--- a/crates/spur-k8s/src/quota_controller.rs
+++ b/crates/spur-k8s/src/quota_controller.rs
@@ -221,11 +221,12 @@ mod tests {
     }
 
     #[test]
-    fn empty_grp_tres_yields_uncapped_allocation() {
-        // An account with no allocation string -> empty TresRecord -> ResourceQuota with no caps.
+    fn empty_grp_tres_yields_closed_quota() {
+        // An account with no allocation string -> empty TresRecord -> a *closed* ResourceQuota
+        // (pods: 0), never an empty/uncapped one that would let it consume the cluster.
         let aq = build_account_quota(&account("open", ""), &[]).unwrap();
         assert_eq!(aq.grp_tres.get(TresType::Cpu), 0);
-        assert!(quota::quota_hard(&aq.grp_tres).is_empty());
+        assert_eq!(quota::quota_hard(&aq.grp_tres)["pods"].0, "0");
         assert!(aq.members.is_empty());
     }
 

--- a/docs/deployment/kubernetes.rst
+++ b/docs/deployment/kubernetes.rst
@@ -127,6 +127,8 @@ The operator serves a virtual-agent gRPC surface on ``--listen`` (port 6818) tha
 cluster-wide pod-create privilege, so reaching it must not be enough to ask the operator to run
 work. Authentication mirrors the cluster ``[auth] mode``:
 
+- ``--auth-mode disabled`` does not authenticate callers at all; treat the port as an
+  administrative boundary if you use this.
 - ``--auth-mode permissive`` (default) verifies a credential when one is presented and otherwise
   logs and allows — the migration default.
 - ``--auth-mode required`` rejects every call that carries no credential. It refuses to start
@@ -137,6 +139,18 @@ work. Authentication mirrors the cluster ``[auth] mode``:
   controllers start sending one.
 
 See the commented ``--auth-mode`` / ``SPUR_JWT_KEY`` lines in ``examples/k8s/operator.yaml``.
+
+Enforcing account quotas
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``--enable-quota`` turns on a reconciler that projects each SPUR account's ``GrpTRES`` allocation
+into a per-account ``ResourceQuota``/``LimitRange``. An account with no ``GrpTRES`` set gets a
+**closed** quota (``pods: 0``) rather than an uncapped one, so pods submitted under it are rejected
+until an allocation is granted:
+
+.. code-block:: bash
+
+   sacctmgr modify account name=myaccount set grptres=cpu=16,mem=32768,gres/gpu=8
 
 Verify
 ------

--- a/docs/deployment/kubernetes.rst
+++ b/docs/deployment/kubernetes.rst
@@ -129,7 +129,8 @@ work. Authentication mirrors the cluster ``[auth] mode``:
 
 - ``--auth-mode permissive`` (default) verifies a credential when one is presented and otherwise
   logs and allows — the migration default.
-- ``--auth-mode required`` rejects every uncredentialed call. It refuses to start without a key.
+- ``--auth-mode required`` rejects every call that carries no credential. It refuses to start
+  without a key.
 - ``--jwt-key`` / ``SPUR_JWT_KEY`` is the cluster ``[auth] jwt_key`` the operator verifies
   credentials against; source it from a Secret. In ``permissive`` mode with no key, a controller
   that *does* present a credential is rejected (there is no key to verify it), so set the key before

--- a/docs/deployment/kubernetes.rst
+++ b/docs/deployment/kubernetes.rst
@@ -120,6 +120,23 @@ Apply with ``kubectl``:
 
 The operator watches SpurJob resources, submits them to the controller, and updates status fields as the job progresses.
 
+Authenticating the operator agent surface
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The operator serves a virtual-agent gRPC surface on ``--listen`` (port 6818) that carries a
+cluster-wide pod-create privilege, so reaching it must not be enough to ask the operator to run
+work. Authentication mirrors the cluster ``[auth] mode``:
+
+- ``--auth-mode permissive`` (default) verifies a credential when one is presented and otherwise
+  logs and allows — the migration default.
+- ``--auth-mode required`` rejects every uncredentialed call. It refuses to start without a key.
+- ``--jwt-key`` / ``SPUR_JWT_KEY`` is the cluster ``[auth] jwt_key`` the operator verifies
+  credentials against; source it from a Secret. In ``permissive`` mode with no key, a controller
+  that *does* present a credential is rejected (there is no key to verify it), so set the key before
+  controllers start sending one.
+
+See the commented ``--auth-mode`` / ``SPUR_JWT_KEY`` lines in ``examples/k8s/operator.yaml``.
+
 Verify
 ------
 

--- a/examples/k8s/operator.yaml
+++ b/examples/k8s/operator.yaml
@@ -37,7 +37,20 @@ spec:
             - --controller-addr=spurctld.spur.svc.cluster.local:6817
             - --listen=[::]:6818
             - --health-addr=[::]:8080
+            # Authenticate the virtual-agent surface (port 6818), which carries a cluster-wide
+            # pod-create privilege. "permissive" (default) verifies a credential when presented and
+            # otherwise logs+allows — the migration default. Move to "required" once the controller
+            # presents a credential, and set --jwt-key / SPUR_JWT_KEY (below) to the cluster
+            # [auth] jwt_key so credentials verify. required + no key refuses to start.
+            # - --auth-mode=required
           env:
+            # Cluster JWT signing key the operator verifies agent credentials against; must match the
+            # controllers' [auth] jwt_key. Source it from a Secret rather than inlining it.
+            # - name: SPUR_JWT_KEY
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: spur-auth
+            #       key: jwt_key
             - name: POD_IP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Hardening of the Kubernetes operator plane (`--enable-quota` / `[cluster] enabled`), which today provides no node-side tenant isolation. This is the **bounded subset**; the full node-side projection is deferred (see below).

## Change

- **PodSecurity Admission labels** (`enforce`/`warn`/`audit = baseline`) on every account Namespace (`quota.rs`).
- **AgentAuthLayer on the operator's virtual-agent gRPC server** — new `spur-k8s/src/auth_middleware.rs` mirroring spurd's, so the operator's agent surface is no longer unauthenticated (added `http`/`tower` deps).
- **`target_node` validation** in `agent.rs launch_job`: `resolve_job()` reads `status.assignedNodes` and rejects a spec targeting a node not in the job's allocation (allow-on-empty while the status poll hasn't projected yet — noted).
- **Quota caps `limits.cpu`/`limits.memory`** alongside requests, with matching `LimitRange` defaults so unset-limit pods still admit; an account with no `grp_tres` no longer gets an uncapped namespace.

14 tests; `spur-k8s` fmt/clippy/tests green.

## Deferred (follow-ups — the full node-side projection is a multi-day design item)

- Per-partition node labels + taints on the kubelet/k0s args.
- A validating admission policy that rejects `spec.nodeName` from kubectl-created pods and derives a `nodeSelector` from the account's partitions (the primary kubectl node-placement escape).
- A `NetworkPolicy` fronting the operator agent Service.
- Deriving the launch namespace from an authenticated identity rather than the caller-supplied `job_id`.
- Docs: mark `--enable-quota` / `[cluster] enabled` as single-tenant until the above land.

Part of the multi-tenancy authorization hardening (epic #665).