### PR TITLE
fix(spurctld): reject unusable --nodelist/--exclude at submission (follow-up to #679)

### DIFF
--- a/crates/spur-core/src/hostlist.rs
+++ b/crates/spur-core/src/hostlist.rs
@@ -421,6 +421,79 @@ pub fn count(pattern: &str) -> Result<usize, HostlistError> {
     Ok(expand(pattern)?.len())
 }
 
+/// Validate a hostlist pattern without materializing it.
+///
+/// Applies exactly the same grammar and error conditions as [`expand`] —
+/// unmatched or misordered brackets, reversed ranges, and the
+/// `MAX_HOSTLIST_SIZE` cap — but counts hosts instead of building the
+/// `Vec<String>`. The submit path validates attacker-influenced `--nodelist`
+/// and `--exclude` here, so counting avoids the throwaway multi-megabyte
+/// allocation a full `expand` would make only to drop it.
+pub fn validate(pattern: &str) -> Result<(), HostlistError> {
+    let mut count: u64 = 0;
+    for part in split_top_level(pattern) {
+        count_single(part.trim(), &mut count)?;
+    }
+    Ok(())
+}
+
+/// Counting twin of [`expand_single`]: accumulates the host count into `count`,
+/// enforcing the cap with the same pre-loop and incremental guards rather than
+/// pushing names. Kept structurally parallel to `expand_single` so the two
+/// cannot drift in what they accept.
+fn count_single(pattern: &str, count: &mut u64) -> Result<(), HostlistError> {
+    if let Some(bracket_start) = pattern.find('[') {
+        let bracket_end = pattern
+            .find(']')
+            .ok_or_else(|| HostlistError::InvalidPattern("unmatched [".into()))?;
+
+        // ']' before '[' would make the slice below reversed (start > end) and panic.
+        if bracket_end < bracket_start {
+            return Err(HostlistError::InvalidPattern(format!(
+                "']' before '[': {pattern}"
+            )));
+        }
+
+        let prefix = &pattern[..bracket_start];
+        let range_str = &pattern[bracket_start + 1..bracket_end];
+        let suffix = &pattern[bracket_end + 1..];
+
+        for range_part in range_str.split(',') {
+            if let Some((start, end, width)) = parse_range_bounds(range_part)? {
+                let range_count = (end - start).saturating_add(1);
+                if count.saturating_add(range_count) > MAX_HOSTLIST_SIZE as u64 {
+                    return Err(HostlistError::TooLarge {
+                        max: MAX_HOSTLIST_SIZE,
+                    });
+                }
+
+                for i in start..=end {
+                    // Backstop nested products that multiply past the cap.
+                    if *count >= MAX_HOSTLIST_SIZE as u64 {
+                        return Err(HostlistError::TooLarge {
+                            max: MAX_HOSTLIST_SIZE,
+                        });
+                    }
+                    if suffix.contains('[') {
+                        let name = format!("{}{:0>width$}{}", prefix, i, suffix, width = width);
+                        count_single(&name, count)?;
+                    } else {
+                        *count += 1;
+                    }
+                }
+            } else if suffix.contains('[') {
+                let name = format!("{}{}{}", prefix, range_part, suffix);
+                count_single(&name, count)?;
+            } else {
+                *count += 1;
+            }
+        }
+    } else {
+        *count += 1;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -824,5 +897,57 @@ mod tests {
     #[test]
     fn count_rejects_oversized_range() {
         assert!(count("node[0-18446744073709551615]").is_err());
+    }
+
+    #[test]
+    fn validate_accepts_the_same_patterns_expand_does() {
+        for pattern in [
+            "node[001-003,005,010-012]",
+            "rack[1-2]-node[1-2]",
+            "gpu[01-04],cpu[01-02]",
+            "node9,node010,node011",
+            "login01",
+            "node[0-999999]", // exactly the cap
+        ] {
+            assert!(
+                validate(pattern).is_ok(),
+                "validate rejected a pattern expand accepts: {pattern}"
+            );
+            assert!(expand(pattern).is_ok(), "expand sanity check: {pattern}");
+        }
+    }
+
+    #[test]
+    fn validate_rejects_the_same_patterns_expand_does() {
+        // Malformed brackets, reversed range, and every over-cap shape, each
+        // returning the same error class as expand without allocating the list.
+        assert!(matches!(
+            validate("node[1-2"),
+            Err(HostlistError::InvalidPattern(_))
+        ));
+        assert!(matches!(
+            validate("a]b[1-2]"),
+            Err(HostlistError::InvalidPattern(_))
+        ));
+        assert!(matches!(
+            validate("node[5-3]"),
+            Err(HostlistError::InvalidRange(_))
+        ));
+        assert!(matches!(
+            validate("node[0-18446744073709551615]"),
+            Err(HostlistError::TooLarge { .. })
+        ));
+        assert!(matches!(
+            validate("node[0-1000000]"),
+            Err(HostlistError::TooLarge { .. })
+        ));
+        assert!(matches!(
+            validate("rack[0-9999]-node[0-9999]"),
+            Err(HostlistError::TooLarge { .. })
+        ));
+        assert!(matches!(
+            validate("rack[0-999999]-node[1,2]"),
+            Err(HostlistError::TooLarge { .. })
+        ));
     }
 }

--- a/crates/spur-core/src/hostlist.rs
+++ b/crates/spur-core/src/hostlist.rs
@@ -12,8 +12,8 @@ pub enum HostlistError {
     InvalidPattern(String),
     #[error("invalid range: {0}")]
     InvalidRange(String),
-    #[error("hostlist too large: {count} hosts exceeds maximum {max}")]
-    TooLarge { count: u64, max: usize },
+    #[error("hostlist too large: exceeds maximum {max} hosts")]
+    TooLarge { max: usize },
 }
 
 /// Expand a Slurm hostlist pattern into individual hostnames.
@@ -349,25 +349,22 @@ fn expand_single(pattern: &str, results: &mut Vec<String>) -> Result<(), Hostlis
                 let range_count = (end - start).saturating_add(1);
                 if (results.len() as u64).saturating_add(range_count) > MAX_HOSTLIST_SIZE as u64 {
                     return Err(HostlistError::TooLarge {
-                        count: (results.len() as u64).saturating_add(range_count),
                         max: MAX_HOSTLIST_SIZE,
                     });
                 }
 
                 for i in start..=end {
+                    // Backstop nested products that multiply past the cap.
+                    if results.len() >= MAX_HOSTLIST_SIZE {
+                        return Err(HostlistError::TooLarge {
+                            max: MAX_HOSTLIST_SIZE,
+                        });
+                    }
                     let name = format!("{}{:0>width$}{}", prefix, i, suffix, width = width);
                     if suffix.contains('[') {
                         expand_single(&name, results)?;
                     } else {
                         results.push(name);
-                    }
-                    // Incremental backstop: nested products like rack[0-9999]-node[0-9999]
-                    // can exceed the cap even when each single range is under it.
-                    if results.len() > MAX_HOSTLIST_SIZE {
-                        return Err(HostlistError::TooLarge {
-                            count: results.len() as u64,
-                            max: MAX_HOSTLIST_SIZE,
-                        });
                     }
                 }
             } else {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -3500,10 +3500,18 @@ fn proto_to_job_spec(spec: JobSpec) -> Result<spur_core::job::JobSpec, Status> {
     let gpus_per_node = spur_core::gpu_request::GpuRequest::from_proto(spec.gpus_per_node);
     let gpus_per_task = spur_core::gpu_request::GpuRequest::from_proto(spec.gpus_per_task);
 
-    // Reject an unexpandable --nodelist/--exclude here, else it matches no node and hangs the job.
+    // Reject an unexpandable --nodelist/--exclude at the submit boundary. An
+    // invalid pattern otherwise falls back to a literal name that matches no
+    // node: a bad --nodelist then never schedules (the job hangs with no
+    // reason), and a bad --exclude silently excludes nothing, so a job the user
+    // meant to keep off specific nodes can land on exactly those nodes. Both are
+    // failures the submitter cannot see, so both are rejected here as Slurm does.
+    //
+    // `validate` only counts hosts; it does not build the (possibly ~1M-element)
+    // Vec that `expand` would, since the scheduler re-expands the pattern later.
     for (flag, pattern) in [("nodelist", &spec.nodelist), ("exclude", &spec.exclude)] {
         if !pattern.is_empty() {
-            spur_core::hostlist::expand(pattern).map_err(|e| {
+            spur_core::hostlist::validate(pattern).map_err(|e| {
                 Status::invalid_argument(format!("invalid --{flag} '{pattern}': {e}"))
             })?;
         }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -3500,6 +3500,15 @@ fn proto_to_job_spec(spec: JobSpec) -> Result<spur_core::job::JobSpec, Status> {
     let gpus_per_node = spur_core::gpu_request::GpuRequest::from_proto(spec.gpus_per_node);
     let gpus_per_task = spur_core::gpu_request::GpuRequest::from_proto(spec.gpus_per_task);
 
+    // Reject an unexpandable --nodelist/--exclude here, else it matches no node and hangs the job.
+    for (flag, pattern) in [("nodelist", &spec.nodelist), ("exclude", &spec.exclude)] {
+        if !pattern.is_empty() {
+            spur_core::hostlist::expand(pattern).map_err(|e| {
+                Status::invalid_argument(format!("invalid --{flag} '{pattern}': {e}"))
+            })?;
+        }
+    }
+
     let job_spec = spur_core::job::JobSpec {
         name: spec.name,
         partition: if spec.partition.is_empty() {
@@ -7013,6 +7022,38 @@ mod tests {
         let core = proto_to_job_spec(spec).unwrap();
         assert_eq!(core.num_tasks, 1);
         assert_eq!(core.effective_num_nodes(), 1);
+    }
+
+    #[test]
+    fn proto_to_job_spec_rejects_unexpandable_node_patterns() {
+        let over_cap = spur_proto::proto::JobSpec {
+            nodelist: "node[0-2000000]".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            proto_to_job_spec(over_cap).unwrap_err().code(),
+            tonic::Code::InvalidArgument,
+            "an over-cap nodelist is rejected at submission"
+        );
+
+        let malformed = spur_proto::proto::JobSpec {
+            exclude: "node]1-2[".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            proto_to_job_spec(malformed).unwrap_err().code(),
+            tonic::Code::InvalidArgument,
+            "a malformed exclude pattern is rejected too"
+        );
+
+        let valid = spur_proto::proto::JobSpec {
+            nodelist: "node[1-4],other5".into(),
+            ..Default::default()
+        };
+        assert!(
+            proto_to_job_spec(valid).is_ok(),
+            "a valid pattern still passes"
+        );
     }
 
     #[test]

--- a/docs/user-guide/submitting-jobs.rst
+++ b/docs/user-guide/submitting-jobs.rst
@@ -177,10 +177,14 @@ patterns for ``--output`` and ``--error``, the token expands to the job ID.
      - Required node features, e.g. ``mi300x,nvlink``.
    * - ``--nodelist``
      - ``-w``
-     - Request a specific list of nodes.
+     - Request a specific list of nodes. A malformed hostlist, or one that
+       expands to more than 1,000,000 hosts, is rejected at submission rather
+       than accepted and left unschedulable.
    * - ``--exclude``
      - ``-x``
-     - Exclude specific nodes from the allocation.
+     - Exclude specific nodes from the allocation. Validated at submission the
+       same way as ``--nodelist``, so a malformed or over-cap pattern is
+       rejected instead of silently excluding nothing.
    * - ``--exclusive``
      -
      - Do not share allocated nodes with other jobs. Default off.


### PR DESCRIPTION
## Summary

Closes #822

Follow-up to #679, addressing both review items @sajmera-pensando raised:

1. **In-loop hostlist guard was off-by-one.** The pre-loop guard rejects when the
   total *would exceed* `MAX_HOSTLIST_SIZE`, but the in-loop backstop ran *after*
   the push and used `>`, so `results` could transiently hold `MAX_HOSTLIST_SIZE + 1`
   before erroring. The two guards disagreed.
2. **Over-cap / malformed `--nodelist` / `--exclude` silently hung the job.** An
   unexpandable pattern fell back to a literal name (via
   `node_match::expand_hostlist_or_split`) that matches no node, so the job sat in
   the queue forever with no error. Slurm rejects this at submission.

## Changes

- **`hostlist.rs`** — move the in-loop size check *before* the push and compare with
  `>=`, so `results` never grows past the cap. Also drop the `count` field from
  `TooLarge`: the in-loop path can't know the true request size without expanding
  (the OOM we're preventing), so it reported a misleading `MAX + 1`. Both guards now
  report the limit only — `hostlist too large: exceeds maximum {max} hosts`.
- **`server.rs`** — validate `--nodelist` and `--exclude` in `proto_to_job_spec`,
  returning `InvalidArgument` with the offending pattern and reason before the spec
  reaches the scheduler.

> Note: the suggested one-character `>` → `>=` could not be applied in place. In the
> old position (after the push), `>=` rejects a list of *exactly* `MAX_HOSTLIST_SIZE`,
> which the pre-loop guard deliberately allows and `expand_allows_cap_boundary` asserts.
> Moving the check before the push is what makes `>=` both consistent and
> boundary-correct.

## Test plan

- [x] `expand_allows_cap_boundary` — a list of exactly 1,000,000 hosts still expands
- [x] `expand_rejects_nested_product_over_cap`, `expand_rejects_recursive_overshoot_past_cap` — nested patterns that multiply past the cap are rejected
- [x] New `proto_to_job_spec_rejects_unexpandable_node_patterns` — over-cap nodelist and malformed exclude are rejected, a valid pattern still passes
- [x] `cargo fmt --check` clean, `cargo clippy -D warnings` clean
- [x] Full `spur-core` + `spurctld` suites pass single-threaded (1,536 tests, 0 failures)