### PR TITLE
feat(spur-core): WireGuard mesh + k0s lifecycle CLI for node add/remove

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -270,3 +270,4 @@ MTU
 drivable
 enablement
 AllowedIPs
+Deregister

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -265,3 +265,8 @@ cryptokey
 VRRP
 reprovision
 reconciler
+CSV
+MTU
+drivable
+enablement
+AllowedIPs

--- a/crates/spur-cli/src/net.rs
+++ b/crates/spur-cli/src/net.rs
@@ -96,6 +96,16 @@ pub enum NetCommand {
         #[arg(long, default_value = "spur0")]
         interface: String,
     },
+    /// Remove a peer from the running WireGuard interface by its public key (the counterpart to
+    /// add-peer; e.g. when a node leaves the mesh). Idempotent — removing an absent peer succeeds.
+    RemovePeer {
+        /// Peer's WireGuard public key
+        #[arg(long)]
+        key: String,
+        /// WireGuard interface name
+        #[arg(long, default_value = "spur0")]
+        interface: String,
+    },
     /// Apply a full-mesh peering from a membership file on the local node.
     ///
     /// Adds every other node as a direct peer with pod-CIDR-aware AllowedIPs,
@@ -172,6 +182,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             endpoint.as_deref(),
             &interface,
         ),
+        NetCommand::RemovePeer { key, interface } => cmd_remove_peer(&key, &interface),
         NetCommand::Mesh {
             config,
             self_ip,
@@ -359,6 +370,13 @@ fn cmd_add_peer(
     Ok(())
 }
 
+fn cmd_remove_peer(key: &str, interface: &str) -> Result<()> {
+    wireguard::remove_peer(interface, key)?;
+    eprintln!("Peer removed from {}:", interface);
+    eprintln!("  Public key: {}", key);
+    Ok(())
+}
+
 fn cmd_mesh(
     config: &Path,
     self_ip: &str,
@@ -499,5 +517,22 @@ mod tests {
         assert!(address_network("not-an-ip", 24).is_err());
         assert!(address_network("10.42.7", 24).is_err());
         assert!(address_network("::1", 24).is_err());
+    }
+
+    #[test]
+    fn parses_remove_peer_with_key_and_iface_default() {
+        let args = NetArgs::try_parse_from(["net", "remove-peer", "--key", "abc="]).unwrap();
+        match args.command {
+            NetCommand::RemovePeer { key, interface } => {
+                assert_eq!(key, "abc=");
+                assert_eq!(interface, "spur0");
+            }
+            _ => panic!("wrong command"),
+        }
+    }
+
+    #[test]
+    fn remove_peer_requires_key() {
+        assert!(NetArgs::try_parse_from(["net", "remove-peer"]).is_err());
     }
 }

--- a/crates/spur-net/src/wireguard.rs
+++ b/crates/spur-net/src/wireguard.rs
@@ -258,6 +258,45 @@ pub fn list_peers(interface: &str) -> anyhow::Result<Vec<String>> {
         .collect())
 }
 
+/// Map each peer's pubkey to its known underlay endpoint (`wg show <iface> endpoints`); peers with
+/// `(none)` are skipped. Lets the controller re-advertise worker↔worker endpoints in membership.
+pub fn peer_endpoints(
+    interface: &str,
+) -> anyhow::Result<std::collections::HashMap<String, String>> {
+    let output = Command::new("wg")
+        .args(["show", interface, "endpoints"])
+        .output()
+        .context("failed to run `wg show endpoints`")?;
+    if !output.status.success() {
+        bail!(
+            "wg show {interface} endpoints failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(parse_peer_endpoints(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
+
+/// Parse `wg show <iface> endpoints` stdout (tab-separated `<pubkey>\t<endpoint>` per line) into a
+/// pubkey→endpoint map. Peers with an empty or `(none)` endpoint are skipped. Split out from
+/// [`peer_endpoints`] so the parsing is unit-testable without invoking `wg`.
+fn parse_peer_endpoints(stdout: &str) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    for line in stdout.lines() {
+        let mut parts = line.split('\t');
+        let (Some(key), Some(endpoint)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        let (key, endpoint) = (key.trim(), endpoint.trim());
+        if key.is_empty() || endpoint.is_empty() || endpoint == "(none)" {
+            continue;
+        }
+        map.insert(key.to_string(), endpoint.to_string());
+    }
+    map
+}
+
 /// The public key of an existing WireGuard interface (`wg show <iface> public-key`).
 pub fn interface_public_key(interface: &str) -> anyhow::Result<String> {
     let output = Command::new("wg")
@@ -309,5 +348,49 @@ mod tests {
         };
         let ini = config.to_ini();
         assert!(!ini.contains("ListenPort"));
+    }
+
+    // Canned `wg show <iface> endpoints` stdout modeled on real testbed output
+    // (tab-separated `<pubkey>\t<endpoint>` per line), with keys/addresses replaced by
+    // placeholders and the documentation endpoint range (203.0.113.0/24, TEST-NET-3).
+    #[test]
+    fn test_parse_peer_endpoints_happy_path() {
+        let stdout = "peerAAA=\t203.0.113.1:51820\n\
+                      peerBBB=\t203.0.113.2:51820\n\
+                      peerCCC=\t203.0.113.3:51820\n";
+        let map = parse_peer_endpoints(stdout);
+        assert_eq!(map.len(), 3);
+        assert_eq!(
+            map.get("peerAAA=").map(String::as_str),
+            Some("203.0.113.1:51820")
+        );
+        assert_eq!(
+            map.get("peerCCC=").map(String::as_str),
+            Some("203.0.113.3:51820")
+        );
+    }
+
+    #[test]
+    fn test_parse_peer_endpoints_skips_none_and_malformed() {
+        // A peer with no established endpoint reports `(none)`; blank lines and lines
+        // without a tab separator must be ignored, not panic or produce empty entries.
+        let stdout = "peerAAA=\t203.0.113.1:51820\n\
+                      peerBBB=\t(none)\n\
+                      \n\
+                      malformed-no-tab\n\
+                      peerCCC=\t\n";
+        let map = parse_peer_endpoints(stdout);
+        assert_eq!(map.len(), 1);
+        assert_eq!(
+            map.get("peerAAA=").map(String::as_str),
+            Some("203.0.113.1:51820")
+        );
+        assert!(!map.contains_key("peerBBB="));
+        assert!(!map.contains_key("peerCCC="));
+    }
+
+    #[test]
+    fn test_parse_peer_endpoints_empty() {
+        assert!(parse_peer_endpoints("").is_empty());
     }
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -17598,6 +17598,7 @@ mod tests {
             cm.get_node("node-a").is_some() && cm.get_node("node-b").is_some()
         });
         let net = crate::cluster_k8s::ClusterNetworking {
+            wg_enabled: true,
             mesh_cidr: "10.44.0.0/16".into(),
             mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
@@ -17645,6 +17646,7 @@ mod tests {
 
     fn provision_net_calico() -> crate::cluster_k8s::ClusterNetworking {
         crate::cluster_k8s::ClusterNetworking {
+            wg_enabled: true,
             mesh_cidr: "10.44.0.0/16".into(),
             mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
@@ -17905,6 +17907,7 @@ mod tests {
         assert!(cm.get_node("node-a").and_then(|n| n.k0s_role).is_none());
 
         let net = crate::cluster_k8s::ClusterNetworking {
+            wg_enabled: true,
             mesh_cidr: "10.44.0.0/16".into(),
             mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
@@ -17925,6 +17928,7 @@ mod tests {
 
     fn k0s_test_net() -> crate::cluster_k8s::ClusterNetworking {
         crate::cluster_k8s::ClusterNetworking {
+            wg_enabled: true,
             mesh_cidr: "10.44.0.0/16".into(),
             mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
@@ -18020,6 +18024,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         let net = crate::cluster_k8s::ClusterNetworking {
+            wg_enabled: true,
             mesh_cidr: "10.44.0.0/16".into(),
             mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
@@ -18199,6 +18204,7 @@ mod tests {
         });
 
         let net = crate::cluster_k8s::ClusterNetworking {
+            wg_enabled: true,
             mesh_cidr: "10.44.0.0/16".into(),
             mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
@@ -18252,6 +18258,7 @@ mod tests {
         wait_for("scope recorded", || cm.k0s_state().member_nodes.len() == 2);
 
         let net = crate::cluster_k8s::ClusterNetworking {
+            wg_enabled: true,
             mesh_cidr: "10.44.0.0/16".into(),
             mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
@@ -18378,6 +18385,7 @@ mod tests {
         });
 
         let net = crate::cluster_k8s::ClusterNetworking {
+            wg_enabled: true,
             mesh_cidr: "10.44.0.0/16".into(),
             mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
@@ -18444,6 +18452,7 @@ mod tests {
         });
 
         let net = crate::cluster_k8s::ClusterNetworking {
+            wg_enabled: true,
             mesh_cidr: "10.44.0.0/16".into(),
             mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -17599,6 +17599,7 @@ mod tests {
         });
         let net = crate::cluster_k8s::ClusterNetworking {
             mesh_cidr: "10.44.0.0/16".into(),
+            mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
             service_cidr: "10.43.0.0/16".into(),
             cni_mtu: 1450,
@@ -17645,6 +17646,7 @@ mod tests {
     fn provision_net_calico() -> crate::cluster_k8s::ClusterNetworking {
         crate::cluster_k8s::ClusterNetworking {
             mesh_cidr: "10.44.0.0/16".into(),
+            mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
             service_cidr: "10.43.0.0/16".into(),
             cni_mtu: 1450,
@@ -17904,6 +17906,7 @@ mod tests {
 
         let net = crate::cluster_k8s::ClusterNetworking {
             mesh_cidr: "10.44.0.0/16".into(),
+            mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
             service_cidr: "10.43.0.0/16".into(),
             cni_mtu: 1450,
@@ -17923,6 +17926,7 @@ mod tests {
     fn k0s_test_net() -> crate::cluster_k8s::ClusterNetworking {
         crate::cluster_k8s::ClusterNetworking {
             mesh_cidr: "10.44.0.0/16".into(),
+            mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
             service_cidr: "10.43.0.0/16".into(),
             cni_mtu: 1450,
@@ -18017,6 +18021,7 @@ mod tests {
         let cm = test_cluster(&dir).await;
         let net = crate::cluster_k8s::ClusterNetworking {
             mesh_cidr: "10.44.0.0/16".into(),
+            mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
             service_cidr: "10.43.0.0/16".into(),
             cni_mtu: 1450,
@@ -18195,6 +18200,7 @@ mod tests {
 
         let net = crate::cluster_k8s::ClusterNetworking {
             mesh_cidr: "10.44.0.0/16".into(),
+            mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
             service_cidr: "10.43.0.0/16".into(),
             cni_mtu: 1450,
@@ -18247,6 +18253,7 @@ mod tests {
 
         let net = crate::cluster_k8s::ClusterNetworking {
             mesh_cidr: "10.44.0.0/16".into(),
+            mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
             service_cidr: "10.43.0.0/16".into(),
             cni_mtu: 1450,
@@ -18372,6 +18379,7 @@ mod tests {
 
         let net = crate::cluster_k8s::ClusterNetworking {
             mesh_cidr: "10.44.0.0/16".into(),
+            mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
             service_cidr: "10.43.0.0/16".into(),
             cni_mtu: 1450,
@@ -18437,6 +18445,7 @@ mod tests {
 
         let net = crate::cluster_k8s::ClusterNetworking {
             mesh_cidr: "10.44.0.0/16".into(),
+            mesh_interface: "spur0".into(),
             pod_cidr: "10.42.0.0/16".into(),
             service_cidr: "10.43.0.0/16".into(),
             cni_mtu: 1450,

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -38,6 +38,10 @@ const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 /// Network CIDRs the reconcile loop needs (from `[network]` + `[cluster]` config).
 #[derive(Clone, Debug)]
 pub struct ClusterNetworking {
+    /// Whether the WireGuard mesh is enabled (network.wg_enabled). Independent of `[cluster].enabled`:
+    /// a k0s cluster can run without the mesh, in which case the reconcile skips reading peer
+    /// endpoints from `wg` (nothing to advertise, and `wg show` would just error every tick).
+    pub wg_enabled: bool,
     /// WireGuard mesh CIDR (network.wg_cidr) — node mesh IPs are allocated from here.
     pub mesh_cidr: String,
     /// WireGuard interface name (network.wg_interface) — the controller reads its peer endpoints
@@ -92,7 +96,27 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>, net: Clust
         // reconcile_mesh is idempotent + prunes) so node-local drift (reboot, wg restart), a failed
         // push, and controller failover all self-heal. Only meaningful with ≥2 meshed nodes; the
         // membership diff gates only the log line, not the push.
-        let mesh = build_mesh_membership(&cluster, &net.mesh_cidr, &net.mesh_interface);
+        // build_mesh_membership shells out to `wg` (peer_endpoints); keep that off the async
+        // runtime with spawn_blocking, matching the agent side's apply_mesh handler.
+        let mesh = {
+            let cluster = cluster.clone();
+            let (wg_enabled, mesh_cidr, mesh_interface) = (
+                net.wg_enabled,
+                net.mesh_cidr.clone(),
+                net.mesh_interface.clone(),
+            );
+            match tokio::task::spawn_blocking(move || {
+                build_mesh_membership(&cluster, wg_enabled, &mesh_cidr, &mesh_interface)
+            })
+            .await
+            {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!(error = %e, "build_mesh_membership task panicked; skipping mesh push this tick");
+                    MeshMembership::default()
+                }
+            }
+        };
         if mesh.nodes.len() >= 2 {
             if mesh.nodes != last_mesh {
                 info!(
@@ -631,30 +655,34 @@ pub fn node_statuses(cluster: &ClusterManager) -> Vec<ClusterNodeStatus> {
 /// mesh (no pubkey) are skipped rather than fabricated, so an incomplete membership is never emitted.
 pub fn build_mesh_membership(
     cluster: &ClusterManager,
+    wg_enabled: bool,
     mesh_cidr: &str,
     mesh_interface: &str,
 ) -> MeshMembership {
-    // Snapshot the controller's own peer→endpoint table so worker↔worker peers get an endpoint
-    // (net join only wires worker→controller; without this the full mesh has no worker path).
-    // Log on failure instead of swallowing it: an empty table silently regresses the mesh to
-    // hub-and-spoke, so operators need the reason (wrong interface name, `wg` unavailable, etc.).
-    let endpoints = spur_net::wireguard::peer_endpoints(mesh_interface).unwrap_or_else(|e| {
-        warn!(
-            interface = %mesh_interface, error = %e,
-            "could not read WireGuard peer endpoints; mesh membership will omit them, so \
-             worker↔worker tunnels may fall back to hub-and-spoke"
-        );
+    // Peer endpoints only matter under WireGuard; when the mesh is off, skip the `wg` shell-out
+    // entirely (it would just error every reconcile tick). Otherwise snapshot the controller's
+    // peer→endpoint table so worker↔worker peers get an endpoint (net join only wires
+    // worker→controller). Log on failure — an empty table silently regresses to hub-and-spoke.
+    let endpoints = if wg_enabled {
+        spur_net::wireguard::peer_endpoints(mesh_interface).unwrap_or_else(|e| {
+            warn!(
+                interface = %mesh_interface, error = %e,
+                "could not read WireGuard peer endpoints; mesh membership will omit them, so \
+                 worker↔worker tunnels may fall back to hub-and-spoke"
+            );
+            std::collections::HashMap::new()
+        })
+    } else {
         std::collections::HashMap::new()
-    });
+    };
     mesh_from_nodes(cluster.get_nodes(), mesh_cidr, &endpoints)
 }
 
 /// Pure core of [`build_mesh_membership`] (testable without a `ClusterManager`).
 ///
-/// Includes any meshed node (non-empty `wg_pubkey`) with a known mesh IP — `k0s_mesh_ip` if it has
-/// a role, else its advertised mesh-interface address (the configured `network.wg_interface`,
-/// `spur0` by default) — so the controller/login nodes stay in membership and aren't pruned.
-/// `endpoints` supplies each peer's underlay endpoint for worker↔worker tunnels.
+/// Includes any meshed node (non-empty `wg_pubkey`) with a known mesh IP — its `k0s_mesh_ip` if it
+/// has a role, else its advertised address when that falls inside `mesh_cidr` — so controller/login
+/// nodes stay in membership. `endpoints` supplies each peer's underlay endpoint for worker↔worker.
 fn mesh_from_nodes(
     nodes: Vec<spur_core::node::Node>,
     mesh_cidr: &str,

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -40,6 +40,9 @@ const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 pub struct ClusterNetworking {
     /// WireGuard mesh CIDR (network.wg_cidr) — node mesh IPs are allocated from here.
     pub mesh_cidr: String,
+    /// WireGuard interface name (network.wg_interface) — the controller reads its peer endpoints
+    /// from this to re-advertise worker↔worker underlay endpoints in the mesh membership.
+    pub mesh_interface: String,
     /// Pod CIDR (cluster.pod_cidr) — per-node /24s are carved from here.
     pub pod_cidr: String,
     /// Service CIDR (cluster.service_cidr) — for the generated k0s config.
@@ -89,7 +92,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>, net: Clust
         // reconcile_mesh is idempotent + prunes) so node-local drift (reboot, wg restart), a failed
         // push, and controller failover all self-heal. Only meaningful with ≥2 meshed nodes; the
         // membership diff gates only the log line, not the push.
-        let mesh = build_mesh_membership(&cluster);
+        let mesh = build_mesh_membership(&cluster, &net.mesh_cidr, &net.mesh_interface);
         if mesh.nodes.len() >= 2 {
             if mesh.nodes != last_mesh {
                 info!(
@@ -626,27 +629,51 @@ pub fn node_statuses(cluster: &ClusterManager) -> Vec<ClusterNodeStatus> {
 /// the mesh — the controller is the source of truth for `MeshNode.public_key`/`pod_cidr`, which an
 /// operator feeds to `apply_mesh` on each node via `spur net mesh --config`. Nodes not yet on the
 /// mesh (no pubkey) are skipped rather than fabricated, so an incomplete membership is never emitted.
-pub fn build_mesh_membership(cluster: &ClusterManager) -> MeshMembership {
-    mesh_from_nodes(cluster.get_nodes())
+pub fn build_mesh_membership(
+    cluster: &ClusterManager,
+    mesh_cidr: &str,
+    mesh_interface: &str,
+) -> MeshMembership {
+    // Snapshot the controller's own peer→endpoint table so worker↔worker peers get an endpoint
+    // (net join only wires worker→controller; without this the full mesh has no worker path).
+    // Log on failure instead of swallowing it: an empty table silently regresses the mesh to
+    // hub-and-spoke, so operators need the reason (wrong interface name, `wg` unavailable, etc.).
+    let endpoints = spur_net::wireguard::peer_endpoints(mesh_interface).unwrap_or_else(|e| {
+        warn!(
+            interface = %mesh_interface, error = %e,
+            "could not read WireGuard peer endpoints; mesh membership will omit them, so \
+             worker↔worker tunnels may fall back to hub-and-spoke"
+        );
+        std::collections::HashMap::new()
+    });
+    mesh_from_nodes(cluster.get_nodes(), mesh_cidr, &endpoints)
 }
 
 /// Pure core of [`build_mesh_membership`] (testable without a `ClusterManager`).
-fn mesh_from_nodes(nodes: Vec<spur_core::node::Node>) -> MeshMembership {
+///
+/// Includes any meshed node (non-empty `wg_pubkey`) with a known mesh IP — `k0s_mesh_ip` if it has
+/// a role, else its advertised mesh-interface address (the configured `network.wg_interface`,
+/// `spur0` by default) — so the controller/login nodes stay in membership and aren't pruned.
+/// `endpoints` supplies each peer's underlay endpoint for worker↔worker tunnels.
+fn mesh_from_nodes(
+    nodes: Vec<spur_core::node::Node>,
+    mesh_cidr: &str,
+    endpoints: &std::collections::HashMap<String, String>,
+) -> MeshMembership {
     let mut nodes: Vec<MeshNode> = nodes
         .into_iter()
         .filter_map(|n| {
-            let mesh_ip = n.k0s_mesh_ip.clone()?;
             let public_key = n.wg_pubkey.clone().filter(|k| !k.is_empty())?;
+            let mesh_ip = match n.k0s_mesh_ip.clone() {
+                Some(ip) => ip,
+                None => real_mesh_address(&n, mesh_cidr).ok().flatten()?.to_string(),
+            };
+            let endpoint = endpoints.get(&public_key).cloned().unwrap_or_default();
             Some(MeshNode {
                 hostname: n.name,
                 public_key,
                 mesh_ip,
-                // No endpoint: Node.address is the agent's advertised address, which
-                // `detect_node_address` makes the *mesh* IP when WireGuard is up — not a valid WG
-                // underlay endpoint (using it would clobber the working tunnel). Empty makes
-                // apply_mesh preserve the endpoint `spur net join` already established; membership
-                // reconciliation only maintains peers + AllowedIPs, not the underlay tunnel.
-                endpoint: String::new(),
+                endpoint,
                 pod_cidr: n.k0s_pod_cidr.clone(),
             })
         })
@@ -1770,15 +1797,15 @@ mod tests {
                 Some("198.51.100.4"),
                 None,
             ),
-            // no mesh IP (not assigned) -> skip
+            // no k0s mesh IP and an out-of-mesh (underlay) address -> skip
             mesh_node("w5", None, Some("pk-w5"), Some("198.51.100.5"), None),
         ];
-        let m = mesh_from_nodes(nodes);
+        let m = mesh_from_nodes(nodes, "10.44.0.0/16", &std::collections::HashMap::new());
         assert_eq!(m.nodes.len(), 2, "only fully-meshed nodes included");
         // sorted by mesh_ip
         assert_eq!(m.nodes[0].mesh_ip, "10.44.0.1");
         assert_eq!(m.nodes[0].public_key, "pk-cp");
-        // endpoint is left empty on purpose — apply_mesh preserves the tunnel `spur net join` set.
+        // no endpoint known for this peer -> left empty; apply_mesh preserves the existing tunnel.
         assert_eq!(m.nodes[0].endpoint, "");
         assert_eq!(m.nodes[0].pod_cidr.as_deref(), Some("10.42.0.0/24"));
         assert_eq!(m.nodes[1].mesh_ip, "10.44.0.2");
@@ -1786,6 +1813,48 @@ mod tests {
         assert_eq!(
             spur_net::mesh::peer_allowed_ips(&m.nodes[1]),
             "10.44.0.2/32,10.42.1.0/24"
+        );
+    }
+
+    #[test]
+    fn mesh_membership_includes_meshed_node_without_k0s_role() {
+        // The controller/head (and login nodes) join the mesh via `net join` but never get a
+        // k0s role, so `k0s_mesh_ip`/`k0s_pod_cidr` are None. They must still be in the
+        // membership — derived from the mesh-range address they advertise — or the agent's
+        // reconcile prunes them and severs the control-plane path.
+        let nodes = vec![
+            // controller: meshed (pubkey + spur0 address in mesh range), no k0s role
+            mesh_node("cp", None, Some("pk-cp"), Some("10.44.0.1"), None),
+            // worker: assigned a k0s role
+            mesh_node(
+                "w2",
+                Some("10.44.0.2"),
+                Some("pk-w2"),
+                Some("10.44.0.2"),
+                Some("10.42.1.0/24"),
+            ),
+        ];
+        // Controller knows w2's underlay endpoint from its own peer table; it must be folded in.
+        let endpoints = std::collections::HashMap::from([(
+            "pk-w2".to_string(),
+            "198.51.100.2:51820".to_string(),
+        )]);
+        let m = mesh_from_nodes(nodes, "10.44.0.0/16", &endpoints);
+        assert_eq!(
+            m.nodes.len(),
+            2,
+            "controller kept despite having no k0s role"
+        );
+        assert_eq!(m.nodes[0].mesh_ip, "10.44.0.1");
+        assert_eq!(m.nodes[0].public_key, "pk-cp");
+        assert_eq!(m.nodes[0].pod_cidr, None);
+        // cp has no endpoint in the map -> empty; w2's underlay endpoint is carried through.
+        assert_eq!(m.nodes[0].endpoint, "");
+        assert_eq!(m.nodes[1].endpoint, "198.51.100.2:51820");
+        // /32-only peer: no pod CIDR folded in.
+        assert_eq!(
+            spur_net::mesh::peer_allowed_ips(&m.nodes[0]),
+            "10.44.0.1/32"
         );
     }
 }

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -276,6 +276,7 @@ async fn main() -> anyhow::Result<()> {
         let k8s_cluster = cluster.clone();
         let k8s_raft = raft_handle.clone();
         let k8s_net = cluster_k8s::ClusterNetworking {
+            wg_enabled: config.network.wg_enabled,
             mesh_cidr: config.network.wg_cidr.clone(),
             mesh_interface: config.network.wg_interface.clone(),
             pod_cidr: config.cluster.pod_cidr.clone(),

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -277,6 +277,7 @@ async fn main() -> anyhow::Result<()> {
         let k8s_raft = raft_handle.clone();
         let k8s_net = cluster_k8s::ClusterNetworking {
             mesh_cidr: config.network.wg_cidr.clone(),
+            mesh_interface: config.network.wg_interface.clone(),
             pod_cidr: config.cluster.pod_cidr.clone(),
             service_cidr: config.cluster.service_cidr.clone(),
             cni_mtu: config.cluster.cni_mtu,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2579,7 +2579,9 @@ impl SlurmAgent for AgentService {
         &self,
         request: Request<MeshMembership>,
     ) -> Result<Response<ApplyMeshResponse>, Status> {
-        let iface = std::env::var("SPUR_WG_INTERFACE").unwrap_or_else(|_| "spur0".into());
+        // Use the interface spurd resolved at startup (via the reporter), not a fresh env read
+        // that would ignore spur.conf and could diverge from the rest of spurd.
+        let iface = self.reporter.wg_iface.clone();
         // proto -> spur-net mesh types.
         let members: Vec<spur_net::mesh::MeshNode> = request
             .into_inner()

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -168,6 +168,15 @@ async fn main() -> anyhow::Result<()> {
     };
     let hooks_config = config.as_ref().map(|c| c.hooks.clone()).unwrap_or_default();
 
+    // WireGuard interface for mesh address/key/peers. Resolution: SPUR_WG_INTERFACE env >
+    // [network] wg_interface in spur.conf > "spur0", so a non-default conf name is honored.
+    let wg_iface = std::env::var("SPUR_WG_INTERFACE").ok().unwrap_or_else(|| {
+        config
+            .as_ref()
+            .map(|c| c.network.wg_interface.clone())
+            .unwrap_or_else(|| "spur0".into())
+    });
+
     // Background update check (non-blocking)
     spur_update::spawn_startup_check(
         "ROCm/spur",
@@ -226,9 +235,9 @@ async fn main() -> anyhow::Result<()> {
         }
     } else {
         let detect_hostname = hostname.clone();
-        let wg_interface = std::env::var("SPUR_WG_INTERFACE").unwrap_or_else(|_| "spur0".into());
+        let detect_iface = wg_iface.clone();
         tokio::task::spawn_blocking(move || {
-            spur_net::detect_node_address(&detect_hostname, listen_port, &wg_interface)
+            spur_net::detect_node_address(&detect_hostname, listen_port, &detect_iface)
         })
         .await
         .map_err(|e| anyhow::anyhow!("node address detection task failed: {e}"))?
@@ -266,9 +275,8 @@ async fn main() -> anyhow::Result<()> {
         })
         .collect();
 
-    // The WireGuard interface this node's mesh key is read from; the reporter re-reads the key on
-    // every register/heartbeat so the controller learns a key that appears/changes after startup.
-    let wg_iface = std::env::var("SPUR_WG_INTERFACE").unwrap_or_else(|_| "spur0".into());
+    // The reporter re-reads the mesh key from `wg_iface` (resolved above) each heartbeat, so a
+    // key that appears/changes after startup reaches the controller.
 
     // Shared between the reporter (reads held ids for heartbeats) and the agent
     // service (owns/mutates it) so the controller can reconcile stale allocations.

--- a/docs/deployment/ansible.rst
+++ b/docs/deployment/ansible.rst
@@ -99,14 +99,14 @@ Deployment shape is determined entirely by the inventory groups and the
      - One host in ``spur_controllers``, all compute in ``spur_agents``
      - LAN IP, unencrypted
    * - Multi-node, WireGuard mesh
-     - As above, plus ``spur_transport=wireguard`` (single controller only)
+     - As above, plus ``spur_transport=wireguard``
      - encrypted mesh on ``spur0``
    * - HA — multi-controller Raft
      - Odd N ≥ 3 hosts in ``spur_controllers``; auto-enabled
-     - direct
+     - direct, or wireguard (multi-controller mesh via spur-toolkit#23)
    * - HA — separate compute
      - ``spur_controllers`` and ``spur_agents`` are disjoint sets
-     - direct
+     - direct, or wireguard (via spur-toolkit#23)
 
 Single-node
 ~~~~~~~~~~~
@@ -162,8 +162,12 @@ WireGuard mesh. See :ref:`ansible-wireguard`.
 
 .. note::
 
-   WireGuard is **single-controller only** — the mesh has no multi-controller
-   command. HA therefore requires the ``direct`` transport.
+   The Ansible WireGuard role currently supports a **single controller** — for
+   multi-controller HA today, use the ``direct`` transport. Multi-controller HA
+   *over* WireGuard is added by `spur-toolkit#23
+   <https://github.com/ROCm/spur-toolkit/pull/23>`_ (not yet merged); see
+   :doc:`wireguard` for how that mesh forms (bootstrap ``net init`` + a full-mesh
+   ``net mesh`` pass wiring controller↔controller tunnels for Raft).
 
 HA — multi-controller Raft
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -300,9 +304,18 @@ only lasts until reboot).
 
 .. note::
 
-   HA (multiple controllers) is supported over WireGuard. For the full mesh story —
-   bring-up, why peer endpoints matter for worker↔worker connectivity, node removal,
-   HA, and k0s over the mesh — see :doc:`wireguard`.
+   The full WireGuard mesh story — bring-up, why peer endpoints matter for
+   worker↔worker connectivity, node removal, HA, and k0s over the mesh — is in
+   :doc:`wireguard`.
+
+.. note::
+
+   ``spur_wg_persist`` and the ``spur_k8s_*`` variables / k0s playbooks documented
+   in this and the following section ship in `spur-toolkit#23
+   <https://github.com/ROCm/spur-toolkit/pull/23>`_, which is not yet merged. On the
+   current toolkit ``main`` these variables are unconsumed and ``k8s_up.yml`` /
+   ``k8s_add_nodes.yml`` do not exist; drive ``spur k8s up`` / ``add-nodes``
+   directly (see :doc:`wireguard`) until #23 lands.
 
 SPUR-managed k0s cluster
 ------------------------

--- a/docs/deployment/ansible.rst
+++ b/docs/deployment/ansible.rst
@@ -292,9 +292,64 @@ The mesh defaults are ``spur_wg_cidr=10.44.0.0/16``, ``spur_wg_port=51820``, and
 ``spur_wg_interface=spur0``. The control node needs the ``ansible.utils`` collection and
 ``netaddr`` (see Prerequisites).
 
+The mesh interface is enabled as a ``wg-quick@<iface>`` systemd unit
+(``spur_wg_persist=true``, the default) so it is recreated on boot from
+``/etc/wireguard/<iface>.conf``; the controller's reconcile then re-pushes peer
+membership. Set ``spur_wg_persist=false`` to skip boot enablement (the interface then
+only lasts until reboot).
+
 .. note::
 
-   WireGuard is **single-controller only**; HA requires the ``direct`` transport.
+   HA (multiple controllers) is supported over WireGuard. For the full mesh story —
+   bring-up, why peer endpoints matter for worker↔worker connectivity, node removal,
+   HA, and k0s over the mesh — see :doc:`wireguard`.
+
+SPUR-managed k0s cluster
+------------------------
+
+Set ``spur_k8s_enabled=true`` to render the ``[cluster]`` section into the controller
+``spur.conf`` (pod/service CIDRs, CNI, MTU) so ``spur k8s up`` is drivable. Combine with
+``spur_transport=wireguard`` and ``spur_k8s_cni=calico`` to run pod traffic over the mesh
+(Calico ``bird`` native routing; the API is advertised on the control-plane mesh IP).
+
+.. code-block:: ini
+
+   [all:vars]
+   spur_transport=wireguard
+   spur_k8s_enabled=true
+   spur_k8s_pod_cidr=10.42.0.0/16
+   spur_k8s_service_cidr=10.43.0.0/16
+   spur_k8s_cni=calico
+   spur_k8s_control_plane_nodes=k8-master        # 1 name = single CP; 3 or 5 = HA (etcd quorum)
+   spur_k8s_nodes=k8-master,gpu-1                 # scope k0s to a subset; empty = whole inventory
+
+``spur_k8s_control_plane_nodes`` is a single CSV that covers both the single and HA cases: one
+name is a single control plane, three or five names form an HA control plane (the first is the
+etcd bootstrap). It is the k0s control plane and is independent of how many SPUR controllers
+(spurctld) run. For an HA k0s control plane, name each control-plane node explicitly
+(``spur_k8s_control_plane_nodes=cp1,cp2,cp3``); the ``[N-M]`` hostlist form is only expanded by
+``spur_k8s_nodes`` / ``--nodes``.
+
+Run ``deploy.yml`` first (so the controller is rendered with ``[cluster]``), then bring
+the cluster up and grow it:
+
+.. code-block:: bash
+
+   ansible-playbook playbooks/k8s_up.yml        -i inventory/hosts.ini
+   ansible-playbook playbooks/k8s_add_nodes.yml -i inventory/hosts.ini -e k8s_new_nodes=gpu-3
+
+``k8s_up.yml`` calls ``spur k8s up`` on the first controller and polls ``spur k8s status``
+until the cluster is ``ready`` (or fails on ``degraded``). ``k8s_add_nodes.yml`` wraps
+``spur k8s add-nodes`` for already-registered agents. The k0s binary is pre-installed by the
+``spur_agent`` role on each k0s-scoped node at deploy time (pinned ``spur_k8s_version``), so
+``spur k8s up`` does not wait on a runtime download.
+
+.. note::
+
+   When the spurctld controller is **not** itself a k0s node (a mesh-only head node),
+   set ``spur_k8s_control_plane_nodes`` to the intended k8s control-plane agent(s). The
+   controller still stays on the mesh — it is carried in the mesh membership even without
+   a k0s role, so the reconcile does not prune it.
 
 Key variables
 -------------
@@ -329,6 +384,24 @@ overrides:
    * - ``spur_wg_cidr``
      - ``10.44.0.0/16``
      - WireGuard mesh subnet.
+   * - ``spur_wg_persist``
+     - ``true``
+     - Enable ``wg-quick@<iface>`` so the mesh interface survives reboot.
+   * - ``spur_k8s_enabled``
+     - ``false``
+     - Render the ``[cluster]`` section and allow ``k8s_up.yml`` to run.
+   * - ``spur_k8s_pod_cidr`` / ``spur_k8s_service_cidr``
+     - ``10.42.0.0/16`` / ``10.43.0.0/16``
+     - k0s pod and service networks.
+   * - ``spur_k8s_cni``
+     - ``calico``
+     - ``calico`` (bird native routing over the mesh) or ``kuberouter`` (k0s default).
+   * - ``spur_k8s_control_plane_nodes``
+     - *(first controller)*
+     - CSV of k0s control-plane node names — one for a single CP, 3 or 5 for HA (etcd quorum).
+   * - ``spur_k8s_nodes``
+     - *(whole inventory)*
+     - Hostlist/CSV scoping the k0s cluster to a subset.
    * - ``spur_log_level``
      - ``info``
      - Daemon log verbosity.

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -126,6 +126,13 @@ LAN deployment):
 This sets up a WireGuard mesh, prints the server public key, and outputs a join command
 template for workers.
 
+.. note::
+
+   The steps below cover a single-controller mesh by hand. For the full mesh reference —
+   why ``net add-peer --endpoint`` is required for worker↔worker connectivity, node
+   removal with ``net remove-peer``, HA over the mesh, and k0s inside the mesh — see
+   :doc:`wireguard`.
+
 Create ``/etc/spur/spur.conf``. The repository includes ``examples/spur.conf`` with the
 full annotated set of fields. A minimal example:
 

--- a/docs/deployment/wireguard.rst
+++ b/docs/deployment/wireguard.rst
@@ -1,0 +1,163 @@
+========================
+WireGuard mesh clusters
+========================
+
+This is the authoritative, end-to-end guide to running a Spur cluster over an
+encrypted WireGuard mesh: mesh bring-up, why peer endpoints matter for
+worker-to-worker connectivity, online node removal, HA over the mesh, and
+bringing up a SPUR-managed k0s cluster inside the meshed cluster.
+
+The :doc:`ansible` and :doc:`native-host` pages show the mechanics (variables and
+by-hand commands respectively); this page is the conceptual reference they link
+to. When a mesh detail matters for correctness, it is explained here.
+
+Why a mesh (and why endpoints matter)
+======================================
+
+With ``[network] wg_enabled = true`` every node gets a stable address on the mesh
+CIDR (default ``10.44.0.0/16``): the first controller is ``.1``, and each other
+node is ``.2``, ``.3``, … All control-plane traffic (scheduler, Raft, agent
+heartbeats) and — when k0s runs over the mesh — pod traffic ride the encrypted
+``spur0`` interface instead of the underlay LAN.
+
+WireGuard is a **cryptokey router**: a peer entry needs both an *AllowedIPs* set
+(which mesh/pod addresses route to that peer) and an *endpoint* (the peer's real
+underlay ``host:port`` to send packets to). ``spur net join`` establishes exactly
+one tunnel — worker→controller — so a plain join/add-peer flow yields a
+**hub-and-spoke**: every node can reach the controller, but two workers have each
+other's AllowedIPs with **no endpoint**, so worker↔worker packets are dropped.
+
+A full mesh therefore requires each peer to be advertised **with its underlay
+endpoint**. Two mechanisms supply this:
+
+- ``spur net add-peer --endpoint <host:port>`` — register one peer with its
+  underlay endpoint (not its mesh IP, which is circular).
+- ``spur net mesh --config <membership.json> --self <mesh-ip>`` — apply a full
+  mesh from a shared membership document on every node, wiring all remaining
+  node↔node tunnels (including controller↔controller) in one pass.
+
+Under a SPUR-managed k0s cluster the controller's reconcile loop maintains this
+automatically; for a pure-scheduler mesh (no k0s) the ``spur net mesh`` pass is
+what converges the cluster to all-to-all.
+
+Mesh bring-up
+=============
+
+On the bootstrap controller (assigned ``.1``):
+
+.. code-block:: bash
+
+   sudo spur net init --cidr 10.44.0.0/16 --port 51820 --interface spur0
+   wg show spur0 public-key      # the server key workers need to join
+
+On each other node (controllers included, for HA), join the mesh and read back
+its own public key:
+
+.. code-block:: bash
+
+   sudo spur net join \
+       --endpoint <bootstrap-underlay>:51820 \
+       --server-key <bootstrap-pubkey> \
+       --address 10.44.0.2 \
+       --prefix-len 16 \
+       --interface spur0
+   wg show spur0 public-key
+
+Then, on the bootstrap controller, register each joiner **with its underlay
+endpoint** so worker↔worker tunnels can form (not just hub-and-spoke):
+
+.. code-block:: bash
+
+   sudo spur net add-peer \
+       --key <joiner-pubkey> \
+       --allowed-ip 10.44.0.2/32 \
+       --endpoint <joiner-underlay>:51820 \
+       --interface spur0
+
+Verify all-to-all reachability over the mesh IPs (every node should reach every
+other, not just the controller):
+
+.. code-block:: bash
+
+   spur net status                # peers + handshake times
+   ping -c1 10.44.0.3             # from a worker, to another worker's mesh IP
+
+Boot persistence
+----------------
+
+``spur net init`` / ``join`` bring the interface up but do not enable it for boot.
+Enable the ``wg-quick@<iface>`` unit so the interface is recreated on reboot from
+``/etc/wireguard/<iface>.conf``:
+
+.. code-block:: bash
+
+   sudo systemctl enable wg-quick@spur0
+
+The Ansible toolkit does this automatically when ``spur_wg_persist=true`` (the
+default).
+
+Removing a node from the mesh
+=============================
+
+When a node leaves, drop its peer entry so it does not linger as a "ghost" peer
+(and, on the node itself, tear the interface down so it does not rejoin on
+reboot):
+
+.. code-block:: bash
+
+   # On the controller — drop the departed node's peer (idempotent):
+   sudo spur net remove-peer --key <departed-node-pubkey> --interface spur0
+
+   # On the departed node — stop and de-persist the interface:
+   sudo systemctl disable --now wg-quick@spur0
+   sudo rm -f /etc/wireguard/spur0.conf
+
+In an HA mesh, remove the peer on **every** controller, not just the bootstrap —
+otherwise the others keep a stale peer. The Ansible ``remove_nodes.yml`` playbook
+handles both the controller-side ``remove-peer`` (on all controllers) and the
+node-side teardown.
+
+High availability over the mesh
+===============================
+
+HA (3 or 5 controllers with Raft) is supported over WireGuard. All controllers
+join the same mesh; because Raft elections require the controllers to reach each
+other directly, the full-mesh pass must wire controller↔controller tunnels — a
+plain hub-and-spoke would leave the non-bootstrap controllers unable to elect a
+leader if the bootstrap goes down.
+
+Point every controller's ``hosts`` / ``peers`` at the **mesh** IPs (not underlay
+addresses), in the same order on every controller (``node_id`` is the 1-based
+position):
+
+.. code-block:: toml
+
+   [controller]
+   hosts = ["10.44.0.1", "10.44.0.3", "10.44.0.4"]
+   peers = [
+     "10.44.0.1:6821",
+     "10.44.0.3:6821",
+     "10.44.0.4:6821",
+   ]
+
+Raft elects a leader automatically; clients and agents may target any controller
+and are redirected to the current leader. See :doc:`native-host` for the full
+per-node controller/agent setup and :doc:`ansible` for the inventory-driven
+equivalent.
+
+k0s cluster inside the mesh
+===========================
+
+Once the mesh is up, a SPUR-managed k0s cluster can run pod traffic over it. Set
+``[cluster] enabled = true`` (or ``spur_k8s_enabled=true`` in Ansible) with Calico
+``bird`` native routing so pods ride the mesh:
+
+- ``pod_cidr`` (default ``10.42.0.0/16``) and ``service_cidr`` (``10.43.0.0/16``)
+  are carved per node; each node's pod ``/24`` is folded into its peer's
+  ``AllowedIPs`` so cross-node pod traffic routes over ``spur0``.
+- The k8s API is advertised on the control-plane's mesh IP.
+
+The controller reconcile converges the full mesh (endpoints included) as part of
+``spur k8s up``, so a k0s-over-mesh cluster does not need the manual ``net mesh``
+pass. See :doc:`ansible` for the ``k8s_up.yml`` / ``k8s_add_nodes.yml`` flow and
+:doc:`managed-kubernetes` for running Spur inside an existing Kubernetes cluster.

--- a/docs/deployment/wireguard.rst
+++ b/docs/deployment/wireguard.rst
@@ -99,23 +99,50 @@ default).
 Removing a node from the mesh
 =============================
 
+.. important::
+
+   **Deregister the node from the cluster first, then drop its mesh peer** — not
+   the other way around. ``spur net remove-peer`` is a purely local ``wg``
+   mutation; it does not touch cluster state. Under a SPUR-managed k0s cluster the
+   controller's reconcile loop rebuilds mesh membership from live node inventory
+   every ~30s, so if the node is still registered it will simply re-push the peer
+   you just removed. Run ``spur node remove <node>`` (or the equivalent) first, so
+   the reconcile no longer includes it, then remove the peer.
+
 When a node leaves, drop its peer entry so it does not linger as a "ghost" peer
 (and, on the node itself, tear the interface down so it does not rejoin on
 reboot):
 
 .. code-block:: bash
 
-   # On the controller — drop the departed node's peer (idempotent):
+   # 1. Deregister from the cluster so the reconcile stops advertising it:
+   sudo spur node remove <departed-node>
+
+   # 2. On the controller — drop the departed node's peer (idempotent):
    sudo spur net remove-peer --key <departed-node-pubkey> --interface spur0
 
-   # On the departed node — stop and de-persist the interface:
+   # 3. On the departed node — stop and de-persist the interface:
    sudo systemctl disable --now wg-quick@spur0
    sudo rm -f /etc/wireguard/spur0.conf
 
 In an HA mesh, remove the peer on **every** controller, not just the bootstrap —
-otherwise the others keep a stale peer. The Ansible ``remove_nodes.yml`` playbook
-handles both the controller-side ``remove-peer`` (on all controllers) and the
-node-side teardown.
+otherwise the others keep a stale peer.
+
+.. note::
+
+   ``spur net add-peer --program-routes`` (used only on the no-CNI bare-mesh test
+   path) installs a kernel route for the peer's pod CIDR. ``remove-peer`` does not
+   remove that route, so on a bare-mesh setup drop it by hand
+   (``ip route del <pod-cidr> dev spur0``). With a CNI (the normal case) the CNI
+   owns the routes and this does not apply.
+
+.. note::
+
+   The Ansible ``remove_nodes.yml`` playbook automates all of the above — the
+   controller-side ``remove-peer`` (on all controllers) and the node-side teardown
+   — but that WireGuard cleanup ships in `spur-toolkit#23
+   <https://github.com/ROCm/spur-toolkit/pull/23>`_, which is not yet merged. Until
+   it lands, perform these steps manually.
 
 High availability over the mesh
 ===============================
@@ -142,8 +169,10 @@ position):
 
 Raft elects a leader automatically; clients and agents may target any controller
 and are redirected to the current leader. See :doc:`native-host` for the full
-per-node controller/agent setup and :doc:`ansible` for the inventory-driven
-equivalent.
+per-node controller/agent setup. An inventory-driven, multi-controller
+WireGuard-mesh flow is added by `spur-toolkit#23
+<https://github.com/ROCm/spur-toolkit/pull/23>`_ (not yet merged — until it lands
+the Ansible role supports a single controller under WireGuard only).
 
 k0s cluster inside the mesh
 ===========================
@@ -159,5 +188,13 @@ Once the mesh is up, a SPUR-managed k0s cluster can run pod traffic over it. Set
 
 The controller reconcile converges the full mesh (endpoints included) as part of
 ``spur k8s up``, so a k0s-over-mesh cluster does not need the manual ``net mesh``
-pass. See :doc:`ansible` for the ``k8s_up.yml`` / ``k8s_add_nodes.yml`` flow and
-:doc:`managed-kubernetes` for running Spur inside an existing Kubernetes cluster.
+pass. See :doc:`managed-kubernetes` for running Spur inside an existing Kubernetes
+cluster.
+
+.. note::
+
+   The Ansible ``spur_k8s_*`` variables and the ``k8s_up.yml`` /
+   ``k8s_add_nodes.yml`` playbooks referenced for this flow ship in `spur-toolkit#23
+   <https://github.com/ROCm/spur-toolkit/pull/23>`_, which is not yet merged. Until
+   it lands, drive ``spur k8s up`` / ``add-nodes`` directly (as shown above) rather
+   than via those playbooks.

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -25,6 +25,7 @@ subtrees:
           - entries:
               - file: deployment/ansible
               - file: deployment/native-host
+              - file: deployment/wireguard
               - file: deployment/kubernetes
               - file: deployment/managed-kubernetes
               - file: deployment/partitioning


### PR DESCRIPTION
## Summary

Adds the WireGuard-mesh and k0s-lifecycle primitives needed to run and maintain a
Spur cluster over an encrypted mesh, and to add/remove nodes without a full teardown:

- **`spur net remove-peer --key [--interface]`** — the missing counterpart to
  `net add-peer`, for cleanly dropping a node's WireGuard peer when it leaves the
  mesh (idempotent; removing an absent peer succeeds).
- **`net add-peer --endpoint`** — carry each peer's underlay endpoint into the
  membership so worker↔worker (and controller↔controller) tunnels actually form,
  instead of a hub-and-spoke where only node↔controller works.
- **k0s online worker add/remove + mesh membership** plumbing in `spurctld`/`spurd`
  (`cluster_k8s.rs`, `agent_server.rs`), and honoring `[network] wg_interface` from
  `spur.conf` in `spurd` instead of hardcoding `spur0`.
- Docs: `docs/deployment/ansible.rst` updated for the mesh/k0s node-membership flow.

## Approach / design notes

- Membership is built from mesh facts (each node's `wg_pubkey` + mesh IP + underlay
  endpoint) so the reconcile can program a full mesh, not just AllowedIPs.
- `spur net mesh --config <file> --self <ip>` applies a full-mesh peering from a
  shared membership doc — the supported route to all-to-all when a caller (e.g. the
  ansible toolkit) drives it on every node.

## Test summary (validated live on a 4-node hardware testbed)

WireGuard mesh `10.44.0.0/16`, pods `10.42.0.0/16`, services `10.43.0.0/16`.

- **Mesh bring-up:** 1 controller + 3 workers join the mesh; all-to-all reachable
  over the mesh IPs (controller↔worker and worker↔worker).
- **k0s over mesh:** `spur k8s up` with a control-plane node + worker; cluster
  reaches `ready`, k8s node InternalIPs are the mesh IPs, controller stays meshed.
- **Cross-node pods on the mesh:** a pod on each of two different workers reach each
  other over the pod CIDR, and the traffic rides the WireGuard tunnel — verified via
  per-peer routes (`10.42.x via <peer-mesh-ip>`), pod-CIDR folded into peer
  AllowedIPs, and rising `wg` transfer counters on the exact peer during the ping.
- **Online node add/remove:** worker added via `k8s add-nodes` and removed cleanly;
  `net remove-peer` drops the stale peer so no ghost peer remains.
- **HA over the mesh (3 controllers):** Raft quorum forms over mesh IPs; stopping the
  leader triggers a re-election among the survivors while the cluster keeps serving,
  and the restarted controller rejoins as a follower.

Unit tests added for `net remove-peer` arg parsing; `cargo test` / `cargo clippy`
clean.

## Dependency

**ROCm/spur-toolkit#23** (ansible: multi-controller WireGuard mesh for HA) **depends
on this PR** — its playbooks call `spur net mesh`, `net add-peer --endpoint`, and
`net remove-peer` introduced here. Merge this PR first, then spur-toolkit#23.
