### PR TITLE
fix(spur-cli): stop sprio and sshare panicking on every invocation

### DIFF
--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -330,3 +330,40 @@ fn print_usage() {
     eprintln!("  salloc sbatch srun squeue scancel sinfo sacct sacctmgr scontrol");
     eprintln!("  sprio sshare sstat sdiag sreport strigger sattach scrontab smd");
 }
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+
+    // Every command owns its own parser, so nothing builds them all until a user runs
+    // one. A malformed definition (a short option claimed twice, say) is caught only
+    // when its parser is constructed, so each one is listed here by hand and a new
+    // command must be added alongside it.
+    #[test]
+    fn every_command_parser_is_well_formed() {
+        crate::exec::ExecArgs::command().debug_assert();
+        crate::image::ImageArgs::command().debug_assert();
+        crate::k8s::K8sArgs::command().debug_assert();
+        crate::net::NetArgs::command().debug_assert();
+        crate::node::NodeArgs::command().debug_assert();
+        crate::sacct::SacctArgs::command().debug_assert();
+        crate::sacctmgr::SacctmgrArgs::command().debug_assert();
+        crate::salloc::SallocArgs::command().debug_assert();
+        crate::sattach::SattachArgs::command().debug_assert();
+        crate::sbatch::SbatchArgs::command().debug_assert();
+        crate::scancel::ScancelArgs::command().debug_assert();
+        crate::scontrol::ScontrolArgs::command().debug_assert();
+        crate::scrontab::ScrontabArgs::command().debug_assert();
+        crate::sdiag::SdiagArgs::command().debug_assert();
+        crate::sinfo::SinfoArgs::command().debug_assert();
+        crate::smd::SmdArgs::command().debug_assert();
+        crate::sprio::SprioArgs::command().debug_assert();
+        crate::squeue::SqueueArgs::command().debug_assert();
+        crate::sreport::SreportArgs::command().debug_assert();
+        crate::srun::SrunArgs::command().debug_assert();
+        crate::sshare::SshareArgs::command().debug_assert();
+        crate::sstat::SstatArgs::command().debug_assert();
+        crate::strigger::StriggerArgs::command().debug_assert();
+        crate::token::TokenArgs::command().debug_assert();
+    }
+}

--- a/crates/spur-cli/src/sprio.rs
+++ b/crates/spur-cli/src/sprio.rs
@@ -7,7 +7,13 @@ use spur_proto::proto::{GetJobsRequest, GetPartitionsRequest, JobState};
 
 /// View job priority breakdown for pending jobs.
 #[derive(Parser, Debug)]
-#[command(name = "sprio", about = "View job priority factors")]
+// -h is sprio's --noheader (Slurm convention), so disable clap's auto -h and
+// re-add --help below as long-only.
+#[command(
+    name = "sprio",
+    about = "View job priority factors",
+    disable_help_flag = true
+)]
 pub struct SprioArgs {
     /// Show only these job IDs (comma-separated)
     #[arg(short = 'j', long)]
@@ -24,6 +30,10 @@ pub struct SprioArgs {
     /// Don't print header
     #[arg(short = 'h', long)]
     pub noheader: bool,
+
+    /// Print help
+    #[arg(long, action = clap::ArgAction::Help)]
+    pub help: Option<bool>,
 
     /// Controller address
     #[arg(
@@ -162,4 +172,21 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_h_means_noheader() {
+        let args = SprioArgs::try_parse_from(["sprio", "-h"]).expect("-h is accepted");
+        assert!(args.noheader);
+    }
+
+    #[test]
+    fn help_is_still_reachable_by_its_long_name() {
+        let err = SprioArgs::try_parse_from(["sprio", "--help"]).expect_err("--help stops parsing");
+        assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
+    }
 }

--- a/crates/spur-cli/src/sshare.rs
+++ b/crates/spur-cli/src/sshare.rs
@@ -7,7 +7,13 @@ use spur_proto::proto::{GetUsageRequest, ListAccountsRequest, ListUsersRequest};
 
 /// Display fair-share information by account and user.
 #[derive(Parser, Debug)]
-#[command(name = "sshare", about = "Show fair-share information")]
+// -h is sshare's --noheader (Slurm convention), so disable clap's auto -h and
+// re-add --help below as long-only.
+#[command(
+    name = "sshare",
+    about = "Show fair-share information",
+    disable_help_flag = true
+)]
 pub struct SshareArgs {
     /// Show only this user
     #[arg(short = 'u', long)]
@@ -24,6 +30,10 @@ pub struct SshareArgs {
     /// Don't print header
     #[arg(short = 'h', long)]
     pub noheader: bool,
+
+    /// Print help
+    #[arg(long, action = clap::ArgAction::Help)]
+    pub help: Option<bool>,
 
     /// Controller address (accounting is served on the same port)
     #[arg(
@@ -219,4 +229,22 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_h_means_noheader() {
+        let args = SshareArgs::try_parse_from(["sshare", "-h"]).expect("-h is accepted");
+        assert!(args.noheader);
+    }
+
+    #[test]
+    fn help_is_still_reachable_by_its_long_name() {
+        let err =
+            SshareArgs::try_parse_from(["sshare", "--help"]).expect_err("--help stops parsing");
+        assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
+    }
 }


### PR DESCRIPTION
Fixes #696.

`sprio` and `sshare` could not be run at all. Both declared Slurm's `-h`/`--noheader` while leaving clap's generated `--help` in place, which also claims `-h`. clap rejects a duplicate short option when the parser is *constructed*, so both aborted before looking at a single argument, with or without one:

```
$ sprio
thread 'main' panicked at clap_builder-4.6.6/src/builder/debug_asserts.rs:125:17:
Command sprio: Short option names must be unique for each argument, but '-h' is in
use by both 'noheader' and 'help'
```

`spur priority` and `spur share` hit the same two parsers, so the panic was reachable four ways. Because it aborts rather than exiting with a usage error, a calling script saw a crash rather than a message it could act on.

## Approach

`squeue` and `sinfo` already declare the same Slurm flag and already solve this: turn the generated help off and re-add `--help` as long-only. This does the same on both commands, so the four spellings behave like the rest of the CLI. `-h` suppresses the header as declared, `--help` still prints help.

The more interesting question was why it shipped. clap's check fires at parser construction, and nothing in the tree ever constructed these two parsers: neither module had a test, and every command owns its own parser, so there was no single place where a malformed definition would be caught. Two commands were unusable in every debug build without a test noticing.

So the second commit walks every parser in the binary in one test. That is a class fix rather than a fix for these two: any command that claims a short option twice now fails in CI rather than at a user's terminal. The list is maintained by hand because a Slurm-named command's parser is not reachable from a single root type, and a comment says a new command must be added to it.

## Trade-offs

The exhaustive test's list can go stale for a *newly added* command, which is the same weakness as the hand-maintained tables elsewhere in the tree. It is still strictly better than the status quo, where nothing checks any of them. Deriving the list would mean restructuring dispatch, which is not worth doing for this.

Nothing else changed. `--help` on every command in this binary prints its help prefixed with `Error:` and exits 1, `squeue` and `sacct` included. That is pre-existing and repo-wide, so it is not touched here.

Docs need no change: both commands are already listed as supported, which is precisely what the panic contradicted.

## Testing

- Verified all four invocations against a live single-node cluster, before and after. `sprio`, `sshare`, `spur priority` and `spur share` now print their tables; `sshare -h` prints no header; `sprio --help` prints help.
- Mutation-checked the tests rather than trusting them: removing `disable_help_flag` from `sprio` turns all three red (`short_h_means_noheader`, `help_is_still_reachable_by_its_long_name`, `every_command_parser_is_well_formed`), each on the duplicate-short-option assertion.
- `cargo fmt --check`, `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` clean, and `cargo test --locked` green.
