### PR TITLE
fix: use checked arithmetic for CIDR prefixes and token TTLs

### DIFF
--- a/crates/spur-cli/src/net.rs
+++ b/crates/spur-cli/src/net.rs
@@ -453,7 +453,49 @@ fn cmd_mesh(
 /// Given an IP and prefix length, compute the network address.
 fn address_network(ip: &str, prefix_len: u8) -> Result<String> {
     let addr: Ipv4Addr = ip.parse().context("invalid IP address")?;
-    let mask = !((1u32 << (32 - prefix_len)) - 1);
+    if prefix_len > 32 {
+        bail!("invalid prefix length /{}, expected 0-32", prefix_len);
+    }
+    // A /0 has no network bits, and shifting a u32 by a full 32 would overflow.
+    let mask = if prefix_len == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix_len)
+    };
     let network = u32::from(addr) & mask;
     Ok(Ipv4Addr::from(network).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn address_network_masks_host_bits() {
+        assert_eq!(address_network("10.42.7.9", 24).unwrap(), "10.42.7.0");
+        assert_eq!(address_network("10.42.7.9", 16).unwrap(), "10.42.0.0");
+        assert_eq!(address_network("10.42.7.130", 25).unwrap(), "10.42.7.128");
+        assert_eq!(address_network("10.42.7.9", 32).unwrap(), "10.42.7.9");
+    }
+
+    /// A /0 shifts the mask by 32 bits, which is where the unchecked shift
+    /// overflowed instead of yielding the empty mask.
+    #[test]
+    fn address_network_handles_zero_prefix() {
+        assert_eq!(address_network("10.42.7.9", 0).unwrap(), "0.0.0.0");
+    }
+
+    /// Above /32 the `32 - prefix_len` subtraction underflowed before the shift
+    /// was ever reached, so the length is now rejected up front.
+    #[test]
+    fn address_network_rejects_prefix_above_32() {
+        assert!(address_network("10.42.7.9", 33).is_err());
+        assert!(address_network("10.42.7.9", u8::MAX).is_err());
+    }
+
+    #[test]
+    fn address_network_rejects_malformed_addresses() {
+        assert!(address_network("not-an-ip", 24).is_err());
+        assert!(address_network("::1", 24).is_err());
+    }
 }

--- a/crates/spur-cli/src/net.rs
+++ b/crates/spur-cli/src/net.rs
@@ -474,6 +474,7 @@ mod tests {
     fn address_network_masks_host_bits() {
         assert_eq!(address_network("10.42.7.9", 24).unwrap(), "10.42.7.0");
         assert_eq!(address_network("10.42.7.9", 16).unwrap(), "10.42.0.0");
+        assert_eq!(address_network("10.42.7.9", 8).unwrap(), "10.0.0.0");
         assert_eq!(address_network("10.42.7.130", 25).unwrap(), "10.42.7.128");
         assert_eq!(address_network("10.42.7.9", 32).unwrap(), "10.42.7.9");
     }
@@ -496,6 +497,7 @@ mod tests {
     #[test]
     fn address_network_rejects_malformed_addresses() {
         assert!(address_network("not-an-ip", 24).is_err());
+        assert!(address_network("10.42.7", 24).is_err());
         assert!(address_network("::1", 24).is_err());
     }
 }

--- a/crates/spur-cli/src/token.rs
+++ b/crates/spur-cli/src/token.rs
@@ -3,7 +3,7 @@
 
 //! `spur token` subcommands for admission token management.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 use spur_proto::proto::{CreateTokenRequest, ListTokensRequest, RevokeTokenRequest};
@@ -117,17 +117,21 @@ fn cmd_user_token(user: &str, admin: bool, ttl: Option<String>, config_path: &st
 
 fn parse_ttl(s: &str) -> Result<u32> {
     let s = s.trim();
-    if let Some(days) = s.strip_suffix('d') {
-        Ok(days.parse::<u32>()? * 86400)
+    let (value, unit_secs) = if let Some(days) = s.strip_suffix('d') {
+        (days, 86400)
     } else if let Some(hours) = s.strip_suffix('h') {
-        Ok(hours.parse::<u32>()? * 3600)
+        (hours, 3600)
     } else if let Some(mins) = s.strip_suffix('m') {
-        Ok(mins.parse::<u32>()? * 60)
+        (mins, 60)
     } else if let Some(secs) = s.strip_suffix('s') {
-        Ok(secs.parse::<u32>()?)
+        (secs, 1)
     } else {
-        Ok(s.parse::<u32>()?)
-    }
+        (s, 1)
+    };
+    value
+        .parse::<u32>()?
+        .checked_mul(unit_secs)
+        .with_context(|| format!("TTL {} exceeds {} seconds", s, u32::MAX))
 }
 
 async fn cmd_create(controller: &str, ttl: Option<String>) -> Result<()> {
@@ -177,4 +181,40 @@ async fn cmd_revoke(controller: &str, token_id: &str) -> Result<()> {
         .await?;
     println!("Token {} revoked.", token_id);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ttl_expands_each_suffix() {
+        assert_eq!(parse_ttl("30s").unwrap(), 30);
+        assert_eq!(parse_ttl("5m").unwrap(), 300);
+        assert_eq!(parse_ttl("2h").unwrap(), 7_200);
+        assert_eq!(parse_ttl("1d").unwrap(), 86_400);
+        assert_eq!(parse_ttl("90").unwrap(), 90, "bare value is seconds");
+    }
+
+    /// 50000d is 4.32e9 seconds, past u32, where the unchecked multiply wrapped
+    /// to roughly 290 days and silently issued a shorter-lived token.
+    #[test]
+    fn parse_ttl_rejects_values_that_overflow() {
+        assert!(parse_ttl("50000d").is_err());
+        assert!(parse_ttl("2000000h").is_err());
+        assert!(parse_ttl("100000000m").is_err());
+        assert_eq!(
+            parse_ttl("4294967295").unwrap(),
+            u32::MAX,
+            "the ceiling still parses"
+        );
+    }
+
+    #[test]
+    fn parse_ttl_rejects_non_numeric_values() {
+        assert!(parse_ttl("").is_err());
+        assert!(parse_ttl("abc").is_err());
+        assert!(parse_ttl("-1h").is_err());
+        assert!(parse_ttl("1.5h").is_err());
+    }
 }

--- a/crates/spur-cli/src/token.rs
+++ b/crates/spur-cli/src/token.rs
@@ -194,6 +194,7 @@ mod tests {
         assert_eq!(parse_ttl("2h").unwrap(), 7_200);
         assert_eq!(parse_ttl("1d").unwrap(), 86_400);
         assert_eq!(parse_ttl("90").unwrap(), 90, "bare value is seconds");
+        assert_eq!(parse_ttl("  7h  ").unwrap(), 25_200, "padding is trimmed");
     }
 
     /// 50000d is 4.32e9 seconds, past u32, where the unchecked multiply wrapped
@@ -216,5 +217,6 @@ mod tests {
         assert!(parse_ttl("abc").is_err());
         assert!(parse_ttl("-1h").is_err());
         assert!(parse_ttl("1.5h").is_err());
+        assert!(parse_ttl("h").is_err());
     }
 }

--- a/crates/spur-net/src/address.rs
+++ b/crates/spur-net/src/address.rs
@@ -62,9 +62,12 @@ impl AddressPool {
         let prefix_len: u8 = prefix_str
             .parse()
             .map_err(|_| AddressError::InvalidCidr(cidr.into()))?;
-        if prefix_len > 30 {
+        // A /0 would shift the mask below by a full 32 bits, and would do the
+        // same to `allocate`'s host_bits; the pool also needs host bits to hand
+        // out, which is what bounds the other end.
+        if prefix_len == 0 || prefix_len > 30 {
             return Err(AddressError::InvalidCidr(
-                "prefix length must be <= 30".into(),
+                "prefix length must be between 1 and 30".into(),
             ));
         }
         let base = u32::from(addr);
@@ -169,5 +172,19 @@ mod tests {
         assert!(AddressPool::new("not-a-cidr").is_err());
         assert!(AddressPool::new("10.0.0.0/33").is_err());
         assert!(AddressPool::new("10.0.0.0").is_err());
+    }
+
+    /// The prefix guard only bounded the top end, so a /0 reached an unchecked
+    /// 32-bit shift instead of being rejected.
+    #[test]
+    fn test_zero_prefix_rejected() {
+        assert!(AddressPool::new("0.0.0.0/0").is_err());
+        assert!(AddressPool::new("10.0.0.0/0").is_err());
+    }
+
+    #[test]
+    fn test_widest_accepted_prefix_allocates() {
+        let mut pool = AddressPool::new("10.0.0.0/1").unwrap();
+        assert!(pool.allocate().is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Nine new tests covering `/0`, `/33` and `u8::MAX` prefixes alongside the valid `/8`, `/16`, `/24`, `/25` and `/32` masks and malformed addresses including a truncated IP; TTL suffix expansion with surrounding padding, overflow rejection, and rejection of non-numeric and bare-suffix input; and `/0` CIDR rejection plus the `/1` boundary that must still allocate. The last commit folds in four assertions that previously lived in #712, so that PR could drop these two files and stop overlapping with this one.

- `address_network` (`spur-cli/src/net.rs`) built its WireGuard netmask with `!((1u32 << (32 - prefix_len)) - 1)`. A `/0`, which `spur net join --prefix-len 0` accepts, shifted a u32 by a full 32 bits, and any prefix above `/32` underflowed the `32 - prefix_len` subtraction before the shift was even reached. The result feeds a peer's `allowed_ips`.
- `parse_ttl` (`spur-cli/src/token.rs`) multiplied without checking, so `spur token create --ttl 50000d` overflowed u32 and wrapped to roughly 290 days. The caller asked for ~137 years and got a much shorter-lived token with no error.
- `AddressPool::new` (`spur-net/src/address.rs`) bounded only the top of the prefix range, so a `/0` passed the guard and reached the same unchecked shift; `allocate` would have done the same to its `host_bits`. It is reachable from `spur net init --cidr 10.0.0.0/0`, and from config as well, since `is_valid_cidr` only checks `prefix <= 32`.

Closes #715

## Approach

- `net.rs`: validate the prefix length up front and mask with an explicit `/0` case. This is the same guard shape already used by `cidr_contains` in `spurctld/src/cluster_k8s.rs` (`prefix > 32` bail plus an explicit `prefix == 0`). `u32::MAX << (32 - n)` is arithmetically identical to the old expression for every valid `n`, including `/32`, so behavior is unchanged for input that already worked.
- `token.rs`: fold the four multiply branches into a single `checked_mul` that reports the overflow. `parse_ttl("4294967295")` still returns `u32::MAX`, so the accepted range is not narrowed — only the silent wrap is removed.
- `address.rs`: widen the existing prefix guard into a range instead of teaching the mask about an empty prefix. A pool needs host bits to hand out, which is what the upper bound already exists for, and one guard covers both overflow sites (`new`'s mask and `allocate`'s `host_bits`). Note that `/0` stays valid in `spur-cli`, where `0.0.0.0/0` is a legitimate `allowed_ips` default route — the two call sites genuinely want different answers.

## Testing

Nine new tests covering `/0`, `/33` and `u8::MAX` prefixes alongside the valid `/16`, `/24`, `/25` and `/32` masks and malformed addresses; TTL suffix expansion, overflow rejection and non-numeric rejection; and `/0` CIDR rejection plus the `/1` boundary that must still allocate.

Each new boundary test was verified to fail against the previous code, by reverting the production change and keeping the tests:

| Test | Failure without the fix |
|---|---|
| `address_network_handles_zero_prefix` | `net.rs:456` attempt to shift left with overflow |
| `address_network_rejects_prefix_above_32` | `net.rs:456` attempt to subtract with overflow |
| `parse_ttl_rejects_values_that_overflow` | `token.rs:121` attempt to multiply with overflow |
| `test_zero_prefix_rejected` | `address.rs:72` attempt to shift left with overflow |

- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — 0 warnings.
- `cargo build --all-targets --locked` — clean.
- `cargo test --locked` — 3144 passed, 0 failed.