### PR TITLE
fix(spurctld): adopt each node's real WireGuard address as its k0s mesh IP

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -15656,33 +15656,77 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn provision_refuses_conflicting_real_addresses() {
-        // Two meshed nodes claiming the same real address is a genuine operator mistake: assigning
-        // both would push an exclusive AllowedIPs entry for two peers. Refuse with a reason.
+        // Two unassigned meshed nodes advertising the same real address is a genuine operator mistake:
+        // assigning either would push an exclusive AllowedIPs entry for an address two peers claim. Both
+        // stay unprovisioned and both carry the reason, but the call still succeeds so any other node in
+        // the same tick provisions normally.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_meshed_node(&cm, "n005", "10.44.0.7");
         register_meshed_node(&cm, "n006", "10.44.0.7"); // duplicate
+        register_meshed_node(&cm, "n007", "10.44.0.9"); // healthy bystander
         record_cp_set(&cm, "n005", &["n005"]);
 
-        let err = crate::cluster_k8s::provision_assignments(
-            &cm,
-            &provision_net_calico(),
-            &cm.k0s_state(),
-        )
-        .unwrap_err();
-        assert!(
-            format!("{err:#}").to_lowercase().contains("mismatch")
-                || format!("{err:#}").to_lowercase().contains("conflict"),
-            "duplicate real address must fail loud: {err:#}"
+        crate::cluster_k8s::provision_assignments(&cm, &provision_net_calico(), &cm.k0s_state())
+            .unwrap();
+
+        // The healthy node adopts its real address and provisions despite the conflicting pair.
+        wait_for("healthy bystander provisions", || {
+            cm.get_node("n007").and_then(|n| n.k0s_role).is_some()
+        });
+        assert_eq!(
+            cm.get_node("n007").unwrap().k0s_mesh_ip.as_deref(),
+            Some("10.44.0.9")
         );
-        // The reason is surfaced on BOTH sides of the conflict so `spur k8s status` points at each.
-        wait_for("both nodes carry the conflict reason", || {
-            let a = cm.get_node("n005").and_then(|n| n.k0s_last_error);
-            let b = cm.get_node("n006").and_then(|n| n.k0s_last_error);
-            a.map(|e| e.to_lowercase().contains("mismatch"))
-                .unwrap_or(false)
-                && b.map(|e| e.to_lowercase().contains("mismatch"))
-                    .unwrap_or(false)
+
+        // Neither conflicting node is assigned, and both name each other in an exact-shape reason so
+        // `spur k8s status` points at the whole conflict.
+        assert!(cm.get_node("n005").and_then(|n| n.k0s_role).is_none());
+        assert!(cm.get_node("n006").and_then(|n| n.k0s_role).is_none());
+        let want = "network mismatch: mesh address 10.44.0.7 claimed by n005, n006";
+        wait_for("both conflicting nodes carry the exact reason", || {
+            cm.get_node("n005")
+                .and_then(|n| n.k0s_last_error)
+                .as_deref()
+                == Some(want)
+                && cm
+                    .get_node("n006")
+                    .and_then(|n| n.k0s_last_error)
+                    .as_deref()
+                    == Some(want)
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provision_refuses_newcomer_colliding_with_assigned_node() {
+        // An already-assigned member owns its mesh IP. A newcomer advertising that same address is the
+        // one refused — the incumbent keeps its assignment, the newcomer stays out with a reason.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_meshed_node(&cm, "n005", "10.44.0.7");
+        record_cp_set(&cm, "n005", &["n005"]);
+        crate::cluster_k8s::provision_assignments(&cm, &provision_net_calico(), &cm.k0s_state())
+            .unwrap();
+        wait_for("incumbent assigned", || {
+            cm.get_node("n005").and_then(|n| n.k0s_role).is_some()
+        });
+
+        register_meshed_node(&cm, "n006", "10.44.0.7"); // collides with the incumbent's owned address
+        crate::cluster_k8s::provision_assignments(&cm, &provision_net_calico(), &cm.k0s_state())
+            .unwrap();
+
+        // Incumbent untouched; newcomer refused and told who owns the address.
+        assert_eq!(
+            cm.get_node("n005").unwrap().k0s_mesh_ip.as_deref(),
+            Some("10.44.0.7")
+        );
+        assert!(cm.get_node("n006").and_then(|n| n.k0s_role).is_none());
+        let want = "network mismatch: mesh address 10.44.0.7 already owned by n005";
+        wait_for("newcomer carries the ownership reason", || {
+            cm.get_node("n006")
+                .and_then(|n| n.k0s_last_error)
+                .as_deref()
+                == Some(want)
         });
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -7390,6 +7390,35 @@ mod tests {
         });
     }
 
+    /// Register a node already on the WireGuard mesh: it advertises its real `spur0` address (what
+    /// `detect_node_address` reports when WireGuard is up) and a wg pubkey, so `provision_assignments`
+    /// adopts that real address as its `k0s_mesh_ip` instead of allocating from a pool.
+    fn register_meshed_node(cm: &ClusterManager, name: &str, mesh_addr: &str) {
+        cm.register_node(
+            name.into(),
+            name.into(),
+            ResourceSet {
+                cpus: 4,
+                memory_mb: 8000,
+                ..Default::default()
+            },
+            mesh_addr.into(),
+            6818,
+            format!("pk-{name}"),
+            String::new(),
+            spur_core::node::NodeSource::NativeHost,
+            HashMap::new(),
+        )
+        .unwrap();
+        let n = name.to_string();
+        let want = mesh_addr.to_string();
+        wait_for(&format!("meshed node '{n}' registered"), || {
+            cm.get_node(&n)
+                .map(|x| x.address.as_deref() == Some(want.as_str()))
+                .unwrap_or(false)
+        });
+    }
+
     fn submit_and_wait(cm: &ClusterManager, spec: JobSpec) -> JobId {
         let id = cm.submit_job(spec).unwrap().job_id;
         wait_for(&format!("job {id} applied"), || cm.get_job(id).is_some());
@@ -15485,6 +15514,201 @@ mod tests {
         assert_eq!(b.k0s_pod_cidr, b_cidr, "same pod CIDR after re-add");
         // The untouched node keeps its assignment (provisioning is idempotent).
         assert!(cm.get_node("node-a").and_then(|n| n.k0s_role).is_some());
+    }
+
+    // ---- k0s adopts each node's real WireGuard address as its mesh IP ----
+
+    fn provision_net_calico() -> crate::cluster_k8s::ClusterNetworking {
+        crate::cluster_k8s::ClusterNetworking {
+            mesh_cidr: "10.44.0.0/16".into(),
+            pod_cidr: "10.42.0.0/16".into(),
+            service_cidr: "10.43.0.0/16".into(),
+            cni_mtu: 1450,
+            cni: "calico".into(),
+            control_plane_node: None,
+            provisioning_timeout: std::time::Duration::from_secs(600),
+        }
+    }
+
+    /// Record the HA control-plane set (what `cluster_up` persists) so `provision_assignments`
+    /// treats `cp` as controllers and the first as bootstrap.
+    fn record_cp_set(cm: &ClusterManager, bootstrap: &str, cp: &[&str]) {
+        use spur_core::k0s::K0sPhase;
+        cm.set_k0s_phase(
+            K0sPhase::Provisioning,
+            Some(bootstrap.into()),
+            cp.iter().map(|s| s.to_string()).collect(),
+            Vec::new(),
+            false,
+        )
+        .unwrap();
+        wait_for("cp set recorded", || {
+            cm.k0s_state().control_plane_nodes.len() == cp.len()
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provision_adopts_real_address_adversarial_cp_selection() {
+        // The core regression: nodes joined the mesh in address order matching hostname
+        // order (005=.1 .. 009=.5), but the chosen control-plane set is NOT an alphabetical prefix
+        // of that order ({006,007,008}). Each node's k0s_mesh_ip must equal its REAL address — not
+        // a pool-allocated value that drifts one-off from reality and corrupts the mesh.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let reals = [
+            ("n005", "10.44.0.1"),
+            ("n006", "10.44.0.2"),
+            ("n007", "10.44.0.3"),
+            ("n008", "10.44.0.4"),
+            ("n009", "10.44.0.5"),
+        ];
+        for (name, addr) in reals {
+            register_meshed_node(&cm, name, addr);
+        }
+        // Adversarial: CP set is the middle three, bootstrap 006 (whose real addr is .2, not .1).
+        record_cp_set(&cm, "n006", &["n006", "n007", "n008"]);
+
+        crate::cluster_k8s::provision_assignments(&cm, &provision_net_calico(), &cm.k0s_state())
+            .unwrap();
+        wait_for("all assigned", || {
+            reals
+                .iter()
+                .all(|(n, _)| cm.get_node(n).and_then(|x| x.k0s_role).is_some())
+        });
+
+        for (name, addr) in reals {
+            let n = cm.get_node(name).unwrap();
+            assert_eq!(
+                n.k0s_mesh_ip.as_deref(),
+                Some(addr),
+                "{name}: k0s_mesh_ip must equal its real spur0 address"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provision_adopts_real_address_scrambled_join_order() {
+        // Even an alphabetical-prefix CP set mismatches under a pool allocator if physical join
+        // order was scrambled (real addresses not in hostname order). Adopting the real address
+        // must track physical reality regardless of the name sort.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let reals = [
+            ("n005", "10.44.0.5"),
+            ("n006", "10.44.0.3"),
+            ("n007", "10.44.0.1"),
+            ("n008", "10.44.0.4"),
+            ("n009", "10.44.0.2"),
+        ];
+        for (name, addr) in reals {
+            register_meshed_node(&cm, name, addr);
+        }
+        record_cp_set(&cm, "n005", &["n005", "n006", "n007"]);
+
+        crate::cluster_k8s::provision_assignments(&cm, &provision_net_calico(), &cm.k0s_state())
+            .unwrap();
+        wait_for("all assigned", || {
+            reals
+                .iter()
+                .all(|(n, _)| cm.get_node(n).and_then(|x| x.k0s_role).is_some())
+        });
+
+        for (name, addr) in reals {
+            let n = cm.get_node(name).unwrap();
+            assert_eq!(
+                n.k0s_mesh_ip.as_deref(),
+                Some(addr),
+                "{name}: k0s_mesh_ip must track the real address, not the name sort"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provision_pools_node_with_underlay_comm_address() {
+        // A node whose advertised comm address is OUTSIDE mesh_cidr (e.g. a control plane advertising
+        // its routable underlay address, as real deployments do) is not reporting a mesh address — it
+        // must fall through to pool allocation, NOT be refused. Only an in-mesh address is adopted.
+        // (wg_cidr-vs-mesh_cidr config validation is a separate concern.)
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_meshed_node(&cm, "n005", "198.51.100.5"); // underlay, outside 10.44.0.0/16
+        register_meshed_node(&cm, "n006", "10.44.0.3"); // in-mesh -> adopted
+        record_cp_set(&cm, "n005", &["n005"]);
+
+        crate::cluster_k8s::provision_assignments(&cm, &provision_net_calico(), &cm.k0s_state())
+            .unwrap();
+        wait_for("both assigned", || {
+            cm.get_node("n005").and_then(|n| n.k0s_role).is_some()
+                && cm.get_node("n006").and_then(|n| n.k0s_role).is_some()
+        });
+        // Bootstrap n005 advertised underlay -> pool gives it .1; n006 adopts its real .3.
+        assert_eq!(
+            cm.get_node("n005").unwrap().k0s_mesh_ip.as_deref(),
+            Some("10.44.0.1"),
+            "underlay-advertising bootstrap falls back to pool .1"
+        );
+        assert_eq!(
+            cm.get_node("n006").unwrap().k0s_mesh_ip.as_deref(),
+            Some("10.44.0.3"),
+            "in-mesh node adopts its real address"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provision_refuses_conflicting_real_addresses() {
+        // Two meshed nodes claiming the same real address is a genuine operator mistake: assigning
+        // both would push an exclusive AllowedIPs entry for two peers. Refuse with a reason.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_meshed_node(&cm, "n005", "10.44.0.7");
+        register_meshed_node(&cm, "n006", "10.44.0.7"); // duplicate
+        record_cp_set(&cm, "n005", &["n005"]);
+
+        let err = crate::cluster_k8s::provision_assignments(
+            &cm,
+            &provision_net_calico(),
+            &cm.k0s_state(),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").to_lowercase().contains("mismatch")
+                || format!("{err:#}").to_lowercase().contains("conflict"),
+            "duplicate real address must fail loud: {err:#}"
+        );
+        // The reason is surfaced on BOTH sides of the conflict so `spur k8s status` points at each.
+        wait_for("both nodes carry the conflict reason", || {
+            let a = cm.get_node("n005").and_then(|n| n.k0s_last_error);
+            let b = cm.get_node("n006").and_then(|n| n.k0s_last_error);
+            a.map(|e| e.to_lowercase().contains("mismatch"))
+                .unwrap_or(false)
+                && b.map(|e| e.to_lowercase().contains("mismatch"))
+                    .unwrap_or(false)
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provision_falls_back_to_pool_for_unmeshed_node() {
+        // A node not yet on the mesh (no wg pubkey / no real mesh address) keeps pool allocation so
+        // the pre-mesh provisioning path still works. Bootstrap still gets .1 in that path.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "node-a", 4, 8000); // 127.0.0.1, no pubkey -> unmeshed
+        register_node(&cm, "node-b", 4, 8000);
+        record_cp_set(&cm, "node-a", &["node-a"]);
+
+        crate::cluster_k8s::provision_assignments(&cm, &provision_net_calico(), &cm.k0s_state())
+            .unwrap();
+        wait_for("assigned", || {
+            cm.get_node("node-a").and_then(|n| n.k0s_role).is_some()
+                && cm.get_node("node-b").and_then(|n| n.k0s_role).is_some()
+        });
+        // Bootstrap keeps .1 via the pool path; the other gets a distinct pooled address.
+        assert_eq!(
+            cm.get_node("node-a").unwrap().k0s_mesh_ip.as_deref(),
+            Some("10.44.0.1")
+        );
+        let b = cm.get_node("node-b").unwrap().k0s_mesh_ip.clone().unwrap();
+        assert_ne!(b, "10.44.0.1", "second node gets a distinct pooled address");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -212,49 +212,76 @@ pub(crate) fn provision_assignments(
         cp_set.insert(bootstrap.clone());
     }
 
-    // Re-seed the mesh pool from persisted assignments + reserve .1 for the bootstrap controller.
+    // Re-seed the mesh pool from persisted assignments + reserve .1 for the bootstrap controller. An
+    // already-assigned node's persisted `k0s_mesh_ip` is authoritative, so remember which node owns each
+    // in-mesh address to arbitrate newcomer conflicts below.
     let mut pool = AddressPool::new(&net.mesh_cidr)?;
     let controller_ip = first_host(&net.mesh_cidr)?;
     let _ = pool.allocate_specific(controller_ip); // reserve .1 (ignore if already reserved)
+    let mut assigned_addr: HashMap<Ipv4Addr, String> = HashMap::new();
     for n in &nodes {
         if let Some(ip) = &n.k0s_mesh_ip {
             let parsed: Ipv4Addr = ip
                 .parse()
                 .with_context(|| format!("persisted k0s_mesh_ip {ip} for {}", n.name))?;
             pool.mark_allocated(parsed);
+            if n.k0s_role.is_some() {
+                assigned_addr.insert(parsed, n.name.clone());
+            }
         }
     }
 
-    // Adopt each node's REAL mesh address: a node on the mesh advertises its `spur0` IP as
-    // `Node.address`; when that address falls within `mesh_cidr` it IS the node's mesh IP, and is the
-    // single source of truth for it. Re-deriving from an independent pool is what silently corrupts the
-    // mesh when the control-plane set isn't an alphabetical prefix of join order. A node whose comm
-    // address is OUTSIDE `mesh_cidr` (e.g. a control plane advertising its routable underlay address)
-    // is simply not reporting a mesh address — it falls through to pool allocation, not an error.
-    // Reserve every adopted address up front so pooled nodes never collide, and fail loud only on a
-    // genuine conflict: two nodes claiming the same in-mesh address.
-    let mut real_ip: HashMap<String, Ipv4Addr> = HashMap::new();
-    let mut claimed: HashMap<Ipv4Addr, String> = HashMap::new();
+    // Adopt each node's REAL mesh address: a meshed node advertises its `spur0` IP as `Node.address`,
+    // and when it falls within `mesh_cidr` that IS its mesh IP — the single source of truth. Re-deriving
+    // from an independent pool is what silently corrupts the mesh when the control-plane set is not an
+    // alphabetical prefix of join order. An out-of-mesh (underlay) address falls through to pool
+    // allocation below.
+    //
+    // A conflict — two nodes advertising the same in-mesh address — is contained, not fatal: only the
+    // conflicting nodes stay unprovisioned (each tagged with the reason for `spur k8s status`), while
+    // healthy nodes provision normally. An already-assigned member owns its address, so a newcomer
+    // colliding with it is the one refused; two unassigned newcomers on the same address both stay out.
+    //
+    // Group unassigned claimants by advertised in-mesh address so an N-way conflict resolves in one shot.
+    let mut claimants: HashMap<Ipv4Addr, Vec<String>> = HashMap::new();
     for n in &nodes {
         if n.k0s_role.is_some() {
             continue; // already assigned; its persisted mesh IP is authoritative
         }
-        let Some(addr) = real_mesh_address(n, &net.mesh_cidr)? else {
-            continue; // no in-mesh address reported — pool allocation handles it below
-        };
-        if let Some(other) = claimed.insert(addr, n.name.clone()) {
-            // Surface the conflict on BOTH sides so `spur k8s status` points at each node sharing the
-            // address, not just the second one seen.
+        if let Some(addr) = real_mesh_address(n, &net.mesh_cidr)? {
+            claimants.entry(addr).or_default().push(n.name.clone());
+        }
+    }
+
+    let mut real_ip: HashMap<String, Ipv4Addr> = HashMap::new();
+    let mut refused: HashSet<String> = HashSet::new();
+    for (addr, mut names) in claimants {
+        if let Some(owner) = assigned_addr.get(&addr) {
+            // An in-cluster node already owns this address; every newcomer claiming it is refused.
+            for name in &names {
+                let reason =
+                    format!("network mismatch: mesh address {addr} already owned by {owner}");
+                record_node_k0s_error(cluster, name, &reason);
+                refused.insert(name.clone());
+            }
+            continue;
+        }
+        if names.len() > 1 {
+            // Two or more unassigned nodes advertise the same address: none can adopt it. Keep all out
+            // and name every claimant on each so status points at the whole conflict.
+            names.sort();
             let reason = format!(
-                "network mismatch: mesh address {addr} claimed by both {} and {other}",
-                n.name
+                "network mismatch: mesh address {addr} claimed by {}",
+                names.join(", ")
             );
-            record_node_k0s_error(cluster, &n.name, &reason);
-            record_node_k0s_error(cluster, &other, &reason);
-            anyhow::bail!("{reason}");
+            for name in &names {
+                record_node_k0s_error(cluster, name, &reason);
+                refused.insert(name.clone());
+            }
+            continue;
         }
         pool.mark_allocated(addr);
-        real_ip.insert(n.name.clone(), addr);
+        real_ip.insert(names.remove(0), addr);
     }
 
     // Pod-/24 ordinals already in use (so a new node never collides).
@@ -277,6 +304,9 @@ pub(crate) fn provision_assignments(
         if node.k0s_role.is_some() {
             continue; // already assigned
         }
+        if refused.contains(&node.name) {
+            continue; // conflicting mesh address; stays unprovisioned until the operator resolves it
+        }
         let is_cp = cp_set.contains(&node.name);
         let role = if is_cp {
             if single {
@@ -287,10 +317,8 @@ pub(crate) fn provision_assignments(
         } else {
             K0sRole::Worker
         };
-        // Prefer the node's real WireGuard address (adopt-from-host); the bootstrap is treated the
-        // same as any other node — `.1` results naturally when the operator gave the controller `.1`,
-        // and a divergent join order works instead of corrupting the mesh. Fall back to `.1` for a
-        // not-yet-meshed bootstrap, else the pool.
+        // Adopt the node's real WireGuard address; fall back to `.1` for a not-yet-meshed bootstrap,
+        // else the pool.
         let mesh_ip = if let Some(addr) = real_ip.get(&node.name) {
             *addr
         } else if node.name == bootstrap {
@@ -457,11 +485,9 @@ fn first_host(cidr: &str) -> anyhow::Result<Ipv4Addr> {
     Ok(Ipv4Addr::from(u32::from(cidr_base(cidr)?) + 1))
 }
 
-/// A node's real WireGuard mesh address: the `spur0` IP it advertises (`Node.address`) once it has
-/// joined the mesh (non-empty `wg_pubkey`), but only when that address falls within `mesh_cidr`.
-/// Returns Ok(None) for a node not on the mesh (no pubkey / unparseable address) OR one whose comm
-/// address is outside the mesh (e.g. a control plane advertising its routable underlay address) — in
-/// both cases the caller falls back to pool allocation. Errs only on a malformed `mesh_cidr`.
+/// A node's real WireGuard mesh address: the `spur0` IP it advertises (`Node.address`) once meshed
+/// (non-empty `wg_pubkey`), but only when it falls within `mesh_cidr`. Ok(None) for an unmeshed node
+/// or an out-of-mesh (underlay) address — both fall back to pool allocation. Errs on malformed CIDR.
 fn real_mesh_address(
     node: &spur_core::node::Node,
     mesh_cidr: &str,

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -225,6 +225,38 @@ pub(crate) fn provision_assignments(
         }
     }
 
+    // Adopt each node's REAL mesh address: a node on the mesh advertises its `spur0` IP as
+    // `Node.address`; when that address falls within `mesh_cidr` it IS the node's mesh IP, and is the
+    // single source of truth for it. Re-deriving from an independent pool is what silently corrupts the
+    // mesh when the control-plane set isn't an alphabetical prefix of join order. A node whose comm
+    // address is OUTSIDE `mesh_cidr` (e.g. a control plane advertising its routable underlay address)
+    // is simply not reporting a mesh address — it falls through to pool allocation, not an error.
+    // Reserve every adopted address up front so pooled nodes never collide, and fail loud only on a
+    // genuine conflict: two nodes claiming the same in-mesh address.
+    let mut real_ip: HashMap<String, Ipv4Addr> = HashMap::new();
+    let mut claimed: HashMap<Ipv4Addr, String> = HashMap::new();
+    for n in &nodes {
+        if n.k0s_role.is_some() {
+            continue; // already assigned; its persisted mesh IP is authoritative
+        }
+        let Some(addr) = real_mesh_address(n, &net.mesh_cidr)? else {
+            continue; // no in-mesh address reported — pool allocation handles it below
+        };
+        if let Some(other) = claimed.insert(addr, n.name.clone()) {
+            // Surface the conflict on BOTH sides so `spur k8s status` points at each node sharing the
+            // address, not just the second one seen.
+            let reason = format!(
+                "network mismatch: mesh address {addr} claimed by both {} and {other}",
+                n.name
+            );
+            record_node_k0s_error(cluster, &n.name, &reason);
+            record_node_k0s_error(cluster, &other, &reason);
+            anyhow::bail!("{reason}");
+        }
+        pool.mark_allocated(addr);
+        real_ip.insert(n.name.clone(), addr);
+    }
+
     // Pod-/24 ordinals already in use (so a new node never collides).
     let pod_base = cidr_base(&net.pod_cidr)?;
     let mut used_ordinals: HashSet<u32> = nodes
@@ -255,7 +287,13 @@ pub(crate) fn provision_assignments(
         } else {
             K0sRole::Worker
         };
-        let mesh_ip = if node.name == bootstrap {
+        // Prefer the node's real WireGuard address (adopt-from-host); the bootstrap is treated the
+        // same as any other node — `.1` results naturally when the operator gave the controller `.1`,
+        // and a divergent join order works instead of corrupting the mesh. Fall back to `.1` for a
+        // not-yet-meshed bootstrap, else the pool.
+        let mesh_ip = if let Some(addr) = real_ip.get(&node.name) {
+            *addr
+        } else if node.name == bootstrap {
             controller_ip
         } else {
             pool.allocate()?
@@ -417,6 +455,59 @@ fn order_bootstrap_first(set: &mut [String], pinned_bootstrap: Option<&str>) {
 /// The `.1` host of a CIDR (mesh controller IP).
 fn first_host(cidr: &str) -> anyhow::Result<Ipv4Addr> {
     Ok(Ipv4Addr::from(u32::from(cidr_base(cidr)?) + 1))
+}
+
+/// A node's real WireGuard mesh address: the `spur0` IP it advertises (`Node.address`) once it has
+/// joined the mesh (non-empty `wg_pubkey`), but only when that address falls within `mesh_cidr`.
+/// Returns Ok(None) for a node not on the mesh (no pubkey / unparseable address) OR one whose comm
+/// address is outside the mesh (e.g. a control plane advertising its routable underlay address) — in
+/// both cases the caller falls back to pool allocation. Errs only on a malformed `mesh_cidr`.
+fn real_mesh_address(
+    node: &spur_core::node::Node,
+    mesh_cidr: &str,
+) -> anyhow::Result<Option<Ipv4Addr>> {
+    if node
+        .wg_pubkey
+        .as_deref()
+        .filter(|k| !k.is_empty())
+        .is_none()
+    {
+        return Ok(None);
+    }
+    let Some(addr) = node
+        .address
+        .as_deref()
+        .and_then(|a| a.parse::<Ipv4Addr>().ok())
+    else {
+        return Ok(None);
+    };
+    if cidr_contains(mesh_cidr, addr)? {
+        Ok(Some(addr))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Whether `ip` falls within `cidr` (same network prefix).
+fn cidr_contains(cidr: &str, ip: Ipv4Addr) -> anyhow::Result<bool> {
+    let (base, prefix) = cidr
+        .split_once('/')
+        .ok_or_else(|| anyhow::anyhow!("{cidr} is not a CIDR"))?;
+    let base: Ipv4Addr = base
+        .parse()
+        .with_context(|| format!("CIDR base in {cidr}"))?;
+    let prefix: u8 = prefix
+        .parse()
+        .with_context(|| format!("CIDR prefix in {cidr}"))?;
+    if prefix > 32 {
+        anyhow::bail!("{cidr} prefix must be <= 32");
+    }
+    let mask = if prefix == 0 {
+        0
+    } else {
+        !((1u32 << (32 - prefix)) - 1)
+    };
+    Ok(u32::from(base) & mask == u32::from(ip) & mask)
 }
 
 /// The base address of a CIDR string.
@@ -858,6 +949,15 @@ fn clear_node_error(cluster: &ClusterManager, node: &spur_core::node::Node) {
     }
     if let Err(e) = cluster.set_node_k0s_error(&node.name, None) {
         warn!(node = %node.name, error = %e, "failed to clear k0s node error");
+    }
+}
+
+/// Record a node's k0s error reason so it surfaces in `spur k8s status`. A failed WAL write is logged
+/// rather than dropped silently — otherwise the reason for a fail-loud abort would vanish on a Raft
+/// write error, leaving status with no explanation.
+fn record_node_k0s_error(cluster: &ClusterManager, node: &str, reason: &str) {
+    if let Err(e) = cluster.set_node_k0s_error(node, Some(reason.to_string())) {
+        warn!(node = %node, error = %e, "failed to record k0s node error");
     }
 }
 


### PR DESCRIPTION
## What this fixes

`spur k8s up` over a live WireGuard mesh could silently corrupt the mesh whenever the chosen control-plane set was not an alphabetical prefix of the order in which nodes physically joined.

`provision_assignments` allocated each node's `k0s_mesh_ip` from a fresh, independent address pool and never consulted the real `spur0` address the node already advertises via `Node.address`. When the CP set was a non-prefix subset (or join order was scrambled), the assigned mesh IPs drifted off the real addresses. `ApplyMesh` then pushed `AllowedIPs` built from that wrong table, and because a WireGuard `AllowedIPs` entry is exclusive per peer per interface, this reassigned real IPs away from their rightful peers — breaking every tunnel, including nodes that were never being reconfigured. No error was surfaced; `spur k8s status` just showed a generic `degraded`.

## Approach

Adopt each node's real mesh address instead of re-deriving it:

- `Node.address` **within** `mesh_cidr` → it *is* the mesh IP → use it as `k0s_mesh_ip`.
- `Node.address` **outside** `mesh_cidr` (e.g. a control plane advertising its routable underlay address) → reports no mesh address → falls through to pool allocation (bootstrap gets `.1`).
- Two nodes claiming the same **in-mesh** address → genuine conflict → fail loud with a per-node "network mismatch" reason.

The bootstrap is treated the same as any other node — `.1` results naturally when the operator gave the controller `.1` via `spur net init`, and etcd seeding / CP ordering key off the node **name**, not the IP, so a divergent join order now works instead of corrupting the mesh.

This aligns Spur with how both Slurm (static `NodeAddr`) and Kubernetes (kubelet adopts the host's `--node-ip`) treat a node's own transport address: adopted from a single source of truth, never re-derived by a second component. The pod-CIDR plane already follows this model correctly.

## Compatibility

Reads an existing field (`Node.address`) and writes the same `k0s_mesh_ip` field already persisted — **no proto, config, or persisted-state change**, no Raft/WAL break.

## Testing

- Unit tests in `cluster_k8s.rs` (exercise the real `provision_assignments` via a `ClusterManager` fixture): adversarial (non-prefix) CP selection, scrambled join order, underlay-advertising node pools (not refused), conflicting in-mesh addresses fail loud, idempotency preserved, pool fallback for unmeshed nodes. All green.
- Full `spurctld` suite passes; `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` and `cargo fmt --check` clean.
- **Hardware validated before/after** on a 2-node mesh testbed with two binaries built from the same tree differing only by this patch. The worker joined at a real address the pool would not pick (real `.3`; pool would give `.2`): pre-fix assigned `.2` (worker stuck, assigned IP unreachable); post-fix adopted `.3` (both nodes active, cluster `ready`, mesh IP reachable). The full-fidelity adversarial 3+-CP-over-mesh case (the original incident) needs ≥3 mesh nodes and is covered by the unit tests.

fixes SPUR-196