### PR TITLE
docs(admin-guide): say where GrpWall is enforced and what a zero budget does

### DIFF
--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -516,6 +516,8 @@ Set ``DenyOnLimit`` through the QOS ``flags`` key:
 
    sacctmgr modify qos name=highprio set flags=DenyOnLimit
 
+.. _grpwall-budgets:
+
 Group wall-clock budgets (GrpWall)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -524,6 +526,11 @@ reaches the cap, jobs in that QOS stop being scheduled and wait with reason
 ``QOSGrpWallLimit`` (visible in ``squeue``); they become eligible again once
 consumption has fallen back below the cap *and* the next refresh has read it, not
 at the moment the older usage ages out of the window.
+
+Unlike the per-job QOS limits, ``grpwall`` is enforced only while scheduling,
+never at the submit gate: a breach never rejects a submission — not even under
+``DenyOnLimit`` (see :ref:`deny-on-limit`) — so the job is always accepted and
+simply pends as above.
 
 Consumption is summed from job history over a trailing window, set by
 ``grp_wall_window_days`` under ``[accounting]`` (default ``14``). Running jobs
@@ -574,6 +581,12 @@ one in place rather than discarding it, exactly as the QOS cache retains its
 definitions, so a budget keeps applying across an outage — but on the last figure
 read, however old that now is, and consumption accrued during the outage is
 invisible until the database returns.
+
+The same gap governs the ``0`` sentinel. Under :ref:`limit-values`, ``grpwall=0``
+is a literal budget of zero — it blocks every job in the QOS rather than meaning
+"no limit"; use ``-1`` to lift the cap. But because enforcement needs a figure
+first, ``grpwall=0`` too blocks nothing until one has been read: with no
+consumption known, no budget applies.
 
 If the database is unreachable when the controller *starts*, the refresh loop is
 never started at all: the budget is not applied for the life of that process and

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -528,9 +528,10 @@ consumption has fallen back below the cap *and* the next refresh has read it, no
 at the moment the older usage ages out of the window.
 
 Unlike the per-job QOS limits, ``grpwall`` is enforced only while scheduling,
-never at the submit gate: a breach never rejects a submission — not even under
-``DenyOnLimit`` (see :ref:`deny-on-limit`) — so the job is always accepted and
-simply pends as above.
+never at the submit gate: an exhausted budget never rejects a submission — not
+even under ``DenyOnLimit`` (see :ref:`deny-on-limit`) — so a job held back by it
+is still accepted, and pends as above. The limits that do gate at submit still
+reject there; only ``grpwall`` is exempt.
 
 Consumption is summed from job history over a trailing window, set by
 ``grp_wall_window_days`` under ``[accounting]`` (default ``14``). Running jobs

--- a/docs/migration-from-slurm.rst
+++ b/docs/migration-from-slurm.rst
@@ -73,6 +73,8 @@ noted as "accepted for compatibility" parse without error but have no effect yet
      - Array-element syntax (``123_4``) is not yet supported client-side; cancel by plain job id.
    * - ``scontrol show``
      - Output is always the multi-line ``Key=Value`` block; there is no ``--oneliner``.
+   * - QOS ``GrpWall``
+     - Enforced at scheduling admission only: an over-budget QOS stops admitting jobs, and running jobs are never killed where Slurm cancels them. Consumption is a trailing window (``accounting.grp_wall_window_days``) rather than decayed usage, and the cap exists on a QOS only, not on an association. See :ref:`grpwall-budgets`.
 
 Accounting and QOS Mapping
 --------------------------

--- a/docs/migration-from-slurm.rst
+++ b/docs/migration-from-slurm.rst
@@ -74,7 +74,7 @@ noted as "accepted for compatibility" parse without error but have no effect yet
    * - ``scontrol show``
      - Output is always the multi-line ``Key=Value`` block; there is no ``--oneliner``.
    * - QOS ``GrpWall``
-     - Enforced at scheduling admission only: an over-budget QOS stops admitting jobs, and running jobs are never killed where Slurm cancels them. Consumption is a trailing window (``accounting.grp_wall_window_days``) rather than decayed usage, and the cap exists on a QOS only, not on an association. See :ref:`grpwall-budgets`.
+     - Enforced at scheduling admission only: an over-budget QOS stops admitting jobs, and running jobs are never killed where Slurm cancels them. Consumption is a trailing window (``grp_wall_window_days`` under ``[accounting]``) rather than decayed usage, and the cap exists on a QOS only, not on an association. See :ref:`grpwall-budgets`.
 
 Accounting and QOS Mapping
 --------------------------


### PR DESCRIPTION
## What this adds

Two facts about `GrpWall` that an operator could previously only learn by experiment, plus the entry a migrating admin looks for first.

**Where the limit is enforced.** `grp_wall_minutes` is read in `check_qos_limits` and nowhere else — neither `check_qos_submit_limits` nor `check_qos_standalone_limits` consults it. A breach therefore never rejects a submission, not even under `DenyOnLimit`: the job is accepted and pends. An admin who sets `DenyOnLimit` expecting an over-budget QOS to bounce submissions gets a growing pending queue instead, with nothing in the docs to explain why.

**What a zero budget does.** Limit values carry Slurm's sentinel meanings, so `grpwall=0` is a literal budget of zero that blocks every job in the QOS rather than lifting the cap. But because enforcement needs a consumption figure before it applies, `grpwall=0` blocks nothing until one has been read — the same fail-open gap that governs the budget generally also governs its most destructive value, in both directions: set as a hard stop it lets jobs through, and set in the belief that `0` means "unlimited" it freezes the QOS once the first refresh lands.

**The migration table.** The three deliberate divergences from Slurm — admission-only enforcement with running jobs never killed, a trailing window instead of decayed usage, and no association-level cap — were documented only in the admin guide. `docs/migration-from-slurm.rst` never mentioned `GrpWall` at all, and its "Behavioral Differences and Current Limitations" table is where someone porting a Slurm setup reads first. The row cross-references the admin guide rather than restating it.

## Why separately

The GrpWall enforcement change is already merged. These gaps were found while reviewing that work against the QOS submit-time limits that landed alongside it: the submit gate and the sentinel semantics are what make the enforcement point and the meaning of `0` worth stating, and neither existed when the original docs were written.

## Testing

Docs-only; no code paths touched.

- Every claim verified against `crates/spur-core/src/qos.rs` on `main`: `grp_wall_minutes` appears only in `check_qos_limits`, guarded by `if let (Some(cap), Some(consumed))` with a `consumed >= cap` comparison, which is what makes both the zero-budget and unknown-consumption statements true.
- reST structure checked with docutils on both files.
- `pyspelling` run differentially against `main`'s copy of each file: no newly flagged words, so no wordlist change was needed.
- Both `:ref:` targets used (`grpwall-budgets`, `deny-on-limit`) resolve to real labels; `grpwall-budgets` is added here.
