### PR TITLE
fix(security): fail closed on account ACLs and the required-mode signing key

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -697,12 +697,8 @@ pub struct AuthConfig {
     /// How strictly callers are authenticated. See [`AuthMode`].
     #[serde(default)]
     pub mode: AuthMode,
-    /// HMAC signing secret, used verbatim as the HS256 key — the string's bytes are the key, this is
-    /// not a path to a key file. It is the cluster-wide authentication secret: it verifies both node
-    /// admission tokens and, under `auth.mode = permissive`/`required`, the user-identity credentials
-    /// callers present on the control-plane RPCs. Leave it unset only with `auth.mode =
-    /// disabled`/`permissive`; `required` refuses to start without it, because an unset key would
-    /// otherwise fall back to a well-known constant that anyone can forge against.
+    /// HMAC signing secret (raw bytes) for node admission and user-identity RPC auth; `required`
+    /// refuses to start without one. Captured at startup, not updated by `reconfigure`.
     pub jwt_key: Option<String>,
     /// Allow jobs to execute as uid 0 (root).
     ///
@@ -1485,10 +1481,8 @@ impl SlurmConfig {
                     .into(),
             });
         }
-        // `required` promises every caller is verified against the cluster signing key. Without a key
-        // the controller would fall back to a well-known constant that anyone can sign with, turning
-        // the hardened mode into universal forgeability (an attacker could mint an admin identity).
-        // Refuse to start rather than run in that strictly-worse-than-default posture.
+        // Without a key, `required` would fall back to a well-known signing constant —
+        // forgeable, so strictly worse than the default. Refuse to start instead.
         if self.auth.mode == AuthMode::Required
             && self.auth.jwt_key.as_deref().unwrap_or("").is_empty()
         {

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -501,6 +501,14 @@ pub struct AccountingConfig {
     pub txn_retention_days: Option<u32>,
 }
 
+impl AccountingConfig {
+    /// True when accounting is configured (a database URL is set). When false there is no
+    /// association database to consult, so account/association checks have nothing to enforce.
+    pub fn enabled(&self) -> bool {
+        !self.database_url.is_empty()
+    }
+}
+
 fn default_fairshare_refresh_secs() -> u32 {
     300
 }
@@ -689,8 +697,12 @@ pub struct AuthConfig {
     /// How strictly callers are authenticated. See [`AuthMode`].
     #[serde(default)]
     pub mode: AuthMode,
-    /// JWT secret key (file path or inline). Currently used only to sign/verify NODE admission
-    /// tokens, not user identity.
+    /// HMAC signing secret, used verbatim as the HS256 key — the string's bytes are the key, this is
+    /// not a path to a key file. It is the cluster-wide authentication secret: it verifies both node
+    /// admission tokens and, under `auth.mode = permissive`/`required`, the user-identity credentials
+    /// callers present on the control-plane RPCs. Leave it unset only with `auth.mode =
+    /// disabled`/`permissive`; `required` refuses to start without it, because an unset key would
+    /// otherwise fall back to a well-known constant that anyone can forge against.
     pub jwt_key: Option<String>,
     /// Allow jobs to execute as uid 0 (root).
     ///
@@ -1471,6 +1483,21 @@ impl SlurmConfig {
                 field: "auth.mode".into(),
                 value: "required with auth.plugin = \"none\" (no credential can be verified)"
                     .into(),
+            });
+        }
+        // `required` promises every caller is verified against the cluster signing key. Without a key
+        // the controller would fall back to a well-known constant that anyone can sign with, turning
+        // the hardened mode into universal forgeability (an attacker could mint an admin identity).
+        // Refuse to start rather than run in that strictly-worse-than-default posture.
+        if self.auth.mode == AuthMode::Required
+            && self.auth.jwt_key.as_deref().unwrap_or("").is_empty()
+        {
+            return Err(ConfigError::InvalidValue {
+                field: "auth.jwt_key".into(),
+                value:
+                    "unset with auth.mode = \"required\" (set a secret signing key; the hardened \
+                        mode cannot verify credentials without one)"
+                        .into(),
             });
         }
 
@@ -2600,6 +2627,71 @@ max_batch_requeue = 0
             err.to_string().contains("max_batch_requeue"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn auth_required_without_jwt_key_is_refused() {
+        // `required` with no signing key would fall back to a public constant that anyone can forge
+        // an admin identity against — strictly worse than the default. Startup must refuse it.
+        let toml = r#"
+cluster_name = "test"
+
+[auth]
+plugin = "jwt"
+mode = "required"
+"#;
+        let err = SlurmConfig::load_from_str(toml).unwrap_err();
+        assert!(
+            err.to_string().contains("jwt_key"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn auth_required_with_empty_jwt_key_is_refused() {
+        let toml = r#"
+cluster_name = "test"
+
+[auth]
+plugin = "jwt"
+mode = "required"
+jwt_key = ""
+"#;
+        let err = SlurmConfig::load_from_str(toml).unwrap_err();
+        assert!(
+            err.to_string().contains("jwt_key"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn auth_required_with_jwt_key_is_accepted() {
+        let toml = r#"
+cluster_name = "test"
+
+[auth]
+plugin = "jwt"
+mode = "required"
+jwt_key = "a-real-secret"
+"#;
+        let config = SlurmConfig::load_from_str(toml).expect("required + a key must be accepted");
+        assert_eq!(config.auth.mode, AuthMode::Required);
+        assert_eq!(config.auth.jwt_key.as_deref(), Some("a-real-secret"));
+    }
+
+    #[test]
+    fn auth_permissive_without_jwt_key_is_accepted() {
+        // Only `required` is refused key-less; permissive must still come up so a cluster can adopt
+        // authentication incrementally.
+        let toml = r#"
+cluster_name = "test"
+
+[auth]
+plugin = "jwt"
+mode = "permissive"
+"#;
+        let config = SlurmConfig::load_from_str(toml).expect("permissive must not require a key");
+        assert_eq!(config.auth.mode, AuthMode::Permissive);
     }
 
     #[test]

--- a/crates/spurctld/src/association_cache.rs
+++ b/crates/spurctld/src/association_cache.rs
@@ -73,6 +73,12 @@ impl AssociationCache {
                 .is_some_and(|lvl| lvl.eq_ignore_ascii_case("admin"))
     }
 
+    /// Whether `user` is associated with `account`. Fails closed like [`is_admin`](Self::is_admin):
+    /// an unloaded cache reports `CacheUnavailable`, which callers enforcing a tenancy fence MUST
+    /// treat as "cannot verify — deny" (see `validate_user_account`), never as an implicit allow.
+    /// The distinction is left to the caller because "cache never loaded" spans two cases — accounting
+    /// genuinely off (nothing to enforce) versus accounting on but the first fetch not yet completed
+    /// (the fence is real and must hold) — that this cache cannot tell apart on its own.
     pub fn account_membership(&self, user: &str, account: &str) -> AccountMembership {
         let snapshot = self.snapshot.read();
         if !snapshot.loaded {

--- a/crates/spurctld/src/association_cache.rs
+++ b/crates/spurctld/src/association_cache.rs
@@ -73,12 +73,8 @@ impl AssociationCache {
                 .is_some_and(|lvl| lvl.eq_ignore_ascii_case("admin"))
     }
 
-    /// Whether `user` is associated with `account`. Fails closed like [`is_admin`](Self::is_admin):
-    /// an unloaded cache reports `CacheUnavailable`, which callers enforcing a tenancy fence MUST
-    /// treat as "cannot verify — deny" (see `validate_user_account`), never as an implicit allow.
-    /// The distinction is left to the caller because "cache never loaded" spans two cases — accounting
-    /// genuinely off (nothing to enforce) versus accounting on but the first fetch not yet completed
-    /// (the fence is real and must hold) — that this cache cannot tell apart on its own.
+    /// Whether `user` is associated with `account`. An unloaded cache reports `CacheUnavailable`
+    /// rather than guessing; see `validate_user_account` in `cluster.rs` for how callers must treat that.
     pub fn account_membership(&self, user: &str, account: &str) -> AccountMembership {
         let snapshot = self.snapshot.read();
         if !snapshot.loaded {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -7055,15 +7055,9 @@ fn apply_default_account(spec: &mut JobSpec, assoc_cache: &AssociationCache) {
     }
 }
 
-/// Reject a client-supplied account that is not a real user→account association, and — when
-/// `accounting.require_association` is set — a submit resolving to no account at all (unconditional,
-/// like `require_qos`'s final check).
-///
-/// Fails closed on an unloaded association cache: when accounting is enabled the fence is real, so a
-/// cold cache (fresh start, restart, or a DB that was unreachable at boot) must deny rather than wave
-/// the account through — otherwise the cache-cold window silently clears every per-tenant partition
-/// ACL. When accounting is disabled there is no association database to consult, so an account is an
-/// unverified free label and the check stays permissive (matching prior behaviour).
+/// Reject a client-supplied account that isn't a real association, or — with `require_association`
+/// set — no account at all. Fails closed on a cold cache when accounting is enabled (an unverified
+/// free label otherwise), so a not-yet-loaded cache can't wave a spoofed account through.
 fn validate_user_account(
     spec: &JobSpec,
     assoc_cache: &AssociationCache,
@@ -7098,7 +7092,8 @@ fn validate_user_account(
             );
             Err(SubmitError::invalid(format!(
                 "account associations are temporarily unavailable (accounting cache not loaded); \
-                 cannot verify user '{}' is associated with account '{account}'. Retry shortly.",
+                 cannot verify user '{}' is associated with account '{account}'. Try again once \
+                 the accounting database is reachable.",
                 spec.user
             )))
         }
@@ -19337,6 +19332,23 @@ mod tests {
         assert!(err
             .to_string()
             .contains("is not associated with account 'other'"));
+    }
+
+    #[test]
+    fn validate_user_account_fails_closed_on_cold_cache_with_explicit_account_and_require_association(
+    ) {
+        // require_association=true doesn't bypass the cold-cache fence for an explicit account.
+        let assoc = AssociationCache::new(); // never loaded
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+        let cfg = spur_core::config::AccountingConfig {
+            database_url: "postgresql://test".into(),
+            require_association: true,
+            ..Default::default()
+        };
+
+        let err = super::validate_user_account(&spec, &assoc, &cfg).unwrap_err();
+        assert!(err.to_string().contains("temporarily unavailable"));
     }
 
     #[test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -7055,8 +7055,15 @@ fn apply_default_account(spec: &mut JobSpec, assoc_cache: &AssociationCache) {
     }
 }
 
-/// Reject a client-supplied account that is not a real association, and, when
-/// `require_association` is set, a submit resolving to no account at all (unconditional, like `require_qos`'s final check).
+/// Reject a client-supplied account that is not a real user→account association, and — when
+/// `accounting.require_association` is set — a submit resolving to no account at all (unconditional,
+/// like `require_qos`'s final check).
+///
+/// Fails closed on an unloaded association cache: when accounting is enabled the fence is real, so a
+/// cold cache (fresh start, restart, or a DB that was unreachable at boot) must deny rather than wave
+/// the account through — otherwise the cache-cold window silently clears every per-tenant partition
+/// ACL. When accounting is disabled there is no association database to consult, so an account is an
+/// unverified free label and the check stays permissive (matching prior behaviour).
 fn validate_user_account(
     spec: &JobSpec,
     assoc_cache: &AssociationCache,
@@ -7079,7 +7086,22 @@ fn validate_user_account(
         return Ok(());
     };
     match assoc_cache.account_membership(&spec.user, account) {
-        AccountMembership::CacheUnavailable | AccountMembership::Member => Ok(()),
+        AccountMembership::Member => Ok(()),
+        AccountMembership::CacheUnavailable if !accounting.enabled() => Ok(()),
+        AccountMembership::CacheUnavailable => {
+            // Operator-visible alarm: the fence is meant to hold but we cannot read associations.
+            warn!(
+                user = %spec.user,
+                account,
+                "association cache not loaded while accounting is enabled — denying account-scoped \
+                 submission (fail closed). Check the accounting database is reachable."
+            );
+            Err(SubmitError::invalid(format!(
+                "account associations are temporarily unavailable (accounting cache not loaded); \
+                 cannot verify user '{}' is associated with account '{account}'. Retry shortly.",
+                spec.user
+            )))
+        }
         AccountMembership::NotMember(valid_accounts) if valid_accounts.is_empty() => {
             Err(SubmitError::invalid(format!(
                 "user '{}' has no account associations. Contact your cluster admin to run: sacctmgr add user name={} account=<account>",
@@ -13078,6 +13100,92 @@ mod tests {
         assert!(
             cm.submit_job(spec).is_err(),
             "unlisted account must be rejected"
+        );
+    }
+
+    /// An `AccountingConfig` whose `enabled()` is `true`/`false` (accounting is enabled iff a
+    /// database URL is set), for the fail-closed-when-enabled account checks.
+    fn acct_cfg_enabled(enabled: bool) -> spur_core::config::AccountingConfig {
+        spur_core::config::AccountingConfig {
+            database_url: if enabled {
+                "postgresql://test".into()
+            } else {
+                String::new()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn validate_user_account_fails_closed_on_cold_cache_when_accounting_enabled() {
+        // The inducible cache-cold window (fresh start / restart / DB unreachable at boot) must not
+        // wave an account-scoped submission through — that would clear every partition ACL at once.
+        let cache = AssociationCache::new(); // never loaded
+        let mut spec = basic_spec("cold");
+        spec.account = Some("tenant-b".into());
+        let err = validate_user_account(&spec, &cache, &acct_cfg_enabled(true)).unwrap_err();
+        assert!(
+            matches!(&err, SubmitError::InvalidArgument(m) if m.contains("temporarily unavailable")),
+            "cold cache with accounting enabled must fail closed, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_user_account_permits_cold_cache_when_accounting_disabled() {
+        // With accounting off there is no association database, so an account is an unverified free
+        // label and there is no fence to hold — stay permissive (matches prior behaviour).
+        let cache = AssociationCache::new();
+        let mut spec = basic_spec("cold-noacct");
+        spec.account = Some("tenant-b".into());
+        assert!(validate_user_account(&spec, &cache, &acct_cfg_enabled(false)).is_ok());
+    }
+
+    #[test]
+    fn validate_user_account_allows_real_member_on_loaded_cache() {
+        let cache = AssociationCache::new();
+        cache.insert_association("testuser", "research");
+        let mut spec = basic_spec("member");
+        spec.account = Some("research".into());
+        assert!(validate_user_account(&spec, &cache, &acct_cfg_enabled(true)).is_ok());
+    }
+
+    #[test]
+    fn validate_user_account_rejects_nonmember_on_loaded_cache() {
+        let cache = AssociationCache::new();
+        cache.insert_association("testuser", "research");
+        let mut spec = basic_spec("spoof");
+        spec.account = Some("tenant-b".into());
+        let err = validate_user_account(&spec, &cache, &acct_cfg_enabled(true)).unwrap_err();
+        assert!(
+            matches!(&err, SubmitError::InvalidArgument(m) if m.contains("not associated with account 'tenant-b'")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_user_account_ignores_an_unset_account() {
+        // No account requested — nothing to verify — even accounting-enabled + cold cache is fine.
+        let cache = AssociationCache::new();
+        let spec = basic_spec("noacct");
+        assert!(validate_user_account(&spec, &cache, &acct_cfg_enabled(true)).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_fails_closed_on_cold_cache_when_accounting_enabled() {
+        // End-to-end: accounting configured (a DB URL is set) but the cache has not loaded — an
+        // account-scoped submit is denied rather than admitted across the cold-cache window.
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.accounting.database_url = "postgres://unused-in-test".into();
+        let cm = test_cluster_with_config(&dir, cfg).await;
+        // Deliberately do NOT load the association cache (mirrors a controller that never completed
+        // its first fetch).
+        let mut spec = basic_spec("coldsubmit");
+        spec.account = Some("tenant-b".into());
+        let err = cm.submit_job(spec).unwrap_err();
+        assert!(
+            matches!(&err, SubmitError::InvalidArgument(m) if m.contains("temporarily unavailable")),
+            "cold cache must fail closed end-to-end, got {err:?}"
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -3345,11 +3345,8 @@ pub async fn serve(
 
     let jwt_key = resolve_startup_jwt_key(&cluster.config());
     let auth_mode = cluster.config().auth.mode;
-    // User-identity RPC verification uses the operator's real signing key, NOT the node-admission
-    // default fallback. An unset key here must mean "no credential can be verified" (presented tokens
-    // are rejected by the auth layer), never "verify against a public constant" — which would let
-    // anyone forge an admin identity. `auth.mode = required` refuses to start key-less (see
-    // config validation), so an empty key here can only accompany permissive/disabled.
+    // Unlike node admission, an unset key here must reject every credential, never fall back
+    // to a forgeable constant; `required` mode refuses to start key-less (see config validation).
     let auth_verification_key = cluster.config().auth.jwt_key.clone().unwrap_or_default();
 
     let service = ControllerService {
@@ -5703,6 +5700,26 @@ mod tests {
             }))
             .await
             .expect_err("a non-admin caller must not bring the cluster up");
+        assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    // Real RPC path, not just the raw cache method: a named caller must not become admin just
+    // because the association cache hasn't loaded yet (fail closed on a cold cache).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_up_denied_for_non_root_caller_on_cold_cache_with_accounting_enabled() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut config = step_test_config();
+        config.accounting.database_url = "postgresql://unused-in-test".into();
+        let svc = test_service_with(&dir, config).await;
+        assert!(!svc.cluster.association_cache().is_loaded());
+
+        let err = svc
+            .cluster_up(Request::new(ClusterUpRequest {
+                caller: "alice".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("a cold association cache must not grant admin");
         assert_eq!(err.code(), Code::PermissionDenied);
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -3345,8 +3345,12 @@ pub async fn serve(
 
     let jwt_key = resolve_startup_jwt_key(&cluster.config());
     let auth_mode = cluster.config().auth.mode;
-    // Same key the node-admission path already uses; cloned because `jwt_key` moves into the service.
-    let jwt_key_for_auth = jwt_key.clone();
+    // User-identity RPC verification uses the operator's real signing key, NOT the node-admission
+    // default fallback. An unset key here must mean "no credential can be verified" (presented tokens
+    // are rejected by the auth layer), never "verify against a public constant" — which would let
+    // anyone forge an admin identity. `auth.mode = required` refuses to start key-less (see
+    // config validation), so an empty key here can only accompany permissive/disabled.
+    let auth_verification_key = cluster.config().auth.jwt_key.clone().unwrap_or_default();
 
     let service = ControllerService {
         cluster,
@@ -3362,7 +3366,7 @@ pub async fn serve(
     let stats_layer = RpcStatsLayer::new(rpc_stats, raft_handle);
     // Applied as a layer, not a per-service interceptor, so it also covers the accounting service —
     // which carries no authorization of its own yet exposes `add_user(admin_level)`.
-    let auth_layer = crate::auth_middleware::AuthLayer::new(auth_mode, &jwt_key_for_auth);
+    let auth_layer = crate::auth_middleware::AuthLayer::new(auth_mode, &auth_verification_key);
 
     let mut builder = tonic::transport::Server::builder()
         .layer(stats_layer)


### PR DESCRIPTION
Hardening of fail-open authorization defaults. This is the **tractable subset** (the highest-value, lowest-risk items); the behaviour-changing defaults are deferred.

## Change

- **`account_membership`/`validate_user_account` fail closed** on an unloaded cache when accounting is enabled, with an operator-visible warning (mirrors `is_admin`, which already fails closed). Previously a never-loaded cache cleared every partition account ACL. Stays permissive when accounting is disabled.
- **Startup refusal** of `auth.mode = required` with an unset/empty `jwt_key` in `SlurmConfig::validate()`.
- The RPC auth layer **no longer uses the `"spur-default-key"` constant** as the user-identity verification key — it uses the operator's real key (empty when unset, which the layer then treats as unconfigured).
- Corrected the `jwt_key` config doc comment (it is used verbatim as the HMAC secret and is now the cluster-wide auth secret, not node-admission-only).

10 tests (fail-closed cache, required-without-key startup refusal); `spurctld`/`spur-core` green.

## Deferred (follow-ups — each is a broader default/behaviour change)

- No-ACL partition is still implicitly world-open in `validate_partition`'s `needs_acl` early return — needs the least-surprising fix (require accounting for partition ACLs, or an explicit `AllowAccounts=ALL`).
- An unmatched node still falls into the default partition (the three membership-derivation sites) rather than being left unschedulable.
- `AdmissionMode` still defaults to `Open`; defaulting to `Token` and binding tokens to a hostname/label set is a broader change.
- `GetUsage` rate-limit/auth + query bound.

Part of the multi-tenancy authorization hardening (epic #665).