### PR TITLE
fix(spurctld)!: enforce reservation management privileges server-side

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -28,6 +28,7 @@ Kubernetes
 kubeconfig
 kubelet
 Landlock
+LDAP
 LIF
 localhost
 Loopback
@@ -36,6 +37,7 @@ MyST
 namespace
 namespaces
 NCCL
+NSS
 openraft
 OCI
 PBS
@@ -92,6 +94,7 @@ sreport
 srun
 SCP
 sshare
+SSSD
 sstat
 strigger
 subcommand

--- a/crates/spur-cli/src/privilege.rs
+++ b/crates/spur-cli/src/privilege.rs
@@ -1,94 +1,28 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Client-side privilege gate for privileged CLI actions; not a security
-//! boundary (the controller doesn't authenticate callers — real enforcement is
-//! future server-side RBAC). Allows root or `sudo`/`wheel` membership, not
-//! proof the caller actually elevated via `sudo`.
+//! Client-side pre-check for privileged CLI actions.
+//!
+//! Kept for the error it gives — immediate, offline, naming the action — but enforcement is the
+//! controller's (`require_reservation_manager`). Checks the invoking process, which no server can
+//! verify, and does not prove the caller elevated via `sudo`. The rule lives in
+//! [`spur_core::privilege`] so the two sides cannot drift.
 
 use anyhow::{bail, Context, Result};
+use spur_core::privilege::{is_privileged, PRIVILEGED_GROUPS, PRIVILEGE_REQUIREMENT};
 
-/// Unix groups whose members are treated as privileged, covering the
-/// Debian/Ubuntu (`sudo`) and RHEL/CentOS (`wheel`) conventions.
-const PRIVILEGED_GROUPS: &[&str] = &["sudo", "wheel"];
-
-/// Pure decision core, split from the syscalls so it is unit-testable.
-fn is_privileged(euid: u32, caller_groups: &[String], privileged_groups: &[&str]) -> bool {
-    euid == 0
-        || caller_groups
-            .iter()
-            .any(|g| privileged_groups.contains(&g.as_str()))
-}
-
-/// Resolve the invoking process's group names (supplementary groups plus the
-/// effective gid). Returns `Err` on any lookup failure so callers fail closed.
-fn caller_group_names() -> Result<Vec<String>> {
-    use nix::unistd::{getegid, getgroups, Group};
-
-    let mut gids = getgroups().context("failed to read process groups")?;
-    gids.push(getegid());
-
-    let mut names = Vec::new();
-    for gid in gids {
-        // A gid without a matching group entry cannot be privileged; skip it.
-        if let Some(group) = Group::from_gid(gid).context("failed to resolve group name")? {
-            names.push(group.name);
-        }
-    }
-    Ok(names)
-}
-
-/// Gate a privileged CLI action. Fails closed: any identity/group lookup error
-/// denies the action rather than allowing it.
+/// Gate a privileged CLI action. Fails closed: any identity/group lookup error denies the action
+/// rather than allowing it.
 pub fn require_privileged(action: &str) -> Result<()> {
     let euid = nix::unistd::geteuid().as_raw();
-    // Root is always privileged; short-circuit so a group-lookup failure can
-    // never deny root.
+    // Root is always privileged; short-circuit so a group-lookup failure can never deny root.
     if euid == 0 {
         return Ok(());
     }
-    let groups = caller_group_names()?;
+    let groups = spur_core::privilege::current_process_groups()
+        .context("failed to read the invoking process's groups")?;
     if is_privileged(euid, &groups, PRIVILEGED_GROUPS) {
         return Ok(());
     }
-    bail!(
-        "insufficient privileges to {action}: requires root or membership in the 'sudo' or 'wheel' group"
-    );
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    const PRIV: &[&str] = &["sudo", "wheel"];
-
-    #[test]
-    fn root_is_privileged_regardless_of_groups() {
-        assert!(is_privileged(0, &[], PRIV));
-    }
-
-    #[test]
-    fn sudo_member_is_privileged() {
-        assert!(is_privileged(1000, &["users".into(), "sudo".into()], PRIV));
-    }
-
-    #[test]
-    fn wheel_member_is_privileged() {
-        assert!(is_privileged(1000, &["wheel".into()], PRIV));
-    }
-
-    #[test]
-    fn plain_user_is_denied() {
-        assert!(!is_privileged(
-            1000,
-            &["users".into(), "docker".into()],
-            PRIV
-        ));
-    }
-
-    #[test]
-    fn empty_groups_are_denied() {
-        // Simulates a lookup that resolved no privileged groups.
-        assert!(!is_privileged(1000, &[], PRIV));
-    }
+    bail!("insufficient privileges to {action}: {PRIVILEGE_REQUIREMENT}");
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -697,8 +697,8 @@ pub struct AuthConfig {
     /// How strictly callers are authenticated. See [`AuthMode`].
     #[serde(default)]
     pub mode: AuthMode,
-    /// HMAC signing secret (raw bytes) for node admission and user-identity RPC auth; `required`
-    /// refuses to start without one. Captured at startup, not updated by `reconfigure`.
+    /// JWT secret key (file path or inline), signing and verifying both user credentials
+    /// (`spur token user`) and node admission tokens.
     pub jwt_key: Option<String>,
     /// Allow jobs to execute as uid 0 (root).
     ///

--- a/crates/spur-core/src/lib.rs
+++ b/crates/spur-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod k0s;
 pub mod mpi;
 pub mod node;
 pub mod partition;
+pub mod privilege;
 pub mod process;
 pub mod qos;
 pub mod quota_names;

--- a/crates/spur-core/src/privilege.rs
+++ b/crates/spur-core/src/privilege.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Who counts as a privileged operator: root, or a member of `sudo`/`wheel`.
+//!
+//! Shared by the CLI and the controller so the two cannot drift. The CLI asks about the invoking
+//! process, the controller about a username through NSS — which is what makes the rule enforceable
+//! against a caller that never went through the CLI. Both fail closed.
+
+use crate::auth::AuthError;
+
+/// Unix groups whose members are treated as privileged, covering the Debian/Ubuntu (`sudo`) and
+/// RHEL/CentOS (`wheel`) conventions.
+pub const PRIVILEGED_GROUPS: &[&str] = &["sudo", "wheel"];
+
+/// The requirement, worded once so the CLI's pre-check and the controller's denial read the same.
+pub const PRIVILEGE_REQUIREMENT: &str =
+    "requires root or membership in the 'sudo' or 'wheel' group";
+
+/// Pure decision core, split from the syscalls so it is unit-testable.
+pub fn is_privileged(uid: u32, group_names: &[String], privileged_groups: &[&str]) -> bool {
+    uid == 0
+        || group_names
+            .iter()
+            .any(|g| privileged_groups.contains(&g.as_str()))
+}
+
+/// Group names of the *invoking process*: supplementary groups plus the effective gid.
+pub fn current_process_groups() -> Result<Vec<String>, AuthError> {
+    use nix::unistd::{getegid, getgroups};
+
+    let mut gids = getgroups()
+        .map_err(|e| AuthError::PermissionDenied(format!("read process groups: {e}")))?;
+    gids.push(getegid());
+    Ok(resolve_group_names(&gids))
+}
+
+/// Whether `user` is privileged on *this host*, resolved through NSS — so it holds for any caller,
+/// including one that bypassed the CLI. Assumes the controller shares a user directory with the
+/// login nodes; a name it cannot resolve is an error, never an allow.
+pub fn named_user_is_privileged(user: &str) -> Result<bool, AuthError> {
+    let (uid, gid) = crate::auth::resolve_unix_credentials(user)?;
+    if uid == 0 {
+        return Ok(true);
+    }
+    let groups = user_group_names(user, gid)?;
+    Ok(is_privileged(uid, &groups, PRIVILEGED_GROUPS))
+}
+
+/// Group names of a named user. Uses `getgrouplist` rather than reading `/etc/group` so
+/// directory-provided supplementary groups (LDAP/sssd) count.
+fn user_group_names(user: &str, gid: u32) -> Result<Vec<String>, AuthError> {
+    let name = std::ffi::CString::new(user)
+        .map_err(|_| AuthError::UnknownUser(format!("{user}: embedded NUL")))?;
+    let gids = nix::unistd::getgrouplist(&name, nix::unistd::Gid::from_raw(gid))
+        .map_err(|e| AuthError::PermissionDenied(format!("read groups for '{user}': {e}")))?;
+    Ok(resolve_group_names(&gids))
+}
+
+/// A gid that does not resolve is dropped rather than failing the lookup: it cannot be privileged,
+/// and one flaky directory entry among a user's groups must not deny an operator who is in `sudo`.
+fn resolve_group_names(gids: &[nix::unistd::Gid]) -> Vec<String> {
+    gids.iter()
+        .filter_map(|gid| nix::unistd::Group::from_gid(*gid).ok().flatten())
+        .map(|group| group.name)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PRIV: &[&str] = &["sudo", "wheel"];
+
+    #[test]
+    fn root_is_privileged_regardless_of_groups() {
+        assert!(is_privileged(0, &[], PRIV));
+    }
+
+    #[test]
+    fn sudo_member_is_privileged() {
+        assert!(is_privileged(1000, &["users".into(), "sudo".into()], PRIV));
+    }
+
+    #[test]
+    fn wheel_member_is_privileged() {
+        assert!(is_privileged(1000, &["wheel".into()], PRIV));
+    }
+
+    #[test]
+    fn plain_user_is_denied() {
+        assert!(!is_privileged(
+            1000,
+            &["users".into(), "docker".into()],
+            PRIV
+        ));
+    }
+
+    #[test]
+    fn empty_groups_are_denied() {
+        // Simulates a lookup that resolved no privileged groups.
+        assert!(!is_privileged(1000, &[], PRIV));
+    }
+
+    /// On the wire an empty username is what an old or hand-written client sends; treating it as
+    /// trusted is how "no user" becomes "root".
+    #[test]
+    fn empty_user_is_an_error_not_an_allow() {
+        let err = named_user_is_privileged("").expect_err("empty user must not resolve");
+        assert!(matches!(err, AuthError::UnknownUser(_)));
+    }
+
+    /// A NUL in the name cannot reach `getgrouplist`; it must be an error rather than a panic.
+    #[test]
+    fn user_name_with_nul_is_rejected() {
+        assert!(matches!(
+            user_group_names("al\0ice", 1000),
+            Err(AuthError::UnknownUser(_))
+        ));
+    }
+}

--- a/crates/spur-core/src/reservation.rs
+++ b/crates/spur-core/src/reservation.rs
@@ -80,9 +80,8 @@ pub struct Reservation {
     pub users: Vec<String>,
     #[serde(default)]
     pub flags: ReservationFlags,
-    /// User who created the reservation. Empty for reservations created before
-    /// ownership tracking existed (and for trusted internal callers), which are
-    /// treated as unowned and mutable by any authenticated user.
+    /// Who created the reservation, recorded for attribution only — not an authorization input, as
+    /// an operator may manage any reservation. Empty for reservations predating the field.
     #[serde(default)]
     pub owner: String,
 }
@@ -112,14 +111,6 @@ impl Reservation {
 
     pub fn covers_node(&self, node: &str) -> bool {
         self.nodes.iter().any(|n| n == node)
-    }
-
-    /// Whether `user` may modify or delete this reservation. Root and trusted
-    /// internal callers (empty user) are always allowed, as is the recorded
-    /// owner. Reservations with no recorded owner (created before ownership
-    /// tracking) stay mutable by any authenticated user.
-    pub fn can_be_managed_by(&self, user: &str) -> bool {
-        user.is_empty() || user == "root" || self.owner.is_empty() || self.owner == user
     }
 
     pub fn allows_user(&self, user: &str, account: Option<&str>) -> bool {
@@ -344,26 +335,6 @@ mod tests {
         assert!(res.allows_user("bob", Some("research")));
         assert!(!res.allows_user("bob", Some("other")));
         assert!(!res.allows_user("bob", None));
-    }
-
-    #[test]
-    fn owner_can_manage_and_others_cannot() {
-        let mut res = make_reservation();
-        res.owner = "alice".into();
-        assert!(res.can_be_managed_by("alice"), "owner may manage");
-        assert!(res.can_be_managed_by("root"), "root may manage");
-        assert!(res.can_be_managed_by(""), "internal calls may manage");
-        assert!(!res.can_be_managed_by("bob"), "non-owner may not manage");
-    }
-
-    #[test]
-    fn unowned_reservation_is_manageable_by_anyone() {
-        let res = make_reservation();
-        assert_eq!(res.owner, "");
-        assert!(
-            res.can_be_managed_by("bob"),
-            "reservations without a recorded owner stay mutable"
-        );
     }
 
     #[test]

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -22,6 +22,19 @@ fn validate_tres(field: &str, raw: &str) -> Result<(), Status> {
         .map_err(|e| Status::invalid_argument(format!("invalid {field}: {e}")))
 }
 
+/// Canonicalize an `adminlevel` for storage, rejecting anything that is not a level. The column is
+/// free text, so an unrecognised value would otherwise store and display as if it were a privilege.
+fn normalize_admin_level(raw: &str) -> Result<&str, Status> {
+    if raw.is_empty() {
+        return Ok(raw);
+    }
+    super::canonical_admin_level(raw).ok_or_else(|| {
+        Status::invalid_argument(format!(
+            "invalid adminlevel '{raw}': expected None, Operator, or Admin"
+        ))
+    })
+}
+
 /// Map an optional TRES/text proto field to a nullable-column patch: unset ->
 /// keep, empty -> clear (SQL NULL), otherwise -> set.
 fn nullable_str(field: &Option<String>) -> Option<Option<&str>> {
@@ -440,6 +453,11 @@ impl SlurmAccounting for AccountingService {
         require_admin(&request, "add user")?;
         let pool = self.pool()?;
         let req = request.into_inner();
+        let admin_level = req
+            .admin_level
+            .as_deref()
+            .map(normalize_admin_level)
+            .transpose()?;
         // QOS references are validated against the live DB, not QosCache: a QOS
         // created just now may not have reached the cache's next refresh yet,
         // the same lag job submission already accepts for QosCache reads. Each
@@ -493,7 +511,7 @@ impl SlurmAccounting for AccountingService {
             validate_tres("grptres", t)?;
         }
         let update = db::UserUpdate {
-            admin_level: req.admin_level.as_deref(),
+            admin_level,
             is_default: req.is_default,
             default_qos: nullable_str(&req.default_qos),
             allowed_qos: allowed_qos_normalized.as_deref().map(|s| {
@@ -968,6 +986,42 @@ mod tests {
         assert_admin_gated!(remove_user, RemoveUserRequest::default());
         assert_admin_gated!(create_qos, CreateQosRequest::default());
         assert_admin_gated!(delete_qos, DeleteQosRequest::default());
+    }
+
+    /// Every spelling Slurm accepts must survive, and the admin ones must converge: `sacctmgr show
+    /// user` prints `Administrator`, so rejecting it would break round-tripping Slurm's own output.
+    #[test]
+    fn normalize_admin_level_canonicalizes_slurm_spellings() {
+        for (input, want) in [
+            ("", ""),
+            ("none", "None"),
+            ("None", "None"),
+            ("operator", "Operator"),
+            ("Operator", "Operator"),
+            ("admin", "Administrator"),
+            ("Admin", "Administrator"),
+            ("Administrator", "Administrator"),
+            ("SuperUser", "Administrator"),
+        ] {
+            assert_eq!(
+                normalize_admin_level(input).unwrap(),
+                want,
+                "input {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_admin_level_rejects_non_levels() {
+        for level in ["adminn", "root", "yes"] {
+            let err = normalize_admin_level(level).expect_err("level must be rejected");
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+            assert!(
+                err.message().contains("Admin"),
+                "denial must name the accepted levels: {}",
+                err.message()
+            );
+        }
     }
 
     #[test]

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -30,7 +30,8 @@ fn normalize_admin_level(raw: &str) -> Result<&str, Status> {
     }
     super::canonical_admin_level(raw).ok_or_else(|| {
         Status::invalid_argument(format!(
-            "invalid adminlevel '{raw}': expected None, Operator, or Admin"
+            "invalid adminlevel '{raw}': expected None, Operator, or Admin \
+             (also spelled Administrator or SuperUser)"
         ))
     })
 }

--- a/crates/spurctld/src/accounting/mod.rs
+++ b/crates/spurctld/src/accounting/mod.rs
@@ -74,14 +74,16 @@ pub fn admin_level_is_admin(raw: &str) -> bool {
 }
 
 /// Fold one user-row's admin_level into the per-user map, keeping the highest: admin wins over
-/// any lower level so a later non-admin row for a multi-account user can't clobber it.
+/// any lower level so a later non-admin row for a multi-account user can't clobber it. Stored
+/// canonical, so rows predating the column's normalization cannot leave several spellings of one
+/// level in the cache; a value that is no level at all is kept verbatim, to stay visible.
 fn merge_admin_level(map: &mut HashMap<String, String>, user: &str, level: &str) {
     if level.is_empty() || level.eq_ignore_ascii_case("none") {
         return;
     }
     let entry = map.entry(user.to_owned()).or_default();
     if entry.is_empty() || admin_level_is_admin(level) {
-        *entry = level.to_owned();
+        *entry = canonical_admin_level(level).unwrap_or(level).to_owned();
     }
 }
 
@@ -182,13 +184,32 @@ mod tests {
         let mut m = HashMap::new();
         merge_admin_level(&mut m, "carol", "Admin");
         merge_admin_level(&mut m, "carol", "Operator");
-        assert_eq!(m.get("carol").map(String::as_str), Some("Admin"));
+        assert_eq!(m.get("carol").map(String::as_str), Some("Administrator"));
 
         // Operator then Admin: Admin must still win.
         let mut m = HashMap::new();
         merge_admin_level(&mut m, "carol", "Operator");
         merge_admin_level(&mut m, "carol", "Admin");
-        assert_eq!(m.get("carol").map(String::as_str), Some("Admin"));
+        assert_eq!(m.get("carol").map(String::as_str), Some("Administrator"));
+    }
+
+    /// Rows written before the column was normalized must not leave several spellings of one level
+    /// in the cache.
+    #[test]
+    fn legacy_spellings_fold_to_one_canonical_level() {
+        for raw in ["admin", "Admin", "Administrator", "SuperUser"] {
+            let mut m = HashMap::new();
+            merge_admin_level(&mut m, "carol", raw);
+            assert_eq!(
+                m.get("carol").map(String::as_str),
+                Some("Administrator"),
+                "raw {raw:?}"
+            );
+        }
+
+        let mut m = HashMap::new();
+        merge_admin_level(&mut m, "dave", "operator");
+        assert_eq!(m.get("dave").map(String::as_str), Some("Operator"));
     }
 
     #[test]

--- a/crates/spurctld/src/accounting/mod.rs
+++ b/crates/spurctld/src/accounting/mod.rs
@@ -54,14 +54,33 @@ pub async fn fairshare_factors(
     ))
 }
 
-/// Fold one user-row's admin_level into the per-user map, keeping the highest: `Admin` wins over
+/// Canonicalize an `adminlevel` to Slurm's spelling, or `None` if it is not a level.
+///
+/// Slurm prints `Administrator` for the highest level and its parser also takes `Admin` and
+/// `SuperUser`, so all three must resolve to the same thing — recognising only one spelling would
+/// leave a stored level that looks like a privilege and confers nothing.
+pub fn canonical_admin_level(raw: &str) -> Option<&'static str> {
+    match raw.to_ascii_lowercase().as_str() {
+        "none" => Some("None"),
+        "operator" => Some("Operator"),
+        "admin" | "administrator" | "superuser" => Some("Administrator"),
+        _ => None,
+    }
+}
+
+/// Whether a stored `admin_level` is the level that confers control-plane privilege.
+pub fn admin_level_is_admin(raw: &str) -> bool {
+    canonical_admin_level(raw) == Some("Administrator")
+}
+
+/// Fold one user-row's admin_level into the per-user map, keeping the highest: admin wins over
 /// any lower level so a later non-admin row for a multi-account user can't clobber it.
 fn merge_admin_level(map: &mut HashMap<String, String>, user: &str, level: &str) {
     if level.is_empty() || level.eq_ignore_ascii_case("none") {
         return;
     }
     let entry = map.entry(user.to_owned()).or_default();
-    if entry.is_empty() || level.eq_ignore_ascii_case("admin") {
+    if entry.is_empty() || admin_level_is_admin(level) {
         *entry = level.to_owned();
     }
 }

--- a/crates/spurctld/src/association_cache.rs
+++ b/crates/spurctld/src/association_cache.rs
@@ -62,15 +62,15 @@ impl AssociationCache {
         self.snapshot.read().loaded
     }
 
-    /// Whether `user` holds the `Admin` accounting admin-level. Fails closed: an unloaded cache
-    /// (accounting off or not yet fetched) reports no admins.
+    /// Whether `user` holds the admin accounting level, in any spelling Slurm accepts. Fails closed:
+    /// an unloaded cache (accounting off or not yet fetched) reports no admins.
     pub fn is_admin(&self, user: &str) -> bool {
         let snapshot = self.snapshot.read();
         snapshot.loaded
             && snapshot
                 .admin_level
                 .get(user)
-                .is_some_and(|lvl| lvl.eq_ignore_ascii_case("admin"))
+                .is_some_and(|lvl| crate::accounting::admin_level_is_admin(lvl))
     }
 
     /// Whether `user` is associated with `account`. An unloaded cache reports `CacheUnavailable`
@@ -329,12 +329,22 @@ mod tests {
         assert!(!cache.is_admin("carol"));
     }
 
+    /// Every spelling Slurm's parser maps to super-user must resolve here, or a row stored as
+    /// `Administrator` (what `sacctmgr show user` prints) would confer nothing.
     #[test]
-    fn is_admin_true_only_for_admin_level_case_insensitive() {
+    fn is_admin_accepts_every_slurm_admin_spelling() {
         let cache = AssociationCache::new();
-        cache.insert_admin_level("carol", "admin");
+        for (user, level) in [
+            ("carol", "admin"),
+            ("frank", "Admin"),
+            ("grace", "Administrator"),
+            ("heidi", "SuperUser"),
+        ] {
+            cache.insert_admin_level(user, level);
+            assert!(cache.is_admin(user), "level {level:?} must be admin");
+        }
+
         cache.insert_admin_level("dave", "Operator");
-        assert!(cache.is_admin("carol"));
         assert!(!cache.is_admin("dave"));
         assert!(!cache.is_admin("erin"));
     }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -86,7 +86,6 @@ pub enum ReservationError {
     InvalidArgument(String),
     NotFound(String),
     AlreadyExists(String),
-    PermissionDenied(String),
     Raft(String),
 }
 
@@ -96,7 +95,6 @@ impl std::fmt::Display for ReservationError {
             Self::InvalidArgument(m)
             | Self::NotFound(m)
             | Self::AlreadyExists(m)
-            | Self::PermissionDenied(m)
             | Self::Raft(m) => f.write_str(m),
         }
     }
@@ -250,10 +248,6 @@ impl ReservationError {
 
     pub fn already_exists(msg: impl Into<String>) -> Self {
         Self::AlreadyExists(msg.into())
-    }
-
-    pub fn permission_denied(msg: impl Into<String>) -> Self {
-        Self::PermissionDenied(msg.into())
     }
 
     pub fn raft(msg: impl Into<String>) -> Self {
@@ -3993,10 +3987,8 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Update an existing reservation (validated, persisted via Raft). The
-    /// requesting `user` must be the reservation owner, root, or empty (trusted
-    /// internal calls); legacy reservations with no recorded owner are
-    /// modifiable by anyone.
+    /// Update an existing reservation (validated, persisted via Raft). Authorization is the RPC
+    /// boundary's (`require_reservation_manager`): an operator may manage any reservation.
     #[allow(clippy::too_many_arguments)]
     pub fn update_reservation(
         &self,
@@ -4008,7 +4000,6 @@ impl ClusterManager {
         remove_users: &[String],
         add_accounts: &[String],
         remove_accounts: &[String],
-        user: &str,
     ) -> Result<(), ReservationError> {
         let mut preview = self
             .reservations
@@ -4019,13 +4010,6 @@ impl ClusterManager {
             .ok_or_else(|| {
                 ReservationError::not_found(format!("reservation '{}' not found", name))
             })?;
-
-        if !preview.can_be_managed_by(user) {
-            return Err(ReservationError::permission_denied(format!(
-                "user '{}' cannot modify reservation '{}' owned by '{}'",
-                user, name, preview.owner
-            )));
-        }
 
         if duration_minutes > 0 {
             preview.end_time =
@@ -4085,24 +4069,14 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Delete a reservation by name (persisted via Raft). The requesting `user`
-    /// must be the reservation owner, root, or empty (trusted internal calls);
-    /// legacy reservations with no recorded owner are deletable by anyone.
-    pub fn delete_reservation(&self, name: &str, user: &str) -> Result<(), ReservationError> {
-        {
-            let reservations = self.reservations.read();
-            let res = reservations
-                .iter()
-                .find(|r| r.name == name)
-                .ok_or_else(|| {
-                    ReservationError::not_found(format!("reservation '{}' not found", name))
-                })?;
-            if !res.can_be_managed_by(user) {
-                return Err(ReservationError::permission_denied(format!(
-                    "user '{}' cannot delete reservation '{}' owned by '{}'",
-                    user, name, res.owner
-                )));
-            }
+    /// Delete a reservation by name (persisted via Raft). Authorization is the RPC boundary's
+    /// (`require_reservation_manager`): an operator may manage any reservation.
+    pub fn delete_reservation(&self, name: &str) -> Result<(), ReservationError> {
+        if !self.reservations.read().iter().any(|r| r.name == name) {
+            return Err(ReservationError::not_found(format!(
+                "reservation '{}' not found",
+                name
+            )));
         }
 
         for job in self.jobs.read().values() {
@@ -14554,7 +14528,7 @@ mod tests {
         spec.reservation = Some("r1".into());
         let job_id = submit_and_wait(&cm, spec);
 
-        cm.delete_reservation("r1", "root").unwrap();
+        cm.delete_reservation("r1").unwrap();
         wait_for("reservation deleted", || cm.get_reservations().is_empty());
 
         let job = cm.get_job(job_id).unwrap();
@@ -14568,8 +14542,10 @@ mod tests {
         );
     }
 
+    /// Authorization is the RPC boundary's, not the state machine's: an operator may manage any
+    /// reservation, so `owner` is attribution only.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn delete_reservation_rejects_non_owner() {
+    async fn reservation_management_does_not_consult_the_owner() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "n1", 8, 16000);
@@ -14586,17 +14562,19 @@ mod tests {
         })
         .unwrap();
 
-        let err = cm.delete_reservation("r1", "bob").unwrap_err();
-        assert!(
-            matches!(err, ReservationError::PermissionDenied(_)),
-            "non-owner delete must be denied, got {err:?}"
-        );
-        assert_eq!(cm.get_reservations().len(), 1, "reservation must survive");
-
-        cm.delete_reservation("r1", "alice").unwrap();
+        cm.update_reservation("r1", 30, &[], &[], &[], &[], &[], &[])
+            .expect("update must not depend on the recorded owner");
+        cm.delete_reservation("r1")
+            .expect("delete must not depend on the recorded owner");
         assert!(
             cm.get_reservations().is_empty(),
-            "owner delete must succeed"
+            "deleted reservation must not survive"
+        );
+
+        let err = cm.delete_reservation("r1").unwrap_err();
+        assert!(
+            matches!(err, ReservationError::NotFound(_)),
+            "deleting a reservation that is gone must report not-found, got {err:?}"
         );
     }
 
@@ -14630,74 +14608,6 @@ mod tests {
             cm.get_reservations().is_empty(),
             "rejected reservation must not persist"
         );
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn update_reservation_rejects_non_owner() {
-        let dir = TempDir::new().unwrap();
-        let cm = test_cluster(&dir).await;
-        register_node(&cm, "n1", 8, 16000);
-        let now = chrono::Utc::now();
-        cm.create_reservation(Reservation {
-            name: "r1".into(),
-            start_time: now - chrono::Duration::minutes(5),
-            end_time: now + chrono::Duration::hours(2),
-            nodes: vec!["n1".into()],
-            accounts: Vec::new(),
-            users: Vec::new(),
-            flags: Default::default(),
-            owner: "alice".into(),
-        })
-        .unwrap();
-
-        let err = cm
-            .update_reservation("r1", 30, &[], &[], &[], &[], &[], &[], "bob")
-            .unwrap_err();
-        assert!(
-            matches!(err, ReservationError::PermissionDenied(_)),
-            "non-owner update must be denied, got {err:?}"
-        );
-
-        cm.update_reservation("r1", 30, &[], &[], &[], &[], &[], &[], "alice")
-            .expect("owner update must succeed");
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn delete_reservation_allows_root_and_unowned() {
-        let dir = TempDir::new().unwrap();
-        let cm = test_cluster(&dir).await;
-        register_node(&cm, "n1", 8, 16000);
-        let now = chrono::Utc::now();
-        cm.create_reservation(Reservation {
-            name: "owned".into(),
-            start_time: now - chrono::Duration::minutes(5),
-            end_time: now + chrono::Duration::hours(2),
-            nodes: vec!["n1".into()],
-            accounts: Vec::new(),
-            users: Vec::new(),
-            flags: Default::default(),
-            owner: "alice".into(),
-        })
-        .unwrap();
-        cm.create_reservation(Reservation {
-            name: "legacy".into(),
-            start_time: now - chrono::Duration::minutes(5),
-            end_time: now + chrono::Duration::hours(2),
-            nodes: vec!["n1".into()],
-            accounts: Vec::new(),
-            users: Vec::new(),
-            flags: spur_core::reservation::ReservationFlags {
-                overlap: true,
-                ..Default::default()
-            },
-            owner: String::new(),
-        })
-        .unwrap();
-
-        cm.delete_reservation("owned", "root")
-            .expect("root may delete any reservation");
-        cm.delete_reservation("legacy", "bob")
-            .expect("unowned reservation stays manageable by anyone");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -14887,7 +14797,7 @@ mod tests {
             let mut spec = basic_spec("resv-hold");
             spec.reservation = Some("r1".into());
             let job_id = submit_and_wait(&cm, spec);
-            cm.delete_reservation("r1", "root").unwrap();
+            cm.delete_reservation("r1").unwrap();
             wait_for("job held after delete", || {
                 cm.get_job(job_id).is_some_and(|j| {
                     j.pending_reason == PendingReason::ReservationDeleted && j.priority == 0
@@ -14930,7 +14840,7 @@ mod tests {
             let mut spec = basic_spec("resv-no-hold");
             spec.reservation = Some("r1".into());
             job_id = submit_and_wait(&cm, spec);
-            cm.delete_reservation("r1", "root").unwrap();
+            cm.delete_reservation("r1").unwrap();
             wait_for("reservation detached from job", || {
                 cm.get_job(job_id)
                     .is_some_and(|j| j.spec.reservation.is_none() && j.priority > 0)
@@ -14965,7 +14875,7 @@ mod tests {
         let mut spec = basic_spec("release-me");
         spec.reservation = Some("r1".into());
         let job_id = submit_and_wait(&cm, spec);
-        cm.delete_reservation("r1", "root").unwrap();
+        cm.delete_reservation("r1").unwrap();
         wait_for("job held after delete", || {
             cm.get_job(job_id).is_some_and(|j| {
                 j.pending_reason == PendingReason::ReservationDeleted && j.priority == 0

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -519,8 +519,8 @@ impl ControllerService {
         user: &str,
         identity: Option<&spur_core::auth::Identity>,
     ) -> Result<(), Status> {
-        // Returning before the lookup keeps a credential working on a controller that shares no
-        // user directory with the login nodes, and keeps NSS off an unauthenticated caller's path.
+        // Skipping the lookup for a verified admin keeps a credential working on a controller that
+        // shares no user directory with the login nodes and cannot resolve the name at all.
         if self.caller_is_admin(identity) {
             return Ok(());
         }
@@ -7246,17 +7246,27 @@ mod tests {
     }
 
     /// Reservations also reject an anonymous caller, unlike the generic gate: the asserted name is
-    /// still checkable, and a client skipping the CLI is the gap being closed. Host-independent —
-    /// `mallory` and the empty user are unprivileged or unresolvable, and both deny.
+    /// still checkable, and a client skipping the CLI is the gap being closed.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn reservation_mutations_deny_non_operators() {
         let dir = tempfile::TempDir::new().unwrap();
         let svc = test_service(&dir).await;
 
+        // A name no host resolves, so the outcome cannot turn on the runner's user database.
+        const UNKNOWN: &str = "no_such_user_in_nss_7f3a";
+
         macro_rules! assert_operator_gated {
             ($method:ident, $req:expr) => {{
-                for identity in [Some(viewer("mallory", false)), None] {
-                    let mut r = Request::new($req);
+                // Verified non-admin, anonymous asserting a name, and anonymous asserting nothing —
+                // the last being what the retired ownership rule took for a trusted internal call.
+                for (identity, user) in [
+                    (Some(viewer(UNKNOWN, false)), UNKNOWN),
+                    (None, UNKNOWN),
+                    (None, ""),
+                ] {
+                    let mut msg = $req;
+                    msg.user = user.to_string();
+                    let mut r = Request::new(msg);
                     if let Some(id) = identity {
                         r.extensions_mut().insert(id);
                     }
@@ -7267,7 +7277,8 @@ mod tests {
                     assert_eq!(
                         err.code(),
                         Code::PermissionDenied,
-                        concat!(stringify!($method), " must be PermissionDenied")
+                        "{} must be PermissionDenied for user {user:?}",
+                        stringify!($method)
                     );
                 }
             }};

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -489,7 +489,8 @@ impl ControllerService {
     }
 
     /// Rejects an identified non-admin from a cluster-tenancy mutation (partitions, node placement,
-    /// tokens, reservations); anonymous is allowed, matching `caller_is_privileged`. Call as a prologue, before `into_inner`.
+    /// tokens); anonymous is allowed, matching `caller_is_privileged`. Call as a prologue, before
+    /// `into_inner`. Reservations use the stricter [`Self::require_reservation_manager`].
     #[allow(clippy::result_large_err)]
     fn require_admin<T>(&self, request: &Request<T>, op: &str) -> Result<(), Status> {
         if self.caller_is_privileged(Self::verified_identity(request)) {
@@ -507,6 +508,30 @@ impl ControllerService {
     /// deployments. `required` never reaches here without an identity, so real users are still bound.
     fn caller_is_privileged(&self, identity: Option<&spur_core::auth::Identity>) -> bool {
         identity.is_none() || self.caller_is_admin(identity)
+    }
+
+    /// Stricter form of [`Self::require_admin`] for reservations: the admin bar, or the
+    /// root-or-`sudo`/`wheel` rule the CLI states, resolved from the caller's name on this host.
+    /// `require_admin` alone would be inert under the default `permissive` mode, since it waves an
+    /// unidentified caller through, and would deny a `sudo`/`wheel` operator under `required`.
+    async fn require_reservation_manager(
+        &self,
+        user: &str,
+        identity: Option<&spur_core::auth::Identity>,
+    ) -> Result<(), Status> {
+        // Returning before the lookup keeps a credential working on a controller that shares no
+        // user directory with the login nodes, and keeps NSS off an unauthenticated caller's path.
+        if self.caller_is_admin(identity) {
+            return Ok(());
+        }
+        // NSS can reach sssd/LDAP over the network, so it must not run on a runtime worker.
+        let owned = user.to_string();
+        let privileged = tokio::task::spawn_blocking(move || {
+            spur_core::privilege::named_user_is_privileged(&owned)
+        })
+        .await
+        .map_err(|e| Status::internal(format!("privilege lookup failed: {e}")))?;
+        reservation_manager_ruling(user, privileged)
     }
 
     /// Clamp a non-privileged caller's base priority to `[scheduler] max_user_priority`, mirroring
@@ -658,6 +683,26 @@ fn is_k0s_admin(cache: &crate::association_cache::AssociationCache, caller: &str
     // reports no admins at all, and removing it would strand `spur k8s up` on every cluster that
     // does not run accounting.
     caller == "root" || cache.is_admin(caller)
+}
+
+/// Ruling for a non-admin caller, split from the lookup so the policy is testable without the
+/// host's user database. An error denies: a name the controller cannot resolve is a name it cannot
+/// vouch for.
+fn reservation_manager_ruling(
+    user: &str,
+    privileged: Result<bool, spur_core::auth::AuthError>,
+) -> Result<(), Status> {
+    match privileged {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(Status::permission_denied(format!(
+            "user '{user}' may not manage reservations: {}",
+            spur_core::privilege::PRIVILEGE_REQUIREMENT
+        ))),
+        Err(e) => Err(Status::permission_denied(format!(
+            "cannot verify that '{user}' may manage reservations ({e}); reservation management {}",
+            spur_core::privilege::PRIVILEGE_REQUIREMENT
+        ))),
+    }
 }
 
 /// Whether `node` may release what it holds for `job_id`: the run is over, the
@@ -2327,11 +2372,11 @@ impl SlurmController for ControllerService {
             }
         }
 
-        self.require_admin(&request, "create reservation")?;
-
         let identity = Self::verified_identity(&request).cloned();
         let mut req = request.into_inner();
         Self::authoritative_user(&mut req.user, identity.as_ref());
+        self.require_reservation_manager(&req.user, identity.as_ref())
+            .await?;
 
         let details = txn::create_details(
             &req.start_time,
@@ -2374,11 +2419,11 @@ impl SlurmController for ControllerService {
             }
         }
 
-        self.require_admin(&request, "update reservation")?;
-
         let identity = Self::verified_identity(&request).cloned();
         let mut req = request.into_inner();
         Self::authoritative_user(&mut req.user, identity.as_ref());
+        self.require_reservation_manager(&req.user, identity.as_ref())
+            .await?;
 
         let details = txn::update_details(
             req.duration_minutes,
@@ -2403,7 +2448,6 @@ impl SlurmController for ControllerService {
                 &req.remove_users,
                 &req.add_accounts,
                 &req.remove_accounts,
-                &req.user,
             )
             .map_err(reservation_rpc_status);
         self.audit_reservation(
@@ -2435,18 +2479,18 @@ impl SlurmController for ControllerService {
             }
         }
 
-        self.require_admin(&request, "delete reservation")?;
-
         let identity = Self::verified_identity(&request).cloned();
         let mut req = request.into_inner();
         Self::authoritative_user(&mut req.user, identity.as_ref());
+        self.require_reservation_manager(&req.user, identity.as_ref())
+            .await?;
 
         let entity_name = req.name.clone();
         let actor = req.user.clone();
 
         let result = self
             .cluster
-            .delete_reservation(&req.name, &req.user)
+            .delete_reservation(&req.name)
             .map_err(reservation_rpc_status);
         self.audit_reservation(
             TxnAction::Delete,
@@ -4099,7 +4143,6 @@ fn reservation_rpc_status(err: ReservationError) -> Status {
         ReservationError::InvalidArgument(m) => Status::invalid_argument(m),
         ReservationError::NotFound(m) => Status::not_found(m),
         ReservationError::AlreadyExists(m) => Status::already_exists(m),
-        ReservationError::PermissionDenied(m) => Status::permission_denied(m),
         ReservationError::Raft(m) => Status::internal(m),
     }
 }
@@ -7198,27 +7241,116 @@ mod tests {
                 token_id: "t".into(),
             }
         );
-        assert_admin_gated!(
+        // Reservations use the stricter `require_reservation_manager` instead — see
+        // `reservation_mutations_deny_non_operators`.
+    }
+
+    /// Reservations also reject an anonymous caller, unlike the generic gate: the asserted name is
+    /// still checkable, and a client skipping the CLI is the gap being closed. Host-independent —
+    /// `mallory` and the empty user are unprivileged or unresolvable, and both deny.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reservation_mutations_deny_non_operators() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+
+        macro_rules! assert_operator_gated {
+            ($method:ident, $req:expr) => {{
+                for identity in [Some(viewer("mallory", false)), None] {
+                    let mut r = Request::new($req);
+                    if let Some(id) = identity {
+                        r.extensions_mut().insert(id);
+                    }
+                    let err = svc.$method(r).await.expect_err(concat!(
+                        stringify!($method),
+                        " must reject a non-operator caller"
+                    ));
+                    assert_eq!(
+                        err.code(),
+                        Code::PermissionDenied,
+                        concat!(stringify!($method), " must be PermissionDenied")
+                    );
+                }
+            }};
+        }
+
+        assert_operator_gated!(
             create_reservation,
             CreateReservationRequest {
                 name: "r".into(),
                 ..Default::default()
             }
         );
-        assert_admin_gated!(
+        assert_operator_gated!(
             update_reservation,
             UpdateReservationRequest {
                 name: "r".into(),
                 ..Default::default()
             }
         );
-        assert_admin_gated!(
+        assert_operator_gated!(
             delete_reservation,
             DeleteReservationRequest {
                 name: "r".into(),
                 ..Default::default()
             }
         );
+
+        assert!(
+            svc.cluster.get_reservations().is_empty(),
+            "a denied create must not reach the state machine"
+        );
+    }
+
+    /// An admin credential must work on a controller that shares no user directory with the login
+    /// nodes. The name here resolves nowhere, so only the pre-lookup admin return can allow it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn admin_manages_reservations_without_a_resolvable_name() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        register_plain_node(&svc, "node-a", 6822).await;
+
+        let mut req = Request::new(CreateReservationRequest {
+            name: "maint".into(),
+            start_time: "now".into(),
+            duration_minutes: 60,
+            nodes: vec!["node-a".into()],
+            ..Default::default()
+        });
+        req.extensions_mut()
+            .insert(viewer("no_such_user_in_nss_7f3a", true));
+
+        svc.create_reservation(req)
+            .await
+            .expect("an admin credential must not depend on an NSS lookup");
+        assert_eq!(svc.cluster.get_reservations().len(), 1);
+    }
+
+    #[test]
+    fn privileged_user_manages_reservations() {
+        assert!(reservation_manager_ruling("alice", Ok(true)).is_ok());
+    }
+
+    #[test]
+    fn unprivileged_user_may_not_manage_reservations() {
+        let err = reservation_manager_ruling("alice", Ok(false))
+            .expect_err("an unprivileged user must be denied");
+        assert_eq!(err.code(), Code::PermissionDenied);
+        assert!(
+            err.message().contains("alice") && err.message().contains("sudo"),
+            "denial must name the user and the requirement: {}",
+            err.message()
+        );
+    }
+
+    /// An unresolvable name must deny rather than fall through to an allow.
+    #[test]
+    fn unresolvable_user_is_denied() {
+        let err = reservation_manager_ruling(
+            "ghost",
+            Err(spur_core::auth::AuthError::UnknownUser("ghost".into())),
+        )
+        .expect_err("an unresolvable user must be denied");
+        assert_eq!(err.code(), Code::PermissionDenied);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -245,12 +245,27 @@ Add a user with a QOS allow-list
 Set an admin level
 ~~~~~~~~~~~~~~~~~~~
 
-``adminlevel`` is passed through as given (``Operator``, ``Administrator``, or
-``none``).
+``adminlevel`` takes Slurm's levels: ``None``, ``Operator``, or ``Admin``.
+``Administrator`` and ``SuperUser`` are accepted as Slurm spells them and stored
+as ``Administrator``, which is what ``sacctmgr show user`` displays. Anything
+else is rejected, so a level that would confer nothing cannot be stored.
 
 .. code-block:: bash
 
-   sacctmgr add user name=bob account=research adminlevel=Operator
+   sacctmgr add user name=bob account=research adminlevel=Admin
+
+.. warning::
+
+   The admin level is a control-plane privilege, not just an accounting label: it
+   admits the user to the admin-gated controller mutations (partitions, node
+   labels, tokens, reservations), so grant it as carefully as root. See
+   :ref:`privileged-operations`.
+
+.. note::
+
+   ``Operator`` is accepted and stored, but Spur does not yet act on it — unlike
+   Slurm, where it confers reservation management. Use the admin level for a user
+   who needs control-plane privileges today.
 
 Set per-association limits
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -314,7 +329,9 @@ User keys
        user's default account.
    * - ``adminlevel``
      - ``none``
-     - Admin level: ``none``, ``Operator``, or ``Administrator``.
+     - Admin level: ``None``, ``Operator``, or ``Admin`` (also spelled
+       ``Administrator``/``SuperUser``). Any other value is rejected. Only the
+       admin level currently confers privilege.
    * - ``defaultqos``
      - ``""``
      - QOS applied when the user does not request one.

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -461,7 +461,7 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
 ``[auth]``
 ----------
 
-Authentication plugin for client requests.
+How client requests are authenticated.
 
 .. list-table::
    :header-rows: 1
@@ -475,16 +475,28 @@ Authentication plugin for client requests.
    * - ``plugin``
      - string
      - ``"jwt"``
-     - Not implemented
-     - Intended to select an authentication plugin. No code reads it, and no
-       plugin is enforced regardless of its value — see the warning below.
+     - Restart
+     - Constrains startup only: ``"munge"`` and any unrecognised value are
+       rejected rather than silently ignored, and ``"none"`` with
+       ``mode = "required"`` is refused as contradictory. Nothing reads it
+       afterwards — whether a presented credential is verified is decided by
+       ``mode`` and ``jwt_key`` alone, so ``plugin = "none"`` does **not** turn
+       verification off.
+   * - ``mode``
+     - string
+     - ``"permissive"``
+     - Restart
+     - ``"disabled"`` ignores credentials entirely, even valid ones.
+       ``"permissive"`` verifies a credential that is presented — an invalid or
+       malformed one is always refused — but allows a request that carries none.
+       ``"required"`` refuses every request without a valid credential.
    * - ``jwt_key``
      - string
      - none
      - Restart
-     - Signing key for node admission tokens, given as a file path or inline
-       value. Deliberately not reloadable: swapping it live would immediately
-       invalidate every outstanding node token.
+     - Signing key for user credentials (``spur token user``) and node admission
+       tokens, given as a file path or inline value. Deliberately not reloadable:
+       swapping it live would immediately invalidate every outstanding token.
    * - ``allow_root_jobs``
      - bool
      - ``false``
@@ -493,19 +505,72 @@ Authentication plugin for client requests.
 
 .. warning::
 
-   ``[auth] plugin`` is inert. Setting it to ``"jwt"`` does **not** authenticate
-   RPCs — the controller accepts requests from anyone who can reach its gRPC port,
-   and ``spurctld`` warns about this at startup whenever it binds a non-loopback
-   address. Restrict access to the controller port at the network layer. See
-   :doc:`accounting` for how identity maps to accounts and admin rights.
+   Under the default ``mode = "permissive"``, a caller that presents no
+   credential is unauthenticated, and the username it asserts in the request is
+   taken at face value. Identity-dependent decisions — job ownership, reservation
+   management, job-info visibility — are then only as trustworthy as the network.
+   Set ``mode = "required"`` (with a ``jwt_key``) to make them enforceable, and
+   restrict the controller port at the network layer either way. ``spurctld``
+   warns at startup whenever it binds a non-loopback address without
+   ``required``.
 
 .. note::
 
-   ``jwt_key`` is used for node admission tokens (``[admission] mode = "token"``),
-   which is a separate mechanism from the unimplemented ``plugin`` field. When
-   ``jwt_key`` is unset, admission tokens are signed with a well-known built-in
-   key and are therefore forgeable; set an explicit key before enabling token
-   admission.
+   When ``jwt_key`` is unset, admission tokens are signed with a well-known
+   built-in key and are therefore forgeable; set an explicit key before enabling
+   token admission (``[admission] mode = "token"``).
+
+.. _privileged-operations:
+
+Privileged operations
+~~~~~~~~~~~~~~~~~~~~~
+
+The control-plane mutations that define cluster tenancy — partitions, node
+placement and labels, ``reconfigure``, admission tokens, reservations, and the
+accounting account/user/QOS records — require a **cluster admin**. A caller with
+a verified non-admin identity is refused with ``PermissionDenied``. A caller with
+*no* verified identity is allowed, so that ``disabled`` and credential-less
+``permissive`` deployments keep working; under ``mode = "required"`` every caller
+is authenticated, so the bar binds everyone.
+
+Admin means one of the following:
+
+* a credential minted with ``spur token user --admin``;
+* a credential for the user ``root``;
+* an accounting admin level of ``Admin`` (see :doc:`accounting`).
+
+Only the first counts for the accounting service's own mutations: it holds no
+association cache and does not special-case ``root``, so it accepts the token
+claim alone. The controller RPCs honour all three.
+
+Reservations are the one exception, and are stricter in two ways. An
+unidentified caller is **not** waved through, and membership of ``sudo`` or
+``wheel`` also qualifies. Creating, updating, or deleting a reservation is
+allowed when any of these holds:
+
+* the caller is a cluster admin, as above;
+* the caller resolves to UID 0 on the controller;
+* the caller is a member of the ``sudo`` or ``wheel`` group, as the controller's
+  own NSS resolves the name — so a site using LDAP or SSSD grants this by group
+  membership, and a controller with no shared user directory can only resolve
+  local accounts.
+
+Anyone else is refused, as is a name the controller cannot resolve at all — a
+caller it cannot vouch for is denied, not allowed. The rule mirrors the one the
+CLI applies locally before it ever connects, which is the point — a client that
+does not go through the CLI cannot skip it. The cost is that a ``sudo``/``wheel``
+operator must be resolvable *on the controller*, not only on the login node.
+
+Ownership is not part of this decision. The creator is recorded as ``Owner`` for
+attribution and shown by ``scontrol show reservation``, but any operator may
+update or delete any reservation, matching Slurm's operator semantics.
+
+.. warning::
+
+   Without a credential the controller can only check the username the client
+   asserted, so under ``permissive`` this stops an unprivileged client but not a
+   deliberately crafted request. ``mode = "required"`` is what makes it a
+   boundary, because there the name comes from the verified credential.
 
 ``[[partitions]]``
 ------------------

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -60,6 +60,12 @@ database_url = "postgresql://spur:spur@localhost/spur"
 
 [auth]
 plugin = "none"
+# How strictly callers are authenticated: "disabled", "permissive" (default), or
+# "required". Under permissive a request without a credential is allowed and the
+# username it asserts is trusted, so identity-dependent rules (job ownership,
+# reservation management) are advisory. Use "jwt" above with a jwt_key and
+# mode = "required" to make them enforceable.
+# mode = "permissive"
 
 [[partitions]]
 name = "gpu"

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1585,6 +1585,10 @@ message DeletePartitionRequest {
 
 // ============================================================
 // Reservation Management
+//
+// Create, update, and delete require an operator: a cluster admin, or a caller the controller
+// resolves to uid 0 or a `sudo`/`wheel` member. The `user` fields below are overwritten with the
+// authenticated name when a credential is presented, so they are only trusted without one.
 // ============================================================
 
 message CreateReservationRequest {
@@ -1595,7 +1599,7 @@ message CreateReservationRequest {
   repeated string accounts = 5;
   repeated string users = 6;
   repeated string flags = 7;
-  string user = 8;            // requesting user; recorded as reservation owner
+  string user = 8;            // requesting user; must be an operator, and is recorded as the owner
 }
 
 message UpdateReservationRequest {
@@ -1607,12 +1611,12 @@ message UpdateReservationRequest {
   repeated string remove_users = 6;
   repeated string add_accounts = 7;
   repeated string remove_accounts = 8;
-  string user = 9;              // requesting user; must be the owner (root and trusted internal callers always allowed; legacy reservations with no recorded owner are mutable by anyone)
+  string user = 9;              // requesting user; must be an operator, who may update any reservation
 }
 
 message DeleteReservationRequest {
   string name = 1;
-  string user = 2;             // requesting user; must be the owner (root and trusted internal callers always allowed; legacy reservations with no recorded owner are mutable by anyone)
+  string user = 2;             // requesting user; must be an operator, who may delete any reservation
 }
 
 message ListReservationsRequest {

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -367,7 +367,11 @@ class SpurCluster:
         return self.nodes[0].exec_allow_fail(" ".join(cmd_parts))
 
     def cli_as_user(
-        self, run_as: str, args: list[str], controller_addr: str | None = None
+        self,
+        run_as: str,
+        args: list[str],
+        controller_addr: str | None = None,
+        extra_env: dict[str, str] | None = None,
     ) -> str:
         """Run a spur CLI command as a specific UNIX user via sudo, returning
         stdout+stderr regardless of exit code.
@@ -375,12 +379,17 @@ class SpurCluster:
         Commands that carry an identity (reservation create/update/delete,
         job cancel, ...) derive it from the invoking account (``whoami``), so
         this is how a test exercises owner-vs-non-owner behavior end to end.
+
+        *extra_env* adds variables to the environment. Pass ``SPUR_AUTH_TOKEN`` to
+        separate the identity the controller verifies from the invoking account.
         """
         inner = [
             f"SPUR_CONTROLLER_ADDR='{controller_addr or self.controller_addr}'",
             f"PATH='{self.bin_dir}':$PATH",
-            f"'{self.bin_dir}/{args[0]}'",
         ]
+        for key, value in (extra_env or {}).items():
+            inner.append(f"{key}='{value}'")
+        inner.append(f"'{self.bin_dir}/{args[0]}'")
         inner.extend(f"'{a}'" for a in args[1:])
         cmd = f"{self._sudo_prefix()}-u '{run_as}' env {' '.join(inner)}"
         return self.nodes[0].exec_allow_fail(cmd)

--- a/tests/native_host/e2e/test_reservations.py
+++ b/tests/native_host/e2e/test_reservations.py
@@ -490,7 +490,7 @@ class TestReservations:
         """Managing a reservation takes operator privilege, not ownership: an
         operator may update or delete a reservation somebody else created, while
         an unprivileged user is refused even for one it could see. Exercises the
-        full CLI -> gRPC -> controller path (SPUR-69)."""
+        full CLI -> gRPC -> controller path."""
         submit_user = cluster.nodes[0].user
         if submit_user == "root":
             pytest.skip("need a non-root SSH user to test a non-owner operator")
@@ -578,3 +578,78 @@ class TestReservations:
         finally:
             # A leaked reservation fences a node for an hour; best-effort cleanup.
             cluster.cli_as_user("root", ["scontrol", "delete-reservation", res_name])
+
+
+class TestReservationServerGate:
+    """The controller's operator rule, proven independently of the CLI's own check.
+
+    Every other path here is refused client-side before a request is sent, so none
+    of them show the controller enforcing anything. A credential splits the two:
+    the CLI runs as root and passes locally, while the gate judges the token's
+    identity."""
+
+    AUTH_CONFIG = {"auth": {"plugin": "jwt", "jwt_key": "e2e-reservation-key"}}
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return self.AUTH_CONFIG
+
+    def _token_for(self, cluster, user: str) -> str:
+        out = cluster.cli(
+            [
+                "spur",
+                "token",
+                "user",
+                f"--user={user}",
+                f"--config={cluster.etc_dir}/spur.conf",
+            ]
+        )
+        token = out.strip().split("\n")[0]
+        assert token.count(".") == 2, f"unexpected token format: {out}"
+        return token
+
+    def _create_as(self, cluster, token: str, name: str) -> str:
+        return cluster.cli_as_user(
+            "root",
+            [
+                "scontrol",
+                "create-reservation",
+                f"--name={name}",
+                "--start-time=now",
+                "--duration=60",
+                f"--nodes={cluster.node_names[0]}",
+                "--flags=ignore_jobs",
+            ],
+            extra_env={"SPUR_AUTH_TOKEN": token},
+        )
+
+    def test_credential_the_controller_cannot_resolve_is_denied(self, cluster):
+        """A verified non-admin whose name resolves nowhere is refused, even though
+        the CLI ran as root. Fails closed: an unresolvable caller is not an allow."""
+        name = f"res-gate-{int(time.time())}"
+        try:
+            out = self._create_as(
+                cluster, self._token_for(cluster, "no_such_user_in_nss_7f3a"), name
+            ).lower()
+
+            # The CLI's own refusal would prove nothing, so require the server's wording.
+            assert "insufficient privileges" not in out, (
+                f"the client pre-check fired, so the controller was never asked: {out}"
+            )
+            assert "cannot verify" in out and "may manage reservations" in out, (
+                f"expected the controller's unresolvable-caller denial: {out}"
+            )
+            assert name not in cluster.scontrol("show", "reservation")
+        finally:
+            cluster.cli_as_user("root", ["scontrol", "delete-reservation", name])
+
+    def test_operator_credential_is_allowed(self, cluster):
+        """The counterpart, so the denial above cannot be explained by credentials
+        being broken: the same path with a token for root creates the reservation."""
+        name = f"res-gate-ok-{int(time.time())}"
+        try:
+            out = self._create_as(cluster, self._token_for(cluster, "root"), name)
+            assert "created" in out.lower(), f"an operator credential must be accepted: {out}"
+            assert name in cluster.scontrol("show", "reservation")
+        finally:
+            cluster.cli_as_user("root", ["scontrol", "delete-reservation", name])

--- a/tests/native_host/e2e/test_reservations.py
+++ b/tests/native_host/e2e/test_reservations.py
@@ -486,13 +486,14 @@ class TestReservations:
         finally:
             cluster.cli_as_user("root", ["scontrol", "delete-reservation", omit_name])
 
-    def test_non_owner_cannot_delete_or_update_reservation(self, cluster):
-        """A reservation is owned by its creator; a different user must not be
-        able to delete or update it, but the owner still can. Exercises the
-        full CLI -> gRPC -> controller ownership check (SPUR-69)."""
+    def test_reservation_management_is_privilege_not_ownership(self, cluster):
+        """Managing a reservation takes operator privilege, not ownership: an
+        operator may update or delete a reservation somebody else created, while
+        an unprivileged user is refused even for one it could see. Exercises the
+        full CLI -> gRPC -> controller path (SPUR-69)."""
         submit_user = cluster.nodes[0].user
         if submit_user == "root":
-            pytest.skip("need a non-root SSH user to test non-owner rejection")
+            pytest.skip("need a non-root SSH user to test a non-owner operator")
 
         # Verify passwordless/known-password sudo -u works in this environment;
         # otherwise we cannot assume a second identity.
@@ -502,51 +503,78 @@ class TestReservations:
         ):
             pytest.skip(f"sudo -u unavailable in this environment: {probe.strip()}")
 
-        # A non-owner is denied by the server ownership check or, if unprivileged,
-        # by the client gate first. Accept both so this never silently skips.
-        denied = ("cannot delete", "cannot modify", "permission", "requires root or membership")
+        groups = cluster.nodes[0].exec_allow_fail(f"id -nG '{submit_user}'").split()
+        submit_user_is_operator = bool({"sudo", "wheel"} & set(groups))
+
+        # Denial can come from the client pre-check or the controller's gate; both
+        # are legitimate, so accept either wording.
+        denied = ("may not manage", "permission", "requires root or membership")
 
         res_name = f"res-owner-{int(time.time())}"
         node = cluster.node_names[0]
 
-        # Create as root -> owner is root.
-        create_out = cluster.cli_as_user(
-            "root",
-            [
-                "scontrol",
-                "create-reservation",
-                f"--name={res_name}",
-                "--start-time=now",
-                "--duration=60",
-                f"--nodes={node}",
-                "--users=testuser",
-            ],
-        )
-        assert "created" in create_out.lower(), f"create failed: {create_out}"
+        try:
+            # Create as root -> owner is root, so every later caller is a non-owner.
+            create_out = cluster.cli_as_user(
+                "root",
+                [
+                    "scontrol",
+                    "create-reservation",
+                    f"--name={res_name}",
+                    "--start-time=now",
+                    "--duration=60",
+                    f"--nodes={node}",
+                    "--users=testuser",
+                ],
+            )
+            assert "created" in create_out.lower(), f"create failed: {create_out}"
 
-        show_out = cluster.scontrol("show", "reservation")
-        assert res_name in show_out
-        assert "Owner=root" in show_out
+            show_out = cluster.scontrol("show", "reservation")
+            assert res_name in show_out
+            assert "Owner=root" in show_out
 
-        # Non-owner (the ordinary SSH user) delete must be rejected.
-        del_denied = cluster.cli_as_user(
-            submit_user, ["scontrol", "delete-reservation", res_name]
-        )
-        assert "deleted" not in del_denied.lower(), f"unexpected delete: {del_denied}"
-        assert any(m in del_denied.lower() for m in denied), f"unexpected: {del_denied}"
-        assert res_name in cluster.scontrol("show", "reservation")
+            # An unprivileged non-owner is refused both operations.
+            for args, verb in (
+                (["delete-reservation", res_name], "deleted"),
+                (
+                    ["update-reservation", f"--name={res_name}", "--duration=120"],
+                    "updated",
+                ),
+            ):
+                out = cluster.cli_as_user("nobody", ["scontrol"] + args)
+                assert verb not in out.lower(), f"unprivileged {verb}: {out}"
+                assert any(m in out.lower() for m in denied), f"unexpected: {out}"
+                assert res_name in cluster.scontrol("show", "reservation")
 
-        # Non-owner update must be rejected too.
-        upd_denied = cluster.cli_as_user(
-            submit_user,
-            ["scontrol", "update-reservation", f"--name={res_name}", "--duration=120"],
-        )
-        assert any(m in upd_denied.lower() for m in denied), f"unexpected: {upd_denied}"
-        assert res_name in cluster.scontrol("show", "reservation")
-
-        # Owner (root) can still delete.
-        del_ok = cluster.cli_as_user(
-            "root", ["scontrol", "delete-reservation", res_name]
-        )
-        assert "deleted" in del_ok.lower(), f"owner delete failed: {del_ok}"
-        assert res_name not in cluster.scontrol("show", "reservation")
+            # The SSH user is a non-owner either way; whether it may manage the
+            # reservation follows from its privilege, which is the whole point.
+            upd_out = cluster.cli_as_user(
+                submit_user,
+                [
+                    "scontrol",
+                    "update-reservation",
+                    f"--name={res_name}",
+                    "--duration=120",
+                ],
+            )
+            if submit_user_is_operator:
+                assert "updated" in upd_out.lower(), (
+                    f"an operator must be able to update another user's "
+                    f"reservation: {upd_out}"
+                )
+                del_out = cluster.cli_as_user(
+                    submit_user, ["scontrol", "delete-reservation", res_name]
+                )
+                assert "deleted" in del_out.lower(), (
+                    f"an operator must be able to delete another user's "
+                    f"reservation: {del_out}"
+                )
+                assert res_name not in cluster.scontrol("show", "reservation")
+            else:
+                assert any(m in upd_out.lower() for m in denied), (
+                    f"unexpected: {upd_out}"
+                )
+                assert res_name in cluster.scontrol("show", "reservation")
+        finally:
+            # A leaked reservation fences a node for an hour; best-effort cleanup.
+            cluster.cli_as_user("root", ["scontrol", "delete-reservation", res_name])


### PR DESCRIPTION
## What this fixes

Reservation create/update/delete was enforced only by the CLI's local
root-or-`sudo`/`wheel` check — something no server can verify, so any client that
skipped the CLI walked through. #685 added the generic `require_admin`, but that
deliberately allows an unidentified caller so no-auth clusters keep working,
which under the default `permissive` mode leaves the path open. The old ownership
rule also read an empty `user` as a trusted internal caller and `user: "root"` as
authorized.

## Changes

- The rule now lives once in `spur_core::privilege`. The CLI keeps its local
  pre-check for the fast offline error; the controller resolves the caller's name
  through its own NSS (`getgrouplist`, so LDAP/sssd groups count) and applies the
  same rule.
- `require_reservation_manager` replaces `require_admin` on the three reservation
  RPCs: same admin bar, plus the `sudo`/`wheel` path, minus the free pass for
  unidentified callers. Runs after `authoritative_user`, on the leader. An
  unresolvable name denies. The lookup is on `spawn_blocking` and only for
  non-admins, keeping network-backed NSS off the runtime and off an
  unauthenticated caller's path.
- Ownership retires: under operator semantics it could never deny anyone who
  passed the gate. `owner` stays as attribution. Nothing persisted changed and
  the proto edits are comment-only, so a rolling upgrade is unaffected.
- Fixes an `adminlevel` trap found while documenting the admin bar: the docs
  listed `Administrator`, which Slurm prints and accepts, but `is_admin` matched
  `admin` alone — so following the docs stored a level that looked privileged and
  conferred nothing. Levels are canonicalized on write and recognized in every
  Slurm spelling on read.

## Trade-off

Without a credential the controller can only check the name the client asserted,
so this stops an honest client rather than a determined one; `auth.mode =
"required"` is what makes it a boundary. Documented rather than implied. A
`sudo`/`wheel` operator must now also be resolvable *on the controller*.

## Breaking

Refused now: unprivileged non-CLI clients, callers relying on an empty `user` or
an unowned reservation, and `sudo`/`wheel` operators the controller cannot
resolve. Newly allowed: an operator may manage another user's reservation
directly rather than via `sudo`, and a stored `Administrator` grants what it
always appeared to.

## Testing

`cargo fmt --check`, clippy, and the full suite pass (34 suites). The policy is a
pure function, so its arms are host-independent; a handler test covers a direct
RPC from an identified non-admin *and* an anonymous caller being refused without
reaching the state machine.

Verified on the 3-node bare-metal cluster. The server gate was proven
independently of the CLI by creating a user in `sudo` on node2 only and running
the CLI from there against the controller on node1 — the local check passed, the
controller refused with `cannot verify that 'resvtest' may manage reservations
(no such user on this host)`. A user resolvable but unprivileged on the
controller hit the other arm. `nobody` was refused by the CLI; root created a
reservation; a non-owner in `sudo` updated and deleted root's reservation
(previously denied); job scheduling unaffected.

## Follow-ups, not fixed here

[1] The accounting mutation gate also allows anonymous, so on a `permissive`
cluster with a `jwt_key` a user can self-promote via a tokenless `add_user` and
then present their real token as admin for every gate #685 added.

[2] The controller's agent credential is a replayable `is_admin` token verified
with the same key and no audience check, and the Raft port has no auth layer
while `install_snapshot` replaces the reservation set wholesale. Both defeat this
gate in every mode.

[3] Four overlapping privilege predicates now exist (`caller_is_admin`,
`caller_is_privileged`, `require_admin`, `require_reservation_manager`).
Collapsing them into one principal, with the anonymous allowance driven by
`auth.mode` rather than by RPC, is the right shape but changes behaviour for the
ten RPCs #685 gated.