### PR TITLE
fix(spurctld): report array task throttle reason

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -264,6 +264,7 @@ pub enum PendingReason {
     /// time limit. Sibling of `DeadLine`, which fires before the job ever starts.
     TimeLimit,
     Licenses,
+    JobArrayTaskLimit,
     NonZeroExitCode,
     RaisedSignal,
     JobLaunchFailure,
@@ -366,6 +367,7 @@ impl PendingReason {
             Self::DeadLine => "DeadLine",
             Self::TimeLimit => "TimeLimit",
             Self::Licenses => "Licenses",
+            Self::JobArrayTaskLimit => "JobArrayTaskLimit",
             Self::NonZeroExitCode => "NonZeroExitCode",
             Self::RaisedSignal => "RaisedSignal",
             Self::JobLaunchFailure => "JobLaunchFailure",
@@ -2220,6 +2222,7 @@ mod tests {
         (PendingReason::BurstBufferStageIn, "BurstBufferStageIn"),
         (PendingReason::JobHoldMaxRequeue, "JobHoldMaxRequeue"),
         (PendingReason::TimeLimit, "TimeLimit"),
+        (PendingReason::JobArrayTaskLimit, "JobArrayTaskLimit"),
         (PendingReason::AssocMaxJobsLimit, "AssocMaxJobsLimit"),
         (
             PendingReason::AssocMaxSubmitJobLimit,
@@ -2263,6 +2266,16 @@ mod tests {
             assert_eq!(reason.display(), *expected, "Display for {reason:?}");
             assert_eq!(format!("{reason}"), *expected, "fmt for {reason:?}");
         }
+    }
+
+    #[test]
+    fn job_array_task_limit_reason_serializes_by_name() {
+        let encoded = serde_json::to_string(&PendingReason::JobArrayTaskLimit).unwrap();
+        assert_eq!(encoded, r#""JobArrayTaskLimit""#);
+        assert_eq!(
+            serde_json::from_str::<PendingReason>(&encoded).unwrap(),
+            PendingReason::JobArrayTaskLimit
+        );
     }
 
     #[test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -442,7 +442,7 @@ pub struct ClusterManager {
 
 struct PendingJobClassification {
     jobs: Vec<Job>,
-    blocked: Vec<(JobId, PendingReason)>,
+    reason_updates: Vec<(JobId, PendingReason)>,
     bb_stage_candidates: Vec<JobId>,
 }
 
@@ -3172,11 +3172,11 @@ impl ClusterManager {
         self.classify_pending_jobs().jobs
     }
 
-    /// Classify pending jobs once, apply displayed block reasons, advance burst-buffer
+    /// Classify pending jobs once, apply pending-reason updates, advance burst-buffer
     /// stage-in for selected candidates, and return the jobs eligible for scheduling.
     pub fn pending_jobs_and_tag_reasons(&self) -> Vec<Job> {
         let classification = self.classify_pending_jobs();
-        self.apply_blocked_pending_reasons(classification.blocked);
+        self.apply_pending_reason_updates(classification.reason_updates);
         self.advance_bb_staging_for(&classification.bb_stage_candidates);
         classification.jobs
     }
@@ -3213,13 +3213,13 @@ impl ClusterManager {
                 })
             })
             .collect();
-        let mut blocked = Vec::new();
+        let mut reason_updates = Vec::new();
 
         // Structural blockers retain their precedence before begin-time eligibility;
         // unlike consumables, they do not reserve capacity while the job waits.
         {
             let partitions = self.partitions.read();
-            retain_unblocked(&mut candidates, &mut blocked, |job| {
+            retain_unblocked(&mut candidates, &mut reason_updates, |job| {
                 partition_block(job, &partitions)
             });
         }
@@ -3238,7 +3238,7 @@ impl ClusterManager {
                 .collect()
         };
 
-        retain_unblocked(&mut candidates, &mut blocked, |job| {
+        retain_unblocked(&mut candidates, &mut reason_updates, |job| {
             if job.spec.dependency.is_empty() {
                 return None;
             }
@@ -3257,7 +3257,7 @@ impl ClusterManager {
             .collect();
 
         let reservations = self.get_reservations();
-        retain_unblocked(&mut candidates, &mut blocked, |job| {
+        retain_unblocked(&mut candidates, &mut reason_updates, |job| {
             reservation_block(job, &reservations, now)
         });
 
@@ -3297,8 +3297,21 @@ impl ClusterManager {
             };
             let count = array_counts.entry(array_id).or_insert(0);
             if *count >= max {
+                record_pending_reason_update(
+                    &mut reason_updates,
+                    candidate,
+                    PendingReason::JobArrayTaskLimit,
+                );
                 candidate.scheduling_eligible = false;
             } else {
+                if candidate.job.pending_reason == PendingReason::JobArrayTaskLimit {
+                    record_pending_reason_update(
+                        &mut reason_updates,
+                        candidate,
+                        PendingReason::None,
+                    );
+                    candidate.job.set_pending_reason(PendingReason::None);
+                }
                 *count += 1;
             }
         }
@@ -3307,7 +3320,7 @@ impl ClusterManager {
             let mut reserved = PassReservations::default();
             let grp_wall_usage = self.grp_wall_cache.usage();
             let nodes = self.nodes.read();
-            retain_eligible(&mut candidates, &mut blocked, |job| {
+            retain_eligible(&mut candidates, &mut reason_updates, |job| {
                 let account_charge = match account_block_with(
                     job,
                     &self.association_cache,
@@ -3342,7 +3355,7 @@ impl ClusterManager {
         {
             let available = self.available_licenses_with(&jobs);
             let mut remaining = available.clone();
-            retain_eligible(&mut candidates, &mut blocked, |job| {
+            retain_eligible(&mut candidates, &mut reason_updates, |job| {
                 if let Some(reason) = license_block(job, &available) {
                     return GateOutcome::Block(reason);
                 }
@@ -3367,7 +3380,7 @@ impl ClusterManager {
         {
             let available = self.available_bb_with(&jobs);
             let mut remaining = available;
-            retain_eligible(&mut candidates, &mut blocked, |job| {
+            retain_eligible(&mut candidates, &mut reason_updates, |job| {
                 if job.bb_stage_state == BbStageState::Staging {
                     return GateOutcome::Block(PendingReason::BurstBufferStageIn);
                 }
@@ -3401,7 +3414,11 @@ impl ClusterManager {
                 return true;
             }
             if candidate.job.is_begin_held(now) {
-                record_blocked(&mut blocked, candidate, PendingReason::BeginTime);
+                record_pending_reason_update(
+                    &mut reason_updates,
+                    candidate,
+                    PendingReason::BeginTime,
+                );
             }
             false
         });
@@ -3411,7 +3428,7 @@ impl ClusterManager {
                 .into_iter()
                 .map(|candidate| candidate.job)
                 .collect(),
-            blocked,
+            reason_updates,
             bb_stage_candidates,
         }
     }
@@ -3671,23 +3688,23 @@ impl ClusterManager {
         cancelled
     }
 
-    /// Reclassify pending jobs and apply their displayed block reasons.
+    /// Reclassify pending jobs and apply their pending-reason updates.
     /// Leader-only; enforced by the scheduler-loop caller, not this function
     /// itself (mirrors `cancel_unsatisfiable_dependency_jobs()`).
     #[cfg(test)]
     fn tag_blocked_pending_reasons(&self) {
-        let blocked = self.classify_pending_jobs().blocked;
-        self.apply_blocked_pending_reasons(blocked);
+        let reason_updates = self.classify_pending_jobs().reason_updates;
+        self.apply_pending_reason_updates(reason_updates);
     }
 
-    fn apply_blocked_pending_reasons(&self, blocked: Vec<(JobId, PendingReason)>) {
-        if blocked.is_empty() {
+    fn apply_pending_reason_updates(&self, reason_updates: Vec<(JobId, PendingReason)>) {
+        if reason_updates.is_empty() {
             return;
         }
 
         let mut jobs = self.jobs.write();
         let now = Utc::now();
-        for (id, reason) in blocked {
+        for (id, reason) in reason_updates {
             if let Some(j) = jobs.get_mut(&id) {
                 // Re-check under the write lock: the read snapshot was released,
                 // so the job may have started or been held/deadlined since.
@@ -3696,6 +3713,13 @@ impl ClusterManager {
                     && j.pending_reason != PendingReason::DeadLine
                     && !j.reason_explains_begin_hold(now)
                 {
+                    // A clear derived from an older read snapshot must not erase
+                    // a different reason written before this lock was acquired.
+                    if reason == PendingReason::None
+                        && j.pending_reason != PendingReason::JobArrayTaskLimit
+                    {
+                        continue;
+                    }
                     j.set_pending_reason(reason);
                 }
             }
@@ -6439,14 +6463,14 @@ fn reservation_fence_reason(
 
 fn retain_unblocked(
     candidates: &mut Vec<PendingJobCandidate>,
-    blocked: &mut Vec<(JobId, PendingReason)>,
+    reason_updates: &mut Vec<(JobId, PendingReason)>,
     mut block: impl FnMut(&Job) -> Option<PendingReason>,
 ) {
     candidates.retain(|candidate| {
         let Some(reason) = block(&candidate.job) else {
             return true;
         };
-        record_blocked(blocked, candidate, reason);
+        record_pending_reason_update(reason_updates, candidate, reason);
         false
     });
 }
@@ -6467,11 +6491,11 @@ enum GateOutcome {
 
 /// Like [`retain_unblocked`], but skips not-yet-eligible candidates and lets
 /// `gate` reserve in-pass headroom on the keep path. A [`GateOutcome::Block`]
-/// drop is recorded via `record_blocked` (a no-op for already-tagged
+/// drop is recorded via `record_pending_reason_update` (a no-op for already-tagged
 /// candidates); [`GateOutcome::DropUntagged`] drops without a reason.
 fn retain_eligible(
     candidates: &mut Vec<PendingJobCandidate>,
-    blocked: &mut Vec<(JobId, PendingReason)>,
+    reason_updates: &mut Vec<(JobId, PendingReason)>,
     mut gate: impl FnMut(&mut Job) -> GateOutcome,
 ) {
     candidates.retain_mut(|candidate| {
@@ -6481,7 +6505,7 @@ fn retain_eligible(
         match gate(&mut candidate.job) {
             GateOutcome::Keep => true,
             GateOutcome::Block(reason) => {
-                record_blocked(blocked, candidate, reason);
+                record_pending_reason_update(reason_updates, candidate, reason);
                 false
             }
             GateOutcome::DropUntagged => false,
@@ -6489,13 +6513,13 @@ fn retain_eligible(
     });
 }
 
-fn record_blocked(
-    blocked: &mut Vec<(JobId, PendingReason)>,
+fn record_pending_reason_update(
+    reason_updates: &mut Vec<(JobId, PendingReason)>,
     candidate: &PendingJobCandidate,
     reason: PendingReason,
 ) {
     if candidate.tag_reason {
-        blocked.push((candidate.job.job_id, reason));
+        reason_updates.push((candidate.job.job_id, reason));
     }
 }
 
@@ -16629,6 +16653,12 @@ mod tests {
             .collect();
         let admitted = task_ids.iter().filter(|id| pending.contains(id)).count();
         assert_eq!(admitted, 1);
+        for id in task_ids.iter().filter(|id| !pending.contains(id)) {
+            assert_eq!(
+                cm.get_job(*id).unwrap().pending_reason,
+                PendingReason::JobArrayTaskLimit
+            );
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -16658,7 +16688,40 @@ mod tests {
                 !pending.contains(id),
                 "array-throttled task {id} must be excluded from scheduling"
             );
+            assert_eq!(
+                cm.get_job(*id).unwrap().pending_reason,
+                PendingReason::JobArrayTaskLimit
+            );
         }
+
+        cm.cancel_job(task_ids[0], "testuser").unwrap();
+        settle(&cm, task_ids[0], JobState::Cancelled);
+
+        let pending: Vec<JobId> = cm
+            .pending_jobs_and_tag_reasons()
+            .iter()
+            .map(|job| job.job_id)
+            .collect();
+        let admitted: Vec<JobId> = task_ids[1..]
+            .iter()
+            .copied()
+            .filter(|id| pending.contains(id))
+            .collect();
+        assert_eq!(admitted.len(), 1);
+        assert_eq!(
+            cm.get_job(admitted[0]).unwrap().pending_reason,
+            PendingReason::None
+        );
+
+        let still_throttled = task_ids[1..]
+            .iter()
+            .copied()
+            .find(|id| *id != admitted[0])
+            .unwrap();
+        assert_eq!(
+            cm.get_job(still_throttled).unwrap().pending_reason,
+            PendingReason::JobArrayTaskLimit
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -16707,9 +16770,9 @@ mod tests {
             pending.contains(&solo),
             "the eligible job must still receive the remaining license slot"
         );
-        assert_ne!(
+        assert_eq!(
             cm.get_job(t2).unwrap().pending_reason,
-            PendingReason::Licenses
+            PendingReason::JobArrayTaskLimit
         );
     }
 
@@ -16754,6 +16817,10 @@ mod tests {
             "only the running task and eligible solo job may reserve capacity"
         );
         assert_eq!(cm.get_job(t2).unwrap().bb_stage_state, BbStageState::None);
+        assert_eq!(
+            cm.get_job(t2).unwrap().pending_reason,
+            PendingReason::JobArrayTaskLimit
+        );
         assert_eq!(
             cm.get_job(solo).unwrap().bb_stage_state,
             BbStageState::Staging

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3303,17 +3303,12 @@ impl ClusterManager {
                     PendingReason::JobArrayTaskLimit,
                 );
                 candidate.scheduling_eligible = false;
-            } else {
-                if candidate.job.pending_reason == PendingReason::JobArrayTaskLimit {
-                    record_pending_reason_update(
-                        &mut reason_updates,
-                        candidate,
-                        PendingReason::None,
-                    );
-                    candidate.job.set_pending_reason(PendingReason::None);
-                }
-                *count += 1;
+                continue;
             }
+            if candidate.job.pending_reason == PendingReason::JobArrayTaskLimit {
+                record_pending_reason_update(&mut reason_updates, candidate, PendingReason::None);
+            }
+            *count += 1;
         }
 
         {
@@ -3692,7 +3687,7 @@ impl ClusterManager {
     /// Leader-only; enforced by the scheduler-loop caller, not this function
     /// itself (mirrors `cancel_unsatisfiable_dependency_jobs()`).
     #[cfg(test)]
-    fn tag_blocked_pending_reasons(&self) {
+    fn refresh_pending_reasons(&self) {
         let reason_updates = self.classify_pending_jobs().reason_updates;
         self.apply_pending_reason_updates(reason_updates);
     }
@@ -6480,7 +6475,7 @@ fn retain_unblocked(
 enum GateOutcome {
     /// Keep the candidate in the schedulable set.
     Keep,
-    /// Drop and record `reason` (a no-op tag for already-tagged candidates).
+    /// Drop and queue `reason` when the candidate permits reason updates.
     Block(PendingReason),
     /// Drop without recording a reason. Only the burst-buffer stage-in handoff
     /// uses this: the gate reserved capacity and enqueued the job for staging,
@@ -6491,8 +6486,8 @@ enum GateOutcome {
 
 /// Like [`retain_unblocked`], but skips not-yet-eligible candidates and lets
 /// `gate` reserve in-pass headroom on the keep path. A [`GateOutcome::Block`]
-/// drop is recorded via `record_pending_reason_update` (a no-op for already-tagged
-/// candidates); [`GateOutcome::DropUntagged`] drops without a reason.
+/// drop queues its reason when the candidate permits reason updates;
+/// [`GateOutcome::DropUntagged`] drops without a reason.
 fn retain_eligible(
     candidates: &mut Vec<PendingJobCandidate>,
     reason_updates: &mut Vec<(JobId, PendingReason)>,
@@ -11264,11 +11259,11 @@ mod tests {
             PendingReason::Preempted
         );
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::Preempted,
-            "tag_blocked_pending_reasons must not clobber an active Preempted hold"
+            "refresh_pending_reasons must not clobber an active Preempted hold"
         );
     }
 
@@ -11587,12 +11582,12 @@ mod tests {
         cm.requeue_job(job_id).unwrap();
         settle(&cm, job_id, JobState::Pending);
 
-        // Both guard sites in tag_blocked_pending_reasons.
-        cm.tag_blocked_pending_reasons();
+        // Both guard sites in refresh_pending_reasons.
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::JobLaunchFailure,
-            "tag_blocked_pending_reasons must not clobber an active hold"
+            "refresh_pending_reasons must not clobber an active hold"
         );
 
         // The guard site in update_pending_reasons. An empty cluster_state would
@@ -12762,7 +12757,7 @@ mod tests {
         });
         wait_for("job applied", || cm.get_job(job_id).is_some());
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::PartitionConfig
@@ -12806,7 +12801,7 @@ mod tests {
         });
         wait_for("undernodes applied", || cm.get_job(n_id).is_some());
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(t_id).unwrap().pending_reason,
             PendingReason::PartitionTimeLimit,
@@ -12839,7 +12834,7 @@ mod tests {
         spec.partition = Some("default".into());
         let job_id = submit_and_wait(&cm, spec);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::PartitionInactive
@@ -12863,7 +12858,7 @@ mod tests {
         spec.begin_time = Some(Utc::now() + chrono::Duration::hours(1));
         let job_id = submit_and_wait(&cm, spec);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::BeginTime
@@ -12885,7 +12880,7 @@ mod tests {
         let mut spec = basic_spec("begin-lapse");
         spec.begin_time = Some(Utc::now() + chrono::Duration::hours(1));
         let job_id = submit_and_wait(&cm, spec);
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::BeginTime
@@ -12932,7 +12927,7 @@ mod tests {
         spec.begin_time = Some(Utc::now() + chrono::Duration::hours(1));
         let job_id = submit_and_wait(&cm, spec);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::PartitionInactive
@@ -13644,7 +13639,7 @@ mod tests {
         spec.reservation = Some("does-not-exist".into());
         let job_id = submit_and_wait(&cm, spec);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::Reservation
@@ -14781,7 +14776,7 @@ mod tests {
         .unwrap();
 
         let job_id = submit_and_wait(&cm, basic_spec("fence"));
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         let job = cm.get_job(job_id).unwrap();
         assert_ne!(
             job.pending_reason,
@@ -15027,7 +15022,7 @@ mod tests {
             jobs.get_mut(&job_id).unwrap().priority = 0;
         }
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::ReservationDeleted
@@ -15333,7 +15328,7 @@ mod tests {
         spec.gres = vec!["license:flexlm:1".into()];
         let job_id = submit_and_wait(&cm, spec);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::Licenses
@@ -15360,7 +15355,7 @@ mod tests {
         spec.time_limit = Some(chrono::Duration::hours(1));
         let job_id = submit_and_wait(&cm, spec);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::QosMaxWallDurationPerJobLimit
@@ -15405,7 +15400,7 @@ mod tests {
         s2.num_tasks = 1;
         let j2 = submit_and_wait(&cm, s2);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(j2).unwrap().pending_reason,
             PendingReason::QosGrpCpuLimit
@@ -15458,7 +15453,7 @@ mod tests {
             Some("highprio")
         );
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(j2).unwrap().pending_reason,
             PendingReason::QoSMaxJobsPerUser
@@ -15500,7 +15495,7 @@ mod tests {
         settle(&cm, j1, JobState::Running);
 
         let j2 = submit_and_wait(&cm, basic_spec("d2"));
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(j2).unwrap().pending_reason,
             PendingReason::QoSMaxJobsPerUser,
@@ -15539,7 +15534,7 @@ mod tests {
         s2.account = Some("research".into());
         let j2 = submit_and_wait(&cm, s2);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(j2).unwrap().pending_reason,
             PendingReason::AssocMaxJobsLimit
@@ -15573,7 +15568,7 @@ mod tests {
             },
         );
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         // j1 alone is within the limit (max_submit_jobs=1) and must not be
         // blocked by counting itself; only j2, which pushes the count over
         // the cap, should be blocked.
@@ -15613,7 +15608,7 @@ mod tests {
             ..Default::default()
         });
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         // j1 alone is within the limit (max_submit_jobs_per_user=1) and must
         // not be blocked by counting itself; only j2, which pushes the count
         // over the cap, should be blocked.
@@ -15672,7 +15667,7 @@ mod tests {
         s2.num_tasks = 1;
         let j2 = submit_and_wait(&cm, s2);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(j2).unwrap().pending_reason,
             PendingReason::AssocGrpCpuLimit
@@ -15704,7 +15699,7 @@ mod tests {
         s2.qos = Some("capped".into());
         let j2 = submit_and_wait(&cm, s2);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(cm.get_job(j1).unwrap().pending_reason, PendingReason::None);
         assert_eq!(
             cm.get_job(j2).unwrap().pending_reason,
@@ -15799,7 +15794,7 @@ mod tests {
         newjob.num_nodes = 1;
         let new_id = submit_and_wait(&cm, newjob);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(new_id).unwrap().pending_reason,
             PendingReason::QosGrpNodeLimit,
@@ -15846,7 +15841,7 @@ mod tests {
         newjob.num_tasks = 2; // avoid effective_num_nodes() clamping to num_tasks
         let new_id = submit_and_wait(&cm, newjob);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(new_id).unwrap().pending_reason,
             PendingReason::QosGrpNodeLimit,
@@ -16000,7 +15995,7 @@ mod tests {
              (3rd) node and blocked at the grp cap of 2"
         );
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(id_b).unwrap().pending_reason,
             PendingReason::QosGrpNodeLimit,
@@ -16069,7 +16064,7 @@ mod tests {
              already-claimed spare capacity"
         );
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(id_b).unwrap().pending_reason,
             PendingReason::AssocGrpNodeLimit,
@@ -16154,7 +16149,7 @@ mod tests {
         newjob.num_nodes = 1;
         let new_id = submit_and_wait(&cm, newjob);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(new_id).unwrap().pending_reason,
             PendingReason::None,
@@ -16365,7 +16360,7 @@ mod tests {
         s2.account = Some("research".into());
         let j2 = submit_and_wait(&cm, s2);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(cm.get_job(j1).unwrap().pending_reason, PendingReason::None);
         assert_eq!(
             cm.get_job(j2).unwrap().pending_reason,
@@ -16498,7 +16493,7 @@ mod tests {
         newjob.num_tasks = 4; // avoid effective_num_nodes() clamping to num_tasks
         let new_id = submit_and_wait(&cm, newjob);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(new_id).unwrap().pending_reason,
             PendingReason::QosGrpNodeLimit,
@@ -16524,7 +16519,7 @@ mod tests {
         s2.burst_buffer = Some("capacity=60".into());
         let j2 = submit_and_wait(&cm, s2);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(j2).unwrap().pending_reason,
             PendingReason::BurstBufferResources
@@ -16549,7 +16544,7 @@ mod tests {
         let spec = basic_spec("d1");
         let job_id = submit_and_wait(&cm, spec);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_ne!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::AssocMaxJobsLimit
@@ -16773,6 +16768,59 @@ mod tests {
         assert_eq!(
             cm.get_job(t2).unwrap().pending_reason,
             PendingReason::JobArrayTaskLimit
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn array_throttle_reason_hands_off_to_license_blocker() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.license_pool.write().insert("fluent".into(), 1);
+
+        let mut spec = basic_spec("arr-throttle-license");
+        spec.array_spec = Some("0-1%1".into());
+        spec.gres = vec!["license:fluent:2".into()];
+        let parent_id = cm.submit_job(spec).unwrap().job_id;
+        let t1 = parent_id + 1;
+        let t2 = parent_id + 2;
+        wait_for("array license tasks", || {
+            cm.get_job(t1).is_some() && cm.get_job(t2).is_some()
+        });
+
+        let pending: Vec<JobId> = cm
+            .pending_jobs_and_tag_reasons()
+            .iter()
+            .map(|job| job.job_id)
+            .collect();
+
+        assert!(!pending.contains(&t1));
+        assert!(!pending.contains(&t2));
+        assert_eq!(
+            cm.get_job(t1).unwrap().pending_reason,
+            PendingReason::Licenses
+        );
+        assert_eq!(
+            license_block(&cm.get_job(t2).unwrap(), &cm.available_licenses()),
+            Some(PendingReason::Licenses)
+        );
+        assert_eq!(
+            cm.get_job(t2).unwrap().pending_reason,
+            PendingReason::JobArrayTaskLimit
+        );
+
+        cm.cancel_job(t1, "testuser").unwrap();
+        settle(&cm, t1, JobState::Cancelled);
+
+        let pending: Vec<JobId> = cm
+            .pending_jobs_and_tag_reasons()
+            .iter()
+            .map(|job| job.job_id)
+            .collect();
+
+        assert!(!pending.contains(&t2));
+        assert_eq!(
+            cm.get_job(t2).unwrap().pending_reason,
+            PendingReason::Licenses
         );
     }
 
@@ -17148,7 +17196,7 @@ mod tests {
         spec.burst_buffer = Some("capacity=500".into());
         let job_id = submit_and_wait(&cm, spec);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::BurstBufferResources
@@ -17181,7 +17229,7 @@ mod tests {
         );
         assert_eq!(cm.available_bb(), 60);
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::BurstBufferStageIn
@@ -17238,7 +17286,7 @@ mod tests {
             .count();
         assert_eq!((staging, none), (1, 1), "exactly one job stages");
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         let unstaged = states
             .iter()
             .find(|(_, s)| *s == BbStageState::None)
@@ -17306,7 +17354,7 @@ mod tests {
             jobs.get_mut(&job_id).unwrap().pending_reason = PendingReason::Held;
         }
 
-        cm.tag_blocked_pending_reasons();
+        cm.refresh_pending_reasons();
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::Held


### PR DESCRIPTION
Array tasks held behind an `--array=...%N` concurrency limit currently stay pending with `Reason=None`. This adds Slurm's `JobArrayTaskLimit` reason and records it when the per-array cap is full.

Pending-reason changes are applied in order, so a task gets the throttle reason only while it is actually held. When a slot reopens, that stale reason is cleared without overwriting a newer blocker from the same scheduling pass. The existing task ordering and slot accounting are unchanged.

Fixes #618

Tested with:

- `cargo test -p spurctld array_throttle --locked`
- 563 portable `spur-core` tests and 916 `spurctld` tests
- warnings-as-errors Clippy for `spur-core` and `spurctld`
- a local one-controller gRPC smoke with this branch's controller and a Spur 0.7 client; both `queue %R` and `show job` reported `JobArrayTaskLimit`, and cancelling the admitted child immediately cleared the reason on the next task
- formatting, diff, and SPDX checks

The full workspace commands still need Linux CI. On macOS, PMIx fails to link, `spur-cli` imports a `nix::getgroups` API that is unavailable on Apple, and the shell-hook tests execute through `/proc/self/fd`.
