### PR TITLE
fix(spurctld): reject submits from users with no account association

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -490,6 +490,11 @@ pub struct AccountingConfig {
     /// chain. Mirrors Slurm's `AccountingStorageEnforce=qos`. Default false.
     #[serde(default)]
     pub require_qos: bool,
+    /// Reject at submit any job whose user resolves to no account at all
+    /// (no `--account` given and no default account on file). Mirrors Slurm's
+    /// `AccountingStorageEnforce=associations`. Default false.
+    #[serde(default)]
+    pub require_association: bool,
     /// Delete `txn` audit-log rows older than this many days. `None` (default)
     /// or `0` disables purging (rows kept forever, matching Slurm's default-off
     /// behavior); a positive value enables the periodic purge.
@@ -513,6 +518,7 @@ impl Default for AccountingConfig {
             grp_wall_window_days: default_grp_wall_window_days(),
             default_qos: String::new(),
             require_qos: false,
+            require_association: false,
             txn_retention_days: None,
         }
     }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -490,9 +490,8 @@ pub struct AccountingConfig {
     /// chain. Mirrors Slurm's `AccountingStorageEnforce=qos`. Default false.
     #[serde(default)]
     pub require_qos: bool,
-    /// Reject at submit any job whose user resolves to no account at all
-    /// (no `--account` given and no default account on file). Mirrors Slurm's
-    /// `AccountingStorageEnforce=associations`. Default false.
+    /// Reject at submit any job whose user resolves to no account at all.
+    /// Mirrors Slurm's `AccountingStorageEnforce=associations`. Default false.
     #[serde(default)]
     pub require_association: bool,
     /// Delete `txn` audit-log rows older than this many days. `None` (default)

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -569,7 +569,7 @@ impl ClusterManager {
             config.scheduler.default_time_limit_minutes,
         );
         apply_default_account(&mut spec, &self.association_cache);
-        validate_user_account(&spec, &self.association_cache)?;
+        validate_user_account(&spec, &self.association_cache, &config.accounting)?;
         // Default QoS must resolve before the partition ACL, or `allow_qos` sees
         // an empty QoS and wrongly rejects a user's inherited default.
         apply_default_qos(
@@ -839,7 +839,11 @@ impl ClusterManager {
                     "job_submit hook modified spec"
                 );
                 if changes.partition.is_some() || changes.account.is_some() {
-                    validate_user_account(spec, &self.association_cache)?;
+                    validate_user_account(
+                        spec,
+                        &self.association_cache,
+                        &self.config().accounting,
+                    )?;
                     self.validate_partition_node_bounds(spec, partitions)?;
                 }
                 // Existence is enforced first: an unknown QOS silently resolves
@@ -7051,12 +7055,26 @@ fn apply_default_account(spec: &mut JobSpec, assoc_cache: &AssociationCache) {
     }
 }
 
-/// Reject a client-supplied account that is not a real user→account association.
+/// Reject a client-supplied account that is not a real user→account association,
+/// and, when `require_association` is set, a submit that resolved to no account
+/// at all (no `--account` and no default account on file for the user).
+/// Unconditional like `require_qos`'s final check, not gated on cache load state:
+/// an admin enabling this setting without accounting fully up is expected to see
+/// every submission rejected, the same way `require_qos` behaves today.
 fn validate_user_account(
     spec: &JobSpec,
     assoc_cache: &AssociationCache,
+    accounting: &spur_core::config::AccountingConfig,
 ) -> Result<(), SubmitError> {
     let Some(account) = spec.account.as_deref().filter(|a| !a.is_empty()) else {
+        if accounting.require_association {
+            return Err(SubmitError::invalid(format!(
+                "no account resolved for user '{}' (no --account given and no default account on file). \
+                 Specify --account explicitly, or contact your cluster admin to set a default: \
+                 sacctmgr modify user name={} set defaultaccount=<account>",
+                spec.user, spec.user
+            )));
+        }
         return Ok(());
     };
     match assoc_cache.account_membership(&spec.user, account) {
@@ -19115,6 +19133,106 @@ mod tests {
 
         super::apply_default_account(&mut spec, &assoc);
         assert_eq!(spec.account.as_deref(), Some("faculty"));
+    }
+
+    // --- validate_user_account / require_association tests ---
+
+    fn acct_cfg_with_require_association(
+        require_association: bool,
+    ) -> spur_core::config::AccountingConfig {
+        spur_core::config::AccountingConfig {
+            require_association,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn validate_user_account_allows_no_account_when_require_association_off() {
+        let assoc = AssociationCache::new();
+        let spec = basic_spec("j");
+        assert!(spec.account.is_none());
+
+        super::validate_user_account(&spec, &assoc, &acct_cfg_with_require_association(false))
+            .unwrap();
+    }
+
+    #[test]
+    fn validate_user_account_rejects_no_account_when_require_association_on() {
+        let assoc = AssociationCache::new();
+        assoc.insert_association("someone-else", "research"); // loads the cache
+        let spec = basic_spec("j");
+        assert!(spec.account.is_none());
+
+        let err =
+            super::validate_user_account(&spec, &assoc, &acct_cfg_with_require_association(true))
+                .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("no account resolved for user 'testuser'"));
+    }
+
+    #[test]
+    fn validate_user_account_rejects_no_account_even_when_user_has_associations_but_no_default() {
+        // A real reachable state: the user has an association, but no account is
+        // flagged as their default (e.g. an admin cleared it), and no --account
+        // was given. The message must not claim "no account associations" here,
+        // since one exists -- it just isn't resolvable without -A.
+        let assoc = AssociationCache::new();
+        assoc.insert_association("testuser", "research");
+        let spec = basic_spec("j");
+        assert!(spec.account.is_none());
+
+        let err =
+            super::validate_user_account(&spec, &assoc, &acct_cfg_with_require_association(true))
+                .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no account resolved for user 'testuser'"));
+        assert!(!msg.contains("has no account associations"));
+    }
+
+    #[test]
+    fn validate_user_account_allows_resolved_default_account_when_require_association_on() {
+        let assoc = AssociationCache::new();
+        assoc.insert_default_account("testuser", "research");
+        assoc.insert_association("testuser", "research");
+        let mut spec = basic_spec("j");
+        super::apply_default_account(&mut spec, &assoc);
+        assert_eq!(spec.account.as_deref(), Some("research"));
+
+        super::validate_user_account(&spec, &assoc, &acct_cfg_with_require_association(true))
+            .unwrap();
+    }
+
+    #[test]
+    fn validate_user_account_rejects_no_account_even_when_cache_unloaded() {
+        // Unconditional like `require_qos`'s final check: an admin who turns
+        // this on without accounting fully up should see submissions rejected,
+        // not silently pass through.
+        let assoc = AssociationCache::new();
+        let spec = basic_spec("j");
+        assert!(!assoc.is_loaded());
+
+        let err =
+            super::validate_user_account(&spec, &assoc, &acct_cfg_with_require_association(true))
+                .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("no account resolved for user 'testuser'"));
+    }
+
+    #[test]
+    fn validate_user_account_still_rejects_bad_explicit_account_when_require_association_on() {
+        let assoc = AssociationCache::new();
+        assoc.insert_association("testuser", "research");
+        let mut spec = basic_spec("j");
+        spec.account = Some("other".into());
+
+        let err =
+            super::validate_user_account(&spec, &assoc, &acct_cfg_with_require_association(true))
+                .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("is not associated with account 'other'"));
     }
 
     #[test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -7055,12 +7055,8 @@ fn apply_default_account(spec: &mut JobSpec, assoc_cache: &AssociationCache) {
     }
 }
 
-/// Reject a client-supplied account that is not a real user→account association,
-/// and, when `require_association` is set, a submit that resolved to no account
-/// at all (no `--account` and no default account on file for the user).
-/// Unconditional like `require_qos`'s final check, not gated on cache load state:
-/// an admin enabling this setting without accounting fully up is expected to see
-/// every submission rejected, the same way `require_qos` behaves today.
+/// Reject a client-supplied account that is not a real association, and, when
+/// `require_association` is set, a submit resolving to no account at all (unconditional, like `require_qos`'s final check).
 fn validate_user_account(
     spec: &JobSpec,
     assoc_cache: &AssociationCache,
@@ -7068,8 +7064,13 @@ fn validate_user_account(
 ) -> Result<(), SubmitError> {
     let Some(account) = spec.account.as_deref().filter(|a| !a.is_empty()) else {
         if accounting.require_association {
+            let hint = if assoc_cache.is_loaded() {
+                ""
+            } else {
+                QOS_ACCOUNTING_HINT
+            };
             return Err(SubmitError::invalid(format!(
-                "no account resolved for user '{}' (no --account given and no default account on file). \
+                "no account resolved for user '{}' (no --account given and no default account on file){hint}. \
                  Specify --account explicitly, or contact your cluster admin to set a default: \
                  sacctmgr modify user name={} set defaultaccount=<account>",
                 spec.user, spec.user
@@ -19173,10 +19174,7 @@ mod tests {
 
     #[test]
     fn validate_user_account_rejects_no_account_even_when_user_has_associations_but_no_default() {
-        // A real reachable state: the user has an association, but no account is
-        // flagged as their default (e.g. an admin cleared it), and no --account
-        // was given. The message must not claim "no account associations" here,
-        // since one exists -- it just isn't resolvable without -A.
+        // A real reachable state: an association exists but none is flagged default.
         let assoc = AssociationCache::new();
         assoc.insert_association("testuser", "research");
         let spec = basic_spec("j");
@@ -19205,9 +19203,7 @@ mod tests {
 
     #[test]
     fn validate_user_account_rejects_no_account_even_when_cache_unloaded() {
-        // Unconditional like `require_qos`'s final check: an admin who turns
-        // this on without accounting fully up should see submissions rejected,
-        // not silently pass through.
+        // Unconditional like `require_qos`'s final check, but hints at the cold cache.
         let assoc = AssociationCache::new();
         let spec = basic_spec("j");
         assert!(!assoc.is_loaded());
@@ -19215,9 +19211,9 @@ mod tests {
         let err =
             super::validate_user_account(&spec, &assoc, &acct_cfg_with_require_association(true))
                 .unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("no account resolved for user 'testuser'"));
+        let msg = err.to_string();
+        assert!(msg.contains("no account resolved for user 'testuser'"));
+        assert!(msg.contains("accounting may not be enabled"));
     }
 
     #[test]

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -83,6 +83,7 @@ disabled until ``database_url`` names a reachable PostgreSQL database.
    database_url = "postgresql://spur:spur@localhost/spur"
    default_qos = "normal"
    require_qos = false
+   require_association = false
    fairshare_refresh_secs = 300
    grp_wall_window_days = 14
 
@@ -103,6 +104,18 @@ disabled until ``database_url`` names a reachable PostgreSQL database.
 ``require_qos``
    Reject at submit any job that resolves to no QOS. Mirrors Slurm's
    ``AccountingStorageEnforce=qos``.
+
+   :Default: ``false``
+
+``require_association``
+   Reject at submit any job whose user resolves to no account — a submission
+   with no ``--account`` and no default account on file. This check is
+   unconditional, like ``require_qos``: it applies even before accounting has
+   finished loading, so enabling it without accounting fully configured
+   rejects every submission. Mirrors Slurm's
+   ``AccountingStorageEnforce=associations``. A submission naming an account
+   the user is not associated with is always rejected, regardless of this
+   setting.
 
    :Default: ``false``
 
@@ -699,6 +712,22 @@ Limits resolve in two layers:
 
 Associations are managed via ``add user`` and inspected via ``sacctmgr show
 user`` (see `Managing users`_).
+
+How a job's account is resolved
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+At submit, Spur resolves the job's account in this order, matching Slurm:
+
+1. **Explicit** ``--account`` on the job. It must name an account the user is
+   associated with, or the job is rejected — with ``user 'X' is not
+   associated with account 'Y'`` if the user has other associations, or
+   ``user 'X' has no account associations`` if the user has none at all.
+2. Otherwise the **user's default account**, if the user has one on file.
+3. Otherwise, if ``accounting.require_association`` is ``true``, the job is
+   **rejected** (``no account resolved for user 'X'``) — even if the user
+   does have associations, just none flagged as their default. If
+   ``require_association`` is ``false`` (the default), the job runs with no
+   account.
 
 TRES
 ----

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -112,10 +112,10 @@ disabled until ``database_url`` names a reachable PostgreSQL database.
    with no ``--account`` and no default account on file. This check is
    unconditional, like ``require_qos``: it applies even before accounting has
    finished loading, so enabling it without accounting fully configured
-   rejects every submission. Mirrors Slurm's
+   rejects every such submission. Mirrors Slurm's
    ``AccountingStorageEnforce=associations``. A submission naming an account
-   the user is not associated with is always rejected, regardless of this
-   setting.
+   the user is not associated with is rejected regardless of this setting,
+   once the association cache has loaded.
 
    :Default: ``false``
 
@@ -716,18 +716,23 @@ user`` (see `Managing users`_).
 How a job's account is resolved
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-At submit, Spur resolves the job's account in this order, matching Slurm:
+At submit, Spur resolves the job's account in this order, matching Slurm.
+This validation is skipped (fail-open) while the association cache has not
+yet loaded, e.g. at controller startup or while the accounting database is
+unreachable:
 
-1. **Explicit** ``--account`` on the job. It must name an account the user is
-   associated with, or the job is rejected — with ``user 'X' is not
-   associated with account 'Y'`` if the user has other associations, or
-   ``user 'X' has no account associations`` if the user has none at all.
+1. **Explicit** ``--account`` on the job. Once the association cache has
+   loaded, it must name an account the user is associated with, or the job
+   is rejected — with ``user 'X' is not associated with account 'Y'`` if the
+   user has other associations, or ``user 'X' has no account associations``
+   if the user has none at all.
 2. Otherwise the **user's default account**, if the user has one on file.
 3. Otherwise, if ``accounting.require_association`` is ``true``, the job is
    **rejected** (``no account resolved for user 'X'``) — even if the user
-   does have associations, just none flagged as their default. If
-   ``require_association`` is ``false`` (the default), the job runs with no
-   account.
+   does have associations, just none flagged as their default. This step is
+   unconditional, unlike step 1: it applies even before the association
+   cache has loaded. If ``require_association`` is ``false`` (the default),
+   the job runs with no account.
 
 TRES
 ----

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -318,6 +318,13 @@ in-process inside ``spurctld`` (served on port 6817) — there is no separate
      - Live
      - Reject at submit any job that still has no QOS after the resolution chain.
        Mirrors Slurm's ``AccountingStorageEnforce=qos``.
+   * - ``require_association``
+     - bool
+     - ``false``
+     - Live
+     - Reject at submit any job whose user resolves to no account: no
+       ``--account`` given and no default account on file. Unconditional, like
+       ``require_qos``. Mirrors Slurm's ``AccountingStorageEnforce=associations``.
    * - ``txn_retention_days``
      - integer
      - unset
@@ -327,7 +334,8 @@ in-process inside ``spurctld`` (served on port 6817) — there is no separate
        default purge-off behavior); a positive value enables it. See :doc:`accounting`.
 
 See :doc:`accounting` for how ``default_qos`` and ``require_qos`` interact with the
-per-job QOS resolution chain.
+per-job QOS resolution chain, and how ``require_association`` interacts with the
+per-job account resolution chain.
 
 ``[scheduler]``
 ---------------

--- a/docs/migration-from-slurm.rst
+++ b/docs/migration-from-slurm.rst
@@ -84,6 +84,8 @@ Accounting entities map directly from Slurm:
   ordering.
 - The ``[accounting] require_qos`` setting is the equivalent of Slurm's
   ``AccountingStorageEnforce=qos``.
+- The ``[accounting] require_association`` setting is the equivalent of Slurm's
+  ``AccountingStorageEnforce=associations``.
 - The ``default_qos`` setting is the equivalent of Slurm's fallback QOS.
 
 See :doc:`/admin-guide/accounting` for the accounting concept guide.


### PR DESCRIPTION
## Summary

A user with no account association at all could still submit and run jobs as long as they omitted `--account` — enforcement only fired when an explicit `--account` was given and invalid. `validate_user_account` only checked the association cache once an account had actually resolved (explicit or default); a user with neither had nothing to check against and fell through to accept.

Fix SPUR-209

## Approach

- Added `accounting.require_association: bool` (default `false`), same shape as the existing `require_qos`, mirroring Slurm's `AccountingStorageEnforce=associations`.
- `validate_user_account` now rejects a submit that resolves to no account at all when the flag is on. This check is unconditional, matching `require_qos`'s existing final check — it applies even before the association cache has finished loading, so enabling it without accounting fully configured fails closed rather than silently admitting jobs.
- The rejection message distinguishes "user has zero associations" from "user has associations but none flagged as default" (the two states look identical from `spec.account == None`, but the correct remediation differs — `sacctmgr add user` vs. setting a default account or passing `-A`).
- Updated both call sites (`submit_job` and the job_submit-hook re-validation path) to thread the accounting config through.
- Documented the new field and a "How a job's account is resolved" chain in the admin guide, alongside the existing QOS resolution-chain docs.

## Testing

- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean.
- `cargo test -p spurctld -p spur-core --locked` — all pass.
- New unit tests cover: flag off preserves today's behavior, flag on rejects a submit with no account, flag on still accepts a resolved default account, flag on rejects even with a cold/unloaded cache, flag on distinguishes the "has associations, no default" case from "zero associations", and the pre-existing explicit-bad-account rejection is untouched. Verified each new test fails against the pre-fix code before confirming it passes against the fix.
- Validated end-to-end on an isolated single-node deployment: confirmed a no-`--account` submission from an unassociated user is accepted with the flag off (today's behavior preserved), rejected with the flag on, and accepted again once an association + default account exist.