### PR TITLE
fix(spur-core): stop build_node_allocation leaving an empty gpu device key

### DIFF
--- a/crates/spur-core/src/resource.rs
+++ b/crates/spur-core/src/resource.rs
@@ -59,7 +59,7 @@ impl AllocatedDevice {
 
 impl ResourceAllocations {
     pub fn is_empty(&self) -> bool {
-        self.cpus == 0 && self.memory_mb == 0 && self.devices.is_empty()
+        self.cpus == 0 && self.memory_mb == 0 && !self.has_devices()
     }
 
     pub fn has_devices(&self) -> bool {
@@ -378,11 +378,14 @@ pub fn build_node_allocation(
         let mut effective_alloc = current_alloc.clone();
         effective_alloc.add(&alloc);
         let picked = inventory.pick_devices(&effective_alloc, "gpu", dtype, count);
-        alloc
-            .devices
-            .entry("gpu".into())
-            .or_default()
-            .extend(picked);
+        // Guard like the generic loop: an unsatisfiable pick must not leave an empty device key.
+        if !picked.is_empty() {
+            alloc
+                .devices
+                .entry("gpu".into())
+                .or_default()
+                .extend(picked);
+        }
     }
 
     for (name, count) in &request.generic {
@@ -728,16 +731,17 @@ mod accounting_tests {
         assert_eq!(alloc.generic_count("absent"), 0);
     }
 
-    /// `is_empty` inspects the map while `has_devices` inspects inside it, so a
-    /// leftover empty vector reads as non-empty yet holds nothing.
+    /// `is_empty` used to inspect the map while `has_devices` inspected inside it, so a
+    /// leftover empty vector read as non-empty yet held nothing. Both now look inside.
     #[test]
-    fn is_empty_and_has_devices_disagree_on_empty_device_vec() {
+    fn is_empty_agrees_with_has_devices_on_empty_device_vec() {
         let mut alloc = ResourceAllocations::default();
         assert!(alloc.is_empty());
         assert!(!alloc.has_devices());
 
+        // A key with an empty list holds nothing, so both predicates must say so.
         alloc.devices.insert("gpu".into(), Vec::new());
-        assert!(!alloc.is_empty());
+        assert!(alloc.is_empty());
         assert!(!alloc.has_devices());
 
         alloc
@@ -745,6 +749,42 @@ mod accounting_tests {
             .insert("gpu".into(), vec![AllocatedDevice::injectable(3)]);
         assert!(alloc.has_devices());
         assert_eq!(alloc.total_device_count("gpu"), 1);
+    }
+
+    #[test]
+    fn build_node_allocation_adds_no_key_when_no_gpu_is_free() {
+        let one_gpu = || GpuResource {
+            device_id: 0,
+            gpu_type: "mi300x".into(),
+            memory_mb: 192_000,
+            peer_gpus: vec![],
+            link_type: GpuLinkType::XGMI,
+        };
+        let inventory = ResourceSet {
+            cpus: 8,
+            memory_mb: 1024,
+            gpus: vec![one_gpu()],
+            ..Default::default()
+        };
+        // The node's only GPU is already handed out.
+        let mut current = ResourceAllocations::default();
+        current
+            .devices
+            .insert("gpu".into(), vec![AllocatedDevice::injectable(0)]);
+        let request = ResourceSet {
+            cpus: 1,
+            memory_mb: 512,
+            gpus: vec![one_gpu()],
+            ..Default::default()
+        };
+
+        let alloc = build_node_allocation(&inventory, &current, &request);
+
+        assert!(
+            !alloc.devices.contains_key("gpu"),
+            "an unsatisfiable request must not leave an empty device list behind"
+        );
+        assert!(!alloc.has_devices());
     }
 
     #[test]

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -894,6 +894,64 @@ mod tests {
         )
     }
 
+    // A job deferred to a future start must book the GPUs it will occupy. Resolving the
+    // picks against `now` booked none of them, so another job could take the same window.
+    #[test]
+    fn future_gpu_reservation_holds_the_requested_devices() {
+        let mut sched = BackfillScheduler::new(100);
+
+        // One 8-GPU node with every GPU held by a running job.
+        let mut nodes = vec![make_gpu_node(8)];
+        let mut busy = ResourceAllocations::with_scalar(8, 1024);
+        busy.devices.insert(
+            "gpu".into(),
+            (0..8)
+                .map(spur_core::resource::AllocatedDevice::injectable)
+                .collect(),
+        );
+        nodes[0].alloc_resources = busy;
+
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+        let job = Job::new(
+            1,
+            JobSpec {
+                name: "waiter".into(),
+                partition: Some("default".into()),
+                user: "test".into(),
+                num_nodes: 1,
+                num_tasks: 1,
+                cpus_per_task: 1,
+                gres: vec!["gpu:8".into()],
+                time_limit: Some(Duration::hours(1)),
+                ..Default::default()
+            },
+        );
+        let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let now = Utc::now();
+        assert!(
+            sched.schedule(&[job], &cluster).is_empty(),
+            "every GPU is busy, so nothing starts now"
+        );
+
+        // The running allocation is held for 24h, so the deferred job books the hour after.
+        let booked = sched.timelines[0].accumulated_at(now + Duration::minutes(24 * 60 + 1));
+        assert_eq!(
+            booked.total_device_count("gpu"),
+            8,
+            "the deferred job must book all 8 GPUs it needs"
+        );
+    }
+
     #[test]
     fn unplaced_job_records_why_it_was_not_started() {
         let mut sched = BackfillScheduler::new(100);


### PR DESCRIPTION
Closes #825

## Summary

Follow-up to #712. During that review, @sajmera-pensando asked whether the
`is_empty` / `has_devices` disagreement on an empty device vector — documented by
a test there — is actually reachable in production. It is, and this closes the two
spots that let the bad state exist.

## The bug

A node has 8 GPUs. Job A is running and holds all 8; Job B is queued asking for
`--gres=gpu:8`. Job B can't start now, so backfill pencils in a future booking
starting when Job A finishes.

When the GPU pick came back empty, `build_node_allocation` still inserted the
`"gpu"` key, leaving the allocation holding `{"gpu": []}` — key present, list
empty. That is exactly the state the #712 test flagged: `is_empty()` said "not
empty" (the map has a key) while `has_devices()` said "no devices" (the list is
empty).

## The fix

- `build_node_allocation` no longer inserts a `"gpu"` key when the pick is empty,
  matching the generic-gres loop right below it.
- `is_empty()` is now content-based (`!self.has_devices()`), so it cannot disagree
  with `has_devices()` on a leftover empty vector.

> Note: `subtract` was **not** the culprit — it already prunes correctly (drops
> zero-count devices, then removes the key once the list empties). The empty list
> was created on the allocation side, not the release side.

> Rebase note: this PR originally also changed `backfill.rs` to resolve the picks
> at the reserved start rather than `now`. #732 has since landed that fix on
> `main`, so what remains here from that work is the scheduler-level regression
> test.

## Tests

- The #712 test `is_empty_and_has_devices_disagree_on_empty_device_vec` is inverted
  to `..._agrees_...` and now asserts both predicates agree.
- New `build_node_allocation_adds_no_key_when_no_gpu_is_free` — a node whose only
  GPU is taken produces no `"gpu"` key.
- New `future_gpu_reservation_holds_the_requested_devices` — the scheduler-level
  guard: an 8-GPU node fully busy with a queued `--gres=gpu:8` job books all 8 GPUs
  in the deferred window.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p spur-core -p spur-sched -p spurctld --all-targets -- -D warnings` clean
- [x] Full `spur-core` + `spur-sched` + `spurctld` suites pass single-threaded