### PR TITLE
docs(deploy): document HA control-plane, node scoping, and kubeconfig authz for spur k8s

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -254,3 +254,5 @@ artifactory
 TLS
 PDB
 unioned
+ANDed
+ServiceAccount

--- a/docs/deployment/managed-kubernetes.rst
+++ b/docs/deployment/managed-kubernetes.rst
@@ -93,7 +93,52 @@ From the head node (or any host that can reach ``spurctld``):
 This is idempotent and asynchronous — spurctld reconciles toward ``Ready``:
 control plane first, then workers join with freshly minted tokens. A fresh
 cluster typically reaches ``Ready`` in one to two minutes (mostly the k0s
-download + control-plane bootstrap).
+download + control-plane bootstrap). ``spur k8s up`` requires cluster admin
+(``root``, or an accounting admin — see `Access control`_).
+
+Scope the cluster to a subset of nodes
+'''''''''''''''''''''''''''''''''''''
+
+By default ``spur k8s up`` enrolls every registered node. To build a smaller
+cluster, scope it with ``--nodes`` (a hostlist), ``--partition``, and/or
+``--selector`` (repeatable ``key=value``, ANDed) — the three are unioned
+together and resolved once, at up-time:
+
+.. code-block:: bash
+
+   spur k8s up --nodes "gpu[01-08]"
+   spur k8s up --partition batch
+   spur k8s up --selector zone=z1 --selector gpu=mi300
+
+A scoped cluster's membership is frozen until you grow or shrink it with
+``add-nodes`` / ``remove-nodes`` (see `Adding and removing worker nodes`_).
+
+High-availability control plane
+''''''''''''''''''''''''''''''
+
+By default the cluster runs a single control-plane node (``control_plane_node``
+in ``spur.conf``, or the first node). For HA, request 3 or 5 control planes:
+
+.. code-block:: bash
+
+   spur k8s up --replicas 3                                    # lowest-named 3 nodes
+   spur k8s up --control-plane-nodes cp-1,cp-2,cp-3             # explicit set; overrides --replicas
+
+``--control-plane-nodes`` (or a single ``--control-plane-node``) always wins
+over ``--replicas``. The first control-plane node is the etcd bootstrap.
+
+.. important::
+
+   Every control-plane node — whether picked automatically, named with
+   ``--control-plane-node``, or listed in ``--control-plane-nodes`` — **must be
+   part of the cluster's node scope**. If you also pass ``--nodes``,
+   ``--partition``, or ``--selector``, make sure the control-plane node(s) are
+   included in that selection; otherwise ``spur k8s up`` is rejected with
+   ``control-plane node <name> is not a registered node`` (explicit list) or
+   ``control-plane node <name> is not among the selected cluster nodes``
+   (auto-picked). Leave ``--nodes``/``--partition``/``--selector`` unset to
+   scope the cluster to the whole inventory, which trivially satisfies this —
+   any registered node is then a valid control-plane choice.
 
 Check status
 ~~~~~~~~~~~~~
@@ -227,16 +272,42 @@ standard Kubernetes tooling.
 Get a kubeconfig
 ~~~~~~~~~~~~~~~~~
 
-Ask an administrator (or run, if you have controller access):
-
 .. code-block:: bash
 
-   spur k8s kubeconfig > admin.conf
-   export KUBECONFIG=$PWD/admin.conf
+   spur k8s kubeconfig > mine.conf
+   export KUBECONFIG=$PWD/mine.conf
    kubectl get nodes
 
-``spur k8s kubeconfig`` prints the admin kubeconfig to stdout so it can be
-redirected to a file.
+A bare ``spur k8s kubeconfig`` mints a ServiceAccount kubeconfig scoped to
+**your own** SPUR user/account namespace — no admin access required. It prints
+to stdout so it can be redirected to a file.
+
+Access control
+'''''''''''''''
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Command
+     - Who
+     - Result
+   * - ``spur k8s kubeconfig``
+     - anyone
+     - Own scoped kubeconfig (namespace = own SPUR account).
+   * - ``spur k8s kubeconfig --user <name>``
+     - cluster admin
+     - ``<name>``'s scoped kubeconfig. Requesting anyone but yourself needs admin.
+   * - ``spur k8s kubeconfig --admin``
+     - cluster admin
+     - The k0s cluster-admin kubeconfig (full access). Mutually exclusive with ``--user``.
+
+"Cluster admin" is ``root``, or a user the accounting layer marks as an admin
+association (see :doc:`../admin-guide/accounting`). ``--admin`` additionally
+requires ``[cluster] allow_admin_kubeconfig = true`` in ``spur.conf`` — it is
+``false`` by default, since the admin check on ``caller`` is not yet backed by
+authenticated identity. With it off, get the cluster-admin kubeconfig directly
+on the control-plane node instead: ``k0s kubeconfig admin``.
 
 Run a workload
 ~~~~~~~~~~~~~~~
@@ -280,18 +351,20 @@ Command reference
 
    * - Command
      - Purpose
-   * - ``spur k8s up [--control-plane-node <h>]``
-     - Provision + start the cluster (idempotent).
+   * - ``spur k8s up [--nodes <hostlist>] [--partition <p>] [--selector k=v] [--control-plane-node <h> | --control-plane-nodes <h1,h2,h3>] [--replicas 1|3|5]``
+     - Provision + start the cluster (idempotent). Admin only. Control-plane
+       node(s) must lie within the ``--nodes``/``--partition``/``--selector``
+       scope (or leave that scope empty for the whole inventory).
    * - ``spur k8s add-nodes --nodes <hostlist> | --partition <p> | --selector k=v``
-     - Add worker nodes to a running scoped cluster (no down/reset).
+     - Add worker nodes to a running scoped cluster (no down/reset). Admin only.
    * - ``spur k8s remove-nodes --nodes <hostlist> [--drain-timeout <secs>] [--force]``
-     - Drain + ``k0s reset`` + remove a worker (destructive; re-add re-seeds state).
+     - Drain + ``k0s reset`` + remove a worker (destructive; re-add re-seeds state). Admin only.
    * - ``spur k8s status``
      - Cluster phase + per-node component state.
-   * - ``spur k8s kubeconfig``
-     - Print the admin kubeconfig (redirect to a file).
+   * - ``spur k8s kubeconfig [--user <name>] [--admin]``
+     - Print a kubeconfig (redirect to a file). Bare = own scope; ``--user``/``--admin`` need admin.
    * - ``spur k8s down [--reset]``
-     - Stop the cluster; ``--reset`` also wipes k0s state.
+     - Stop the cluster; ``--reset`` also wipes k0s state. Admin only.
    * - ``spur k8s install-k0s [--version <tag>|latest] [--path <p>] [--force]``
      - Install the k0s binary on this node (local; run as root).
 
@@ -308,9 +381,15 @@ Configuration reference (``[cluster]``)
    * - ``enabled``
      - ``false``
      - Enable Spur-managed k0s. When off, spurd never touches systemd/k0s.
+   * - ``distro``
+     - ``k0s``
+     - Kubernetes distribution SPUR manages. Only ``k0s`` is supported today.
    * - ``control_plane_node``
      - (first node)
      - Hostname of the k0s control plane.
+   * - ``control_plane_replicas``
+     - ``1``
+     - HA control-plane count (1, 3, or 5). Overridden per-invocation by ``spur k8s up --replicas``.
    * - ``pod_cidr``
      - ``10.42.0.0/16``
      - Pod network; per-node /24s are carved from it.
@@ -335,3 +414,9 @@ Configuration reference (``[cluster]``)
    * - ``k0s_binary``
      - ``/usr/local/bin/k0s``
      - Install path for the k0s binary.
+   * - ``k8s_provisioning_timeout_secs``
+     - ``600``
+     - Seconds a node may stay non-``active`` during provisioning before the cluster is marked ``degraded``.
+   * - ``allow_admin_kubeconfig``
+     - ``false``
+     - Allow ``spur k8s kubeconfig --admin`` to serve the cluster-admin kubeconfig over RPC.

--- a/docs/deployment/managed-kubernetes.rst
+++ b/docs/deployment/managed-kubernetes.rst
@@ -97,7 +97,7 @@ download + control-plane bootstrap). ``spur k8s up`` requires cluster admin
 (``root``, or an accounting admin — see `Access control`_).
 
 Scope the cluster to a subset of nodes
-'''''''''''''''''''''''''''''''''''''
+''''''''''''''''''''''''''''''''''''''
 
 By default ``spur k8s up`` enrolls every registered node. To build a smaller
 cluster, scope it with ``--nodes`` (a hostlist), ``--partition``, and/or
@@ -114,7 +114,7 @@ A scoped cluster's membership is frozen until you grow or shrink it with
 ``add-nodes`` / ``remove-nodes`` (see `Adding and removing worker nodes`_).
 
 High-availability control plane
-''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''
 
 By default the cluster runs a single control-plane node (``control_plane_node``
 in ``spur.conf``, or the first node). For HA, request 3 or 5 control planes:


### PR DESCRIPTION
## Summary
- Documents the `spur k8s up` node-scoping flags (`--nodes`/`--partition`/`--selector`) and HA control-plane flags (`--replicas`, `--control-plane-node`/`--control-plane-nodes`), which shipped in code but had no docs.
- Calls out explicitly that control-plane node(s) must lie within the `--nodes`/`--partition`/`--selector` scope — or that scope must be left empty to select the whole inventory — including the exact rejection error strings from `spurctld`.
- Fixes a stale claim in the kubeconfig section: it said a bare `spur k8s kubeconfig` returns the cluster-admin kubeconfig; it actually mints a self-scoped ServiceAccount kubeconfig by default now, with `--admin`/`--user` as separate, admin-gated paths (`--admin` additionally requires the `allow_admin_kubeconfig` opt-in).
- Fills in the command reference and `[cluster]` config reference tables with the flags/fields above plus `distro`, `control_plane_replicas`, `k8s_provisioning_timeout_secs`, `allow_admin_kubeconfig`.

## Approach
Rescanned the managed-k0s feature end-to-end against `crates/spur-cli/src/k8s.rs`, `crates/spurctld/src/{server,cluster_k8s}.rs`, and `crates/spur-core/src/config.rs` (on top of latest `main`) to diff current behavior against `docs/deployment/managed-kubernetes.rst`, then updated the doc in place rather than adding a new page.

## Test plan
- [x] `pyspelling -c .spellcheck.yaml` — clean on this file (added `ANDed`/`ServiceAccount` to `.wordlist.txt`); remaining failures elsewhere are pre-existing and unrelated.
- [x] Manual proofread of RST list-table/reference syntax (no Sphinx toolchain available locally to do a full build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)