### PR TITLE
docs(user-guide): document suspend-mode preemption gap in sacct

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -198,6 +198,7 @@ runtimes
 RWO
 SHA
 SIGKILL
+SIGSTOP
 SPDX
 SpurJob
 SpurJobs

--- a/docs/user-guide/monitoring-jobs.rst
+++ b/docs/user-guide/monitoring-jobs.rst
@@ -373,6 +373,19 @@ The accounting database keeps the record permanently. In practice
 ``scontrol show job`` is the right first instinct; use ``sacct`` only if
 ``scontrol`` returns ``Invalid job id``.
 
+.. note::
+
+   **Suspend-mode preemption and accounting.** When ``PreemptMode=Suspend``,
+   the job receives SIGSTOP and stays running — no accounting end-record
+   is written. The provenance fields (``PreemptedBy``, ``PreemptMode``,
+   ``PreemptQOS``) are visible in ``scontrol show job`` while the job is
+   suspended, but are cleared when the job resumes so that a subsequent normal
+   completion is not miscounted as a preemption. As a result, ``sacct`` has
+   no record of the preemption for suspend-mode jobs: the accounting row for
+   that run will show the final completion state only. Requeue and cancel modes
+   are unaffected — both write an accounting end-record (``PREEMPTED``) at the
+   time of preemption.
+
 Cluster Metrics — ``/metrics``
 ------------------------------
 


### PR DESCRIPTION
## Context

Follows up #700 (preemption provenance), addressing a review comment from @sgopinath1.

## The gap

When `PreemptMode=Suspend`, the job is only SIGSTOP'd — it stays running and no accounting end-record is written at preemption time. The provenance fields (`PreemptedBy`, `PreemptMode`, `PreemptQOS`) are visible in `scontrol show job` while the job is suspended, but are cleared on `JobResume` so that a subsequent normal completion is not miscounted as a preemption in accounting.

Result: `sacct` has no record of the preemption for suspend-mode jobs. The accounting row for that run shows the final completion state only. Requeue and cancel are unaffected — both emit an accounting end-record (`PREEMPTED`) at the moment of preemption.

## What this PR does

Adds a note to the preemption section of the monitoring guide explaining this behaviour explicitly, so users understand what to expect when querying `sacct` for suspend-preempted jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)