### PR TITLE
feat(spurctld): record preemption provenance on job state

### DIFF
--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -67,7 +67,7 @@ pub struct SacctArgs {
 
 const SACCT_DEFAULT_FORMAT: &str = "%.8i %.15j %.10u %.10a %.10P %.8T %10M %.8D %6x";
 const SACCT_LONG_FORMAT: &str =
-    "%.8i %.15j %.10u %.10a %.10P %.8T %10M %.8D %6x %.10X %.19S %.19E %.10l";
+    "%.8i %.15j %.10u %.10a %.10P %.8T %10M %.8D %6x %.10X %.19S %.19E %.10l %8y %8m %12q";
 const SACCT_BRIEF_FORMAT: &str = "%.8i %.8T %6x";
 
 pub fn sacct_header(spec: char) -> &'static str {
@@ -91,6 +91,9 @@ pub fn sacct_header(spec: char) -> &'static str {
         'C' => "NCPUS",
         'R' => "ReqMem",
         'Q' => "QOS",
+        'y' => "PreemptedBy",
+        'm' => "PreemptMode",
+        'q' => "PreemptQOS",
         _ => "?",
     }
 }
@@ -115,6 +118,9 @@ fn sacct_field_spec(name: &str) -> Option<char> {
         "ncpus" => Some('C'),
         "reqmem" => Some('R'),
         "qos" => Some('Q'),
+        "preemptedby" => Some('y'),
+        "preemptmode" => Some('m'),
+        "preemptqos" => Some('q'),
         _ => None,
     }
 }
@@ -216,6 +222,27 @@ fn resolve_sacct_field(job: &spur_proto::proto::JobInfo, spec: char) -> String {
         'n' => job.nodelist.clone(),
         'C' => (job.num_tasks * job.cpus_per_task.max(1)).to_string(),
         'Q' => job.qos.clone(),
+        'y' => {
+            if job.preempted_by == 0 {
+                "N/A".into()
+            } else {
+                job.preempted_by.to_string()
+            }
+        }
+        'm' => {
+            if job.preempt_mode.is_empty() {
+                "N/A".into()
+            } else {
+                job.preempt_mode.clone()
+            }
+        }
+        'q' => {
+            if job.preempt_qos.is_empty() {
+                "N/A".into()
+            } else {
+                job.preempt_qos.clone()
+            }
+        }
         _ => "?".into(),
     }
 }
@@ -233,6 +260,7 @@ fn parse_acct_state(s: &str) -> Option<i32> {
         "CA" | "CANCELLED" => Some(5),
         "TO" | "TIMEOUT" => Some(6),
         "NF" | "NODE_FAIL" => Some(7),
+        "PR" | "PREEMPTED" => Some(8),
         "DL" | "DEADLINE" => Some(10),
         "R" | "RUNNING" => Some(1),
         "PD" | "PENDING" => Some(0),
@@ -377,6 +405,7 @@ mod tests {
             ("CANCELLED", JobState::JobCancelled),
             ("TIMEOUT", JobState::JobTimeout),
             ("NODE_FAIL", JobState::JobNodeFail),
+            ("PREEMPTED", JobState::JobPreempted),
             ("DEADLINE", JobState::JobDeadline),
         ];
         for (s, expected) in cases {

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -619,6 +619,26 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                     format_exit(job.derived_exit_code, 0),
                     job.priority
                 );
+                if job.preempted_by != 0 || !job.preempt_mode.is_empty() {
+                    println!(
+                        "   PreemptedBy={} PreemptMode={} PreemptQOS={}",
+                        if job.preempted_by == 0 {
+                            "N/A".to_string()
+                        } else {
+                            job.preempted_by.to_string()
+                        },
+                        if job.preempt_mode.is_empty() {
+                            "N/A"
+                        } else {
+                            &job.preempt_mode
+                        },
+                        if job.preempt_qos.is_empty() {
+                            "N/A"
+                        } else {
+                            &job.preempt_qos
+                        },
+                    );
+                }
                 println!();
             }
         }

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -322,6 +322,11 @@ pub enum PendingReason {
     QosGrpSubmitJobsLimit,
     QosMaxSubmitJobPerAccountLimit,
     K8sReserved,
+
+    /// Job was preempted and is now pending (requeue mode) or terminal (cancel mode).
+    /// Replaces `BeginTime` as the pending reason for preempted-requeued jobs so the
+    /// reason string is unambiguous.
+    Preempted,
 }
 
 impl PendingReason {
@@ -337,7 +342,10 @@ impl PendingReason {
     /// Any other reason on a held job is unrelated to the hold, so recomputing
     /// it loses nothing.
     pub fn explains_begin_hold(&self) -> bool {
-        matches!(self, Self::BeginTime | Self::JobLaunchFailure)
+        matches!(
+            self,
+            Self::BeginTime | Self::JobLaunchFailure | Self::Preempted
+        )
     }
 
     pub fn display(&self) -> &'static str {
@@ -404,6 +412,7 @@ impl PendingReason {
             Self::QosGrpSubmitJobsLimit => "QOSGrpSubmitJobsLimit",
             Self::QosMaxSubmitJobPerAccountLimit => "MaxSubmitJobsPerAccount",
             Self::K8sReserved => "ReqNodeNotAvail, Reserved for Kubernetes cluster",
+            Self::Preempted => "Preempted",
         }
     }
 
@@ -834,6 +843,18 @@ pub struct Job {
     /// Set when a job is evicted during PMIx bootstrap or partial dispatch.
     #[serde(default)]
     pub launch_failure_detail: Option<String>,
+
+    /// Job ID of the higher-priority job that caused this preemption. Set on
+    /// both cancel and requeue preemption; `None` for jobs never preempted.
+    #[serde(default)]
+    pub preempted_by: Option<JobId>,
+    /// How the preemption was carried out: `"Requeue"`, `"Cancel"`, or `"Suspend"`.
+    #[serde(default)]
+    pub preempt_mode: Option<String>,
+    /// QOS name of the preempting job, when `preempt_type = QosPriority` authorized
+    /// the preemption. `None` for plain priority-based preemption.
+    #[serde(default)]
+    pub preempt_qos: Option<String>,
 }
 
 impl Job {
@@ -884,6 +905,9 @@ impl Job {
             actual_stdout_path: None,
             actual_stderr_path: None,
             launch_failure_detail: None,
+            preempted_by: None,
+            preempt_mode: None,
+            preempt_qos: None,
         }
     }
 
@@ -2253,6 +2277,15 @@ mod tests {
             let back: PendingReason = serde_json::from_str(&json).expect("deserialize reason");
             assert_eq!(&back, reason, "serde roundtrip for {reason:?}");
         }
+    }
+
+    #[test]
+    fn preempted_reason_displays_correctly_and_explains_begin_hold() {
+        assert_eq!(PendingReason::Preempted.display(), "Preempted");
+        assert!(
+            PendingReason::Preempted.explains_begin_hold(),
+            "Preempted must be treated as a begin-time hold so it is not clobbered"
+        );
     }
 
     #[test]

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -126,6 +126,13 @@ pub enum WalOperation {
     JobPreemptRequeue {
         job_id: JobId,
         begin_time: chrono::DateTime<chrono::Utc>,
+        /// Job that triggered this preemption. Absent in WAL entries written by
+        /// older controllers; defaults to `None` on replay.
+        #[serde(default)]
+        preempted_by: Option<JobId>,
+        /// QOS of the preempting job (`None` for plain priority-based preemption).
+        #[serde(default)]
+        preempt_qos: Option<String>,
     },
     /// Preempt a running job with cancel. The job transitions Running →
     /// Preempted → Cancelled: Preempted is reported to accounting so the
@@ -134,6 +141,13 @@ pub enum WalOperation {
     /// change cannot strand the job running with its allocations held.
     JobPreemptCancel {
         job_id: JobId,
+        /// Job that triggered this preemption. Absent in WAL entries written by
+        /// older controllers; defaults to `None` on replay.
+        #[serde(default)]
+        preempted_by: Option<JobId>,
+        /// QOS of the preempting job (`None` for plain priority-based preemption).
+        #[serde(default)]
+        preempt_qos: Option<String>,
     },
     /// Admin requeue (`scontrol requeue` / `requeuehold`): return a job to
     /// Pending with the same spec in one atomic step. A running/suspended job is
@@ -152,6 +166,13 @@ pub enum WalOperation {
         job_id: JobId,
         /// Controller-stamped instant of suspension (for replay-deterministic accounting).
         at: chrono::DateTime<chrono::Utc>,
+        /// Preemption provenance — set when suspension is triggered by preemption,
+        /// absent (None) for admin-initiated suspends. Defaults to None on replay
+        /// so old WAL entries remain backward compatible.
+        #[serde(default)]
+        preempted_by: Option<JobId>,
+        #[serde(default)]
+        preempt_qos: Option<String>,
     },
     JobResume {
         job_id: JobId,
@@ -1001,11 +1022,39 @@ mod suspend_wal_tests {
 
     #[test]
     fn preempt_cancel_op_round_trips() {
-        let op = WalOperation::JobPreemptCancel { job_id: 7 };
+        let op = WalOperation::JobPreemptCancel {
+            job_id: 7,
+            preempted_by: Some(3),
+            preempt_qos: Some("burst".into()),
+        };
         let json = serde_json::to_string(&op).unwrap();
         let back: WalOperation = serde_json::from_str(&json).unwrap();
         match back {
-            WalOperation::JobPreemptCancel { job_id } => assert_eq!(job_id, 7),
+            WalOperation::JobPreemptCancel {
+                job_id,
+                preempted_by,
+                preempt_qos,
+            } => {
+                assert_eq!(job_id, 7);
+                assert_eq!(preempted_by, Some(3));
+                assert_eq!(preempt_qos.as_deref(), Some("burst"));
+            }
+            _ => panic!("wrong variant"),
+        }
+
+        // Deserializing a legacy entry (no provenance fields) must succeed with None defaults.
+        let legacy = r#"{"JobPreemptCancel":{"job_id":7}}"#;
+        let back: WalOperation = serde_json::from_str(legacy).unwrap();
+        match back {
+            WalOperation::JobPreemptCancel {
+                job_id,
+                preempted_by,
+                preempt_qos,
+            } => {
+                assert_eq!(job_id, 7);
+                assert_eq!(preempted_by, None, "legacy entry defaults to None");
+                assert_eq!(preempt_qos, None, "legacy entry defaults to None");
+            }
             _ => panic!("wrong variant"),
         }
     }
@@ -1016,6 +1065,8 @@ mod suspend_wal_tests {
         let op = WalOperation::JobPreemptRequeue {
             job_id: 42,
             begin_time,
+            preempted_by: Some(7),
+            preempt_qos: Some("highprio".into()),
         };
         let json = serde_json::to_string(&op).unwrap();
         let back: WalOperation = serde_json::from_str(&json).unwrap();
@@ -1023,9 +1074,28 @@ mod suspend_wal_tests {
             WalOperation::JobPreemptRequeue {
                 job_id,
                 begin_time: b,
+                preempted_by,
+                preempt_qos,
             } => {
                 assert_eq!(job_id, 42);
                 assert_eq!(b, begin_time);
+                assert_eq!(preempted_by, Some(7));
+                assert_eq!(preempt_qos.as_deref(), Some("highprio"));
+            }
+            _ => panic!("wrong variant"),
+        }
+
+        // Deserializing a legacy entry (no provenance fields) must succeed with None defaults.
+        let legacy = r#"{"JobPreemptRequeue":{"job_id":42,"begin_time":"2026-01-01T00:00:00Z"}}"#;
+        let back: WalOperation = serde_json::from_str(legacy).unwrap();
+        match back {
+            WalOperation::JobPreemptRequeue {
+                preempted_by,
+                preempt_qos,
+                ..
+            } => {
+                assert_eq!(preempted_by, None, "legacy entry defaults to None");
+                assert_eq!(preempt_qos, None, "legacy entry defaults to None");
             }
             _ => panic!("wrong variant"),
         }
@@ -1081,7 +1151,12 @@ mod suspend_wal_tests {
     fn suspend_resume_ops_round_trip() {
         let at = chrono::Utc::now();
         for op in [
-            WalOperation::JobSuspend { job_id: 7, at },
+            WalOperation::JobSuspend {
+                job_id: 7,
+                at,
+                preempted_by: None,
+                preempt_qos: None,
+            },
             WalOperation::JobResume { job_id: 7, at },
         ] {
             let json = serde_json::to_string(&op).unwrap();
@@ -1091,10 +1166,12 @@ mod suspend_wal_tests {
                     WalOperation::JobSuspend {
                         job_id: a,
                         at: at_a,
+                        ..
                     },
                     WalOperation::JobSuspend {
                         job_id: b,
                         at: at_b,
+                        ..
                     },
                 ) => {
                     assert_eq!(a, b);

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -156,6 +156,9 @@ ALTER TABLE associations ADD COLUMN IF NOT EXISTS grp_submit_jobs INTEGER;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS grp_tres TEXT;
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS preempt TEXT NOT NULL DEFAULT '';
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS preempt_exempt_time INTEGER;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempted_by INTEGER;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempt_mode TEXT NOT NULL DEFAULT '';
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempt_qos TEXT NOT NULL DEFAULT '';
 
 -- users.default_account is the single source of truth for a user's default
 -- account (the scheduler reads it via the association cache). associations
@@ -267,18 +270,25 @@ pub async fn record_job_end(
     end_time: DateTime<Utc>,
     exit_signal: i32,
     derived_exit_code: i32,
+    preempted_by: Option<i32>,
+    preempt_mode: &str,
+    preempt_qos: &str,
 ) -> anyhow::Result<()> {
     // RETURNING closes the record_job_start job_id-reuse race by reading in the same statement.
     let row = sqlx::query(
         r#"
-        INSERT INTO jobs (job_id, user_name, state, exit_code, end_time, exit_signal, derived_exit_code)
-        VALUES ($1, '', $2, $3, $4, $5, $6)
+        INSERT INTO jobs (job_id, user_name, state, exit_code, end_time, exit_signal, derived_exit_code,
+                          preempted_by, preempt_mode, preempt_qos)
+        VALUES ($1, '', $2, $3, $4, $5, $6, $7, $8, $9)
         ON CONFLICT (job_id) DO UPDATE SET
             state = $2,
             exit_code = $3,
             end_time = $4,
             exit_signal = $5,
-            derived_exit_code = $6
+            derived_exit_code = $6,
+            preempted_by = $7,
+            preempt_mode = $8,
+            preempt_qos = $9
         RETURNING user_name, account, start_time, num_tasks, cpus_per_task
         "#,
     )
@@ -288,6 +298,9 @@ pub async fn record_job_end(
     .bind(end_time)
     .bind(exit_signal)
     .bind(derived_exit_code)
+    .bind(preempted_by)
+    .bind(preempt_mode)
+    .bind(preempt_qos)
     .fetch_one(&mut *conn)
     .await?;
 
@@ -403,6 +416,9 @@ pub struct JobRecord {
     pub start_time: Option<DateTime<Utc>>,
     pub end_time: Option<DateTime<Utc>>,
     pub reservation: String,
+    pub preempted_by: Option<i32>,
+    pub preempt_mode: String,
+    pub preempt_qos: String,
 }
 
 /// Query job history.
@@ -418,7 +434,8 @@ pub async fn get_job_history(
     let mut qb = QueryBuilder::<sqlx::Postgres>::new(
         "SELECT job_id, name, user_name, account, partition_name, state, exit_code, \
          exit_signal, derived_exit_code, num_nodes, num_tasks, nodelist, \
-         submit_time, start_time, end_time, reservation \
+         submit_time, start_time, end_time, reservation, \
+         preempted_by, preempt_mode, preempt_qos \
          FROM jobs WHERE 1=1",
     );
 
@@ -468,6 +485,9 @@ pub async fn get_job_history(
             start_time: row.get("start_time"),
             end_time: row.get("end_time"),
             reservation: row.get("reservation"),
+            preempted_by: row.get("preempted_by"),
+            preempt_mode: row.get("preempt_mode"),
+            preempt_qos: row.get("preempt_qos"),
         })
         .collect();
 
@@ -1258,6 +1278,9 @@ mod job_history_tests {
             end_time,
             exit_signal,
             derived_exit_code,
+            None,
+            "",
+            "",
         )
         .await
     }

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -185,6 +185,9 @@ impl SlurmAccounting for AccountingService {
             end_time,
             req.exit_signal,
             req.derived_exit_code,
+            None,
+            "",
+            "",
         )
         .await
         .map_err(|e| Status::internal(e.to_string()))?;
@@ -214,6 +217,7 @@ impl SlurmAccounting for AccountingService {
                 4 => Some("FAILED".into()),
                 5 => Some("CANCELLED".into()),
                 6 => Some("TIMEOUT".into()),
+                8 => Some("PREEMPTED".into()),
                 10 => Some("DEADLINE".into()),
                 _ => None,
             })
@@ -256,6 +260,7 @@ impl SlurmAccounting for AccountingService {
                     "FAILED" => JobState::JobFailed as i32,
                     "CANCELLED" => JobState::JobCancelled as i32,
                     "TIMEOUT" => JobState::JobTimeout as i32,
+                    "PREEMPTED" => JobState::JobPreempted as i32,
                     "DEADLINE" => JobState::JobDeadline as i32,
                     "RUNNING" => JobState::JobRunning as i32,
                     "PENDING" => JobState::JobPending as i32,
@@ -295,6 +300,9 @@ impl SlurmAccounting for AccountingService {
                 srun_step_dispatch: false,
                 req_gpus: 0,
                 req_gpus_detail: String::new(),
+                preempted_by: r.preempted_by.unwrap_or(0) as u32,
+                preempt_mode: r.preempt_mode.clone(),
+                preempt_qos: r.preempt_qos.clone(),
             })
             .collect();
 

--- a/crates/spurctld/src/accounting/notifier.rs
+++ b/crates/spurctld/src/accounting/notifier.rs
@@ -115,6 +115,7 @@ impl AccountingNotifier {
         });
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn notify_job_end(
         &self,
         job_id: JobId,
@@ -123,6 +124,9 @@ impl AccountingNotifier {
         end_time: DateTime<Utc>,
         exit_signal: i32,
         derived_exit_code: i32,
+        preempted_by: Option<JobId>,
+        preempt_mode: Option<String>,
+        preempt_qos: Option<String>,
     ) {
         let pool = self.pool.clone();
         let state_str = state.display().to_owned();
@@ -137,6 +141,9 @@ impl AccountingNotifier {
                     end_time,
                     exit_signal,
                     derived_exit_code,
+                    preempted_by.map(|id| id as i32),
+                    preempt_mode.as_deref().unwrap_or(""),
+                    preempt_qos.as_deref().unwrap_or(""),
                 )
                 .await
             };

--- a/crates/spurctld/src/accounting/reconcile.rs
+++ b/crates/spurctld/src/accounting/reconcile.rs
@@ -229,6 +229,9 @@ async fn write_end(conn: &mut sqlx::PgConnection, job: &Job) -> anyhow::Result<(
         end_time,
         job.exit_signal,
         job.derived_exit_code,
+        job.preempted_by.map(|id| id as i32),
+        job.preempt_mode.as_deref().unwrap_or(""),
+        job.preempt_qos.as_deref().unwrap_or(""),
     )
     .await
 }
@@ -451,6 +454,9 @@ mod tests {
             job.end_time.unwrap(),
             0,
             0,
+            None,
+            "",
+            "",
         )
         .await?;
         drop(conn);
@@ -587,6 +593,9 @@ mod tests {
                 job.end_time.unwrap(),
                 0,
                 0,
+                None,
+                "",
+                "",
             )
             .await?;
         }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1428,6 +1428,8 @@ impl ClusterManager {
         self.propose(WalOperation::JobSuspend {
             job_id,
             at: chrono::Utc::now(),
+            preempted_by: None,
+            preempt_qos: None,
         })?;
         info!(job_id, "job suspended");
         Ok(())
@@ -1693,7 +1695,17 @@ impl ClusterManager {
     /// Preempt a running job per its partition's PreemptMode. Does the
     /// controller-side state change; the caller dispatches the signal named by
     /// the returned `PreemptOutcome`. `Off` is rejected.
-    pub fn preempt_job(&self, job_id: JobId, mode: PreemptMode) -> anyhow::Result<PreemptOutcome> {
+    ///
+    /// `preempted_by` is the job that triggered the preemption (recorded for
+    /// provenance). `preempt_qos` is the authorizing QOS name when
+    /// `preempt_type = QosPriority`; `None` for plain priority-based preemption.
+    pub fn preempt_job(
+        &self,
+        job_id: JobId,
+        mode: PreemptMode,
+        preempted_by: JobId,
+        preempt_qos: Option<String>,
+    ) -> anyhow::Result<PreemptOutcome> {
         {
             let jobs = self.jobs.read();
             let job = jobs
@@ -1707,12 +1719,26 @@ impl ClusterManager {
         match mode {
             PreemptMode::Off => anyhow::bail!("preemption disabled for job {}", job_id),
             PreemptMode::Suspend => {
-                self.suspend_job(job_id, "")?;
+                // Propose JobSuspend directly (rather than suspend_job) so
+                // provenance fields are inside the WAL entry and survive Raft
+                // replication and leader failover. The job state was already
+                // validated at the top of preempt_job — no re-check needed.
+                let resp = self.propose(WalOperation::JobSuspend {
+                    job_id,
+                    at: chrono::Utc::now(),
+                    preempted_by: Some(preempted_by),
+                    preempt_qos: preempt_qos.clone(),
+                })?;
+                self.run_all_finalized_side_effects(&resp);
                 info!(job_id, "job preempted (suspend)");
                 Ok(PreemptOutcome::Suspended)
             }
             PreemptMode::Cancel => {
-                let resp = self.propose(WalOperation::JobPreemptCancel { job_id })?;
+                let resp = self.propose(WalOperation::JobPreemptCancel {
+                    job_id,
+                    preempted_by: Some(preempted_by),
+                    preempt_qos,
+                })?;
                 self.run_all_finalized_side_effects(&resp);
                 info!(job_id, "job preempted (cancel)");
                 Ok(PreemptOutcome::Killed)
@@ -1738,7 +1764,12 @@ impl ClusterManager {
                     .get(&job_id)
                     .and_then(|j| j.spec.begin_time)
                     .map_or(hold, |user_begin| user_begin.max(hold));
-                let resp = self.propose(WalOperation::JobPreemptRequeue { job_id, begin_time })?;
+                let resp = self.propose(WalOperation::JobPreemptRequeue {
+                    job_id,
+                    begin_time,
+                    preempted_by: Some(preempted_by),
+                    preempt_qos,
+                })?;
                 self.run_all_finalized_side_effects(&resp);
                 info!(job_id, hold_secs, "job preempted (requeue)");
                 Ok(PreemptOutcome::Killed)
@@ -1813,12 +1844,20 @@ impl ClusterManager {
         }
 
         if let Some(ref notifier) = *self.accounting.read() {
-            let (exit_signal, derived_exit_code) = self
+            let (exit_signal, derived_exit_code, preempted_by, preempt_mode, preempt_qos) = self
                 .jobs
                 .read()
                 .get(&job_id)
-                .map(|j| (j.exit_signal, j.derived_exit_code))
-                .unwrap_or((0, 0));
+                .map(|j| {
+                    (
+                        j.exit_signal,
+                        j.derived_exit_code,
+                        j.preempted_by,
+                        j.preempt_mode.clone(),
+                        j.preempt_qos.clone(),
+                    )
+                })
+                .unwrap_or((0, 0, None, None, None));
             notifier.notify_job_end(
                 job_id,
                 state,
@@ -1826,6 +1865,9 @@ impl ClusterManager {
                 Utc::now(),
                 exit_signal,
                 derived_exit_code,
+                preempted_by,
+                preempt_mode,
+                preempt_qos,
             );
         }
 
@@ -3050,7 +3092,12 @@ impl ClusterManager {
             .filter(|job| !job.pending_reason.is_scheduling_hold())
             .filter_map(|job| {
                 let before_begin_time = job.spec.begin_time.is_some_and(|begin| now < begin);
-                if before_begin_time && job.pending_reason == PendingReason::BeginTime {
+                if before_begin_time
+                    && matches!(
+                        job.pending_reason,
+                        PendingReason::BeginTime | PendingReason::Preempted
+                    )
+                {
                     return None;
                 }
                 Some(PendingJobCandidate {
@@ -4883,7 +4930,12 @@ impl ClusterManager {
                 job.spec.begin_time = Some(*begin_time);
                 job.set_pending_reason(PendingReason::JobLaunchFailure);
             }
-            WalOperation::JobPreemptRequeue { job_id, begin_time } => {
+            WalOperation::JobPreemptRequeue {
+                job_id,
+                begin_time,
+                preempted_by,
+                preempt_qos,
+            } => {
                 // Only a running job is preempted; on replay the job is already
                 // Pending, so this is a NoOp (no re-dealloc, no double requeue).
                 let freed_nodes;
@@ -4919,7 +4971,19 @@ impl ClusterManager {
                     }
                     Self::reset_job_for_preempt_requeue(job);
                     job.spec.begin_time = Some(*begin_time);
-                    job.set_pending_reason(PendingReason::BeginTime);
+                    // Provenance fields are set after reset_job_for_preempt_requeue
+                    // clears run state so they survive into the pending phase.
+                    job.preempted_by = *preempted_by;
+                    job.preempt_mode = Some("Requeue".to_string());
+                    job.preempt_qos = preempt_qos.clone();
+                    let desc = match preempted_by {
+                        Some(by) => match preempt_qos.as_deref() {
+                            Some(qos) => format!("preempted by job {by} (QOS: {qos})"),
+                            None => format!("preempted by job {by}"),
+                        },
+                        None => "preempted".to_string(),
+                    };
+                    job.set_pending_reason_desc(PendingReason::Preempted, desc);
                 }
                 Self::deallocate_job_slices(
                     &mut nodes,
@@ -5035,7 +5099,11 @@ impl ClusterManager {
                 }
                 return ClientResponse::default();
             }
-            WalOperation::JobPreemptCancel { job_id } => {
+            WalOperation::JobPreemptCancel {
+                job_id,
+                preempted_by,
+                preempt_qos,
+            } => {
                 let freed_nodes;
                 let allocated_resources;
                 let per_node_map;
@@ -5065,6 +5133,9 @@ impl ClusterManager {
                         warn!(job_id = *job_id, error = %e, "invalid preempt-cancel final transition in WAL apply");
                         return ClientResponse::default();
                     }
+                    job.preempted_by = *preempted_by;
+                    job.preempt_mode = Some("Cancel".to_string());
+                    job.preempt_qos = preempt_qos.clone();
                 }
                 if let Some(ref total) = allocated_resources {
                     let node_count = freed_nodes.len().max(1) as u32;
@@ -5105,10 +5176,22 @@ impl ClusterManager {
                     ..Default::default()
                 };
             }
-            WalOperation::JobSuspend { job_id, at } => {
+            WalOperation::JobSuspend {
+                job_id,
+                at,
+                preempted_by,
+                preempt_qos,
+            } => {
                 if let Some(job) = jobs.get_mut(job_id) {
                     match job.apply_transition(JobState::Suspended) {
-                        Ok(TransitionOutcome::Applied) => job.suspended_at = Some(*at),
+                        Ok(TransitionOutcome::Applied) => {
+                            job.suspended_at = Some(*at);
+                            if preempted_by.is_some() {
+                                job.preempted_by = *preempted_by;
+                                job.preempt_mode = Some("Suspend".to_string());
+                                job.preempt_qos = preempt_qos.clone();
+                            }
+                        }
                         Ok(TransitionOutcome::NoOp) => {}
                         Err(e) => {
                             warn!(job_id = *job_id, error = %e, "invalid suspend transition in WAL apply")
@@ -5123,6 +5206,12 @@ impl ClusterManager {
                             if let Some(since) = job.suspended_at.take() {
                                 job.suspended_secs += (*at - since).num_seconds().max(0);
                             }
+                            // Resuming clears preemption provenance: the job is
+                            // running again and a subsequent normal completion
+                            // must not report it as preempted in accounting.
+                            job.preempted_by = None;
+                            job.preempt_mode = None;
+                            job.preempt_qos = None;
                         }
                         Ok(TransitionOutcome::NoOp) => {}
                         Err(e) => {
@@ -5167,6 +5256,11 @@ impl ClusterManager {
                     job.srun_step_dispatch = *srun_step_dispatch;
                     job.run_attempt = *run_attempt;
                     job.launch_failure_detail = None;
+                    // A new run supersedes any prior preemption provenance; clear so
+                    // this run's accounting record does not inherit the previous one's.
+                    job.preempted_by = None;
+                    job.preempt_mode = None;
+                    job.preempt_qos = None;
                 }
                 let node_count = node_names.len().max(1) as u32;
                 for name in node_names {
@@ -8438,7 +8532,12 @@ mod tests {
             JobState::Running,
         ));
         let t0 = chrono::Utc::now();
-        cm.apply_operation(&WalOperation::JobSuspend { job_id: 1, at: t0 });
+        cm.apply_operation(&WalOperation::JobSuspend {
+            job_id: 1,
+            at: t0,
+            preempted_by: None,
+            preempt_qos: None,
+        });
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Suspended);
         cm.apply_operation(&WalOperation::JobResume {
             job_id: 1,
@@ -8603,14 +8702,24 @@ mod tests {
         ));
         let t0 = chrono::Utc::now();
         // Cycle 1: 10s suspended.
-        cm.apply_operation(&WalOperation::JobSuspend { job_id: 1, at: t0 });
+        cm.apply_operation(&WalOperation::JobSuspend {
+            job_id: 1,
+            at: t0,
+            preempted_by: None,
+            preempt_qos: None,
+        });
         cm.apply_operation(&WalOperation::JobResume {
             job_id: 1,
             at: t0 + chrono::Duration::seconds(10),
         });
         // Cycle 2: 15s suspended.
         let t1 = t0 + chrono::Duration::seconds(40);
-        cm.apply_operation(&WalOperation::JobSuspend { job_id: 1, at: t1 });
+        cm.apply_operation(&WalOperation::JobSuspend {
+            job_id: 1,
+            at: t1,
+            preempted_by: None,
+            preempt_qos: None,
+        });
         cm.apply_operation(&WalOperation::JobResume {
             job_id: 1,
             at: t1 + chrono::Duration::seconds(15),
@@ -8643,6 +8752,8 @@ mod tests {
         cm.apply_operation(&WalOperation::JobSuspend {
             job_id: 1,
             at: since,
+            preempted_by: None,
+            preempt_qos: None,
         });
         cm.apply_operation(&WalOperation::JobComplete {
             job_id: 1,
@@ -10557,7 +10668,9 @@ mod tests {
         let job_id = run_job_on(&cm, "preempt-requeue", "worker1");
         assert_eq!(cm.node_metrics().alloc_cpus, 2);
 
-        let outcome = cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+        let outcome = cm
+            .preempt_job(job_id, PreemptMode::Requeue, 99, None)
+            .unwrap();
         assert_eq!(outcome, PreemptOutcome::Killed);
         settle(&cm, job_id, JobState::Pending);
 
@@ -10567,14 +10680,22 @@ mod tests {
         assert_eq!(cm.node_metrics().alloc_cpus, 0, "nodes must be freed");
 
         // The requeue must carry a future begin_time hold so the scheduler
-        // cannot re-dispatch the job into its own in-flight preemption cancel,
-        // and it must display BeginTime (Slurm parity).
+        // cannot re-dispatch the job into its own in-flight preemption cancel.
         let begin = job
             .spec
             .begin_time
             .expect("requeue must set a begin_time hold");
         assert!(begin > Utc::now(), "begin_time hold must be in the future");
-        assert_eq!(job.pending_reason, PendingReason::BeginTime);
+        assert_eq!(job.pending_reason, PendingReason::Preempted);
+        assert!(
+            job.pending_reason_desc
+                .as_deref()
+                .unwrap_or("")
+                .contains("preempted by job 99"),
+            "pending_reason_desc must name the preempting job"
+        );
+        assert_eq!(job.preempted_by, Some(99));
+        assert_eq!(job.preempt_mode.as_deref(), Some("Requeue"));
 
         // While the hold is active the job is excluded from scheduling.
         assert!(
@@ -10605,7 +10726,8 @@ mod tests {
         .unwrap();
         settle(&cm, job_id, JobState::Running);
 
-        cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+        cm.preempt_job(job_id, PreemptMode::Requeue, 99, None)
+            .unwrap();
         settle(&cm, job_id, JobState::Pending);
 
         assert_eq!(
@@ -10624,18 +10746,19 @@ mod tests {
         register_node(&cm, "worker1", 8, 16000);
 
         let job_id = run_job_on(&cm, "hold-reason", "worker1");
-        cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+        cm.preempt_job(job_id, PreemptMode::Requeue, 99, None)
+            .unwrap();
         settle(&cm, job_id, JobState::Pending);
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
-            PendingReason::BeginTime
+            PendingReason::Preempted
         );
 
         cm.tag_blocked_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
-            PendingReason::BeginTime,
-            "tag_blocked_pending_reasons must not clobber an active BeginTime hold"
+            PendingReason::Preempted,
+            "tag_blocked_pending_reasons must not clobber an active Preempted hold"
         );
     }
 
@@ -10648,7 +10771,8 @@ mod tests {
         register_node(&cm, "worker1", 8, 16000);
 
         let job_id = run_job_on(&cm, "hold-expiry", "worker1");
-        cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+        cm.preempt_job(job_id, PreemptMode::Requeue, 99, None)
+            .unwrap();
         settle(&cm, job_id, JobState::Pending);
 
         // Simulate the hold having elapsed by moving begin_time into the past,
@@ -11110,7 +11234,9 @@ mod tests {
         register_node(&cm, "worker1", 8, 16000);
 
         let job_id = run_job_on(&cm, "preempt-cancel", "worker1");
-        let outcome = cm.preempt_job(job_id, PreemptMode::Cancel).unwrap();
+        let outcome = cm
+            .preempt_job(job_id, PreemptMode::Cancel, 99, None)
+            .unwrap();
         assert_eq!(outcome, PreemptOutcome::Killed);
         settle(&cm, job_id, JobState::Cancelled);
 
@@ -11150,7 +11276,12 @@ mod tests {
         });
         assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 2);
 
-        let resp = cm.apply_operation(&WalOperation::JobPreemptCancel { job_id: 1 });
+        // Apply with explicit provenance to verify field propagation.
+        let resp = cm.apply_operation(&WalOperation::JobPreemptCancel {
+            job_id: 1,
+            preempted_by: Some(42),
+            preempt_qos: Some("highprio".into()),
+        });
 
         assert_eq!(resp.jobs_finalized.len(), 1);
         // Accounting sees Preempted; live state is Cancelled (terminal).
@@ -11159,12 +11290,19 @@ mod tests {
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Cancelled);
         assert_eq!(job.exit_code, Some(-1));
+        assert_eq!(job.preempted_by, Some(42));
+        assert_eq!(job.preempt_mode.as_deref(), Some("Cancel"));
+        assert_eq!(job.preempt_qos.as_deref(), Some("highprio"));
         // allocated_nodes preserved (epilog reads NodeList after finalize).
         assert!(!job.allocated_nodes.is_empty());
         assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 0);
 
         // Replay: job is already Cancelled (not Running) → NoOp.
-        let replay = cm.apply_operation(&WalOperation::JobPreemptCancel { job_id: 1 });
+        let replay = cm.apply_operation(&WalOperation::JobPreemptCancel {
+            job_id: 1,
+            preempted_by: Some(42),
+            preempt_qos: Some("highprio".into()),
+        });
         assert!(
             replay.jobs_finalized.is_empty(),
             "replayed preempt-cancel must not re-finalize"
@@ -11247,12 +11385,20 @@ mod tests {
         register_node(&cm, "worker1", 8, 16000);
 
         let job_id = run_job_on(&cm, "preempt-suspend", "worker1");
-        let outcome = cm.preempt_job(job_id, PreemptMode::Suspend).unwrap();
+        let outcome = cm
+            .preempt_job(job_id, PreemptMode::Suspend, 42, Some("highprio".into()))
+            .unwrap();
         assert_eq!(outcome, PreemptOutcome::Suspended);
         settle(&cm, job_id, JobState::Suspended);
 
         // Suspend retains the allocation (the process is only SIGSTOP'd).
         assert_eq!(cm.node_metrics().alloc_cpus, 2);
+
+        // Provenance is persisted via the WAL op and survives replication.
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.preempted_by, Some(42));
+        assert_eq!(job.preempt_mode.as_deref(), Some("Suspend"));
+        assert_eq!(job.preempt_qos.as_deref(), Some("highprio"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -11262,7 +11408,7 @@ mod tests {
         register_node(&cm, "worker1", 8, 16000);
 
         let job_id = run_job_on(&cm, "preempt-off", "worker1");
-        assert!(cm.preempt_job(job_id, PreemptMode::Off).is_err());
+        assert!(cm.preempt_job(job_id, PreemptMode::Off, 99, None).is_err());
         // Job keeps running; nothing was preempted.
         assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Running);
     }
@@ -11273,7 +11419,9 @@ mod tests {
         let cm = test_cluster(&dir).await;
 
         let job_id = submit_and_wait(&cm, basic_spec("still-pending"));
-        assert!(cm.preempt_job(job_id, PreemptMode::Requeue).is_err());
+        assert!(cm
+            .preempt_job(job_id, PreemptMode::Requeue, 99, None)
+            .is_err());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -11402,9 +11550,13 @@ mod tests {
         assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 2);
 
         let begin_time = Utc::now() + chrono::Duration::seconds(5);
+        // Apply without provenance fields — simulates a WAL entry written by an
+        // older controller; new fields default to None and must not panic.
         let resp = cm.apply_operation(&WalOperation::JobPreemptRequeue {
             job_id: 1,
             begin_time,
+            preempted_by: None,
+            preempt_qos: None,
         });
         // One op finalizes the prior run as PREEMPTED (drives accounting) ...
         assert_eq!(resp.jobs_finalized.len(), 1);
@@ -11413,7 +11565,9 @@ mod tests {
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Pending);
         assert_eq!(job.spec.begin_time, Some(begin_time));
-        assert_eq!(job.pending_reason, PendingReason::BeginTime);
+        assert_eq!(job.pending_reason, PendingReason::Preempted);
+        assert_eq!(job.preempted_by, None, "no preempted_by when field absent");
+        assert_eq!(job.preempt_mode.as_deref(), Some("Requeue"));
         assert_eq!(job.preempt_requeue_count, 1);
         assert_eq!(job.requeue_count, 0);
         assert!(job.allocated_nodes.is_empty());
@@ -11423,6 +11577,8 @@ mod tests {
         let replay = cm.apply_operation(&WalOperation::JobPreemptRequeue {
             job_id: 1,
             begin_time,
+            preempted_by: None,
+            preempt_qos: None,
         });
         assert!(
             replay.jobs_finalized.is_empty(),
@@ -11439,6 +11595,56 @@ mod tests {
             "replayed preempt-requeue must not double-count"
         );
         assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_requeue_wal_apply_with_provenance_clears_on_restart() {
+        // After a preempt-requeue the provenance fields are set; when the job is
+        // re-dispatched (JobStart) they must be cleared so the new run's accounting
+        // row does not inherit the previous preemption's data.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "prov-clear", "worker1");
+        cm.preempt_job(job_id, PreemptMode::Requeue, 77, Some("burst".into()))
+            .unwrap();
+        settle(&cm, job_id, JobState::Pending);
+
+        let after_preempt = cm.get_job(job_id).unwrap();
+        assert_eq!(after_preempt.preempted_by, Some(77));
+        assert_eq!(after_preempt.preempt_mode.as_deref(), Some("Requeue"));
+
+        // Expire the hold and re-dispatch.
+        {
+            let mut jobs = cm.jobs.write();
+            if let Some(j) = jobs.get_mut(&job_id) {
+                j.spec.begin_time = Some(Utc::now() - chrono::Duration::seconds(1));
+            }
+        }
+        let resources = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec!["worker1".into()],
+            resources.clone(),
+            per_node_for(&["worker1"], resources),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
+
+        let after_start = cm.get_job(job_id).unwrap();
+        assert_eq!(
+            after_start.preempted_by, None,
+            "provenance must be cleared on re-dispatch"
+        );
+        assert_eq!(
+            after_start.preempt_mode, None,
+            "provenance must be cleared on re-dispatch"
+        );
+        assert_eq!(
+            after_start.preempt_qos, None,
+            "provenance must be cleared on re-dispatch"
+        );
     }
 
     /// Drive a job to RUNNING on `node` then finalize it as PREEMPTED via the
@@ -13413,7 +13619,8 @@ mod tests {
         register_node(&cm, "worker1", 8, 16000);
 
         let parent_id = run_job_on(&cm, "parent", "worker1");
-        cm.preempt_job(parent_id, PreemptMode::Cancel).unwrap();
+        cm.preempt_job(parent_id, PreemptMode::Cancel, 99, None)
+            .unwrap();
         settle(&cm, parent_id, JobState::Cancelled);
 
         // afterok: parent exited non-zero (preempted) → unsatisfiable; watcher cancels it.
@@ -14140,7 +14347,8 @@ mod tests {
 
         let job_id = run_job_on(&cm, "chronic-preempt", "worker1");
         for _ in 0..(max + 3) {
-            cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+            cm.preempt_job(job_id, PreemptMode::Requeue, 99, None)
+                .unwrap();
             settle(&cm, job_id, JobState::Pending);
             {
                 let mut jobs = cm.jobs.write();
@@ -14157,7 +14365,8 @@ mod tests {
             .unwrap();
             settle(&cm, job_id, JobState::Running);
         }
-        cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+        cm.preempt_job(job_id, PreemptMode::Requeue, 99, None)
+            .unwrap();
         settle(&cm, job_id, JobState::Pending);
 
         let job = cm.get_job(job_id).unwrap();
@@ -14199,7 +14408,8 @@ mod tests {
             )
             .unwrap();
             settle(&cm, job_id, JobState::Running);
-            cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+            cm.preempt_job(job_id, PreemptMode::Requeue, 99, None)
+                .unwrap();
             settle(&cm, job_id, JobState::Pending);
             {
                 let mut jobs = cm.jobs.write();

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -678,7 +678,12 @@ pub(crate) async fn try_preempt(
                 mode = ?mode,
                 "preempting lower-priority job"
             );
-            match cluster.preempt_job(candidate.job_id, mode) {
+            let preempt_qos = if sched.preempt_type == PreemptType::QosPriority {
+                Some(pending_qos.name.clone())
+            } else {
+                None
+            };
+            match cluster.preempt_job(candidate.job_id, mode, pending.job_id, preempt_qos) {
                 Ok(PreemptOutcome::Killed) => {
                     // Signal 0 = graceful cancel (SIGTERM then SIGKILL).
                     send_cancel_to_agents(cluster, candidate, 0).await;

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -3663,6 +3663,9 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
         srun_step_dispatch: job.srun_step_dispatch,
         req_gpus: spur_core::job::effective_gpus(&job.spec, job.spec.num_nodes) as u32,
         req_gpus_detail: requested_gpus_detail(&job.spec),
+        preempted_by: job.preempted_by.unwrap_or(0),
+        preempt_mode: job.preempt_mode.clone().unwrap_or_default(),
+        preempt_qos: job.preempt_qos.clone().unwrap_or_default(),
     }
 }
 

--- a/docs/developer/building.rst
+++ b/docs/developer/building.rst
@@ -156,6 +156,46 @@ If you do **not** set ``SPUR_TEST_REMOTE_BIN_DIR``, binaries go into an ephemera
    sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
    echo kernel.apparmor_restrict_unprivileged_userns=0 | sudo tee /etc/sysctl.d/99-spur-userns.conf
 
+Running on Localhost (single-node quickstart)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+No separate hardware is needed. The test framework SSHes to ``localhost``; the
+controller, agent, and (for accounting tests) a Postgres container all run on
+the same machine. Requires Docker for accounting tests.
+
+.. code-block:: bash
+
+   # 1. Install dependencies
+   sudo apt-get install -y openssh-server
+   pip install paramiko tomli-w pytest pytest-timeout
+
+   # 2. Generate an SSH keypair and authorise it for the current user
+   ssh-keygen -t rsa -f /tmp/e2e_id_rsa -N ""
+   cat /tmp/e2e_id_rsa.pub >> ~/.ssh/authorized_keys
+   chmod 600 ~/.ssh/authorized_keys
+
+   # 3. Start sshd (allow root login if running as root)
+   echo "PermitRootLogin yes" | sudo tee -a /etc/ssh/sshd_config
+   sudo ssh-keygen -A          # generate host keys if missing
+   sudo /usr/sbin/sshd
+
+   # 4. Build release binaries
+   cargo build --release
+
+   # 5. Run the e2e tests
+   cd tests/native_host/e2e
+   SPUR_TEST_NODES=localhost \
+   SPUR_TEST_SSH_USER=$(whoami) \
+   SPUR_TEST_SSH_KEY=/tmp/e2e_id_rsa \
+   SPUR_TEST_BINARIES_DIR=$(git rev-parse --show-toplevel)/target/release \
+   pytest test_preemption_qos_hierarchy.py -v
+
+.. note::
+
+   If running as root, add ``"auth": {"allow_root_jobs": True}`` to the
+   ``cluster_config_overrides`` fixture in your test class, or jobs will be
+   rejected by ``spurd`` (root job execution is off by default).
+
 Running the Tests
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/user-guide/monitoring-jobs.rst
+++ b/docs/user-guide/monitoring-jobs.rst
@@ -170,8 +170,9 @@ SUSPENDED, COMPLETING**.
 For a pending job the ``NODELIST(REASON)`` column shows why it is waiting.
 Common reasons include ``Priority`` (waiting its turn), ``Resources`` (waiting
 for nodes to free up), ``Dependency`` (waiting on another job), ``Reservation``
-(waiting for a reservation window), and various QOS or association limit reasons
-(``QOSMax*``, ``AssocMax*``, ``AssocGrp*``).
+(waiting for a reservation window), ``Preempted`` (requeue-preempted and held
+until its eligibility window reopens), and various QOS or association limit
+reasons (``QOSMax*``, ``AssocMax*``, ``AssocGrp*``).
 
 View Nodes & Partitions — ``sinfo``
 -----------------------------------
@@ -265,7 +266,10 @@ Flags:
      - Latest time to include.
    * - ``--state``
      - ``-s``
-     - Filter by state (comma list).
+     - Filter by state (comma list). Accepted values (long or short code):
+       ``COMPLETED``/``CD``, ``FAILED``/``F``, ``CANCELLED``/``CA``,
+       ``TIMEOUT``/``TO``, ``NODE_FAIL``/``NF``, ``PREEMPTED``/``PR``,
+       ``DEADLINE``/``DL``, ``RUNNING``/``R``, ``PENDING``/``PD``.
    * - ``--format``
      - ``-o``
      - Comma-separated field names (see below).
@@ -286,8 +290,14 @@ Unlike ``squeue``, ``--format`` here takes **comma-separated field names**, not
 ``%`` letters. Available fields include ``JobID``, ``JobName``, ``User``,
 ``Account``, ``Partition``, ``State``, ``Elapsed``, ``NNodes``, ``ExitCode``,
 ``DerivedExitCode``, ``Start``, ``End``, ``Submit``, ``TimeLimit``, ``NodeList``,
-``NCPUS``, and ``QOS``. Set a per-field width with ``Field%N``, e.g.
-``JobName%20``.
+``NCPUS``, ``QOS``, ``PreemptedBy``, ``PreemptMode``, and ``PreemptQOS``. Set a
+per-field width with ``Field%N``, e.g. ``JobName%20``.
+
+``PreemptedBy`` is the job ID of the higher-priority job that caused the
+preemption (``N/A`` when the job was not preempted). ``PreemptMode`` is one of
+``Requeue``, ``Cancel``, or ``Suspend``. ``PreemptQOS`` is the QOS name that
+authorized the preemption under ``preempt_type = qos_priority``; ``N/A`` for
+plain priority-based preemption. All three appear in the long format (``-l``).
 
 The default columns are ``JobID JobName User Account Partition State Elapsed
 NNodes ExitCode``.
@@ -299,6 +309,8 @@ Time arguments accept an absolute date (``YYYY-MM-DD`` or
 
    sacct -S 2026-07-01 -E 2026-07-25 -s FAILED --limit 500
    sacct --format=JobID,JobName,State,Elapsed,ExitCode
+   sacct -s PREEMPTED --format=JobID,JobName,State,ExitCode,PreemptedBy,PreemptMode,PreemptQOS
+   sacct -s PR,CA     # short codes also accepted
 
 Running-Job Stats — ``sstat``
 -----------------------------
@@ -332,6 +344,34 @@ an entity: ``job``, ``node``, ``partition``, ``reservation``, or ``step``.
    scontrol show job 1024
    spur show node node01
    scontrol show partition gpu
+
+When a job has been preempted, ``scontrol show job`` includes three additional
+fields:
+
+* ``PreemptedBy=<job_id>`` — the ID of the higher-priority job that triggered
+  the preemption. Only shown when the job has been preempted.
+* ``PreemptMode=Requeue|Cancel|Suspend`` — how the preemption was carried out.
+* ``PreemptQOS=<name>`` — the QOS that authorized the preemption under
+  ``preempt_type = qos_priority``; ``N/A`` for plain priority-based preemption.
+
+**Quick reference — one command for any preempted job:**
+
+.. code-block:: bash
+
+   scontrol show job <id>
+
+This works regardless of preemption mode (requeue, cancel, or suspend) as long
+as the job is still known to the controller (running, pending, suspended, or
+recently terminal). For cancel-preempted jobs that have been evicted from
+memory, fall back to:
+
+.. code-block:: bash
+
+   sacct -j <id> --format=JobID,State,PreemptedBy,PreemptMode,PreemptQOS
+
+The accounting database keeps the record permanently. In practice
+``scontrol show job`` is the right first instinct; use ``sacct`` only if
+``scontrol`` returns ``Invalid job id``.
 
 Cluster Metrics — ``/metrics``
 ------------------------------

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -244,6 +244,16 @@ message JobInfo {
   // "gpu:2/task".
   uint32 req_gpus = 55;
   string req_gpus_detail = 56;
+
+  // Preemption provenance. Set when this job was preempted.
+  // `preempted_by` is the job ID of the higher-priority job that caused the
+  // preemption (0 when not preempted or unknown). `preempt_mode` is one of
+  // "Requeue", "Cancel", or "Suspend". `preempt_qos` is the QOS name that
+  // authorized the preemption under QosPriority type; empty for plain
+  // priority-based preemption.
+  uint32 preempted_by = 57;
+  string preempt_mode = 58;
+  string preempt_qos = 59;
 }
 
 message NodeInfo {

--- a/tests/native_host/e2e/test_preemption.py
+++ b/tests/native_host/e2e/test_preemption.py
@@ -86,6 +86,12 @@ class TestChronicPreemption:
                 assert "Reason=JobHoldMaxRequeue" not in show, (
                     f"low-priority job held after preemption cycle {i}:\n{show}"
                 )
+                assert f"PreemptedBy={hi_id}" in show, (
+                    f"PreemptedBy not set on preempted job at cycle {i}:\n{show}"
+                )
+                assert "PreemptMode=Requeue" in show, (
+                    f"PreemptMode not set on preempted job at cycle {i}:\n{show}"
+                )
 
                 state = wait_job(cluster, hi_id, timeout=30)
                 assert state == "CD", f"high job {hi_id} did not complete: {state}"

--- a/tests/native_host/e2e/test_preemption_qos_hierarchy.py
+++ b/tests/native_host/e2e/test_preemption_qos_hierarchy.py
@@ -168,6 +168,17 @@ class TestQosPreemptHierarchyAllowed:
 
             # low must be preempted (cancelled) and high must complete.
             wait_job_state(c, low_id, "CA", timeout=30)
+            # Verify preemption provenance on the cancelled job.
+            show = c.scontrol("show", "job", str(low_id))
+            assert f"PreemptedBy={high_id}" in show, (
+                f"PreemptedBy not set on cancel-preempted job:\n{show}"
+            )
+            assert "PreemptMode=Cancel" in show, (
+                f"PreemptMode not set on cancel-preempted job:\n{show}"
+            )
+            assert "PreemptQOS=high-allow" in show, (
+                f"PreemptQOS not set on cancel-preempted job:\n{show}"
+            )
             high_state = wait_job(c, high_id, timeout=30)
             assert high_state == "CD", (
                 f"high-allow job did not complete: {high_state}"

--- a/tests/native_host/e2e/test_qos_preemption.py
+++ b/tests/native_host/e2e/test_qos_preemption.py
@@ -38,6 +38,7 @@ class TestQosPriorityPreemption:
         # the final assertion (low comes back as R, not cancelled) actually
         # exercises the QOS override rather than just the partition default.
         return {
+            "scheduler": {"preempt_type": "qos_priority"},
             "partitions": [
                 {
                     "name": "default",
@@ -60,7 +61,9 @@ class TestQosPriorityPreemption:
         # action from the partition's `cancel` to `requeue` (see
         # cluster_config_overrides above for the partition-level opt-in).
         c.sacctmgr(["add", "qos", "name=low", "priority=-1000", "preemptmode=requeue"])
-        c.sacctmgr(["add", "qos", "name=high", "priority=100000"])
+        # high's preempt list names "low" so preempt_type=qos_priority lets it
+        # preempt the low-QOS job and PreemptQOS is recorded on the victim.
+        c.sacctmgr(["add", "qos", "name=high", "priority=100000", "preempt=low"])
         # Wait past the QoS cache refresh floor (10s) before submitting.
         time.sleep(15)
 
@@ -86,6 +89,18 @@ class TestQosPriorityPreemption:
             # The node is fully allocated to `low`, so `high` can only start
             # once the scheduler's preemption pass evicts it.
             wait_job_state(c, low_id, "PD", timeout=30)
+            show = c.scontrol("show", "job", str(low_id))
+            assert f"PreemptedBy={high_id}" in show, (
+                f"PreemptedBy not set on low-priority job:\n{show}"
+            )
+            assert "PreemptMode=Requeue" in show, (
+                f"PreemptMode not set on low-priority job:\n{show}"
+            )
+            # QOS-driven preemption: PreemptQOS must name the pending job's QOS.
+            assert "PreemptQOS=high" in show, (
+                f"PreemptQOS not set on low-priority job:\n{show}"
+            )
+
             high_state = wait_job(c, high_id, timeout=30)
             assert high_state == "CD", f"high-QoS job did not complete: {high_state}"
 


### PR DESCRIPTION
## Why

When a job is preempted, users have no way to see why it happened or which job caused it. `squeue` shows `Reason=BeginTime` for requeued jobs (opaque), and cancelled-by-preemption jobs show nothing beyond `State=CANCELLED` in `sacct`. The preempting job ID, the mode (cancel/requeue/suspend), and the QOS authorization chain are only in log traces — never persisted.

## What this changes

Three new `#[serde(default)]` fields on `Job` (WAL-safe — old entries replay with `None`):
- `preempted_by: Option<JobId>` — which job triggered the preemption
- `preempt_mode: Option<String>` — `"Requeue"`, `"Cancel"`, or `"Suspend"`
- `preempt_qos: Option<String>` — the QOS name that authorized it under `preempt_type = QosPriority`; empty for plain priority-based preemption

These are threaded from `try_preempt` through `preempt_job()` into all three WAL ops (`JobPreemptRequeue`, `JobPreemptCancel`, `JobSuspend`) → WAL apply → `notify_job_end` → accounting DB (three new nullable columns).

`PendingReason::BeginTime` is replaced by a new `Preempted` variant for requeue-preempted jobs, so `squeue -o "%R"` shows `Preempted` (with a desc naming the preempting job) instead of the opaque `BeginTime`.

Also fixes a pre-existing gap in `sacct`: `PREEMPTED` was missing from both the state filter and the row mapper in `get_job_history`, so `sacct -s PREEMPTED` returned nothing and preempted jobs displayed as `COMPLETED`. Added `"PR" | "PREEMPTED"` to `parse_acct_state` and the corresponding entries to both the filter and the mapper in `grpc.rs`.

## Querying preempted jobs

One command works for any preempted job regardless of mode:

```
scontrol show job <id>          # while job is live (running, pending, suspended, or recently terminal)
sacct -j <id> --format=...      # permanent record in accounting DB
```

### Requeue mode — job pending after preemption

```
JobId=1 JobName=low-job
   UserId=root Account=
   Partition=default QOS=
   JobState=PENDING Reason=preempted by job 2
   NumNodes=1 NumTasks=1 CPUs/Task=1
   SubmitTime=2026-08-19T23:04:04 StartTime=N/A EndTime=N/A
   WorkDir=/root
   StdOut=/root/spur-1.out StdErr=/root/spur-1.out
   ExitCode=0:0 DerivedExitCode=0:0 Priority=1000
   PreemptedBy=2 PreemptMode=Requeue PreemptQOS=N/A
```

### Requeue mode — same job re-running (provenance cleared on re-dispatch)

```
JobId=1 JobName=low-job
   UserId=root Account=
   Partition=default QOS=
   JobState=RUNNING Reason=None
   NumNodes=1 NumTasks=1 CPUs/Task=1
   NodeList=SCSSAJMERA01
   SubmitTime=2026-08-19T23:04:04 StartTime=2026-08-19T23:04:13 EndTime=N/A
   WorkDir=/root
   StdOut=/root/spur-1.out StdErr=/root/spur-1.out
   ExitCode=0:0 DerivedExitCode=0:0 Priority=1000
```

### Cancel mode — scontrol show job (terminal)

```
JobId=1 JobName=low-cancel
   UserId=root Account=
   Partition=default QOS=
   JobState=CANCELLED Reason=None
   NumNodes=1 NumTasks=1 CPUs/Task=1
   NodeList=SCSSAJMERA01
   SubmitTime=2026-08-19T23:18:37 StartTime=2026-08-19T23:18:37 EndTime=2026-08-19T23:18:38
   WorkDir=/root
   StdOut=/root/spur-1.out StdErr=/root/spur-1.out
   ExitCode=-1:0 DerivedExitCode=0:0 Priority=1000
   PreemptedBy=2 PreemptMode=Cancel PreemptQOS=N/A
```

### Cancel mode — sacct (permanent accounting record)

```
$ sacct -j 1 --format=JobID,JobName,State,ExitCode,PreemptedBy,PreemptMode,PreemptQOS --noheader
1   low-cancel   PREEMPTED   -1:0   2   Cancel   N/A

$ sacct -s PREEMPTED --noheader
1   low-cancel   root   default   PREEMPTED   00:00:00   1   -1:0

$ sacct -s PR --noheader
1   low-cancel   root   default   PREEMPTED   00:00:00   1   -1:0
```

Note: `scontrol show job` shows `CANCELLED` (the live job state after cancel-preemption). `sacct` correctly shows `PREEMPTED` — the accounting convention, matching Slurm, is that the finalization event is always recorded as PREEMPTED regardless of the terminal live state.

## Approach / trade-offs

- **WAL-safe**: all new fields use `#[serde(default)]`, so old log entries replay without error. Verified with a backward-compat unit test that applies a legacy WAL entry (no provenance fields) and asserts the fields default to `None`.
- **Accounting DB**: `ADD COLUMN IF NOT EXISTS` with nullable/empty defaults — no migration failures on existing rows.
- **Suspend path**: provenance fields are carried inside the `JobSuspend` WAL op (not written after the fact), so they survive Raft replication and leader failover.
- **Stale provenance**: cleared in `JobStart` WAL apply, so a re-dispatched run's accounting row never inherits the prior preemption's data. Verified by the `preempt_requeue_wal_apply_with_provenance_clears_on_restart` unit test.
- **Proto**: three fields appended to `JobInfo` at tags 57–59 (append-only, backward compatible).
- **`preempt_job()` signature change**: internal only — no proto/REST breaking change.

## Testing

- Unit tests cover WAL apply for all three modes (requeue/cancel/suspend), field propagation, backward-compat replay of old WAL entries, and the `PendingReason::Preempted` display/behavior.
- E2E tests assert `PreemptedBy=`, `PreemptMode=`, `PreemptQOS=` in `scontrol show job` output for requeue, cancel, and QOS-driven preemption against a real running cluster.
- All outputs above captured from live single-node clusters running this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)