### PR TITLE
fix(spur-core): emit node-local load balancing for HA mesh k0s clusters

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -259,3 +259,4 @@ ServiceAccount
 konnectivity
 cryptokey
 VRRP
+reprovision

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -256,3 +256,6 @@ PDB
 unioned
 ANDed
 ServiceAccount
+konnectivity
+cryptokey
+VRRP

--- a/crates/spur-core/src/k0s.rs
+++ b/crates/spur-core/src/k0s.rs
@@ -65,6 +65,12 @@ mod local_path_tests {
 /// the underlay to leave room for WireGuard's ~50-byte overhead, avoiding fragmentation). Returns
 /// `None` for any `cni` other than `"calico"` (the k0s default, kube-router, needs no config file).
 /// `sans` are extra API-server certificate SANs (e.g. the control-plane's mesh + underlay IPs).
+///
+/// `cp_count` is the number of control planes. For a multi-CP (`cp_count > 1`) cluster there is no
+/// VIP that can float over WireGuard cryptokey routing, so each node needs a local balanced endpoint
+/// across all controllers: enabling node-local load balancing (EnvoyProxy) gives konnectivity a
+/// cluster-wide `:8132` endpoint instead of pinning every agent to one controller. Single-CP clusters
+/// do not need it.
 pub fn k0s_controller_config_yaml(
     cni: &str,
     pod_cidr: &str,
@@ -72,6 +78,7 @@ pub fn k0s_controller_config_yaml(
     cni_mtu: u16,
     api_address: &str,
     sans: &[String],
+    cp_count: usize,
 ) -> Option<String> {
     if cni != "calico" {
         return None;
@@ -97,6 +104,11 @@ pub fn k0s_controller_config_yaml(
     y.push_str("    calico:\n");
     y.push_str("      mode: bird\n");
     y.push_str(&format!("      mtu: {cni_mtu}\n"));
+    if cp_count > 1 {
+        y.push_str("    nodeLocalLoadBalancing:\n");
+        y.push_str("      enabled: true\n");
+        y.push_str("      type: EnvoyProxy\n");
+    }
     Some(y)
 }
 
@@ -178,6 +190,7 @@ mod k0s_config_tests {
             1450,
             "192.0.2.1",
             &["192.0.2.1".to_string(), "203.0.113.9".to_string()],
+            1,
         )
         .unwrap();
         assert!(y.contains("address: 192.0.2.1"));
@@ -197,9 +210,44 @@ mod k0s_config_tests {
             "198.51.100.0/24",
             1450,
             "192.0.2.1",
-            &[]
+            &[],
+            3,
         )
         .is_none());
+    }
+
+    #[test]
+    fn multi_cp_calico_enables_node_local_load_balancing() {
+        // Documentation-range addresses only (RFC 5737 TEST-NET); no real infrastructure IPs.
+        let y = k0s_controller_config_yaml(
+            "calico",
+            "192.0.2.0/24",
+            "198.51.100.0/24",
+            1450,
+            "192.0.2.1",
+            &["192.0.2.1".to_string()],
+            3,
+        )
+        .unwrap();
+        assert!(y.contains("nodeLocalLoadBalancing:"));
+        assert!(y.contains("enabled: true"));
+        assert!(y.contains("type: EnvoyProxy"));
+    }
+
+    #[test]
+    fn single_cp_calico_omits_node_local_load_balancing() {
+        // Documentation-range addresses only (RFC 5737 TEST-NET); no real infrastructure IPs.
+        let y = k0s_controller_config_yaml(
+            "calico",
+            "192.0.2.0/24",
+            "198.51.100.0/24",
+            1450,
+            "192.0.2.1",
+            &["192.0.2.1".to_string()],
+            1,
+        )
+        .unwrap();
+        assert!(!y.contains("nodeLocalLoadBalancing"));
     }
 }
 

--- a/crates/spur-core/src/k0s.rs
+++ b/crates/spur-core/src/k0s.rs
@@ -66,11 +66,9 @@ mod local_path_tests {
 /// `None` for any `cni` other than `"calico"` (the k0s default, kube-router, needs no config file).
 /// `sans` are extra API-server certificate SANs (e.g. the control-plane's mesh + underlay IPs).
 ///
-/// `cp_count` is the number of control planes. For a multi-CP (`cp_count > 1`) cluster there is no
-/// VIP that can float over WireGuard cryptokey routing, so each node needs a local balanced endpoint
-/// across all controllers: enabling node-local load balancing (EnvoyProxy) gives konnectivity a
-/// cluster-wide `:8132` endpoint instead of pinning every agent to one controller. Single-CP clusters
-/// do not need it.
+/// For a multi-CP cluster (`cp_count > 1`) no VIP can float over WireGuard cryptokey routing, so
+/// node-local load balancing (EnvoyProxy) is enabled to give konnectivity a cluster-wide balanced
+/// endpoint instead of pinning every agent to one controller.
 pub fn k0s_controller_config_yaml(
     cni: &str,
     pod_cidr: &str,

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -776,9 +776,8 @@ async fn fetch_component_state(cluster: &ClusterManager, node: &str) -> Option<S
 }
 
 /// The mesh-native k0s controller config for `node` (api on its mesh IP + Calico bird), or None for
-/// the default kube-router mode (`cni != "calico"`) / a node without a mesh IP. `cp_count` is the
-/// number of control planes; a multi-CP cluster additionally enables node-local load balancing so
-/// konnectivity gets a cluster-wide endpoint over the mesh.
+/// the default kube-router mode (`cni != "calico"`) / a node without a mesh IP. `cp_count > 1` also
+/// enables node-local load balancing for konnectivity.
 fn controller_k0s_config(
     net: &ClusterNetworking,
     node: &spur_core::node::Node,

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -776,8 +776,14 @@ async fn fetch_component_state(cluster: &ClusterManager, node: &str) -> Option<S
 }
 
 /// The mesh-native k0s controller config for `node` (api on its mesh IP + Calico bird), or None for
-/// the default kube-router mode (`cni != "calico"`) / a node without a mesh IP.
-fn controller_k0s_config(net: &ClusterNetworking, node: &spur_core::node::Node) -> Option<String> {
+/// the default kube-router mode (`cni != "calico"`) / a node without a mesh IP. `cp_count` is the
+/// number of control planes; a multi-CP cluster additionally enables node-local load balancing so
+/// konnectivity gets a cluster-wide endpoint over the mesh.
+fn controller_k0s_config(
+    net: &ClusterNetworking,
+    node: &spur_core::node::Node,
+    cp_count: usize,
+) -> Option<String> {
     let api = node.k0s_mesh_ip.as_deref()?;
     // SANs: the mesh IP (advertised) + the underlay address (so `kubectl` over either works).
     let mut sans = vec![api.to_string()];
@@ -793,6 +799,7 @@ fn controller_k0s_config(net: &ClusterNetworking, node: &spur_core::node::Node) 
         net.cni_mtu,
         api,
         &sans,
+        cp_count,
     )
 }
 
@@ -818,6 +825,7 @@ async fn converge_provisioning(
         return (errors, HashSet::new());
     }
     let bootstrap = cluster.k0s_state().bootstrap();
+    let cp_count = cluster.k0s_state().controllers().len();
     let mut bootstrap_active = false;
     // Active control-plane nodes this tick: Ready is gated on their quorum (partial-Ready), not on
     // every worker being up.
@@ -841,7 +849,7 @@ async fn converge_provisioning(
         }
         // Mesh-native cluster: generate the k0s config (api on the mesh IP + Calico bird) when
         // cni=calico; None keeps the default kube-router. The bootstrap seeds etcd — no join token.
-        let k0s_config = controller_k0s_config(net, node);
+        let k0s_config = controller_k0s_config(net, node, cp_count);
         spawn_start_component(cluster, &node.name, role, None, k0s_config, None);
     }
     // Don't mint join tokens for secondary CPs / workers until the bootstrap's etcd is seeded and its
@@ -881,7 +889,7 @@ async fn converge_provisioning(
         };
         // A secondary control-plane also needs its own generated k0s config (API SANs on its mesh IP).
         let k0s_config = if role == K0sRole::Controller {
-            controller_k0s_config(net, node)
+            controller_k0s_config(net, node, cp_count)
         } else {
             None
         };

--- a/docs/deployment/managed-kubernetes.rst
+++ b/docs/deployment/managed-kubernetes.rst
@@ -145,15 +145,19 @@ cannot follow WireGuard cryptokey routing — so ``spur k8s up`` enables k0s
 node-local load balancing (``nodeLocalLoadBalancing`` with ``EnvoyProxy``) on
 every control plane. This gives each node a local Envoy that round-robins across
 all controllers, so konnectivity has a cluster-wide ``:8132`` endpoint instead of
-pinning every agent to a single controller. It is on automatically for 3/5
-control planes and off for a single control plane (no balancing needed).
+pinning every agent to a single controller. It is on automatically for any
+multi-control-plane count (today 3 or 5) and off for a single control plane (no
+balancing needed).
 
 .. note::
 
-   k0s does not hot-reload node-local load balancing. A fresh
-   ``spur k8s up --replicas 3`` is unaffected (controllers render the setting
-   before any worker joins), but flipping an **existing** cluster onto the fix
-   requires restarting the workers before their local Envoy starts.
+   k0s does not hot-reload node-local load balancing, and Spur only writes a
+   controller's ``k0s.yaml`` while bringing that controller up — an
+   already-active control plane is never rewritten in place. A fresh
+   ``spur k8s up --replicas 3`` is therefore unaffected (controllers render the
+   setting before any worker joins), but an **existing** HA cluster cannot pick
+   up the fix by restarting workers alone: reprovision the control plane with
+   ``spur k8s down --reset`` followed by ``spur k8s up``.
 
 Check status
 ~~~~~~~~~~~~~

--- a/docs/deployment/managed-kubernetes.rst
+++ b/docs/deployment/managed-kubernetes.rst
@@ -140,6 +140,21 @@ over ``--replicas``. The first control-plane node is the etcd bootstrap.
    scope the cluster to the whole inventory, which trivially satisfies this —
    any registered node is then a valid control-plane choice.
 
+On a multi-control-plane mesh cluster there is no floating VIP — a VRRP address
+cannot follow WireGuard cryptokey routing — so ``spur k8s up`` enables k0s
+node-local load balancing (``nodeLocalLoadBalancing`` with ``EnvoyProxy``) on
+every control plane. This gives each node a local Envoy that round-robins across
+all controllers, so konnectivity has a cluster-wide ``:8132`` endpoint instead of
+pinning every agent to a single controller. It is on automatically for 3/5
+control planes and off for a single control plane (no balancing needed).
+
+.. note::
+
+   k0s does not hot-reload node-local load balancing. A fresh
+   ``spur k8s up --replicas 3`` is unaffected (controllers render the setting
+   before any worker joins), but flipping an **existing** cluster onto the fix
+   requires restarting the workers before their local Envoy starts.
+
 Check status
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
## What this fixes

Fixes SPUR-198

HA k0s (`spur k8s up --replicas 3/5`) over the WireGuard mesh had no cluster-wide konnectivity endpoint. Each controller's generated k0s config set `spec.api.address` to its own mesh IP and nothing provided a cluster-scoped endpoint, so the leader-gated `konnectivity-agent` DaemonSet pinned to whichever single controller last held the lease. The agent needs `serverCount` distinct server IDs but only ever reached one, re-dialing that controller ~1/s forever. The other controllers received zero agents and logged `"No agent available"` at ~1900 lines/s — enough to fill the disk and cost etcd its quorum on a long-running cluster. Reads kept serving from the apiserver watch cache, so the cluster looked healthy (`phase: ready`) until it failed.

## Approach

A VIP cannot float over WireGuard's cryptokey routing, so k0s node-local load balancing (NLLB) is the fix rather than an `externalAddress`/VIP. On the calico (mesh-native) path, when the cluster has more than one control plane, the generated config now emits:

```yaml
spec:
  network:
    nodeLocalLoadBalancing:
      enabled: true
      type: EnvoyProxy
```

Each node then runs a local Envoy that round-robins konnectivity across all controllers on `:8132`. Single-CP clusters do not emit it (an Envoy per node is needless there).

The control-plane count is threaded from `converge_provisioning` through `controller_k0s_config` into `k0s_controller_config_yaml`. No `ClusterConfig` schema change and no proto change — NLLB is always-on for multi-CP mesh clusters, so there is no config surface that could re-enable the broken state.

## Caveat (documented)

k0s does not hot-reload NLLB. Flipping an *existing* cluster onto this fix requires restarting workers before their Envoy starts; a fresh `spur k8s up` is unaffected. This is documented in the managed-kubernetes admin page.

## Testing

- Unit (`k0s_config_tests`): multi-CP calico config contains the NLLB stanza; single-CP calico config omits it; existing calico assertions (api address, SANs, bird mode, CIDRs, MTU) and the kube-router `None` path unchanged.
- `cargo test --locked` — spur-core 576 passed / 0 failed, spurctld 871 passed / 0 failed.
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — no warnings.
- `cargo fmt --all -- --check` — clean.

## Out of scope

- The image logrotate defect (`su root syslog` missing) that turned the log noise into a disk-full outage — separate provisioning ticket.
- Extending the Ready gate / `spur k8s status` to detect konnectivity imbalance — optional follow-up.