### PR TITLE
fix(spur-cli): honor sacct -j/--jobs job-ID filter

### DIFF
--- a/crates/spur-cli/src/job_id_arg.rs
+++ b/crates/spur-cli/src/job_id_arg.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared parsing for the Slurm-style `-j/--jobs` job-ID argument used by
+//! `squeue`, `sprio`, and `sacct`.
+
+use spur_core::job::JobId;
+
+/// Parse a comma-separated `-j/--jobs` value into numeric job IDs.
+///
+/// Step suffixes (`30.0`, `30.batch`) match the base job ID, since Spur
+/// schedules and accounts whole jobs rather than individual steps. Unparseable
+/// entries are dropped.
+pub fn parse_job_ids(spec: &str) -> Vec<JobId> {
+    spec.split(',')
+        .filter_map(|tok| {
+            let base = tok.trim().split('.').next().unwrap_or_default();
+            base.parse::<JobId>().ok()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_lists_steps_and_junk() {
+        assert_eq!(parse_job_ids("30"), vec![30]);
+        assert_eq!(parse_job_ids("30,31,32"), vec![30, 31, 32]);
+        assert_eq!(parse_job_ids(" 30 , 31 "), vec![30, 31]);
+        assert_eq!(parse_job_ids("30.0"), vec![30]);
+        assert_eq!(parse_job_ids("30.batch,31.0"), vec![30, 31]);
+        assert_eq!(parse_job_ids("30,abc,31"), vec![30, 31]);
+        assert!(parse_job_ids("").is_empty());
+        assert!(parse_job_ids("abc").is_empty());
+    }
+}

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -8,6 +8,7 @@ mod exit_fmt;
 mod format_engine;
 mod image;
 mod interactive;
+mod job_id_arg;
 mod jobtime;
 mod k8s;
 #[cfg(test)]

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -160,7 +160,11 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         })
         .unwrap_or_default();
 
-    let job_ids = args.jobs.as_deref().map(parse_job_ids).unwrap_or_default();
+    let job_ids = args
+        .jobs
+        .as_deref()
+        .map(crate::job_id_arg::parse_job_ids)
+        .unwrap_or_default();
 
     let channel = crate::authclient::connect(&args.controller)
         .await
@@ -271,21 +275,6 @@ fn parse_acct_state(s: &str) -> Option<i32> {
         "PD" | "PENDING" => Some(0),
         _ => None,
     }
-}
-
-/// Parse a Slurm-style `-j/--jobs` value into numeric job IDs.
-///
-/// Accepts a comma-separated list and tolerates step suffixes (`30.0`,
-/// `30.batch`) by matching the base job ID, since Spur accounting records whole
-/// jobs rather than individual steps. Unparseable entries are dropped, mirroring
-/// squeue's job-ID handling.
-fn parse_job_ids(s: &str) -> Vec<u32> {
-    s.split(',')
-        .filter_map(|tok| {
-            let base = tok.trim().split('.').next().unwrap_or_default();
-            base.parse::<u32>().ok()
-        })
-        .collect()
 }
 
 fn format_elapsed(job: &spur_proto::proto::JobInfo) -> String {
@@ -416,20 +405,5 @@ mod tests {
         .await
         .unwrap_err();
         assert!(err.to_string().contains("no recognized fields"));
-    }
-
-    #[test]
-    fn parse_job_ids_handles_lists_steps_and_junk() {
-        assert_eq!(parse_job_ids("30"), vec![30]);
-        assert_eq!(parse_job_ids("30,31,32"), vec![30, 31, 32]);
-        // Surrounding whitespace is tolerated.
-        assert_eq!(parse_job_ids(" 30 , 31 "), vec![30, 31]);
-        // Step suffixes collapse to the base job ID (Spur records jobs, not steps).
-        assert_eq!(parse_job_ids("30.0"), vec![30]);
-        assert_eq!(parse_job_ids("30.batch,31.0"), vec![30, 31]);
-        // Unparseable tokens are dropped, not turned into a bogus filter.
-        assert_eq!(parse_job_ids("30,abc,31"), vec![30, 31]);
-        assert!(parse_job_ids("").is_empty());
-        assert!(parse_job_ids("abc").is_empty());
     }
 }

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -160,6 +160,8 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         })
         .unwrap_or_default();
 
+    let job_ids = args.jobs.as_deref().map(parse_job_ids).unwrap_or_default();
+
     let channel = crate::authclient::connect(&args.controller)
         .await
         .context("failed to connect to controller")?;
@@ -183,6 +185,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             start_after,
             start_before,
             states,
+            job_ids,
             limit: args.limit,
         })
         .await
@@ -268,6 +271,21 @@ fn parse_acct_state(s: &str) -> Option<i32> {
         "PD" | "PENDING" => Some(0),
         _ => None,
     }
+}
+
+/// Parse a Slurm-style `-j/--jobs` value into numeric job IDs.
+///
+/// Accepts a comma-separated list and tolerates step suffixes (`30.0`,
+/// `30.batch`) by matching the base job ID, since Spur accounting records whole
+/// jobs rather than individual steps. Unparseable entries are dropped, mirroring
+/// squeue's job-ID handling.
+fn parse_job_ids(s: &str) -> Vec<u32> {
+    s.split(',')
+        .filter_map(|tok| {
+            let base = tok.trim().split('.').next().unwrap_or_default();
+            base.parse::<u32>().ok()
+        })
+        .collect()
 }
 
 fn format_elapsed(job: &spur_proto::proto::JobInfo) -> String {
@@ -398,5 +416,20 @@ mod tests {
         .await
         .unwrap_err();
         assert!(err.to_string().contains("no recognized fields"));
+    }
+
+    #[test]
+    fn parse_job_ids_handles_lists_steps_and_junk() {
+        assert_eq!(parse_job_ids("30"), vec![30]);
+        assert_eq!(parse_job_ids("30,31,32"), vec![30, 31, 32]);
+        // Surrounding whitespace is tolerated.
+        assert_eq!(parse_job_ids(" 30 , 31 "), vec![30, 31]);
+        // Step suffixes collapse to the base job ID (Spur records jobs, not steps).
+        assert_eq!(parse_job_ids("30.0"), vec![30]);
+        assert_eq!(parse_job_ids("30.batch,31.0"), vec![30, 31]);
+        // Unparseable tokens are dropped, not turned into a bogus filter.
+        assert_eq!(parse_job_ids("30,abc,31"), vec![30, 31]);
+        assert!(parse_job_ids("").is_empty());
+        assert!(parse_job_ids("abc").is_empty());
     }
 }

--- a/crates/spur-cli/src/sprio.rs
+++ b/crates/spur-cli/src/sprio.rs
@@ -51,15 +51,10 @@ pub async fn main() -> Result<()> {
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let args = SprioArgs::try_parse_from(&args)?;
 
-    // Parse job ID filter
     let job_ids = args
         .jobs
-        .as_ref()
-        .map(|s| {
-            s.split(',')
-                .filter_map(|j| j.trim().parse::<u32>().ok())
-                .collect::<Vec<_>>()
-        })
+        .as_deref()
+        .map(crate::job_id_arg::parse_job_ids)
         .unwrap_or_default();
 
     let channel = crate::authclient::connect(&args.controller)

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -144,15 +144,10 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     } = plan_query(&args)?;
     let fields = format_engine::parse_format(&fmt, &format_engine::squeue_header);
 
-    // Parse job ID filter
     let job_ids = args
         .jobs
-        .as_ref()
-        .map(|s| {
-            s.split(',')
-                .filter_map(|j| j.trim().parse::<u32>().ok())
-                .collect::<Vec<_>>()
-        })
+        .as_deref()
+        .map(crate::job_id_arg::parse_job_ids)
         .unwrap_or_default();
 
     // Expand the -w node filter before any network I/O so a bad hostlist

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -492,17 +492,23 @@ pub struct JobRecord {
     pub preempt_qos: String,
 }
 
+/// Filters for [`get_job_history`]. A `None` or empty-slice field is an
+/// unconstrained dimension; the default value matches everything.
+#[derive(Default)]
+pub struct JobHistoryQuery<'a> {
+    pub user: Option<&'a str>,
+    pub account: Option<&'a str>,
+    pub start_after: Option<DateTime<Utc>>,
+    pub start_before: Option<DateTime<Utc>>,
+    pub states: &'a [String],
+    pub job_ids: &'a [JobId],
+    pub limit: u32,
+}
+
 /// Query job history.
-#[allow(clippy::too_many_arguments)]
 pub async fn get_job_history(
     pool: &PgPool,
-    user: Option<&str>,
-    account: Option<&str>,
-    start_after: Option<DateTime<Utc>>,
-    start_before: Option<DateTime<Utc>>,
-    states: &[String],
-    job_ids: &[i32],
-    limit: u32,
+    query: &JobHistoryQuery<'_>,
 ) -> anyhow::Result<Vec<JobRecord>> {
     let mut qb = QueryBuilder::<sqlx::Postgres>::new(
         "SELECT job_id, name, user_name, account, partition_name, state, exit_code, \
@@ -512,37 +518,37 @@ pub async fn get_job_history(
          FROM jobs WHERE 1=1",
     );
 
-    if let Some(u) = user.filter(|u| !u.is_empty()) {
+    if let Some(u) = query.user.filter(|u| !u.is_empty()) {
         qb.push(" AND user_name = ").push_bind(u);
     }
-    if let Some(a) = account.filter(|a| !a.is_empty()) {
+    if let Some(a) = query.account.filter(|a| !a.is_empty()) {
         qb.push(" AND account = ").push_bind(a);
     }
-    if let Some(after) = start_after {
+    if let Some(after) = query.start_after {
         qb.push(" AND start_time >= ").push_bind(after);
     }
-    if let Some(before) = start_before {
+    if let Some(before) = query.start_before {
         qb.push(" AND start_time <= ").push_bind(before);
     }
-    if !states.is_empty() {
+    if !query.states.is_empty() {
         qb.push(" AND state IN (");
         let mut sep = qb.separated(", ");
-        for s in states {
+        for s in query.states {
             sep.push_bind(s.clone());
         }
         sep.push_unseparated(")");
     }
-    if !job_ids.is_empty() {
+    if !query.job_ids.is_empty() {
         qb.push(" AND job_id IN (");
         let mut sep = qb.separated(", ");
-        for id in job_ids {
-            sep.push_bind(*id);
+        for id in query.job_ids {
+            sep.push_bind(*id as i64);
         }
         sep.push_unseparated(")");
     }
 
     qb.push(" ORDER BY submit_time DESC LIMIT ")
-        .push_bind(effective_query_limit(limit));
+        .push_bind(effective_query_limit(query.limit));
 
     let rows = qb.build().fetch_all(pool).await?;
 
@@ -1701,13 +1707,27 @@ mod job_history_tests {
         .await?;
         end(&pool, id2, "COMPLETED", 0, t2 + Duration::minutes(5), 0, 0).await?;
 
-        let by_user =
-            get_job_history(&pool, Some(&user_a), None, None, None, &[], &[], 100).await?;
+        let by_user = get_job_history(
+            &pool,
+            &JobHistoryQuery {
+                user: Some(&user_a),
+                limit: 100,
+                ..Default::default()
+            },
+        )
+        .await?;
         assert_eq!(by_user.len(), 2);
         assert!(by_user.iter().all(|r| r.user_name == user_a));
 
-        let by_account =
-            get_job_history(&pool, None, Some(&account_one), None, None, &[], &[], 100).await?;
+        let by_account = get_job_history(
+            &pool,
+            &JobHistoryQuery {
+                account: Some(&account_one),
+                limit: 100,
+                ..Default::default()
+            },
+        )
+        .await?;
         assert_eq!(
             by_account
                 .iter()
@@ -1718,26 +1738,24 @@ mod job_history_tests {
 
         let completed = get_job_history(
             &pool,
-            Some(&user_a),
-            None,
-            None,
-            None,
-            &[String::from("COMPLETED")],
-            &[],
-            100,
+            &JobHistoryQuery {
+                user: Some(&user_a),
+                states: &[String::from("COMPLETED")],
+                limit: 100,
+                ..Default::default()
+            },
         )
         .await?;
         assert_eq!(completed.len(), 2);
 
         let failed = get_job_history(
             &pool,
-            Some(&user_b),
-            None,
-            None,
-            None,
-            &[String::from("FAILED")],
-            &[],
-            100,
+            &JobHistoryQuery {
+                user: Some(&user_b),
+                states: &[String::from("FAILED")],
+                limit: 100,
+                ..Default::default()
+            },
         )
         .await?;
         assert_eq!(failed.len(), 1);
@@ -1745,23 +1763,53 @@ mod job_history_tests {
         assert_eq!(failed[0].exit_signal, 9);
         assert_eq!(failed[0].derived_exit_code, 137);
 
-        let after =
-            get_job_history(&pool, Some(&user_a), None, Some(t2), None, &[], &[], 100).await?;
+        let after = get_job_history(
+            &pool,
+            &JobHistoryQuery {
+                user: Some(&user_a),
+                start_after: Some(t2),
+                limit: 100,
+                ..Default::default()
+            },
+        )
+        .await?;
         assert_eq!(after.len(), 1);
         assert_eq!(after[0].job_id, id2);
 
-        let limited = get_job_history(&pool, Some(&user_a), None, None, None, &[], &[], 1).await?;
+        let limited = get_job_history(
+            &pool,
+            &JobHistoryQuery {
+                user: Some(&user_a),
+                limit: 1,
+                ..Default::default()
+            },
+        )
+        .await?;
         assert_eq!(limited.len(), 1);
         assert_eq!(limited[0].job_id, id2);
 
-        // -j/--jobs filter: a single ID returns only that job, a set returns
-        // exactly the matching rows, and a non-existent ID returns nothing.
-        let one = get_job_history(&pool, None, None, None, None, &[], &[id1], 100).await?;
+        let one = get_job_history(
+            &pool,
+            &JobHistoryQuery {
+                job_ids: &[id1],
+                limit: 100,
+                ..Default::default()
+            },
+        )
+        .await?;
         assert_eq!(one.len(), 1);
         assert_eq!(one[0].job_id, id1);
 
-        let subset = get_job_history(&pool, None, None, None, None, &[], &[id0, id2], 100).await?;
-        let mut got: Vec<i32> = subset
+        let subset = get_job_history(
+            &pool,
+            &JobHistoryQuery {
+                job_ids: &[id0, id2],
+                limit: 100,
+                ..Default::default()
+            },
+        )
+        .await?;
+        let mut got: Vec<JobId> = subset
             .iter()
             .map(|r| r.job_id)
             .filter(|id| ids.contains(id))
@@ -1769,20 +1817,26 @@ mod job_history_tests {
         got.sort_unstable();
         assert_eq!(got, vec![id0, id2]);
 
-        let missing =
-            get_job_history(&pool, None, None, None, None, &[], &[404_040_404], 100).await?;
+        let missing = get_job_history(
+            &pool,
+            &JobHistoryQuery {
+                job_ids: &[404_040_404],
+                limit: 100,
+                ..Default::default()
+            },
+        )
+        .await?;
         assert!(missing.is_empty());
 
-        // Filters compose: job-ID set intersected with a user still scopes by user.
+        // Filters compose: a job-ID set intersected with a user still scopes by user.
         let scoped = get_job_history(
             &pool,
-            Some(&user_a),
-            None,
-            None,
-            None,
-            &[],
-            &[id0, id1],
-            100,
+            &JobHistoryQuery {
+                user: Some(&user_a),
+                job_ids: &[id0, id1],
+                limit: 100,
+                ..Default::default()
+            },
         )
         .await?;
         assert_eq!(scoped.len(), 1);
@@ -1823,11 +1877,17 @@ mod job_history_tests {
         )
         .await?;
 
-        let history = get_job_history(&pool, None, None, None, None, &[], &[], 100)
-            .await?
-            .into_iter()
-            .find(|r| r.job_id == id)
-            .expect("reused job_id should still be queryable");
+        let history = get_job_history(
+            &pool,
+            &JobHistoryQuery {
+                limit: 100,
+                ..Default::default()
+            },
+        )
+        .await?
+        .into_iter()
+        .find(|r| r.job_id == id)
+        .expect("reused job_id should still be queryable");
         assert_eq!(history.name, "new-job");
         assert_eq!(history.user_name, "vm");
         assert_eq!(history.account, "acct-new");
@@ -1877,7 +1937,15 @@ mod job_history_tests {
         .await?;
         drop(conn);
 
-        let history = get_job_history(&pool, Some(&user), None, None, None, &[], 100).await?;
+        let history = get_job_history(
+            &pool,
+            &JobHistoryQuery {
+                user: Some(&user),
+                limit: 100,
+                ..Default::default()
+            },
+        )
+        .await?;
         let row = history
             .iter()
             .find(|r| r.job_id == id)
@@ -1931,7 +1999,15 @@ mod job_history_tests {
 
         migrate(pool).await?;
 
-        let history = get_job_history(pool, Some(user), None, None, None, &[], 100).await?;
+        let history = get_job_history(
+            pool,
+            &JobHistoryQuery {
+                user: Some(user),
+                limit: 100,
+                ..Default::default()
+            },
+        )
+        .await?;
         let row = history.first().expect("the migrated row must be returned");
         assert_eq!(
             row.job_id, id,

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -493,6 +493,7 @@ pub struct JobRecord {
 }
 
 /// Query job history.
+#[allow(clippy::too_many_arguments)]
 pub async fn get_job_history(
     pool: &PgPool,
     user: Option<&str>,
@@ -500,6 +501,7 @@ pub async fn get_job_history(
     start_after: Option<DateTime<Utc>>,
     start_before: Option<DateTime<Utc>>,
     states: &[String],
+    job_ids: &[i32],
     limit: u32,
 ) -> anyhow::Result<Vec<JobRecord>> {
     let mut qb = QueryBuilder::<sqlx::Postgres>::new(
@@ -527,6 +529,14 @@ pub async fn get_job_history(
         let mut sep = qb.separated(", ");
         for s in states {
             sep.push_bind(s.clone());
+        }
+        sep.push_unseparated(")");
+    }
+    if !job_ids.is_empty() {
+        qb.push(" AND job_id IN (");
+        let mut sep = qb.separated(", ");
+        for id in job_ids {
+            sep.push_bind(*id);
         }
         sep.push_unseparated(")");
     }
@@ -1691,12 +1701,13 @@ mod job_history_tests {
         .await?;
         end(&pool, id2, "COMPLETED", 0, t2 + Duration::minutes(5), 0, 0).await?;
 
-        let by_user = get_job_history(&pool, Some(&user_a), None, None, None, &[], 100).await?;
+        let by_user =
+            get_job_history(&pool, Some(&user_a), None, None, None, &[], &[], 100).await?;
         assert_eq!(by_user.len(), 2);
         assert!(by_user.iter().all(|r| r.user_name == user_a));
 
         let by_account =
-            get_job_history(&pool, None, Some(&account_one), None, None, &[], 100).await?;
+            get_job_history(&pool, None, Some(&account_one), None, None, &[], &[], 100).await?;
         assert_eq!(
             by_account
                 .iter()
@@ -1712,6 +1723,7 @@ mod job_history_tests {
             None,
             None,
             &[String::from("COMPLETED")],
+            &[],
             100,
         )
         .await?;
@@ -1724,6 +1736,7 @@ mod job_history_tests {
             None,
             None,
             &[String::from("FAILED")],
+            &[],
             100,
         )
         .await?;
@@ -1732,13 +1745,48 @@ mod job_history_tests {
         assert_eq!(failed[0].exit_signal, 9);
         assert_eq!(failed[0].derived_exit_code, 137);
 
-        let after = get_job_history(&pool, Some(&user_a), None, Some(t2), None, &[], 100).await?;
+        let after =
+            get_job_history(&pool, Some(&user_a), None, Some(t2), None, &[], &[], 100).await?;
         assert_eq!(after.len(), 1);
         assert_eq!(after[0].job_id, id2);
 
-        let limited = get_job_history(&pool, Some(&user_a), None, None, None, &[], 1).await?;
+        let limited = get_job_history(&pool, Some(&user_a), None, None, None, &[], &[], 1).await?;
         assert_eq!(limited.len(), 1);
         assert_eq!(limited[0].job_id, id2);
+
+        // -j/--jobs filter: a single ID returns only that job, a set returns
+        // exactly the matching rows, and a non-existent ID returns nothing.
+        let one = get_job_history(&pool, None, None, None, None, &[], &[id1], 100).await?;
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].job_id, id1);
+
+        let subset = get_job_history(&pool, None, None, None, None, &[], &[id0, id2], 100).await?;
+        let mut got: Vec<i32> = subset
+            .iter()
+            .map(|r| r.job_id)
+            .filter(|id| ids.contains(id))
+            .collect();
+        got.sort_unstable();
+        assert_eq!(got, vec![id0, id2]);
+
+        let missing =
+            get_job_history(&pool, None, None, None, None, &[], &[404_040_404], 100).await?;
+        assert!(missing.is_empty());
+
+        // Filters compose: job-ID set intersected with a user still scopes by user.
+        let scoped = get_job_history(
+            &pool,
+            Some(&user_a),
+            None,
+            None,
+            None,
+            &[],
+            &[id0, id1],
+            100,
+        )
+        .await?;
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].job_id, id0);
 
         delete_jobs(&pool, &ids).await?;
         Ok(())
@@ -1775,7 +1823,7 @@ mod job_history_tests {
         )
         .await?;
 
-        let history = get_job_history(&pool, None, None, None, None, &[], 100)
+        let history = get_job_history(&pool, None, None, None, None, &[], &[], 100)
             .await?
             .into_iter()
             .find(|r| r.job_id == id)

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -295,6 +295,8 @@ impl SlurmAccounting for AccountingService {
             Some(req.account.as_str())
         };
 
+        let job_ids: Vec<i32> = req.job_ids.iter().map(|id| *id as i32).collect();
+
         let records = db::get_job_history(
             pool,
             user,
@@ -302,6 +304,7 @@ impl SlurmAccounting for AccountingService {
             start_after,
             start_before,
             &states,
+            &job_ids,
             req.limit,
         )
         .await

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -295,17 +295,17 @@ impl SlurmAccounting for AccountingService {
             Some(req.account.as_str())
         };
 
-        let job_ids: Vec<i32> = req.job_ids.iter().map(|id| *id as i32).collect();
-
         let records = db::get_job_history(
             pool,
-            user,
-            account,
-            start_after,
-            start_before,
-            &states,
-            &job_ids,
-            req.limit,
+            &db::JobHistoryQuery {
+                user,
+                account,
+                start_after,
+                start_before,
+                states: &states,
+                job_ids: &req.job_ids,
+                limit: req.limit,
+            },
         )
         .await
         .map_err(|e| Status::internal(e.to_string()))?;

--- a/docs/user-guide/monitoring-jobs.rst
+++ b/docs/user-guide/monitoring-jobs.rst
@@ -333,6 +333,9 @@ Flags:
        ``COMPLETED``/``CD``, ``FAILED``/``F``, ``CANCELLED``/``CA``,
        ``TIMEOUT``/``TO``, ``NODE_FAIL``/``NF``, ``PREEMPTED``/``PR``,
        ``DEADLINE``/``DL``, ``RUNNING``/``R``, ``PENDING``/``PD``.
+   * - ``--jobs``
+     - ``-j``
+     - Filter by job ID (comma list; step suffixes like ``30.0`` match the base job).
    * - ``--format``
      - ``-o``
      - Comma-separated field names (see below).

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1371,6 +1371,7 @@ message GetJobHistoryRequest {
   google.protobuf.Timestamp start_before = 4;
   repeated JobState states = 5;
   uint32 limit = 6;
+  repeated uint32 job_ids = 7;
 }
 
 message GetJobHistoryResponse {


### PR DESCRIPTION
## Motivation

`sacct -j <id>` accepted the `-j/--jobs` flag but silently ignored it. The value was parsed and then dropped, and `GetJobHistory` carried no job-ID filter at any layer, so every invocation returned the full history (up to `--limit`) regardless of the ID passed — including IDs that do not exist. Being a silent wrong-result (no error), it broke the common `sacct -j <id>` scripting idiom.

Fixes #689.

## Technical Details

The gap spanned the entire accounting read path, so the fix does too:

- **CLI** (`sacct.rs`): parse the comma-separated `--jobs` value and put the IDs in the request. Slurm step suffixes (`30.0`, `30.batch`) collapse to the base job ID — Spur accounting records whole jobs, not steps — and unparseable tokens are dropped, mirroring `squeue`'s handling.
- **Proto** (`slurm.proto`): add `repeated uint32 job_ids = 7` to `GetJobHistoryRequest`. Append-only (new tag), so FFI/REST/wire compatibility is preserved.
- **Controller** (`accounting/grpc.rs`): forward the IDs to the DB layer.
- **DB** (`accounting/db.rs`): filter with `job_id IN (...)` in the query builder. Filtering is **server-side** on purpose — a client-side filter over the default 100-row window would wrongly return nothing for a job older than the last 100 records.

`squeue -j` already worked this way (`GetJobsRequest.job_ids`); this brings `sacct` to parity. `scontrol show job <id>` was unaffected since it uses a fetch-by-id RPC.

## Test Plan

- New `parse_job_ids` unit test: comma-separated lists, whitespace, step suffixes, junk-dropping, empty input.
- Extended the PG-gated `get_job_history` integration test: single ID, multi-ID subset, non-existent ID → empty, and job-ID ∩ user composition (runs in the "DB tests (accounting)" CI job).
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean.
- `cargo test --locked` — all pass.
- `cargo fmt --check` — clean.

Made with [Cursor](https://cursor.com)