### PR TITLE
feat(spurctld): record reservation admin actions in accounting txn log

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -8,7 +8,9 @@ Cargo
 config
 cron
 crontab
+cryptographically
 daemonize
+datetime
 dbd
 deprovision
 dev

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -34,6 +34,7 @@ mod srun;
 mod sshare;
 mod sstat;
 mod strigger;
+mod timearg;
 mod token;
 
 use std::path::Path;

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -7,6 +7,7 @@ use spur_proto::proto::GetJobHistoryRequest;
 
 use crate::exit_fmt::format_exit;
 use crate::format_engine;
+use crate::timearg::{datetime_to_proto, parse_time_arg};
 
 /// Display accounting data for jobs.
 #[derive(Parser, Debug)]
@@ -270,50 +271,6 @@ fn format_timestamp(ts: Option<&prost_types::Timestamp>) -> String {
             dt.format("%Y-%m-%dT%H:%M:%S").to_string()
         }
         _ => "Unknown".into(),
-    }
-}
-
-/// Parse a time argument string into a DateTime.
-/// Supports: "2024-01-01", "2024-01-01T00:00:00", "now-7days", "now-24hours".
-fn parse_time_arg(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
-    use chrono::{NaiveDate, NaiveDateTime, Utc};
-    let s = s.trim();
-
-    // Relative: "now-Ndays", "now-Nhours"
-    if let Some(rest) = s.strip_prefix("now-") {
-        if let Some(days) = rest
-            .strip_suffix("days")
-            .or_else(|| rest.strip_suffix("day"))
-        {
-            let n: i64 = days.trim().parse().ok()?;
-            return Some(Utc::now() - chrono::Duration::days(n));
-        }
-        if let Some(hours) = rest
-            .strip_suffix("hours")
-            .or_else(|| rest.strip_suffix("hour"))
-        {
-            let n: i64 = hours.trim().parse().ok()?;
-            return Some(Utc::now() - chrono::Duration::hours(n));
-        }
-    }
-
-    // ISO datetime: "2024-01-01T00:00:00"
-    if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
-        return Some(ndt.and_utc());
-    }
-
-    // Date only: "2024-01-01"
-    if let Ok(nd) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {
-        return nd.and_hms_opt(0, 0, 0).map(|ndt| ndt.and_utc());
-    }
-
-    None
-}
-
-fn datetime_to_proto(dt: chrono::DateTime<chrono::Utc>) -> prost_types::Timestamp {
-    prost_types::Timestamp {
-        seconds: dt.timestamp(),
-        nanos: dt.timestamp_subsec_nanos() as i32,
     }
 }
 

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -5,6 +5,7 @@ use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 
 use crate::format_engine;
+use crate::timearg::{datetime_to_proto, parse_time_arg};
 use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;
 use spur_proto::proto::*;
 
@@ -951,8 +952,29 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
             println!("{:<5} {:<15} {:<10}", "1002", "billing", "");
             Ok(())
         }
+        "txn" | "transaction" | "transactions" => {
+            let fields = txn_format_fields(p.get("format").map(String::as_str))?;
+            let request = build_txn_request(&p);
+
+            let mut client = connect(addr).await?;
+            let txns = client
+                .get_transactions(request)
+                .await
+                .context("GetTransactions RPC failed")?
+                .into_inner()
+                .transactions;
+
+            format_engine::print_header(&fields);
+            for t in &txns {
+                println!(
+                    "{}",
+                    format_engine::format_row(&fields, &|spec| resolve_txn_field(t, spec))
+                );
+            }
+            Ok(())
+        }
         other => bail!(
-            "sacctmgr: unknown entity '{}'. Use: account, user, qos, association, tres",
+            "sacctmgr: unknown entity '{}'. Use: account, user, qos, association, tres, txn",
             other
         ),
     }
@@ -961,6 +983,128 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
 fn filter_qos_by_name(qos_list: &mut Vec<QosInfo>, filter: &str) {
     let names: Vec<&str> = filter.split(',').map(str::trim).collect();
     qos_list.retain(|q| names.iter().any(|n| n.eq_ignore_ascii_case(&q.name)));
+}
+
+// Slurm's default `sacctmgr show transaction` columns: Time, Action, Actor,
+// Where, Info. Where renders entity_type:entity_name; Info renders details JSON.
+const TXN_DEFAULT_FORMAT: &str = "%-20t %-8a %-14A %-24w %-40i";
+const TXN_ALL_FORMAT: &str = "%-8d %-20t %-8a %-14A %-6v %-8s %-24w %-10o %-8u %-40i";
+
+fn txn_header(spec: char) -> &'static str {
+    match spec {
+        't' => "Time",
+        'a' => "Action",
+        'A' => "Actor",
+        'w' => "Where",
+        'i' => "Info",
+        'o' => "Outcome",
+        'v' => "Verified",
+        's' => "Source",
+        'd' => "ID",
+        'u' => "ActorUID",
+        _ => "?",
+    }
+}
+
+fn txn_field_spec(name: &str) -> Option<char> {
+    match name.to_lowercase().as_str() {
+        "time" | "timestamp" | "ts" => Some('t'),
+        "action" => Some('a'),
+        "actor" => Some('A'),
+        "where" | "entity" => Some('w'),
+        "info" | "details" => Some('i'),
+        "outcome" => Some('o'),
+        "verified" => Some('v'),
+        "source" => Some('s'),
+        "id" => Some('d'),
+        "actoruid" | "uid" => Some('u'),
+        _ => None,
+    }
+}
+
+fn txn_format_fields(
+    format_param: Option<&str>,
+) -> anyhow::Result<Vec<format_engine::FormatToken>> {
+    format_engine::resolve_format(
+        format_param,
+        TXN_DEFAULT_FORMAT,
+        TXN_ALL_FORMAT,
+        &txn_field_spec,
+        &txn_header,
+        "Time, Action, Actor, Where, Info, Outcome, Verified, Source, ID, ActorUID",
+    )
+}
+
+/// Build a `GetTransactions` request from Slurm-style `key=value` filters
+/// (`Actor=`, `Action=`, `Entity=`, `Name=`, `Outcome=`, `Start=`, `End=`,
+/// `limit=`). `action`/`outcome` are lowercased to match the stored values.
+fn build_txn_request(p: &std::collections::HashMap<String, String>) -> GetTransactionsRequest {
+    GetTransactionsRequest {
+        actor: p.get("actor").cloned().unwrap_or_default(),
+        entity_type: p
+            .get("entity")
+            .or_else(|| p.get("entitytype"))
+            .map(|s| s.to_lowercase())
+            .unwrap_or_default(),
+        entity_name: p
+            .get("name")
+            .or_else(|| p.get("entityname"))
+            .cloned()
+            .unwrap_or_default(),
+        action: p
+            .get("action")
+            .map(|s| s.to_lowercase())
+            .unwrap_or_default(),
+        outcome: p
+            .get("outcome")
+            .map(|s| s.to_lowercase())
+            .unwrap_or_default(),
+        start_after: p
+            .get("start")
+            .and_then(|s| parse_time_arg(s))
+            .map(datetime_to_proto),
+        start_before: p
+            .get("end")
+            .and_then(|s| parse_time_arg(s))
+            .map(datetime_to_proto),
+        limit: p.get("limit").and_then(|s| s.parse().ok()).unwrap_or(0),
+    }
+}
+
+fn resolve_txn_field(t: &TransactionRecord, spec: char) -> String {
+    match spec {
+        't' => t.timestamp.as_ref().map(fmt_txn_ts).unwrap_or_default(),
+        'a' => t.action.clone(),
+        'A' => t.actor.clone(),
+        'w' => format!("{}:{}", t.entity_type, t.entity_name),
+        'i' => t.details.clone(),
+        'o' => t.outcome.clone(),
+        'v' => if t.verified { "yes" } else { "no" }.to_string(),
+        's' => t.source.clone(),
+        'd' => t.id.to_string(),
+        // uid is recorded only for a verified identity; render blank otherwise so
+        // the unknown case (stored NULL, flattened to 0 on the wire) can't read as root.
+        'u' => {
+            if t.verified {
+                t.actor_uid.to_string()
+            } else {
+                String::new()
+            }
+        }
+        _ => "?".to_string(),
+    }
+}
+
+fn fmt_txn_ts(ts: &prost_types::Timestamp) -> String {
+    // Sanitize nanos (never displayed) so a negative/out-of-range value can't wrap
+    // via `as u32` and blank an otherwise-valid timestamp.
+    let nanos = u32::try_from(ts.nanos)
+        .ok()
+        .filter(|n| *n < 1_000_000_000)
+        .unwrap_or(0);
+    chrono::DateTime::from_timestamp(ts.seconds, nanos)
+        .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S").to_string())
+        .unwrap_or_default()
 }
 
 const ACCOUNT_DEFAULT_FORMAT: &str = "%-20N %-30D %-15O %-10P %-10S %-10G";
@@ -1930,6 +2074,81 @@ mod tests {
 
         assert!(account.is_empty());
         assert_eq!(user, "testuser");
+    }
+
+    #[test]
+    fn build_txn_request_maps_filters_and_lowercases_action() {
+        let p = parse_params(&[
+            "actor=alice".into(),
+            "action=Delete".into(),
+            "entity=reservation".into(),
+            "name=maint".into(),
+            "outcome=Denied".into(),
+            "start=2024-01-01".into(),
+            "limit=50".into(),
+        ]);
+
+        let req = build_txn_request(&p);
+
+        assert_eq!(req.actor, "alice");
+        assert_eq!(req.action, "delete");
+        assert_eq!(req.entity_type, "reservation");
+        assert_eq!(req.entity_name, "maint");
+        assert_eq!(req.outcome, "denied");
+        assert_eq!(req.limit, 50);
+        assert!(req.start_after.is_some());
+        assert!(req.start_before.is_none());
+    }
+
+    #[test]
+    fn resolve_txn_field_renders_where_and_verified() {
+        let t = TransactionRecord {
+            id: 7,
+            timestamp: None,
+            actor: "bob".into(),
+            actor_uid: 1000,
+            verified: true,
+            source: "api".into(),
+            action: "create".into(),
+            entity_type: "reservation".into(),
+            entity_name: "daily".into(),
+            outcome: "success".into(),
+            details: "{}".into(),
+        };
+        assert_eq!(resolve_txn_field(&t, 'w'), "reservation:daily");
+        assert_eq!(resolve_txn_field(&t, 'v'), "yes");
+        assert_eq!(resolve_txn_field(&t, 'A'), "bob");
+        assert_eq!(resolve_txn_field(&t, 'd'), "7");
+        assert_eq!(resolve_txn_field(&t, 'u'), "1000");
+    }
+
+    #[test]
+    fn resolve_txn_field_blanks_uid_when_unverified() {
+        // Unverified rows carry an unknown uid (stored NULL, 0 on the wire); it
+        // must render blank so it can't be mistaken for root (uid 0).
+        let t = TransactionRecord {
+            actor: "vm".into(),
+            actor_uid: 0,
+            verified: false,
+            ..Default::default()
+        };
+        assert_eq!(resolve_txn_field(&t, 'u'), "");
+        assert_eq!(resolve_txn_field(&t, 'v'), "no");
+    }
+
+    #[test]
+    fn fmt_txn_ts_sanitizes_bad_nanos() {
+        let bad = prost_types::Timestamp {
+            seconds: 1_700_000_000,
+            nanos: -1,
+        };
+        let good = prost_types::Timestamp {
+            seconds: 1_700_000_000,
+            nanos: 0,
+        };
+        // A negative nanos must not wrap via `as u32` and blank the timestamp.
+        assert!(!fmt_txn_ts(&bad).is_empty());
+        assert_eq!(fmt_txn_ts(&bad), fmt_txn_ts(&good));
     }
 
     fn stub_account() -> AccountInfo {

--- a/crates/spur-cli/src/sreport.rs
+++ b/crates/spur-cli/src/sreport.rs
@@ -6,6 +6,8 @@ use clap::{Parser, Subcommand};
 use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;
 use spur_proto::proto::{GetUsageRequest, ListAccountsRequest, ListUsersRequest};
 
+use crate::timearg::{datetime_to_proto, parse_time_arg};
+
 /// Generate usage reports from accounting data.
 #[derive(Parser, Debug)]
 #[command(name = "sreport", about = "Generate usage reports")]
@@ -428,47 +430,4 @@ async fn report_job_sizes_by_user(
     }
 
     Ok(())
-}
-
-/// Parse a time argument string into a DateTime.
-fn parse_time_arg(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
-    use chrono::{NaiveDate, NaiveDateTime, Utc};
-    let s = s.trim();
-
-    // Relative: "now-Ndays", "now-Nhours"
-    if let Some(rest) = s.strip_prefix("now-") {
-        if let Some(days) = rest
-            .strip_suffix("days")
-            .or_else(|| rest.strip_suffix("day"))
-        {
-            let n: i64 = days.trim().parse().ok()?;
-            return Some(Utc::now() - chrono::Duration::days(n));
-        }
-        if let Some(hours) = rest
-            .strip_suffix("hours")
-            .or_else(|| rest.strip_suffix("hour"))
-        {
-            let n: i64 = hours.trim().parse().ok()?;
-            return Some(Utc::now() - chrono::Duration::hours(n));
-        }
-    }
-
-    // ISO datetime
-    if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
-        return Some(ndt.and_utc());
-    }
-
-    // Date only
-    if let Ok(nd) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {
-        return nd.and_hms_opt(0, 0, 0).map(|ndt| ndt.and_utc());
-    }
-
-    None
-}
-
-fn datetime_to_proto(dt: chrono::DateTime<chrono::Utc>) -> prost_types::Timestamp {
-    prost_types::Timestamp {
-        seconds: dt.timestamp(),
-        nanos: dt.timestamp_subsec_nanos() as i32,
-    }
 }

--- a/crates/spur-cli/src/timearg.rs
+++ b/crates/spur-cli/src/timearg.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared CLI time-argument parsing and proto conversion, used by `sacct`,
+//! `sreport`, and `sacctmgr show txn` so `Start=`/`End=`/`-S`/`-E` behave
+//! identically across commands.
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+
+/// Parse a time argument string into a DateTime.
+/// Supports: "2024-01-01", "2024-01-01T00:00:00", "now-7days", "now-24hours".
+pub fn parse_time_arg(s: &str) -> Option<DateTime<Utc>> {
+    let s = s.trim();
+
+    // Relative: "now-Ndays", "now-Nhours". Per Slurm's `now[{+|-}count...]`
+    // grammar the count is unsigned, so parse it as such — a stray sign like
+    // "now--7days" is rejected rather than silently jumping into the future.
+    if let Some(rest) = s.strip_prefix("now-") {
+        if let Some(days) = rest
+            .strip_suffix("days")
+            .or_else(|| rest.strip_suffix("day"))
+        {
+            let n: u64 = days.trim().parse().ok()?;
+            return Some(Utc::now() - chrono::Duration::days(n as i64));
+        }
+        if let Some(hours) = rest
+            .strip_suffix("hours")
+            .or_else(|| rest.strip_suffix("hour"))
+        {
+            let n: u64 = hours.trim().parse().ok()?;
+            return Some(Utc::now() - chrono::Duration::hours(n as i64));
+        }
+    }
+
+    // ISO datetime: "2024-01-01T00:00:00"
+    if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+        return Some(ndt.and_utc());
+    }
+
+    // Date only: "2024-01-01"
+    if let Ok(nd) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        return nd.and_hms_opt(0, 0, 0).map(|ndt| ndt.and_utc());
+    }
+
+    None
+}
+
+/// Convert a DateTime into a protobuf Timestamp.
+pub fn datetime_to_proto(dt: DateTime<Utc>) -> prost_types::Timestamp {
+    prost_types::Timestamp {
+        seconds: dt.timestamp(),
+        nanos: dt.timestamp_subsec_nanos() as i32,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_date_only_as_midnight_utc() {
+        let dt = parse_time_arg("2024-01-02").unwrap();
+        assert_eq!(dt.to_rfc3339(), "2024-01-02T00:00:00+00:00");
+    }
+
+    #[test]
+    fn parses_iso_datetime() {
+        let dt = parse_time_arg("2024-01-02T03:04:05").unwrap();
+        assert_eq!(dt.to_rfc3339(), "2024-01-02T03:04:05+00:00");
+    }
+
+    #[test]
+    fn parses_relative_days_and_hours() {
+        let now = Utc::now();
+        let days = parse_time_arg("now-2days").unwrap();
+        assert!((now - days).num_hours() >= 47 && (now - days).num_hours() <= 49);
+
+        let hours = parse_time_arg("now-6hours").unwrap();
+        assert!((now - hours).num_minutes() >= 359 && (now - hours).num_minutes() <= 361);
+    }
+
+    #[test]
+    fn rejects_unparseable_input() {
+        assert!(parse_time_arg("not-a-time").is_none());
+        assert!(parse_time_arg("now-3weeks").is_none());
+    }
+
+    #[test]
+    fn rejects_stray_negative_offset() {
+        // "now--7days" must not silently resolve to a future time.
+        assert!(parse_time_arg("now--7days").is_none());
+        assert!(parse_time_arg("now--3hours").is_none());
+    }
+
+    #[test]
+    fn proto_roundtrip_preserves_seconds() {
+        let dt = parse_time_arg("2024-01-02T03:04:05").unwrap();
+        let ts = datetime_to_proto(dt);
+        assert_eq!(ts.seconds, dt.timestamp());
+    }
+}

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -490,6 +490,10 @@ pub struct AccountingConfig {
     /// chain. Mirrors Slurm's `AccountingStorageEnforce=qos`. Default false.
     #[serde(default)]
     pub require_qos: bool,
+    /// Delete `txn` audit-log rows older than this many days. `None` (default)
+    /// keeps them forever, matching Slurm's default-off purge behavior.
+    #[serde(default)]
+    pub txn_retention_days: Option<u32>,
 }
 
 fn default_fairshare_refresh_secs() -> u32 {
@@ -508,6 +512,7 @@ impl Default for AccountingConfig {
             grp_wall_window_days: default_grp_wall_window_days(),
             default_qos: String::new(),
             require_qos: false,
+            txn_retention_days: None,
         }
     }
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -491,7 +491,8 @@ pub struct AccountingConfig {
     #[serde(default)]
     pub require_qos: bool,
     /// Delete `txn` audit-log rows older than this many days. `None` (default)
-    /// keeps them forever, matching Slurm's default-off purge behavior.
+    /// or `0` disables purging (rows kept forever, matching Slurm's default-off
+    /// behavior); a positive value enables the periodic purge.
     #[serde(default)]
     pub txn_retention_days: Option<u32>,
 }

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -178,6 +178,26 @@ WHERE default_account IS NOT NULL
   );
 CREATE UNIQUE INDEX IF NOT EXISTS one_default_account_per_user
     ON users (name) WHERE default_account IS NOT NULL;
+
+-- Administrative action / audit log. Records who ran reservation admin commands
+-- (create/update/delete) and their outcome. Entity-agnostic so other admin ops
+-- can reuse it later. `details` is a JSON string (sqlx has no json feature).
+CREATE TABLE IF NOT EXISTS txn (
+    id           BIGSERIAL PRIMARY KEY,
+    ts           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    actor        TEXT NOT NULL DEFAULT '',
+    actor_uid    BIGINT,
+    verified     BOOLEAN NOT NULL DEFAULT FALSE,
+    source       TEXT NOT NULL DEFAULT 'api',
+    action       TEXT NOT NULL,
+    entity_type  TEXT NOT NULL,
+    entity_name  TEXT NOT NULL DEFAULT '',
+    outcome      TEXT NOT NULL DEFAULT 'success',
+    details      TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_txn_ts ON txn(ts);
+CREATE INDEX IF NOT EXISTS idx_txn_actor ON txn(actor);
+CREATE INDEX IF NOT EXISTS idx_txn_entity ON txn(entity_type, entity_name);
 "#;
 
 /// What accounting persists when a job starts. Named fields rather than positional
@@ -451,9 +471,8 @@ pub async fn get_job_history(
         sep.push_unseparated(")");
     }
 
-    qb.push(" ORDER BY submit_time DESC");
-    let effective_limit: i64 = if limit > 0 { limit.into() } else { 1000 };
-    qb.push(" LIMIT ").push_bind(effective_limit);
+    qb.push(" ORDER BY submit_time DESC LIMIT ")
+        .push_bind(effective_query_limit(limit));
 
     let rows = qb.build().fetch_all(pool).await?;
 
@@ -480,6 +499,139 @@ pub async fn get_job_history(
         .collect();
 
     Ok(records)
+}
+
+/// A row from the `txn` audit log.
+pub struct TxnRow {
+    pub id: i64,
+    pub ts: DateTime<Utc>,
+    pub actor: String,
+    pub actor_uid: Option<i64>,
+    pub verified: bool,
+    pub source: String,
+    pub action: String,
+    pub entity_type: String,
+    pub entity_name: String,
+    pub outcome: String,
+    pub details: String,
+}
+
+/// Optional filters for `get_transactions`. Empty string filters are ignored.
+#[derive(Default)]
+pub struct TxnFilter<'a> {
+    pub actor: Option<&'a str>,
+    pub entity_type: Option<&'a str>,
+    pub entity_name: Option<&'a str>,
+    pub action: Option<&'a str>,
+    pub outcome: Option<&'a str>,
+    pub start_after: Option<DateTime<Utc>>,
+    pub start_before: Option<DateTime<Utc>>,
+    pub limit: u32,
+}
+
+/// Insert one audit record. Takes `&mut PgConnection` for the same reason as
+/// `record_job_start`: callers can acquire a standalone connection or borrow
+/// one from an open transaction.
+pub async fn record_txn(
+    conn: &mut PgConnection,
+    rec: &super::txn::TxnRecord,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO txn (ts, actor, actor_uid, verified, source, action, entity_type, entity_name, outcome, details)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        "#,
+    )
+    .bind(rec.ts)
+    .bind(&rec.actor)
+    .bind(rec.actor_uid)
+    .bind(rec.verified)
+    .bind(rec.source.as_str())
+    .bind(rec.action.as_str())
+    .bind(rec.entity_type.as_str())
+    .bind(&rec.entity_name)
+    .bind(rec.outcome.as_str())
+    .bind(&rec.details)
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
+}
+
+/// Default and hard cap on rows a single history/audit query returns, bounding
+/// DB load and response size; a larger request is clamped, not rejected.
+const DEFAULT_QUERY_LIMIT: u32 = 1_000;
+const MAX_QUERY_LIMIT: u32 = 10_000;
+
+fn effective_query_limit(requested: u32) -> i64 {
+    let n = if requested == 0 {
+        DEFAULT_QUERY_LIMIT
+    } else {
+        requested.min(MAX_QUERY_LIMIT)
+    };
+    i64::from(n)
+}
+
+/// Query the `txn` audit log, newest first.
+pub async fn get_transactions(
+    pool: &PgPool,
+    filter: &TxnFilter<'_>,
+) -> anyhow::Result<Vec<TxnRow>> {
+    let mut qb = QueryBuilder::<sqlx::Postgres>::new(
+        "SELECT id, ts, actor, actor_uid, verified, source, action, entity_type, \
+         entity_name, outcome, details FROM txn WHERE 1=1",
+    );
+    if let Some(v) = filter.actor.filter(|s| !s.is_empty()) {
+        qb.push(" AND actor = ").push_bind(v);
+    }
+    if let Some(v) = filter.entity_type.filter(|s| !s.is_empty()) {
+        qb.push(" AND entity_type = ").push_bind(v);
+    }
+    if let Some(v) = filter.entity_name.filter(|s| !s.is_empty()) {
+        qb.push(" AND entity_name = ").push_bind(v);
+    }
+    if let Some(v) = filter.action.filter(|s| !s.is_empty()) {
+        qb.push(" AND action = ").push_bind(v);
+    }
+    if let Some(v) = filter.outcome.filter(|s| !s.is_empty()) {
+        qb.push(" AND outcome = ").push_bind(v);
+    }
+    if let Some(after) = filter.start_after {
+        qb.push(" AND ts >= ").push_bind(after);
+    }
+    if let Some(before) = filter.start_before {
+        qb.push(" AND ts <= ").push_bind(before);
+    }
+
+    qb.push(" ORDER BY ts DESC, id DESC LIMIT ")
+        .push_bind(effective_query_limit(filter.limit));
+
+    let rows = qb.build().fetch_all(pool).await?;
+    let records = rows
+        .iter()
+        .map(|row| TxnRow {
+            id: row.get("id"),
+            ts: row.get("ts"),
+            actor: row.get("actor"),
+            actor_uid: row.get("actor_uid"),
+            verified: row.get("verified"),
+            source: row.get("source"),
+            action: row.get("action"),
+            entity_type: row.get("entity_type"),
+            entity_name: row.get("entity_name"),
+            outcome: row.get("outcome"),
+            details: row.get("details"),
+        })
+        .collect();
+    Ok(records)
+}
+
+/// Delete audit rows older than `older_than`, returning the number removed.
+pub async fn purge_txn(pool: &PgPool, older_than: DateTime<Utc>) -> anyhow::Result<u64> {
+    let res = sqlx::query("DELETE FROM txn WHERE ts < $1")
+        .bind(older_than)
+        .execute(pool)
+        .await?;
+    Ok(res.rows_affected())
 }
 
 /// Get usage data for fair-share calculation.
@@ -2958,6 +3110,176 @@ mod job_history_tests {
 
         sqlx::query("DELETE FROM accounts WHERE name = $1")
             .bind(&account)
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod txn_tests {
+    use super::*;
+    use crate::accounting::txn::{TxnAction, TxnEntity, TxnOutcome, TxnRecord, TxnSource};
+    use chrono::Duration;
+
+    #[test]
+    fn effective_query_limit_defaults_and_caps() {
+        assert_eq!(effective_query_limit(0), i64::from(DEFAULT_QUERY_LIMIT));
+        assert_eq!(effective_query_limit(50), 50);
+        assert_eq!(
+            effective_query_limit(MAX_QUERY_LIMIT),
+            i64::from(MAX_QUERY_LIMIT)
+        );
+        assert_eq!(effective_query_limit(1_000_000), i64::from(MAX_QUERY_LIMIT));
+        assert_eq!(effective_query_limit(u32::MAX), i64::from(MAX_QUERY_LIMIT));
+    }
+
+    async fn test_pool() -> anyhow::Result<PgPool> {
+        let url = std::env::var("DATABASE_URL")?;
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&url)
+            .await?;
+        migrate(&pool).await?;
+        Ok(pool)
+    }
+
+    fn sample(
+        entity: &str,
+        action: TxnAction,
+        outcome: TxnOutcome,
+        ts: DateTime<Utc>,
+    ) -> TxnRecord {
+        TxnRecord {
+            ts,
+            actor: format!("actor_{}", std::process::id()),
+            actor_uid: Some(1000),
+            verified: true,
+            source: TxnSource::Api,
+            action,
+            entity_type: TxnEntity::Reservation,
+            entity_name: entity.to_string(),
+            outcome,
+            details: r#"{"k":"v"}"#.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn record_and_query_transactions() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let entity = format!("resv_txn_{}", std::process::id());
+        let actor = format!("actor_{}", std::process::id());
+
+        sqlx::query("DELETE FROM txn WHERE entity_name = $1")
+            .bind(&entity)
+            .execute(&pool)
+            .await?;
+
+        let now = Utc::now();
+        let mut conn = pool.acquire().await?;
+        record_txn(
+            &mut conn,
+            &sample(
+                &entity,
+                TxnAction::Create,
+                TxnOutcome::Success,
+                now - Duration::minutes(2),
+            ),
+        )
+        .await?;
+        record_txn(
+            &mut conn,
+            &sample(
+                &entity,
+                TxnAction::Delete,
+                TxnOutcome::Denied,
+                now - Duration::minutes(1),
+            ),
+        )
+        .await?;
+
+        // Filter by entity_name; expect newest-first ordering.
+        let rows = get_transactions(
+            &pool,
+            &TxnFilter {
+                entity_name: Some(&entity),
+                ..Default::default()
+            },
+        )
+        .await?;
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].action, "delete");
+        assert_eq!(rows[0].outcome, "denied");
+        assert_eq!(rows[1].action, "create");
+        assert_eq!(rows[0].actor, actor);
+        assert_eq!(rows[0].actor_uid, Some(1000));
+        assert!(rows[0].verified);
+
+        let denied = get_transactions(
+            &pool,
+            &TxnFilter {
+                entity_name: Some(&entity),
+                outcome: Some("denied"),
+                ..Default::default()
+            },
+        )
+        .await?;
+        assert_eq!(denied.len(), 1);
+        assert_eq!(denied[0].action, "delete");
+
+        sqlx::query("DELETE FROM txn WHERE entity_name = $1")
+            .bind(&entity)
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn purge_removes_old_rows() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let entity = format!("resv_purge_{}", std::process::id());
+
+        sqlx::query("DELETE FROM txn WHERE entity_name = $1")
+            .bind(&entity)
+            .execute(&pool)
+            .await?;
+
+        let now = Utc::now();
+        let mut conn = pool.acquire().await?;
+        record_txn(
+            &mut conn,
+            &sample(
+                &entity,
+                TxnAction::Create,
+                TxnOutcome::Success,
+                now - Duration::days(10),
+            ),
+        )
+        .await?;
+        record_txn(
+            &mut conn,
+            &sample(&entity, TxnAction::Update, TxnOutcome::Success, now),
+        )
+        .await?;
+
+        let removed = purge_txn(&pool, now - Duration::days(1)).await?;
+        assert!(removed >= 1);
+
+        let rows = get_transactions(
+            &pool,
+            &TxnFilter {
+                entity_name: Some(&entity),
+                ..Default::default()
+            },
+        )
+        .await?;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].action, "update");
+
+        sqlx::query("DELETE FROM txn WHERE entity_name = $1")
+            .bind(&entity)
             .execute(&pool)
             .await?;
         Ok(())

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -202,12 +202,8 @@ impl SlurmAccounting for AccountingService {
         let pool = self.pool()?;
         let req = request.into_inner();
 
-        let start_after = req
-            .start_after
-            .map(|t| DateTime::from_timestamp(t.seconds, t.nanos as u32).unwrap_or_default());
-        let start_before = req
-            .start_before
-            .map(|t| DateTime::from_timestamp(t.seconds, t.nanos as u32).unwrap_or_default());
+        let start_after = timestamp_to_utc(req.start_after)?;
+        let start_before = timestamp_to_utc(req.start_before)?;
 
         let states: Vec<String> = req
             .states
@@ -720,6 +716,69 @@ impl SlurmAccounting for AccountingService {
 
         Ok(Response::new(GetFairshareFactorsResponse { entries }))
     }
+
+    async fn get_transactions(
+        &self,
+        request: Request<GetTransactionsRequest>,
+    ) -> Result<Response<GetTransactionsResponse>, Status> {
+        // Ungated, consistent with get_job_history and the rest of this service.
+        // Confidentiality of the audit log requires auth.mode = required.
+        let pool = self.pool()?;
+        let req = request.into_inner();
+
+        let start_after = timestamp_to_utc(req.start_after)?;
+        let start_before = timestamp_to_utc(req.start_before)?;
+
+        let filter = db::TxnFilter {
+            actor: (!req.actor.is_empty()).then_some(req.actor.as_str()),
+            entity_type: (!req.entity_type.is_empty()).then_some(req.entity_type.as_str()),
+            entity_name: (!req.entity_name.is_empty()).then_some(req.entity_name.as_str()),
+            action: (!req.action.is_empty()).then_some(req.action.as_str()),
+            outcome: (!req.outcome.is_empty()).then_some(req.outcome.as_str()),
+            start_after,
+            start_before,
+            limit: req.limit,
+        };
+
+        let rows = db::get_transactions(pool, &filter)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let transactions = rows
+            .into_iter()
+            .map(|r| TransactionRecord {
+                id: r.id,
+                timestamp: Some(datetime_to_proto(r.ts)),
+                actor: r.actor,
+                actor_uid: r.actor_uid.and_then(|u| u32::try_from(u).ok()).unwrap_or(0),
+                verified: r.verified,
+                source: r.source,
+                action: r.action,
+                entity_type: r.entity_type,
+                entity_name: r.entity_name,
+                outcome: r.outcome,
+                details: r.details,
+            })
+            .collect();
+
+        Ok(Response::new(GetTransactionsResponse { transactions }))
+    }
+}
+
+/// Convert an optional proto timestamp to UTC, rejecting a present-but-invalid
+/// value with `invalid_argument` instead of silently coercing it to the epoch
+/// (which would widen a query window). Guards the nanos cast against negatives.
+fn timestamp_to_utc(ts: Option<prost_types::Timestamp>) -> Result<Option<DateTime<Utc>>, Status> {
+    let Some(t) = ts else { return Ok(None) };
+    let nanos = u32::try_from(t.nanos)
+        .ok()
+        .filter(|n| *n < 1_000_000_000)
+        .ok_or_else(|| Status::invalid_argument(format!("invalid timestamp nanos: {}", t.nanos)))?;
+    DateTime::from_timestamp(t.seconds, nanos)
+        .map(Some)
+        .ok_or_else(|| {
+            Status::invalid_argument(format!("timestamp out of range (seconds={})", t.seconds))
+        })
 }
 
 fn datetime_to_proto(dt: DateTime<Utc>) -> prost_types::Timestamp {
@@ -771,6 +830,7 @@ mod tests {
         assert_rpc_unavailable!(delete_qos, DeleteQosRequest);
         assert_rpc_unavailable!(list_qos, ListQosRequest);
         assert_rpc_unavailable!(get_fairshare_factors, GetFairshareFactorsRequest);
+        assert_rpc_unavailable!(get_transactions, GetTransactionsRequest);
     }
 
     #[tokio::test]
@@ -907,5 +967,42 @@ mod tests {
         let err = canonicalize_qos_flags("bogus").unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("bogus"));
+    }
+
+    #[test]
+    fn timestamp_to_utc_passes_none_through() {
+        assert_eq!(timestamp_to_utc(None).unwrap(), None);
+    }
+
+    #[test]
+    fn timestamp_to_utc_accepts_valid() {
+        let ts = prost_types::Timestamp {
+            seconds: 1_700_000_000,
+            nanos: 123,
+        };
+        let dt = timestamp_to_utc(Some(ts)).unwrap().unwrap();
+        assert_eq!(dt.timestamp(), 1_700_000_000);
+    }
+
+    #[test]
+    fn timestamp_to_utc_rejects_negative_nanos_instead_of_coercing_to_epoch() {
+        let ts = prost_types::Timestamp {
+            seconds: 1_700_000_000,
+            nanos: -1,
+        };
+        let err = timestamp_to_utc(Some(ts)).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn timestamp_to_utc_rejects_out_of_range_nanos() {
+        let ts = prost_types::Timestamp {
+            seconds: 0,
+            nanos: 1_000_000_000,
+        };
+        assert_eq!(
+            timestamp_to_utc(Some(ts)).unwrap_err().code(),
+            tonic::Code::InvalidArgument
+        );
     }
 }

--- a/crates/spurctld/src/accounting/mod.rs
+++ b/crates/spurctld/src/accounting/mod.rs
@@ -6,12 +6,15 @@ mod fairshare;
 mod grpc;
 mod notifier;
 mod reconcile;
+pub(crate) mod txn;
 
 pub use db::JobStartRecord;
 pub(crate) use grpc::{accounting_server, AccountingService};
 pub use notifier::AccountingNotifier;
 pub use reconcile::spawn_loop as spawn_reconcile_loop;
+pub use reconcile::spawn_txn_purge_loop;
 pub use reconcile::RECONCILE_INTERVAL_SECS;
+pub(crate) use txn::{TxnAction, TxnEntity, TxnOutcome, TxnRecord, TxnSource};
 
 use std::collections::{HashMap, HashSet};
 

--- a/crates/spurctld/src/accounting/notifier.rs
+++ b/crates/spurctld/src/accounting/notifier.rs
@@ -11,6 +11,7 @@ use tracing::error;
 use spur_core::job::{JobId, JobState};
 
 use super::db::JobStartRecord;
+use super::txn::{TxnOutcome, TxnRecord};
 
 const RETRY_ATTEMPTS: u32 = 3;
 const RETRY_BACKOFF: Duration = Duration::from_millis(200);
@@ -103,6 +104,35 @@ impl AccountingNotifier {
             };
             if let Err(e) = retry_with_backoff(write, RETRY_ATTEMPTS, RETRY_BACKOFF).await {
                 error!(job_id, error = %e, "failed to record job end in accounting after retries");
+            }
+        });
+    }
+
+    /// Best-effort async write of an audit record. Only committed (`Success`)
+    /// rows retry; `Denied`/`Error` rows use a single attempt so a flood of
+    /// (cheaply-triggered, possibly unauthenticated) failed attempts cannot pin
+    /// the connection pool against real accounting writes.
+    pub fn notify_txn(&self, record: TxnRecord) {
+        let pool = self.pool.clone();
+        let attempts = if record.outcome == TxnOutcome::Success {
+            RETRY_ATTEMPTS
+        } else {
+            1
+        };
+        tokio::spawn(async move {
+            let write = || async {
+                let mut conn = pool.acquire().await?;
+                super::db::record_txn(&mut conn, &record).await
+            };
+            if let Err(e) = retry_with_backoff(write, attempts, RETRY_BACKOFF).await {
+                error!(
+                    actor = %record.actor,
+                    action = record.action.as_str(),
+                    entity = %record.entity_name,
+                    attempts,
+                    error = %e,
+                    "failed to record txn in accounting"
+                );
             }
         });
     }

--- a/crates/spurctld/src/accounting/reconcile.rs
+++ b/crates/spurctld/src/accounting/reconcile.rs
@@ -49,6 +49,32 @@ pub fn spawn_loop(
     });
 }
 
+/// Periodically delete `txn` audit rows older than `retention_days`. Like
+/// reconcile, this write bypasses Raft (straight to Postgres), so it uses the
+/// consensus-backed leader check rather than the cached `is_leader()`.
+pub fn spawn_txn_purge_loop(
+    pool: PgPool,
+    raft: Arc<RaftHandle>,
+    retention_days: u32,
+    interval: Duration,
+) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        loop {
+            ticker.tick().await;
+            if !raft.ensure_leader().await {
+                continue;
+            }
+            let cutoff = Utc::now() - chrono::Duration::days(retention_days as i64);
+            match db::purge_txn(&pool, cutoff).await {
+                Ok(n) if n > 0 => info!(removed = n, "purged expired txn audit rows"),
+                Ok(_) => {}
+                Err(e) => warn!(error = %e, "txn audit purge failed"),
+            }
+        }
+    });
+}
+
 /// Only jobs that have actually started accrue an accounting record
 /// (`notify_job_start` fires from `start_job`), so jobs still pending are
 /// not candidates.

--- a/crates/spurctld/src/accounting/txn.rs
+++ b/crates/spurctld/src/accounting/txn.rs
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Administrative audit-log records for the accounting `txn` table.
+//!
+//! Pure, DB-agnostic types and helpers: the record built here is handed to the
+//! notifier for a best-effort async write. Kept free of `sqlx`/`tonic` server
+//! plumbing so the mapping and detail-serialization logic stays unit-testable.
+
+use chrono::{DateTime, Utc};
+use tonic::{Code, Status};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TxnAction {
+    Create,
+    Update,
+    Delete,
+}
+
+impl TxnAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Create => "create",
+            Self::Update => "update",
+            Self::Delete => "delete",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TxnEntity {
+    Reservation,
+}
+
+impl TxnEntity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Reservation => "reservation",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TxnOutcome {
+    Success,
+    Denied,
+    Error,
+}
+
+impl TxnOutcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Denied => "denied",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// Where the action originated. `Api` covers any external RPC/CLI caller (a
+/// gRPC server cannot tell the CLI from any other client); `System` is internal
+/// controller maintenance (e.g. expired-reservation purge).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TxnSource {
+    Api,
+    System,
+}
+
+impl TxnSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Api => "api",
+            Self::System => "system",
+        }
+    }
+}
+
+/// One audit row, built at action time and written best-effort by the notifier.
+#[derive(Clone, Debug)]
+pub struct TxnRecord {
+    pub ts: DateTime<Utc>,
+    pub actor: String,
+    pub actor_uid: Option<i64>,
+    /// True only when a JWT identity was cryptographically verified. False for
+    /// permissive/disabled anonymous callers (asserted, trust-on-wire) and for
+    /// `System` rows (trusted by being internal, which `source` conveys).
+    pub verified: bool,
+    pub source: TxnSource,
+    pub action: TxnAction,
+    pub entity_type: TxnEntity,
+    pub entity_name: String,
+    pub outcome: TxnOutcome,
+    pub details: String,
+}
+
+/// Classify a handler's final result into an audit outcome. Mapping off the
+/// final `Status` (rather than a domain error) means handler-level
+/// `invalid_argument` validation failures are captured too, not just
+/// cluster-layer errors.
+pub fn outcome_from_status(result: &Result<(), Status>) -> TxnOutcome {
+    match result {
+        Ok(()) => TxnOutcome::Success,
+        Err(s) if s.code() == Code::PermissionDenied => TxnOutcome::Denied,
+        Err(_) => TxnOutcome::Error,
+    }
+}
+
+/// Details for a reservation create attempt (the requested parameters, pre
+/// server-side normalization).
+pub fn create_details(
+    start_time: &str,
+    duration_minutes: u32,
+    nodes: &[String],
+    accounts: &[String],
+    users: &[String],
+    flags: &[String],
+) -> serde_json::Value {
+    serde_json::json!({
+        "start_time": start_time,
+        "duration_minutes": duration_minutes,
+        "nodes": nodes,
+        "accounts": accounts,
+        "users": users,
+        "flags": flags,
+    })
+}
+
+/// Details for a reservation update attempt (the requested deltas).
+#[allow(clippy::too_many_arguments)]
+pub fn update_details(
+    duration_minutes: u32,
+    add_nodes: &[String],
+    remove_nodes: &[String],
+    add_users: &[String],
+    remove_users: &[String],
+    add_accounts: &[String],
+    remove_accounts: &[String],
+) -> serde_json::Value {
+    serde_json::json!({
+        "duration_minutes": duration_minutes,
+        "add_nodes": add_nodes,
+        "remove_nodes": remove_nodes,
+        "add_users": add_users,
+        "remove_users": remove_users,
+        "add_accounts": add_accounts,
+        "remove_accounts": remove_accounts,
+    })
+}
+
+/// Details for a reservation delete. `reason` is set for internal purges.
+pub fn delete_details(reason: Option<&str>) -> serde_json::Value {
+    match reason {
+        Some(r) => serde_json::json!({ "reason": r }),
+        None => serde_json::json!({}),
+    }
+}
+
+/// Serialize a details object to the stored string, attaching the error message
+/// for non-success outcomes.
+pub fn finalize_details(mut base: serde_json::Value, error: Option<&str>) -> String {
+    if let Some(err) = error {
+        if let Some(obj) = base.as_object_mut() {
+            obj.insert(
+                "error".to_string(),
+                serde_json::Value::String(err.to_string()),
+            );
+        }
+    }
+    base.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcome_maps_status_codes() {
+        assert_eq!(outcome_from_status(&Ok(())), TxnOutcome::Success);
+        assert_eq!(
+            outcome_from_status(&Err(Status::permission_denied("no"))),
+            TxnOutcome::Denied
+        );
+        assert_eq!(
+            outcome_from_status(&Err(Status::invalid_argument("bad"))),
+            TxnOutcome::Error
+        );
+        assert_eq!(
+            outcome_from_status(&Err(Status::not_found("gone"))),
+            TxnOutcome::Error
+        );
+    }
+
+    #[test]
+    fn create_details_captures_requested_values() {
+        let v = create_details(
+            "now",
+            60,
+            &["n1".into(), "n2".into()],
+            &["acct".into()],
+            &["alice".into()],
+            &["MAINT".into()],
+        );
+        assert_eq!(v["start_time"], "now");
+        assert_eq!(v["duration_minutes"], 60);
+        assert_eq!(v["nodes"], serde_json::json!(["n1", "n2"]));
+        assert_eq!(v["users"], serde_json::json!(["alice"]));
+        assert_eq!(v["flags"], serde_json::json!(["MAINT"]));
+    }
+
+    #[test]
+    fn finalize_details_attaches_error_only_on_failure() {
+        let base = delete_details(None);
+        let ok = finalize_details(base.clone(), None);
+        assert_eq!(ok, "{}");
+
+        let failed = finalize_details(base, Some("user 'bob' cannot modify"));
+        let parsed: serde_json::Value = serde_json::from_str(&failed).unwrap();
+        assert_eq!(parsed["error"], "user 'bob' cannot modify");
+    }
+
+    #[test]
+    fn enum_str_values_are_stable() {
+        assert_eq!(TxnAction::Create.as_str(), "create");
+        assert_eq!(TxnAction::Update.as_str(), "update");
+        assert_eq!(TxnAction::Delete.as_str(), "delete");
+        assert_eq!(TxnEntity::Reservation.as_str(), "reservation");
+        assert_eq!(TxnOutcome::Success.as_str(), "success");
+        assert_eq!(TxnOutcome::Denied.as_str(), "denied");
+        assert_eq!(TxnOutcome::Error.as_str(), "error");
+        assert_eq!(TxnSource::Api.as_str(), "api");
+        assert_eq!(TxnSource::System.as_str(), "system");
+    }
+}

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -36,7 +36,9 @@ use spur_metrics::node::NodeMetricsSnapshot;
 use spur_metrics::partition::PartitionMetricsSnapshot;
 use spur_metrics::user_acct::UserAcctMetricsSnapshot;
 
-use crate::accounting::{AccountingNotifier, JobStartRecord};
+use crate::accounting::{
+    txn, AccountingNotifier, JobStartRecord, TxnAction, TxnEntity, TxnOutcome, TxnRecord, TxnSource,
+};
 use crate::association_cache::{qos_permitted, AccountMembership, AssociationCache};
 use crate::fairshare_cache::FairshareCache;
 use crate::limits_cache::{consumed_minutes, GrpWallCache, QosCache};
@@ -3970,6 +3972,14 @@ impl ClusterManager {
         Ok(())
     }
 
+    /// Fire a best-effort audit write when accounting is configured; no-op
+    /// otherwise. Mirrors the job start/end notification path.
+    pub(crate) fn record_txn(&self, record: TxnRecord) {
+        if let Some(ref notifier) = *self.accounting.read() {
+            notifier.notify_txn(record);
+        }
+    }
+
     /// Remove reservations past their end time when no jobs still reference them.
     pub fn purge_expired_reservations(&self) {
         let now = Utc::now();
@@ -3990,9 +4000,35 @@ impl ClusterManager {
             if in_use {
                 continue;
             }
-            if let Err(e) = self.propose(WalOperation::ReservationDelete { name: name.clone() }) {
-                warn!(name = %name, error = %e, "failed to purge expired reservation");
-            }
+            let error = match self.propose(WalOperation::ReservationDelete { name: name.clone() }) {
+                Ok(_) => None,
+                Err(e) => {
+                    warn!(name = %name, error = %e, "failed to purge expired reservation");
+                    Some(e.to_string())
+                }
+            };
+            // Audit both outcomes (like the RPC handlers) so a repeatedly-failing
+            // system purge leaves a trail, not just an ephemeral warn.
+            let outcome = if error.is_none() {
+                TxnOutcome::Success
+            } else {
+                TxnOutcome::Error
+            };
+            self.record_txn(TxnRecord {
+                ts: Utc::now(),
+                actor: "system".to_string(),
+                actor_uid: None,
+                verified: false,
+                source: TxnSource::System,
+                action: TxnAction::Delete,
+                entity_type: TxnEntity::Reservation,
+                entity_name: name.clone(),
+                outcome,
+                details: txn::finalize_details(
+                    txn::delete_details(Some("expired")),
+                    error.as_deref(),
+                ),
+            });
         }
     }
 

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -218,6 +218,15 @@ async fn main() -> anyhow::Result<()> {
                         std::time::Duration::from_secs(accounting::RECONCILE_INTERVAL_SECS),
                     );
 
+                    if let Some(days) = config.accounting.txn_retention_days.filter(|d| *d > 0) {
+                        accounting::spawn_txn_purge_loop(
+                            pool.clone(),
+                            raft_handle.clone(),
+                            days,
+                            std::time::Duration::from_secs(3600),
+                        );
+                    }
+
                     cluster.fairshare_cache().spawn_refresh_loop(
                         pool.clone(),
                         config.scheduler.fairshare_halflife_days,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -21,6 +21,7 @@ use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::slurm_controller_server::SlurmController;
 use spur_proto::proto::*;
 
+use crate::accounting::{txn, TxnAction, TxnEntity, TxnRecord, TxnSource};
 use crate::cluster::{ClusterManager, JobFilter, PartitionError, ReservationError};
 use crate::pmix_dispatch::{self, PmixPrepareNode};
 use crate::raft::RaftHandle;
@@ -403,6 +404,88 @@ impl ControllerService {
         identity.is_some_and(|id| {
             id.is_admin || is_k0s_admin(self.cluster.association_cache(), &id.user)
         })
+    }
+
+    /// Fire a best-effort audit record and a structured log line for a reservation
+    /// admin action, so operators keep attribution even when the accounting DB is
+    /// down. Never alters the RPC result.
+    fn audit_reservation(
+        &self,
+        action: TxnAction,
+        entity_name: &str,
+        actor: &str,
+        identity: Option<&spur_core::auth::Identity>,
+        details_base: serde_json::Value,
+        result: &Result<(), Status>,
+    ) {
+        let record =
+            Self::build_reservation_txn(action, entity_name, actor, identity, details_base, result);
+        info!(
+            actor = %record.actor,
+            entity = %record.entity_name,
+            action = record.action.as_str(),
+            outcome = record.outcome.as_str(),
+            "reservation admin action"
+        );
+        self.cluster.record_txn(record);
+    }
+
+    /// Build the audit record from the resolved outcome and caller identity.
+    /// `verified` is true only for a verified JWT identity, and the actor uid is
+    /// taken from that identity — never the forgeable wire value.
+    fn build_reservation_txn(
+        action: TxnAction,
+        entity_name: &str,
+        actor: &str,
+        identity: Option<&spur_core::auth::Identity>,
+        details_base: serde_json::Value,
+        result: &Result<(), Status>,
+    ) -> TxnRecord {
+        TxnRecord {
+            ts: Utc::now(),
+            actor: actor.to_string(),
+            actor_uid: identity.map(|id| i64::from(id.uid)),
+            verified: identity.is_some(),
+            source: TxnSource::Api,
+            action,
+            entity_type: TxnEntity::Reservation,
+            entity_name: entity_name.to_string(),
+            outcome: txn::outcome_from_status(result),
+            details: txn::finalize_details(
+                details_base,
+                result.as_ref().err().map(|s| s.message()),
+            ),
+        }
+    }
+
+    /// Parse, validate, and submit a create-reservation request. Split out so the
+    /// handler audits the outcome uniformly, including `invalid_argument` parse
+    /// failures that occur before the cluster call.
+    fn build_and_create_reservation(&self, req: CreateReservationRequest) -> Result<(), Status> {
+        let start_time = if req.start_time.is_empty() || req.start_time.eq_ignore_ascii_case("now")
+        {
+            Utc::now()
+        } else {
+            req.start_time
+                .parse::<DateTime<Utc>>()
+                .map_err(|e| Status::invalid_argument(format!("invalid start_time: {}", e)))?
+        };
+        let end_time = start_time + chrono::Duration::minutes(req.duration_minutes as i64);
+        let flags = spur_core::reservation::ReservationFlags::parse_list(&req.flags)
+            .map_err(Status::invalid_argument)?;
+        let reservation = Reservation {
+            name: req.name,
+            start_time,
+            end_time,
+            nodes: req.nodes,
+            accounts: req.accounts,
+            users: req.users,
+            flags,
+            owner: req.user,
+        };
+        self.cluster
+            .create_reservation(reservation)
+            .map_err(reservation_rpc_status)
     }
 
     /// Whether a caller is exempt from the non-admin restrictions (the priority ceiling): an admin,
@@ -2176,40 +2259,31 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let __identity = Self::verified_identity(&request).cloned();
+        let identity = Self::verified_identity(&request).cloned();
         let mut req = request.into_inner();
-        Self::authoritative_user(&mut req.user, __identity.as_ref());
+        Self::authoritative_user(&mut req.user, identity.as_ref());
 
-        let start_time = if req.start_time.is_empty() || req.start_time.eq_ignore_ascii_case("now")
-        {
-            chrono::Utc::now()
-        } else {
-            req.start_time
-                .parse::<chrono::DateTime<chrono::Utc>>()
-                .map_err(|e| Status::invalid_argument(format!("invalid start_time: {}", e)))?
-        };
+        let details = txn::create_details(
+            &req.start_time,
+            req.duration_minutes,
+            &req.nodes,
+            &req.accounts,
+            &req.users,
+            &req.flags,
+        );
+        let entity_name = req.name.clone();
+        let actor = req.user.clone();
 
-        let end_time = start_time + chrono::Duration::minutes(req.duration_minutes as i64);
-
-        let flags = spur_core::reservation::ReservationFlags::parse_list(&req.flags)
-            .map_err(Status::invalid_argument)?;
-
-        let reservation = spur_core::reservation::Reservation {
-            name: req.name,
-            start_time,
-            end_time,
-            nodes: req.nodes,
-            accounts: req.accounts,
-            users: req.users,
-            flags,
-            owner: req.user,
-        };
-
-        self.cluster
-            .create_reservation(reservation)
-            .map_err(reservation_rpc_status)?;
-
-        Ok(Response::new(()))
+        let result = self.build_and_create_reservation(req);
+        self.audit_reservation(
+            TxnAction::Create,
+            &entity_name,
+            &actor,
+            identity.as_ref(),
+            details,
+            &result,
+        );
+        result.map(|()| Response::new(()))
     }
 
     async fn update_reservation(
@@ -2230,10 +2304,24 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let __identity = Self::verified_identity(&request).cloned();
+        let identity = Self::verified_identity(&request).cloned();
         let mut req = request.into_inner();
-        Self::authoritative_user(&mut req.user, __identity.as_ref());
-        self.cluster
+        Self::authoritative_user(&mut req.user, identity.as_ref());
+
+        let details = txn::update_details(
+            req.duration_minutes,
+            &req.add_nodes,
+            &req.remove_nodes,
+            &req.add_users,
+            &req.remove_users,
+            &req.add_accounts,
+            &req.remove_accounts,
+        );
+        let entity_name = req.name.clone();
+        let actor = req.user.clone();
+
+        let result = self
+            .cluster
             .update_reservation(
                 &req.name,
                 req.duration_minutes,
@@ -2245,8 +2333,16 @@ impl SlurmController for ControllerService {
                 &req.remove_accounts,
                 &req.user,
             )
-            .map_err(reservation_rpc_status)?;
-        Ok(Response::new(()))
+            .map_err(reservation_rpc_status);
+        self.audit_reservation(
+            TxnAction::Update,
+            &entity_name,
+            &actor,
+            identity.as_ref(),
+            details,
+            &result,
+        );
+        result.map(|()| Response::new(()))
     }
 
     async fn delete_reservation(
@@ -2267,13 +2363,26 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let __identity = Self::verified_identity(&request).cloned();
+        let identity = Self::verified_identity(&request).cloned();
         let mut req = request.into_inner();
-        Self::authoritative_user(&mut req.user, __identity.as_ref());
-        self.cluster
+        Self::authoritative_user(&mut req.user, identity.as_ref());
+
+        let entity_name = req.name.clone();
+        let actor = req.user.clone();
+
+        let result = self
+            .cluster
             .delete_reservation(&req.name, &req.user)
-            .map_err(reservation_rpc_status)?;
-        Ok(Response::new(()))
+            .map_err(reservation_rpc_status);
+        self.audit_reservation(
+            TxnAction::Delete,
+            &entity_name,
+            &actor,
+            identity.as_ref(),
+            txn::delete_details(None),
+            &result,
+        );
+        result.map(|()| Response::new(()))
     }
 
     async fn list_reservations(
@@ -6720,6 +6829,50 @@ mod tests {
         };
         ControllerService::authoritative_user(&mut user, Some(&id));
         assert_eq!(user, "carol");
+    }
+
+    // --- build_reservation_txn (audit attribution) ---
+
+    #[test]
+    fn build_reservation_txn_records_verified_identity_and_large_uid() {
+        let id = spur_core::auth::Identity {
+            user: "alice".to_string(),
+            uid: 4_000_000_000, // > i32::MAX: must survive as i64, not wrap negative
+            gid: 0,
+            is_admin: false,
+        };
+        let rec = ControllerService::build_reservation_txn(
+            TxnAction::Create,
+            "resv1",
+            "alice",
+            Some(&id),
+            serde_json::json!({}),
+            &Ok(()),
+        );
+        assert!(rec.verified);
+        assert_eq!(rec.actor_uid, Some(4_000_000_000));
+        assert_eq!(rec.actor, "alice");
+        assert_eq!(rec.source, TxnSource::Api);
+        assert_eq!(rec.entity_type, TxnEntity::Reservation);
+        assert_eq!(rec.outcome, crate::accounting::TxnOutcome::Success);
+    }
+
+    #[test]
+    fn build_reservation_txn_anonymous_is_unverified_and_captures_error() {
+        let rec = ControllerService::build_reservation_txn(
+            TxnAction::Delete,
+            "resv1",
+            "bob",
+            None,
+            serde_json::json!({}),
+            &Err(Status::permission_denied(
+                "user 'bob' cannot delete reservation",
+            )),
+        );
+        assert!(!rec.verified);
+        assert_eq!(rec.actor_uid, None);
+        assert_eq!(rec.outcome, crate::accounting::TxnOutcome::Denied);
+        assert!(rec.details.contains("cannot delete"));
     }
 
     // --- bind_spec_to_identity ---

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -773,6 +773,80 @@ unrecognized state defaults to idle with a warning.
    reload the controller. See :doc:`/deployment/partitioning` and
    :doc:`configuration`.
 
+Auditing administrative actions
+-------------------------------
+
+Reservation admin commands (``scontrol create/update/delete-reservation``) are
+recorded in the accounting database's ``txn`` (transaction) log, capturing
+**who** ran the command, **when**, and the **outcome**. This closes a gap in
+stock Slurm, whose ``txn_table`` does not cover ``scontrol`` reservation
+operations and whose reservation records carry no actor. Recording is
+best-effort: a database outage never blocks the reservation operation itself.
+
+Each record captures:
+
+- **Time** — when the action was attempted.
+- **Actor** — the requesting user. Under ``auth.mode = required`` this is the
+  JWT-verified identity; under the default ``permissive`` mode an unauthenticated
+  caller's name is trusted on the wire (see ``Verified``).
+- **Verified** — ``yes`` only when a JWT identity was cryptographically verified;
+  ``no`` for permissive/disabled anonymous callers (asserted, trust-on-wire) and
+  for internal ``system`` actions such as the expired-reservation purge.
+- **Action** — ``create``, ``update``, or ``delete``.
+- **Where** — the target, rendered ``entity_type:entity_name`` (e.g.
+  ``reservation:daily``).
+- **Outcome** — ``success``, ``denied`` (permission/ownership rejected), or
+  ``error`` (validation or other failure). Unlike Slurm, which logs only
+  committed transactions, Spur also records denied and failed attempts.
+- **Info** — a JSON payload of the requested parameters (and the error message on
+  failure). These are the values as requested, before server-side normalization.
+- **Source** — ``api`` for external RPC/CLI callers, ``system`` for internal
+  maintenance.
+
+Viewing the log
+~~~~~~~~~~~~~~~~
+
+List records with ``sacctmgr show txn`` (aliases: ``transaction``,
+``transactions``), modeled on Slurm's ``sacctmgr show transaction``:
+
+.. code-block:: bash
+
+   sacctmgr show txn
+   sacctmgr show txn Actor=alice Action=delete
+   sacctmgr show txn Entity=reservation Name=daily Outcome=denied
+   sacctmgr show txn Start=2026-01-01 End=now-1hours
+   sacctmgr show txn format=Time,Actor,Action,Where,Outcome,Verified,Info
+
+Filters are ``Actor=``, ``Action=``, ``Entity=`` (entity type), ``Name=`` (entity
+name), ``Outcome=``, ``Start=``, ``End=``, and ``limit=``. ``Start``/``End``
+accept the same formats as ``sacct`` (``YYYY-MM-DD``, ISO datetime,
+``now-Ndays``/``now-Nhours``). ``limit=`` defaults to 1000 and is capped at
+10000 rows per query (larger requests are clamped). The default columns match
+Slurm (``Time,Action,Actor,Where,Info``); additional ``format=`` fields are
+``Outcome``, ``Verified``, ``Source``, ``ID``, and ``ActorUID``.
+
+.. note::
+
+   Reads are **not** access-gated — the same as ``sacct`` job history and the
+   rest of the accounting service. Confidentiality of the audit log therefore
+   requires ``auth.mode = required``; under the default ``permissive`` mode any
+   caller that can reach the controller can read it.
+
+Retention
+~~~~~~~~~
+
+The log grows without bound by default. Set ``accounting.txn_retention_days`` to
+have the controller (leader) periodically delete records older than the given
+number of days:
+
+.. code-block:: toml
+
+   [accounting]
+   txn_retention_days = 365
+
+Leaving it unset (the default) keeps records forever, matching Slurm's
+default purge-off behavior.
+
 Declarative management with Ansible
 -----------------------------------
 

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -844,8 +844,8 @@ number of days:
    [accounting]
    txn_retention_days = 365
 
-Leaving it unset (the default) keeps records forever, matching Slurm's
-default purge-off behavior.
+Leaving it unset (the default) or ``0`` keeps records forever, matching Slurm's
+default purge-off behavior; a positive value enables the purge.
 
 Declarative management with Ansible
 -----------------------------------

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -323,8 +323,8 @@ in-process inside ``spurctld`` (served on port 6817) — there is no separate
      - unset
      - Restart
      - Delete admin audit-log (``txn``) rows older than this many days. Unset (the
-       default) keeps them forever, matching Slurm's default purge-off behavior.
-       See :doc:`accounting`.
+       default) or ``0`` disables purging (rows kept forever, matching Slurm's
+       default purge-off behavior); a positive value enables it. See :doc:`accounting`.
 
 See :doc:`accounting` for how ``default_qos`` and ``require_qos`` interact with the
 per-job QOS resolution chain.

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -318,6 +318,13 @@ in-process inside ``spurctld`` (served on port 6817) — there is no separate
      - Live
      - Reject at submit any job that still has no QOS after the resolution chain.
        Mirrors Slurm's ``AccountingStorageEnforce=qos``.
+   * - ``txn_retention_days``
+     - integer
+     - unset
+     - Restart
+     - Delete admin audit-log (``txn``) rows older than this many days. Unset (the
+       default) keeps them forever, matching Slurm's default purge-off behavior.
+       See :doc:`accounting`.
 
 See :doc:`accounting` for how ``default_qos`` and ``require_qos`` interact with the
 per-job QOS resolution chain.

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -467,6 +467,9 @@ service SlurmAccounting {
 
   // Fairshare
   rpc GetFairshareFactors(GetFairshareFactorsRequest) returns (GetFairshareFactorsResponse);
+
+  // Transaction / audit log (reservation admin actions today; entity-agnostic)
+  rpc GetTransactions(GetTransactionsRequest) returns (GetTransactionsResponse);
 }
 
 // ============================================================
@@ -1205,6 +1208,37 @@ message GetJobHistoryRequest {
 
 message GetJobHistoryResponse {
   repeated JobInfo jobs = 1;
+}
+
+// Audit/transaction log query. All string filters are optional (empty = no
+// filter); time bounds are optional (unset = no time constraint).
+message GetTransactionsRequest {
+  string actor = 1;
+  string entity_type = 2;
+  string entity_name = 3;
+  string action = 4;
+  string outcome = 5;
+  google.protobuf.Timestamp start_after = 6;
+  google.protobuf.Timestamp start_before = 7;
+  uint32 limit = 8;
+}
+
+message TransactionRecord {
+  int64 id = 1;
+  google.protobuf.Timestamp timestamp = 2;
+  string actor = 3;
+  uint32 actor_uid = 4;         // 0 when unknown (e.g. unauthenticated caller)
+  bool verified = 5;            // true only when a JWT identity was verified
+  string source = 6;            // "api" | "system"
+  string action = 7;            // "create" | "update" | "delete"
+  string entity_type = 8;       // "reservation"
+  string entity_name = 9;
+  string outcome = 10;          // "success" | "denied" | "error"
+  string details = 11;          // JSON: requested parameters (+ error on failure)
+}
+
+message GetTransactionsResponse {
+  repeated TransactionRecord transactions = 1;
 }
 
 message GetUsageRequest {

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -10,6 +10,8 @@ when Docker is unavailable).
 import re
 import time
 
+import pytest
+
 from cluster import deep_merge, parse_job_id, wait_job, wait_job_state, wait_sacct_row
 
 
@@ -862,3 +864,150 @@ class TestSacctmgrInvalidInput:
 
         show_out = c.sacctmgr(["show", "qos"])
         assert "badtres" not in show_out, "QOS should not have been created"
+
+
+def _parse_txn_rows(out: str, where: str) -> list[dict]:
+    """Parse `sacctmgr show txn` rows into column dicts for `where`. Exact
+    column matching (anchored on the Action verb, which also skips the
+    header/separator) avoids the substring false positives of naive `in` checks."""
+    rows = []
+    for line in out.splitlines():
+        f = line.split()
+        if len(f) == 6 and f[1] in ("create", "update", "delete") and f[3] == where:
+            rows.append(
+                {
+                    "id": f[0],
+                    "action": f[1],
+                    "actor": f[2],
+                    "where": f[3],
+                    "outcome": f[4],
+                    "verified": f[5],
+                }
+            )
+    return rows
+
+
+def _wait_txn_rows(c, res_name: str, predicate, timeout: int = 60) -> list[dict]:
+    """Poll the audit log until some row for `res_name` satisfies `predicate`
+    (audit writes are async), then return all parsed rows for the reservation."""
+    fmt = "format=ID,Action,Actor,Where,Outcome,Verified"
+    where = f"reservation:{res_name}"
+    deadline = time.time() + timeout
+    last: list[dict] = []
+    while time.time() < deadline:
+        rows = _parse_txn_rows(c.sacctmgr(["show", "txn", f"Name={res_name}", fmt]), where)
+        if any(predicate(r) for r in rows):
+            return rows
+        last = rows
+        time.sleep(2)
+    raise TimeoutError(f"txn rows for {res_name} never matched within {timeout}s (last: {last!r})")
+
+
+class TestReservationAudit:
+    """scontrol reservation admin actions are recorded in the accounting txn
+    log with the acting user and outcome (create/update/delete + failures)."""
+
+    def test_reservation_actions_recorded_in_txn_log(self, accounting_cluster):
+        c = accounting_cluster
+        node = c.node_names[0]
+        res_name = f"res-audit-{int(time.time())}"
+
+        create_args = [
+            "scontrol",
+            "create-reservation",
+            f"--name={res_name}",
+            "--start-time=now",
+            "--duration=60",
+            f"--nodes={node}",
+            "--flags=ignore_jobs",
+        ]
+        try:
+            assert "created" in c.cli_as_user("root", create_args).lower()
+
+            # Duplicate create -> server rejects (AlreadyExists) -> outcome=error,
+            # still audited (Spur logs failed attempts, unlike Slurm's txn_table).
+            dup = c.cli_as_user("root", create_args)
+            assert "created" not in dup.lower(), f"duplicate should fail: {dup}"
+
+            assert "updated" in c.cli_as_user(
+                "root",
+                ["scontrol", "update-reservation", f"--name={res_name}", "--duration=120"],
+            ).lower()
+
+            assert "deleted" in c.cli_as_user(
+                "root", ["scontrol", "delete-reservation", res_name]
+            ).lower()
+
+            # Delete is the last write, so waiting for it guarantees the earlier
+            # create/update rows have landed too.
+            rows = _wait_txn_rows(
+                c, res_name, lambda r: r["action"] == "delete" and r["outcome"] == "success"
+            )
+
+            def has(action, outcome, actor=None):
+                return any(
+                    r["action"] == action
+                    and r["outcome"] == outcome
+                    and (actor is None or r["actor"] == actor)
+                    for r in rows
+                )
+
+            assert has("create", "success", actor="root"), rows
+            assert has("create", "error"), rows  # the rejected duplicate
+            assert has("update", "success", actor="root"), rows
+            assert has("delete", "success", actor="root"), rows
+        finally:
+            # A leaked reservation fences a node; best-effort cleanup.
+            c.cli_as_user("root", ["scontrol", "delete-reservation", res_name])
+
+    def test_denied_reservation_action_recorded(self, accounting_cluster):
+        """A non-owner delete is rejected server-side and recorded as
+        outcome=denied. Skips unless a privileged non-root identity (one that
+        passes the CLI gate yet isn't the owner) can reach the server here."""
+        c = accounting_cluster
+        submit_user = c.nodes[0].user
+        if submit_user == "root":
+            pytest.skip("need a non-root SSH user to test a denied action")
+
+        probe = c.cli_as_user("root", ["scontrol", "show", "reservation"])
+        if "sudo" in probe.lower() and (
+            "password" in probe.lower() or "not allowed" in probe.lower()
+        ):
+            pytest.skip(f"sudo -u unavailable in this environment: {probe.strip()}")
+
+        node = c.node_names[0]
+        res_name = f"res-audit-denied-{int(time.time())}"
+        try:
+            assert "created" in c.cli_as_user(
+                "root",
+                [
+                    "scontrol",
+                    "create-reservation",
+                    f"--name={res_name}",
+                    "--start-time=now",
+                    "--duration=60",
+                    f"--nodes={node}",
+                    "--flags=ignore_jobs",
+                    "--users=testuser",
+                ],
+            ).lower()
+
+            # Only a server-side ownership denial is audited. If the delete never
+            # reaches the server (the CLI privilege gate blocks a non-sudo/wheel
+            # user, or sudo -u is unavailable), nothing is written -- so skip.
+            del_out = c.cli_as_user(
+                submit_user, ["scontrol", "delete-reservation", res_name]
+            ).lower()
+            if "cannot delete" not in del_out:
+                pytest.skip(
+                    f"server-side reservation denial not reproducible here: {del_out.strip()}"
+                )
+
+            rows = _wait_txn_rows(
+                c, res_name, lambda r: r["action"] == "delete" and r["outcome"] == "denied"
+            )
+            denied = [r for r in rows if r["action"] == "delete" and r["outcome"] == "denied"]
+            assert denied, rows
+            assert denied[0]["actor"] == submit_user, denied
+        finally:
+            c.cli_as_user("root", ["scontrol", "delete-reservation", res_name])


### PR DESCRIPTION
## feat(spurctld): record reservation admin actions in accounting txn log

### Summary
`scontrol` reservation create/update/delete previously left **no record of who ran the command** — the accounting DB only tracked jobs. This adds an audit trail: a general-purpose `txn` (transaction) table records reservation admin actions — including **denied and failed attempts** — with the acting user, outcome, and requested parameters, and exposes them via a new `GetTransactions` gRPC RPC and a Slurm-compatible `sacctmgr show txn`.

This closes a gap that stock Slurm also has: its `txn_table` doesn't cover `scontrol` reservations, and its reservation records carry no actor.

### What's included
- **Audit `txn` table** in the accounting schema — entity-agnostic (reservations today; extensible to other admin ops), storing actor, actor_uid, `verified`, `source`, action, entity, outcome, and a JSON `details` payload.
- **Write path:** best-effort, leader-side audit fired from the reservation handlers and the expired-reservation purge (`source=system`), mirroring the existing job-accounting notifier (async + bounded retry).
- **Read path:** `GetTransactions` RPC + `sacctmgr show txn|transaction` with Slurm-aligned filters (`Actor=`/`Action=`/`Start=`/`End=`, plus `Entity=`/`Outcome=`) and columns (default `Time,Action,Actor,Where,Info`; extras `Outcome,Verified,Source,ID,ActorUID`).
- **Shared CLI time-arg util** — de-duplicates `parse_time_arg`/`datetime_to_proto` across `sacct`, `sreport`, and the new command.
- **Optional retention:** `accounting.txn_retention_days` (leader-only periodic purge; unset = keep forever, matching Slurm).
- Docs (`accounting.rst`, `configuration.rst`) and unit + e2e tests.

### Design choices / trade-offs
- **Correct-by-construction attribution:** the audit fires strictly *after* the operation resolves and records the *authoritative* actor (JWT subject when verified, else the client-asserted name with `verified=no`). A `success` row can only follow a committed Raft op; `denied`/`error` imply no state change.
- **Best-effort, non-transactional:** a DB outage never blocks or fails a reservation command; the only possible skew is a committed reservation with a missing audit row (logged as an error), never a false success.
- **Non-breaking / safe rolling upgrade + rollback:** no persisted Raft/WAL type changes (WAL replay writes zero audit rows); additive proto (new tags only), additive schema (`CREATE ... IF NOT EXISTS`), one optional config field, additive CLI.
- **Read path is ungated**, consistent with `get_job_history` and the rest of the accounting service; audit-read confidentiality therefore requires `auth.mode = required` (documented).

### Sample output
Produced by (on a 3-node bare-metal cluster, accounting enabled):
```bash
sudo scontrol create-reservation --name=maint-2026 --start-time=now --duration=120 --nodes=spur-node1 --flags=ignore_jobs --users=alice,bob
sudo scontrol create-reservation --name=maint-2026 ...        # duplicate -> error
sudo scontrol update-reservation --name=maint-2026 --duration=240
scontrol delete-reservation maint-2026                        # run as 'vm' (non-owner) -> denied
sudo scontrol delete-reservation maint-2026
```

Default (Slurm-compatible columns):
```
$ sacctmgr show txn
Time                 Action   Actor          Where                    Info
----                 ------   -----          -----                    ----
2026-08-19T11:04:39  delete   root           reservation:maint-2026   {}
2026-08-19T11:04:39  delete   vm             reservation:maint-2026   {"error":"user 'vm' cannot delete reservation 'maint-2026' owned by 'root'"}
2026-08-19T11:04:39  update   root           reservation:maint-2026   {"add_accounts":[],"add_nodes":[],"add_users":[],"duration_minutes":240,"remove_accounts":[],"remove_nodes":[],"remove_users":[]}
2026-08-19T11:04:39  create   root           reservation:maint-2026   {"accounts":[],"duration_minutes":120,"error":"reservation 'maint-2026' already exists","flags":["ignore_jobs"],"nodes":["spur-node1"],"start_time":"now","users":[]}
2026-08-19T11:04:38  create   root           reservation:maint-2026   {"accounts":[],"duration_minutes":120,"flags":["ignore_jobs"],"nodes":["spur-node1"],"start_time":"now","users":["alice","bob"]}
```

Full columns (Spur extensions `Outcome`, `Verified`, `Source`, `ID`):
```
$ sacctmgr show txn format=ID,Time,Actor,Action,Where,Outcome,Verified,Source,Info
ID  Time                 Actor    Action   Where                    Outcome  Verified  Source  Info
--  ----                 -----    ------   -----                    -------  --------  ------  ----
5   2026-08-19T11:04:39  root     delete   reservation:maint-2026   success  no        api     {}
4   2026-08-19T11:04:39  vm       delete   reservation:maint-2026   denied   no        api     {"error":"user 'vm' cannot delete reservation 'maint-2026' owned by 'root'"}
3   2026-08-19T11:04:39  root     update   reservation:maint-2026   success  no        api     {...deltas...}
2   2026-08-19T11:04:39  root     create   reservation:maint-2026   error    no        api     {"error":"reservation 'maint-2026' already exists",...}
1   2026-08-19T11:04:38  root     create   reservation:maint-2026   success  no        api     {"nodes":["spur-node1"],"users":["alice","bob"],...}
```

Filtering (`Actor=`, `Action=`, `Entity=`, `Outcome=`, `Start=`, `End=`):
```
$ sacctmgr show txn Actor=root Action=create Outcome=success
```

(`Verified=no` here because the cluster runs the default `auth.mode = permissive` with no tokens — actors are trust-on-wire; under `required` with JWTs it reads `yes`.)

### Testing
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean.
- `cargo test --locked` — green. Unit tests cover the attribution mapping (`verified`/`actor_uid`, incl. a UID > 2³¹), outcome/details serialization, timestamp validation, the query-limit cap, time-arg parsing (incl. `now--7days` rejection), and CLI filter parsing. DB round-trip tests are `#[ignore]`-gated (no external services in the default run).
- Verified end-to-end on the 3-node bare-metal cluster (Postgres-backed): create / update / delete plus duplicate-create (`error`) and non-owner delete (`denied`) all produce the correct rows (output above). e2e assertions parse rows into columns and match exact values.

### Follow-ups (out of scope)
- **Security (pre-existing):** the whole `SlurmAccounting` gRPC service is unauthenticated — including `add_user`, which sets `admin_level`. Under default `permissive`/`disabled` mode an anonymous caller can self-grant accounting Admin. The coherent fix is service-wide authz; until then, use `auth.mode = required`. This also bounds who can read the audit log.
- Keyset (`ts,id`) **pagination** for large audit history.
- Live-reloadable retention; document that purge is a hard delete (no archive).
- Extend auditing to `sacctmgr` account/user/QoS CRUD and node ops (the table is already entity-agnostic).