### PR TITLE
fix(spurctld): count distinct nodes for the QoS group node limit (#709)

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -6683,12 +6683,32 @@ fn partition_limit_block(job: &Job, part: &Partition) -> Option<spur_core::job::
 
 fn sum_running_tres(jobs: &HashMap<JobId, Job>, pred: impl Fn(&Job) -> bool) -> TresRecord {
     let mut tres = TresRecord::new();
+    // Node TRES is the count of DISTINCT physical nodes the matching running
+    // jobs occupy (the union of their `allocated_nodes`), not the sum of each
+    // job's requested `num_nodes`. Slurm derives the association/QOS node usage
+    // from a per-assoc/QOS node bitmap, so a node shared by two of an
+    // account's/QOS's jobs counts once. Summing `num_nodes` double-counts a
+    // packed node and blocks work the node still has capacity for (ROCm/spur#709).
+    // CPU/Memory/GPU stay additive — those are consumed per job even on a
+    // shared node — so only Node is overridden below.
+    let mut distinct_nodes: HashSet<&str> = HashSet::new();
+    let mut unplaced_nodes: u64 = 0;
     for j in jobs.values() {
         if j.state != JobState::Running || !pred(j) {
             continue;
         }
         tres.add(&job_tres(j));
+        if j.allocated_nodes.is_empty() {
+            // Running job without recorded placement (transient/edge): fall back
+            // to its requested count so the limit is never under-counted.
+            unplaced_nodes += j.spec.num_nodes as u64;
+        } else {
+            distinct_nodes.extend(j.allocated_nodes.iter().map(String::as_str));
+        }
     }
+    // `job_tres` set Node to the summed `num_nodes` above; replace it with the
+    // real distinct-node occupancy.
+    tres.set(TresType::Node, distinct_nodes.len() as u64 + unplaced_nodes);
     tres
 }
 
@@ -15251,6 +15271,140 @@ mod tests {
             cm.get_job(j2).unwrap().pending_reason,
             PendingReason::AssocGrpNodeLimit
         );
+    }
+
+    #[test]
+    fn sum_running_tres_counts_distinct_nodes_not_summed_num_nodes() {
+        // ROCm/spur#709: two RUNNING jobs (num_nodes=2 each) that SHARE node n2
+        // (packing 1 GPU/node onto 8-GPU hosts). Summed num_nodes = 4, but the
+        // distinct-node union {n1,n2,n3} = 3. The node limit must charge 3.
+        let mut a = make_running_job(1, &["n1", "n2"], 1);
+        a.spec.num_nodes = 2;
+        let mut b = make_running_job(2, &["n2", "n3"], 1);
+        b.spec.num_nodes = 2;
+        let mut jobs = HashMap::new();
+        jobs.insert(1, a);
+        jobs.insert(2, b);
+
+        let tres = sum_running_tres(&jobs, |_| true);
+        assert_eq!(
+            tres.get(TresType::Node),
+            3,
+            "Node TRES must be distinct nodes {{n1,n2,n3}}=3, not summed num_nodes=4"
+        );
+    }
+
+    #[test]
+    fn sum_running_tres_falls_back_to_num_nodes_when_placement_missing() {
+        // A running job with no recorded placement (transient/edge) must not
+        // under-count the limit — fall back to its requested num_nodes.
+        let mut a = make_running_job(1, &[], 1);
+        a.spec.num_nodes = 2;
+        a.allocated_nodes.clear();
+        let mut b = make_running_job(2, &["n1"], 1);
+        b.spec.num_nodes = 1;
+        let mut jobs = HashMap::new();
+        jobs.insert(1, a);
+        jobs.insert(2, b);
+
+        let tres = sum_running_tres(&jobs, |_| true);
+        // Placed distinct {n1}=1 + unplaced fallback 2 = 3.
+        assert_eq!(tres.get(TresType::Node), 3);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn qos_grp_node_uses_distinct_allocated_nodes_not_summed_num_nodes() {
+        // ROCm/spur#709: QOS grp node=4. The QOS's running jobs share a node
+        // (packing), so distinct occupancy is 3 but summed num_nodes is 4. A new
+        // 1-node job must pack into the real headroom (3+1=4 <= 4), not be blocked
+        // by the phantom double-count (4+1=5).
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 64, 128000);
+        register_node(&cm, "n2", 64, 128000);
+        register_node(&cm, "n3", 64, 128000);
+
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Node, 4);
+        cm.qos_cache().insert(Qos {
+            name: "burst".into(),
+            limits: spur_core::accounting::QosLimits {
+                grp_tres: Some(grp),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        // Two running QOS jobs sharing n2: A={n1,n2}, B={n2,n3} -> distinct=3,
+        // summed num_nodes=4.
+        {
+            let mut jobs = cm.jobs.write();
+            for (id, nodes) in [(101u32, ["n1", "n2"]), (102, ["n2", "n3"])] {
+                let mut j = make_running_job(id, &nodes, 1);
+                j.spec.num_nodes = 2;
+                j.spec.qos = Some("burst".into());
+                jobs.insert(id, j);
+            }
+        }
+
+        let mut newjob = basic_spec("pack-me");
+        newjob.qos = Some("burst".into());
+        newjob.num_nodes = 1;
+        let new_id = submit_and_wait(&cm, newjob);
+
+        let pending: Vec<JobId> = cm.pending_jobs().iter().map(|j| j.job_id).collect();
+        assert!(
+            pending.contains(&new_id),
+            "1-node job must pack into distinct-node headroom (3+1=4 <= 4); \
+             summing num_nodes (4+1=5) wrongly blocks it on QOSGrpNodeLimit"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn qos_grp_node_still_blocks_when_distinct_cap_reached() {
+        // The distinct-node fix must not over-admit: with grp node=3 already fully
+        // occupied by distinct nodes {n1,n2,n3}, a job needing a 4th distinct node
+        // (num_nodes=4) is still blocked on QOSGrpNodeLimit.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        for n in ["n1", "n2", "n3", "n4"] {
+            register_node(&cm, n, 64, 128000);
+        }
+
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Node, 3);
+        cm.qos_cache().insert(Qos {
+            name: "burst".into(),
+            limits: spur_core::accounting::QosLimits {
+                grp_tres: Some(grp),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        {
+            let mut jobs = cm.jobs.write();
+            for (id, nodes) in [(101u32, ["n1", "n2"]), (102, ["n2", "n3"])] {
+                let mut j = make_running_job(id, &nodes, 1);
+                j.spec.num_nodes = 2;
+                j.spec.qos = Some("burst".into());
+                jobs.insert(id, j);
+            }
+        }
+
+        let mut newjob = basic_spec("too-big");
+        newjob.qos = Some("burst".into());
+        newjob.num_nodes = 4;
+        let new_id = submit_and_wait(&cm, newjob);
+
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(new_id).unwrap().pending_reason,
+            PendingReason::QosGrpNodeLimit,
+            "distinct occupancy 3 + requested 4 = 7 > grp cap 3 must still block"
+        );
+        let pending: Vec<JobId> = cm.pending_jobs().iter().map(|j| j.job_id).collect();
+        assert!(!pending.contains(&new_id));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -6683,14 +6683,8 @@ fn partition_limit_block(job: &Job, part: &Partition) -> Option<spur_core::job::
 
 fn sum_running_tres(jobs: &HashMap<JobId, Job>, pred: impl Fn(&Job) -> bool) -> TresRecord {
     let mut tres = TresRecord::new();
-    // Node TRES is the count of DISTINCT physical nodes the matching running
-    // jobs occupy (the union of their `allocated_nodes`), not the sum of each
-    // job's requested `num_nodes`. Slurm derives the association/QOS node usage
-    // from a per-assoc/QOS node bitmap, so a node shared by two of an
-    // account's/QOS's jobs counts once. Summing `num_nodes` double-counts a
-    // packed node and blocks work the node still has capacity for (ROCm/spur#709).
-    // CPU/Memory/GPU stay additive — those are consumed per job even on a
-    // shared node — so only Node is overridden below.
+    // Node TRES is the count of distinct nodes occupied (union of `allocated_nodes`), not summed
+    // `num_nodes` — a node packed by two jobs counts once. CPU/Memory/GPU stay additive.
     let mut distinct_nodes: HashSet<&str> = HashSet::new();
     let mut unplaced_nodes: u64 = 0;
     for j in jobs.values() {
@@ -15275,9 +15269,7 @@ mod tests {
 
     #[test]
     fn sum_running_tres_counts_distinct_nodes_not_summed_num_nodes() {
-        // ROCm/spur#709: two RUNNING jobs (num_nodes=2 each) that SHARE node n2
-        // (packing 1 GPU/node onto 8-GPU hosts). Summed num_nodes = 4, but the
-        // distinct-node union {n1,n2,n3} = 3. The node limit must charge 3.
+        // Two running jobs share node n2: summed num_nodes = 4, distinct union = 3.
         let mut a = make_running_job(1, &["n1", "n2"], 1);
         a.spec.num_nodes = 2;
         let mut b = make_running_job(2, &["n2", "n3"], 1);
@@ -15296,28 +15288,30 @@ mod tests {
 
     #[test]
     fn sum_running_tres_falls_back_to_num_nodes_when_placement_missing() {
-        // A running job with no recorded placement (transient/edge) must not
-        // under-count the limit — fall back to its requested num_nodes.
+        // An unplaced job (num_nodes=3, no recorded placement) must not under-count via the
+        // distinct-node union, so it still contributes its full requested count; the two placed
+        // jobs share n2, so their contribution is deduped to {n1,n2,n3}=3 rather than summed 2+2=4.
         let mut a = make_running_job(1, &[], 1);
-        a.spec.num_nodes = 2;
+        a.spec.num_nodes = 3;
         a.allocated_nodes.clear();
-        let mut b = make_running_job(2, &["n1"], 1);
-        b.spec.num_nodes = 1;
+        let mut b = make_running_job(2, &["n1", "n2"], 1);
+        b.spec.num_nodes = 2;
+        let mut c = make_running_job(3, &["n2", "n3"], 1);
+        c.spec.num_nodes = 2;
         let mut jobs = HashMap::new();
         jobs.insert(1, a);
         jobs.insert(2, b);
+        jobs.insert(3, c);
 
         let tres = sum_running_tres(&jobs, |_| true);
-        // Placed distinct {n1}=1 + unplaced fallback 2 = 3.
-        assert_eq!(tres.get(TresType::Node), 3);
+        // Unplaced fallback 3 + placed distinct {n1,n2,n3}=3 = 6, not summed 3+2+2=7.
+        assert_eq!(tres.get(TresType::Node), 6);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn qos_grp_node_uses_distinct_allocated_nodes_not_summed_num_nodes() {
-        // ROCm/spur#709: QOS grp node=4. The QOS's running jobs share a node
-        // (packing), so distinct occupancy is 3 but summed num_nodes is 4. A new
-        // 1-node job must pack into the real headroom (3+1=4 <= 4), not be blocked
-        // by the phantom double-count (4+1=5).
+        // QOS grp node=4, running jobs pack onto a shared node (distinct=3, summed=4); a new
+        // 1-node job must pack into the real headroom (3+1=4), not be blocked by the phantom 4+1=5.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "n1", 64, 128000);


### PR DESCRIPTION
Fixes #709.

## Problem

An account with a QoS `node=N` limit hits `QOSGrpNodeLimit` and stops scheduling even though its nodes have free GPUs. Root cause: the running-side node usage is the **sum of each running job's requested `num_nodes`**, not the count of **distinct physical nodes** the account/QoS actually occupies.

- `job_tres` sets `TresType::Node = job.spec.num_nodes` (`cluster.rs`).
- `sum_running_tres` accumulates `job_tres` over the account's/QoS's running jobs, so two jobs that share a physical node double-count it.
- That total is enforced in `qos.rs` (`qos_resource_breach`) and `account_limits.rs`.

`Job.allocated_nodes` (the real placement, set at `JobStart`) was available but unused by the accounting. Slurm counts the association/QoS node usage from a per-assoc node bitmap — a shared node counts once.

## Fix

In `sum_running_tres`, compute `Node` as the size of the **union of `allocated_nodes`** across the matching running jobs (a `HashSet`), overriding the summed value. CPU/Memory/GPU stay additive (they are consumed per job even on a shared node). A running job with no recorded placement falls back to its requested `num_nodes` so the limit is never under-counted. Single choke point — one function, no signature change — so all three running-side consumers (QoS grp, QoS per-user, account grp) are corrected at once. The pending side and `PassReservations` deliberately keep `num_nodes` (an unplaced job has no placement to union against).

## Tests

- `sum_running_tres_counts_distinct_nodes_not_summed_num_nodes` — two running jobs `{n1,n2}`+`{n2,n3}` → Node = 3, not 4.
- `sum_running_tres_falls_back_to_num_nodes_when_placement_missing` — unplaced running job counts its requested nodes.
- `qos_grp_node_uses_distinct_allocated_nodes_not_summed_num_nodes` — end-to-end #709 repro through `pending_jobs()`: grp `node=4`, running jobs share a node (distinct=3), a new 1-node job is admitted (3+1=4 ≤ 4) instead of blocked (phantom 4+1=5).
- `qos_grp_node_still_blocks_when_distinct_cap_reached` — guards against over-admitting.

The two repro tests were confirmed to fail before the change and pass after.

## Scope / follow-up

Resolves the running-side over-count (the reporter's stated scenario). It does **not** cover the pure-packing case where the account already sits at the full distinct-node cap and a new job would land *only* on already-counted nodes (needing 0 new distinct nodes) — that requires making the pending side overlap-aware, i.e. selecting candidate nodes before the limit re-check, an inversion of the current gate-before-select ordering. Correctly a follow-up. Distinct from #439 (GPU-per-node not tracked for QoS/fairshare), though both surface as "nodes look full while GPUs are free."