### PR TITLE
fix(spur-cli)!: reject a zero token TTL and report overflow in seconds (follow-up to #716)

### DIFF
--- a/crates/spur-cli/src/token.rs
+++ b/crates/spur-cli/src/token.rs
@@ -3,7 +3,7 @@
 
 //! `spur token` subcommands for admission token management.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 use spur_proto::proto::{CreateTokenRequest, ListTokensRequest, RevokeTokenRequest};
@@ -118,9 +118,9 @@ fn cmd_user_token(user: &str, admin: bool, ttl: Option<String>, config_path: &st
 fn parse_ttl(s: &str) -> Result<u32> {
     let s = s.trim();
     let (value, unit_secs) = if let Some(days) = s.strip_suffix('d') {
-        (days, 86400)
+        (days, 86_400u64)
     } else if let Some(hours) = s.strip_suffix('h') {
-        (hours, 3600)
+        (hours, 3_600)
     } else if let Some(mins) = s.strip_suffix('m') {
         (mins, 60)
     } else if let Some(secs) = s.strip_suffix('s') {
@@ -128,10 +128,18 @@ fn parse_ttl(s: &str) -> Result<u32> {
     } else {
         (s, 1)
     };
-    value
-        .parse::<u32>()?
-        .checked_mul(unit_secs)
-        .with_context(|| format!("TTL {} exceeds {} seconds", s, u32::MAX))
+    // u64 can't overflow here (max is u32::MAX * 86_400), so the message reports seconds vs seconds.
+    let secs = value.parse::<u32>()? as u64 * unit_secs;
+    if secs == 0 {
+        anyhow::bail!("TTL {s} must be a positive duration");
+    }
+    if secs > u32::MAX as u64 {
+        anyhow::bail!(
+            "TTL {s} is {secs} seconds, over the {} second maximum",
+            u32::MAX
+        );
+    }
+    Ok(secs as u32)
 }
 
 async fn cmd_create(controller: &str, ttl: Option<String>) -> Result<()> {
@@ -209,6 +217,15 @@ mod tests {
             u32::MAX,
             "the ceiling still parses"
         );
+    }
+
+    #[test]
+    fn parse_ttl_rejects_zero() {
+        // A zero TTL used to collapse to a never-expiring token at the server.
+        assert!(parse_ttl("0").is_err());
+        assert!(parse_ttl("0d").is_err());
+        assert!(parse_ttl("0h").is_err());
+        assert!(parse_ttl("0s").is_err());
     }
 
     #[test]

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -1038,8 +1038,9 @@ Manage tokens with ``spur token``, which talks to the controller on port 6817:
 token's ID, creation time, expiry, and status (``active`` or ``revoked``).
 
 ``--ttl`` accepts a duration suffixed with ``d`` (days), ``h`` (hours), ``m``
-(minutes), or ``s`` (seconds), or a bare integer number of seconds. Omitting
-``--ttl`` creates a token that never expires.
+(minutes), or ``s`` (seconds), or a bare integer number of seconds. The duration
+must be positive: ``--ttl 0`` (or ``0d``, ``0h``, ``0s``) is rejected rather than
+read as "no expiry". Omitting ``--ttl`` creates a token that never expires.
 
 See Also
 --------


### PR DESCRIPTION
## Summary

Closes #826

Follow-up to #716, addressing the two token nits from @sajmera-pensando.

## Changes

- **Zero-TTL guard.** `parse_ttl("0d")` returned `0`, and the server's
  `ttl_secs.filter(|&v| v > 0)` collapses `0` to `None` — a **never-expiring**
  token, the opposite of intent. `parse_ttl` now rejects any non-positive
  duration, so both `token create` and `token user` fail clearly (they share
  this parser). Never-expiry stays available the documented way: omit `--ttl`.
- **Overflow message in seconds.** It read `TTL 50000d exceeds 4294967295
  seconds`, mixing a days input with a seconds limit. Computing in `u64`
  (can't overflow for a `u32`-bounded value) lets the message state the actual
  second count: `TTL 50000d is 4320000000 seconds, over the 4294967295 second
  maximum`.

## Tests

- New `parse_ttl_rejects_zero` (`0`, `0d`, `0h`, `0s`).
- Existing overflow / non-numeric / suffix tests unchanged and passing.
- `cargo fmt` / `clippy -D warnings` clean; `spur-cli` suite green.