### PR TITLE
fix(spurctld): apply MaxWall as the default time limit for a job with no -t

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -167,6 +167,7 @@ libpmix
 lifecycle
 MaxTRESPerJob
 MaxTRESPerUser
+MaxWall
 msg
 NNodes
 NODELIST

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -583,11 +583,6 @@ impl ClusterManager {
             }
         }
 
-        apply_default_time_limit(
-            &mut spec,
-            &partitions,
-            config.scheduler.default_time_limit_minutes,
-        );
         apply_default_account(&mut spec, &self.association_cache);
         validate_user_account(&spec, &self.association_cache, &config.accounting)?;
         // Default QoS must resolve before the partition ACL, or `allow_qos` sees
@@ -598,6 +593,14 @@ impl ClusterManager {
             &self.qos_cache,
             &config.accounting,
         )?;
+        // Wall-time defaulting reads the governing QOS, so it follows QOS defaulting.
+        let wall_caps = self.wall_caps(&spec);
+        apply_default_time_limit(
+            &mut spec,
+            &partitions,
+            config.scheduler.default_time_limit_minutes,
+            wall_caps,
+        );
         self.validate_partition(&spec, &partitions)?;
 
         // Fewer tasks than nodes cannot use the surplus nodes; cap at the task
@@ -4664,6 +4667,33 @@ impl ClusterManager {
     /// limits and the association per-job wall deny unconditionally; stand-alone
     /// TRES/wall breaches deny only under the governing QOS's `DenyOnLimit`
     /// (treated as on when the job has no QOS). `incoming` is the task count added.
+    /// The wall-clock ceilings that already govern this submission, for defaulting.
+    /// An unloaded cache reports nothing rather than holding the job, matching how
+    /// `enforce_submit_limits` treats limits it cannot read yet.
+    fn wall_caps(&self, spec: &JobSpec) -> WallCaps {
+        let qos_minutes = spec
+            .qos
+            .as_deref()
+            .filter(|n| !n.is_empty() && self.qos_cache.is_loaded())
+            .and_then(|name| self.qos_cache.get(name))
+            .and_then(|qos| qos.limits.max_wall_minutes);
+
+        let account_minutes = spec
+            .account
+            .as_deref()
+            .filter(|a| !a.is_empty() && self.association_cache.is_loaded())
+            .and_then(|account| {
+                self.association_cache
+                    .limits(&spec.user, account)
+                    .max_wall_minutes
+            });
+
+        WallCaps {
+            qos_minutes,
+            account_minutes,
+        }
+    }
+
     fn enforce_submit_limits(&self, spec: &JobSpec, incoming: u32) -> Result<(), SubmitError> {
         let jobs = self.jobs.read();
         let user = spec.user.as_str();
@@ -7263,37 +7293,64 @@ fn apply_default_partition(spec: &mut JobSpec, partitions: &[Partition]) {
     }
 }
 
-/// Fill in a job's wall-time when none was requested. Each requested partition
-/// resolves to `DefaultTime`, else (only when `cluster_default_minutes > 0`) its
-/// `MaxTime`, else the cluster fallback. The smallest resulting limit is chosen
-/// so the default fits every requested partition; if any requested partition
-/// resolves to no bound the job stays unbounded (unchanged upgrade behavior).
-fn apply_default_time_limit(
-    spec: &mut JobSpec,
-    partitions: &[Partition],
-    cluster_default_minutes: u32,
-) {
-    if spec.time_limit.is_some() {
-        return;
-    }
-
-    // A job may list several partitions (e.g. "gpu,cpu"); fall back to the
-    // default/first partition when the field is unset or names nothing known.
+/// The partitions a job's wall-time defaulting has to satisfy. A job may list
+/// several (e.g. "gpu,cpu"); fall back to the default/first partition when the
+/// field is unset or names nothing known.
+fn partitions_for_defaulting<'a>(
+    spec: &JobSpec,
+    partitions: &'a [Partition],
+) -> Vec<&'a Partition> {
     let matched = spec
         .partition
         .as_deref()
         .map(|p| spur_core::partition::matched_partitions(Some(p), partitions))
         .unwrap_or_default();
-    let requested: Vec<&Partition> = if matched.is_empty() {
-        partitions
-            .iter()
-            .find(|p| p.is_default)
-            .or_else(|| partitions.first())
-            .into_iter()
-            .collect()
-    } else {
-        matched
-    };
+    if !matched.is_empty() {
+        return matched;
+    }
+    partitions
+        .iter()
+        .find(|p| p.is_default)
+        .or_else(|| partitions.first())
+        .into_iter()
+        .collect()
+}
+
+/// The per-job wall-clock ceilings a submission is already subject to, in minutes.
+/// `None` means no figure applies — the limit is unset, or its cache has not loaded
+/// yet, in which case defaulting proceeds as if the limit did not exist rather than
+/// holding the submission. A ceiling of `0` is the "block all" sentinel, not a
+/// zero-length budget, so it is never a value to default to.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct WallCaps {
+    qos_minutes: Option<u32>,
+    account_minutes: Option<u32>,
+}
+
+impl WallCaps {
+    fn usable(minutes: Option<u32>) -> Option<u32> {
+        minutes.filter(|m| *m > 0)
+    }
+}
+
+/// Fill in a job's wall-time when none was requested. Each requested partition
+/// resolves to `DefaultTime`, else (only when `cluster_default_minutes > 0`) its
+/// `MaxTime`, else the cluster fallback. The smallest resulting limit is chosen
+/// so the default fits every requested partition; if any requested partition
+/// resolves to no bound the governing QOS's or account's `MaxWall` supplies the
+/// limit instead, and a job with neither stays unbounded (unchanged upgrade
+/// behavior).
+fn apply_default_time_limit(
+    spec: &mut JobSpec,
+    partitions: &[Partition],
+    cluster_default_minutes: u32,
+    caps: WallCaps,
+) {
+    if spec.time_limit.is_some() {
+        return;
+    }
+
+    let requested = partitions_for_defaulting(spec, partitions);
     if requested.is_empty() {
         return;
     }
@@ -7312,15 +7369,41 @@ fn apply_default_time_limit(
     let mut chosen: Option<u32> = None;
     for part in &requested {
         match resolve(part) {
-            // An unbounded requested partition means the job may run unlimited
-            // there, so don't impose a default.
-            None => return,
+            // A requested partition that imposes no default leaves the job's wall
+            // ceiling as the only source of one.
+            None => {
+                chosen = wall_cap_default(&requested, caps);
+                break;
+            }
             Some(minutes) => chosen = Some(chosen.map_or(minutes, |c| c.min(minutes))),
         }
     }
     if let Some(minutes) = chosen {
         spec.time_limit = Some(chrono::Duration::minutes(i64::from(minutes)));
     }
+}
+
+/// The per-job wall ceiling as a default. A job has to satisfy the QOS's and the
+/// account's `MaxWall` both, so the smaller of the two is the limit it is really
+/// held to. That value is then kept under the requested partitions' `MaxTime`,
+/// above which the job would pend forever on a limit it never asked for — where
+/// today it simply runs unbounded.
+fn wall_cap_default(requested: &[&Partition], caps: WallCaps) -> Option<u32> {
+    let cap = [
+        WallCaps::usable(caps.qos_minutes),
+        WallCaps::usable(caps.account_minutes),
+    ]
+    .into_iter()
+    .flatten()
+    .min()?;
+
+    // The limit has to stay schedulable somewhere: a requested partition with no
+    // `MaxTime` takes any, otherwise the most permissive one is the ceiling.
+    let partition_ceiling = requested
+        .iter()
+        .try_fold(0, |acc: u32, p| p.max_time_minutes.map(|m| acc.max(m)));
+
+    [Some(cap), partition_ceiling].into_iter().flatten().min()
 }
 
 /// Resolve the submitting user's default account from the association cache
@@ -13138,6 +13221,35 @@ mod tests {
         spec.array_spec = Some("0-9".into()); // 10 tasks > 5
         let err = cm.submit_job(spec).unwrap_err();
         assert_submit_denied(&err, "AssocMaxSubmitJobLimit");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_gives_a_job_that_asked_for_no_wall_time_the_qos_max_wall() {
+        // Without this the job runs unbounded and shows UNLIMITED, since the
+        // time-limit watchdog has no deadline to enforce.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.association_cache()
+            .insert_allowed_qos("testuser", "research", &["burst"]);
+        cm.qos_cache().insert(qos_with_limits(
+            "burst",
+            spur_core::accounting::QosLimits {
+                max_wall_minutes: Some(720),
+                ..Default::default()
+            },
+            false,
+        ));
+
+        let mut spec = basic_spec("nolimit");
+        spec.account = Some("research".into());
+        spec.qos = Some("burst".into());
+        spec.time_limit = None;
+
+        let id = submit_and_wait(&cm, spec);
+        assert_eq!(
+            cm.get_job(id).unwrap().spec.time_limit,
+            Some(chrono::Duration::minutes(720))
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -19949,6 +20061,11 @@ mod tests {
         assert_eq!(spec.partition.as_deref(), Some("gpu"));
     }
 
+    /// Defaulting with no QOS or account wall ceiling in play.
+    fn default_time_limit(spec: &mut JobSpec, partitions: &[Partition], cluster_minutes: u32) {
+        super::apply_default_time_limit(spec, partitions, cluster_minutes, WallCaps::default());
+    }
+
     #[test]
     fn apply_default_time_limit_uses_partition_default() {
         let mut spec = basic_spec("j");
@@ -19959,7 +20076,7 @@ mod tests {
             default_time_minutes: Some(30),
             ..Default::default()
         }];
-        super::apply_default_time_limit(&mut spec, &partitions, 0);
+        default_time_limit(&mut spec, &partitions, 0);
         assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(30)));
     }
 
@@ -19972,7 +20089,7 @@ mod tests {
             default_time_minutes: Some(30),
             ..Default::default()
         }];
-        super::apply_default_time_limit(&mut spec, &partitions, 0);
+        default_time_limit(&mut spec, &partitions, 0);
         assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(5)));
     }
 
@@ -19986,7 +20103,7 @@ mod tests {
             default_time_minutes: None,
             ..Default::default()
         }];
-        super::apply_default_time_limit(&mut spec, &partitions, 0);
+        default_time_limit(&mut spec, &partitions, 0);
         assert!(spec.time_limit.is_none());
     }
 
@@ -20002,7 +20119,7 @@ mod tests {
             max_time_minutes: Some(120),
             ..Default::default()
         }];
-        super::apply_default_time_limit(&mut spec, &partitions, 60);
+        default_time_limit(&mut spec, &partitions, 60);
         assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(120)));
     }
 
@@ -20019,7 +20136,7 @@ mod tests {
             max_time_minutes: None,
             ..Default::default()
         }];
-        super::apply_default_time_limit(&mut spec, &partitions, 60);
+        default_time_limit(&mut spec, &partitions, 60);
         assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(60)));
     }
 
@@ -20036,7 +20153,7 @@ mod tests {
             max_time_minutes: None,
             ..Default::default()
         }];
-        super::apply_default_time_limit(&mut spec, &partitions, 0);
+        default_time_limit(&mut spec, &partitions, 0);
         assert!(spec.time_limit.is_none());
     }
 
@@ -20061,7 +20178,7 @@ mod tests {
                 ..Default::default()
             },
         ];
-        super::apply_default_time_limit(&mut spec, &partitions, 60);
+        default_time_limit(&mut spec, &partitions, 60);
         assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(60)));
     }
 
@@ -20085,7 +20202,7 @@ mod tests {
                 ..Default::default()
             },
         ];
-        super::apply_default_time_limit(&mut spec, &partitions, 0);
+        default_time_limit(&mut spec, &partitions, 0);
         assert!(spec.time_limit.is_none());
     }
 
@@ -20102,7 +20219,7 @@ mod tests {
             max_time_minutes: Some(30),
             ..Default::default()
         }];
-        super::apply_default_time_limit(&mut spec, &partitions, 60);
+        default_time_limit(&mut spec, &partitions, 60);
         assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(45)));
     }
 
@@ -20125,8 +20242,181 @@ mod tests {
                 ..Default::default()
             },
         ];
-        super::apply_default_time_limit(&mut spec, &partitions, 0);
+        default_time_limit(&mut spec, &partitions, 0);
         assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(20)));
+    }
+
+    /// A job that asked for no wall-time, in a partition that imposes no default.
+    fn unbounded_spec_and_partition() -> (JobSpec, Vec<Partition>) {
+        let mut spec = basic_spec("j");
+        spec.partition = Some("gpu".into());
+        spec.time_limit = None;
+        let partitions = vec![Partition {
+            name: "gpu".into(),
+            ..Default::default()
+        }];
+        (spec, partitions)
+    }
+
+    fn qos_wall(minutes: u32) -> WallCaps {
+        WallCaps {
+            qos_minutes: Some(minutes),
+            account_minutes: None,
+        }
+    }
+
+    #[test]
+    fn apply_default_time_limit_uses_qos_max_wall_when_partitions_impose_none() {
+        let (mut spec, partitions) = unbounded_spec_and_partition();
+        super::apply_default_time_limit(&mut spec, &partitions, 0, qos_wall(720));
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(720)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_leaves_a_requested_limit_below_max_wall_alone() {
+        let (mut spec, partitions) = unbounded_spec_and_partition();
+        spec.time_limit = Some(chrono::Duration::minutes(30));
+        super::apply_default_time_limit(&mut spec, &partitions, 0, qos_wall(720));
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(30)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_prefers_the_partition_default_over_max_wall() {
+        // MaxWall is a ceiling, not a default: a partition that supplies one keeps it.
+        let mut spec = basic_spec("j");
+        spec.partition = Some("gpu".into());
+        spec.time_limit = None;
+        let partitions = vec![Partition {
+            name: "gpu".into(),
+            default_time_minutes: Some(30),
+            ..Default::default()
+        }];
+        super::apply_default_time_limit(&mut spec, &partitions, 0, qos_wall(720));
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(30)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_stays_unbounded_without_any_wall_cap() {
+        let (mut spec, partitions) = unbounded_spec_and_partition();
+        super::apply_default_time_limit(&mut spec, &partitions, 0, WallCaps::default());
+        assert!(spec.time_limit.is_none());
+    }
+
+    #[test]
+    fn apply_default_time_limit_ignores_a_zero_max_wall() {
+        // `0` is the block-all sentinel; defaulting to it would submit a job that
+        // its own limit kills on the first watchdog tick.
+        let (mut spec, partitions) = unbounded_spec_and_partition();
+        super::apply_default_time_limit(&mut spec, &partitions, 0, qos_wall(0));
+        assert!(spec.time_limit.is_none());
+    }
+
+    #[test]
+    fn apply_default_time_limit_holds_max_wall_under_the_account_wall() {
+        // An account MaxWall rejects the submission outright, so a default above it
+        // would turn a job that runs today into one that cannot be submitted.
+        let (mut spec, partitions) = unbounded_spec_and_partition();
+        let caps = WallCaps {
+            qos_minutes: Some(720),
+            account_minutes: Some(360),
+        };
+        super::apply_default_time_limit(&mut spec, &partitions, 0, caps);
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(360)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_uses_the_account_wall_when_the_qos_has_none() {
+        let (mut spec, partitions) = unbounded_spec_and_partition();
+        let caps = WallCaps {
+            qos_minutes: None,
+            account_minutes: Some(90),
+        };
+        super::apply_default_time_limit(&mut spec, &partitions, 0, caps);
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(90)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_ignores_a_zero_account_wall() {
+        let (mut spec, partitions) = unbounded_spec_and_partition();
+        let caps = WallCaps {
+            qos_minutes: Some(720),
+            account_minutes: Some(0),
+        };
+        super::apply_default_time_limit(&mut spec, &partitions, 0, caps);
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(720)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_holds_max_wall_under_the_partition_max_time() {
+        // Above MaxTime the job would pend forever on PartitionTimeLimit, for a
+        // limit it never asked for.
+        let mut spec = basic_spec("j");
+        spec.partition = Some("gpu".into());
+        spec.time_limit = None;
+        let partitions = vec![Partition {
+            name: "gpu".into(),
+            max_time_minutes: Some(240),
+            ..Default::default()
+        }];
+        super::apply_default_time_limit(&mut spec, &partitions, 0, qos_wall(720));
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(240)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_takes_the_most_permissive_partition_max_time() {
+        // The job only has to be schedulable somewhere, so the widest requested
+        // MaxTime is the ceiling — not the narrowest.
+        let mut spec = basic_spec("j");
+        spec.partition = Some("small,big".into());
+        spec.time_limit = None;
+        let partitions = vec![
+            Partition {
+                name: "small".into(),
+                max_time_minutes: Some(60),
+                ..Default::default()
+            },
+            Partition {
+                name: "big".into(),
+                max_time_minutes: Some(240),
+                ..Default::default()
+            },
+        ];
+        super::apply_default_time_limit(&mut spec, &partitions, 0, qos_wall(720));
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(240)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_ignores_partition_max_time_when_one_is_unlimited() {
+        let mut spec = basic_spec("j");
+        spec.partition = Some("capped,unlimited".into());
+        spec.time_limit = None;
+        let partitions = vec![
+            Partition {
+                name: "capped".into(),
+                max_time_minutes: Some(60),
+                ..Default::default()
+            },
+            Partition {
+                name: "unlimited".into(),
+                ..Default::default()
+            },
+        ];
+        super::apply_default_time_limit(&mut spec, &partitions, 0, qos_wall(720));
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(720)));
+    }
+
+    #[test]
+    fn wall_caps_reports_nothing_until_the_caches_load() {
+        // Fail-open: an unread limit must not decide a job's deadline.
+        let dir = TempDir::new().unwrap();
+        let cluster = ClusterManager::new(test_config(), dir.path()).unwrap();
+        let mut spec = basic_spec("j");
+        spec.qos = Some("burst".into());
+        spec.account = Some("eng".into());
+
+        let caps = cluster.wall_caps(&spec);
+        assert!(caps.qos_minutes.is_none());
+        assert!(caps.account_minutes.is_none());
     }
 
     #[test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -593,14 +593,6 @@ impl ClusterManager {
             &self.qos_cache,
             &config.accounting,
         )?;
-        // Wall-time defaulting reads the governing QOS, so it follows QOS defaulting.
-        let wall_caps = self.wall_caps(&spec);
-        apply_default_time_limit(
-            &mut spec,
-            &partitions,
-            config.scheduler.default_time_limit_minutes,
-            wall_caps,
-        );
         self.validate_partition(&spec, &partitions)?;
 
         // Fewer tasks than nodes cannot use the surplus nodes; cap at the task
@@ -658,6 +650,17 @@ impl ClusterManager {
         check_submission_size(&spec)?;
 
         self.run_job_submit_hook(&mut spec, &partitions)?;
+
+        // Every input to wall-time defaulting — partition, account, QOS — is a field
+        // the hook may rewrite, so defaulting follows the hook and reads the scope
+        // that actually governs the job. A limit the hook set is left alone.
+        let wall_caps = self.wall_caps(&spec);
+        apply_default_time_limit(
+            &mut spec,
+            &partitions,
+            config.scheduler.default_time_limit_minutes,
+            wall_caps,
+        );
 
         // Reject unknown/malformed dependency types up front so users get a
         // clear error instead of a silently-deadlocked job (e.g. `expand:N`).
@@ -8397,6 +8400,84 @@ mod tests {
         assert!(
             err.to_string().contains("outside partition"),
             "expected a node-bounds rejection, got: {err:?}"
+        );
+    }
+
+    // A hook-set QOS governs the job, so its MaxWall has to reach an untimed job
+    // as the default; caps read before the hook would be the wrong QOS's.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_job_hook_set_qos_supplies_the_wall_default() {
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.hooks.job_submit = Some(write_hook_script(&dir, r#"echo '{"qos":"capped"}'"#));
+        let cm = test_cluster_with_config(&dir, config).await;
+        cm.qos_cache().insert(Qos {
+            name: "capped".into(),
+            limits: spur_core::accounting::QosLimits {
+                max_wall_minutes: Some(30),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut spec = basic_spec("hook-qos-wall");
+        spec.time_limit = None;
+        let id = submit_and_wait(&cm, spec);
+        assert_eq!(
+            cm.get_job(id).unwrap().spec.time_limit,
+            Some(chrono::Duration::minutes(30))
+        );
+    }
+
+    // The partition also decides the default, so a hook that reroutes the job
+    // must be defaulted from the partition it ends up on.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_job_hook_set_partition_supplies_the_wall_default() {
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        let mut timed = config.partitions[0].clone();
+        timed.name = "timed".into();
+        timed.default = false;
+        timed.default_time = Some("00:15:00".into());
+        config.partitions.push(timed);
+        config.hooks.job_submit = Some(write_hook_script(&dir, r#"echo '{"partition":"timed"}'"#));
+        let cm = test_cluster_with_config(&dir, config).await;
+
+        let mut spec = basic_spec("hook-part-wall");
+        spec.time_limit = None;
+        let id = submit_and_wait(&cm, spec);
+        assert_eq!(
+            cm.get_job(id).unwrap().spec.time_limit,
+            Some(chrono::Duration::minutes(15))
+        );
+    }
+
+    // Defaulting only fills an absent limit: one the hook set itself stands,
+    // even where a cap would have produced a different value.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_job_hook_set_time_limit_survives_defaulting() {
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.hooks.job_submit = Some(write_hook_script(
+            &dir,
+            r#"echo '{"qos":"capped","time_limit_minutes":45}'"#,
+        ));
+        let cm = test_cluster_with_config(&dir, config).await;
+        cm.qos_cache().insert(Qos {
+            name: "capped".into(),
+            limits: spur_core::accounting::QosLimits {
+                max_wall_minutes: Some(60),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut spec = basic_spec("hook-own-limit");
+        spec.time_limit = None;
+        let id = submit_and_wait(&cm, spec);
+        assert_eq!(
+            cm.get_job(id).unwrap().spec.time_limit,
+            Some(chrono::Duration::minutes(45))
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4666,10 +4666,6 @@ impl ClusterManager {
         }
     }
 
-    /// Submit-time limit gate (Slurm's `acct_policy_validate`). Submit-count
-    /// limits and the association per-job wall deny unconditionally; stand-alone
-    /// TRES/wall breaches deny only under the governing QOS's `DenyOnLimit`
-    /// (treated as on when the job has no QOS). `incoming` is the task count added.
     /// The wall-clock ceilings that already govern this submission, for defaulting.
     /// An unloaded cache reports nothing rather than holding the job, matching how
     /// `enforce_submit_limits` treats limits it cannot read yet.
@@ -4697,6 +4693,10 @@ impl ClusterManager {
         }
     }
 
+    /// Submit-time limit gate (Slurm's `acct_policy_validate`). Submit-count
+    /// limits and the association per-job wall deny unconditionally; stand-alone
+    /// TRES/wall breaches deny only under the governing QOS's `DenyOnLimit`
+    /// (treated as on when the job has no QOS). `incoming` is the task count added.
     fn enforce_submit_limits(&self, spec: &JobSpec, incoming: u32) -> Result<(), SubmitError> {
         let jobs = self.jobs.read();
         let user = spec.user.as_str();
@@ -7401,10 +7401,13 @@ fn wall_cap_default(requested: &[&Partition], caps: WallCaps) -> Option<u32> {
     .min()?;
 
     // The limit has to stay schedulable somewhere: a requested partition with no
-    // `MaxTime` takes any, otherwise the most permissive one is the ceiling.
-    let partition_ceiling = requested
-        .iter()
-        .try_fold(0, |acc: u32, p| p.max_time_minutes.map(|m| acc.max(m)));
+    // `MaxTime` takes any, otherwise the most permissive one is the ceiling. With
+    // no partition in play nothing caps the ceiling, so the wall cap stands.
+    let partition_ceiling = if requested.iter().any(|p| p.max_time_minutes.is_none()) {
+        None
+    } else {
+        requested.iter().filter_map(|p| p.max_time_minutes).max()
+    };
 
     [Some(cap), partition_ceiling].into_iter().flatten().min()
 }
@@ -20344,6 +20347,14 @@ mod tests {
             qos_minutes: Some(minutes),
             account_minutes: None,
         }
+    }
+
+    // No partition in play means nothing caps the wall ceiling. Folding over an
+    // empty slice from a zero seed would instead collapse the cap to a zero-length
+    // limit, so the ceiling is computed without relying on a non-empty caller.
+    #[test]
+    fn wall_cap_default_without_partitions_keeps_the_cap() {
+        assert_eq!(super::wall_cap_default(&[], qos_wall(720)), Some(720));
     }
 
     #[test]

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -598,6 +598,11 @@ the job would pend indefinitely on ``PartitionTimeLimit`` for a limit it never
 asked for. A ``maxwall`` of ``0`` blocks every job it governs
 (:ref:`limit-values`) and is never used as a default.
 
+A ``job_submit`` hook may reassign the partition, account or QOS, so the default
+is resolved after the hook runs and reflects the scope the job ends up in. A
+hook that sets ``time_limit`` itself supplies the job's limit, and no default is
+applied over it.
+
 .. note::
 
    Jobs already running when this behaviour arrives keep the unbounded limit they

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -356,7 +356,8 @@ User keys
      - Aggregate TRES cap across the association's jobs.
    * - ``maxwall`` (alias ``maxwallduration``)
      - unset (no limit)
-     - Maximum wall-clock time per job.
+     - Maximum wall-clock time per job. Also supplies the time limit for a job
+       that requests none — see :ref:`maxwall-default`.
 
 .. note::
 
@@ -490,7 +491,8 @@ QOS keys
      - Maximum running jobs per user under this QOS. See :ref:`limit-values`.
    * - ``maxwall``
      - unset (no limit)
-     - Maximum wall-clock time per job.
+     - Maximum wall-clock time per job. Also supplies the time limit for a job
+       that requests none — see :ref:`maxwall-default`.
    * - ``maxtresperjob``
      - ``""``
      - TRES cap for a single job (see `TRES`_).
@@ -563,6 +565,45 @@ Set ``DenyOnLimit`` through the QOS ``flags`` key:
 .. code-block:: bash
 
    sacctmgr modify qos name=highprio set flags=DenyOnLimit
+
+.. _maxwall-default:
+
+MaxWall as the default time limit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A job that requests no wall-time takes its ``maxwall`` cap as its time limit, as
+in Slurm. Without this a ``-t``-less job would carry no limit at all: it would
+report ``UNLIMITED``, and the running-job watchdog — which acts on a job's own
+limit — would have no deadline to enforce, so the cap would hold only for jobs
+that named a limit themselves.
+
+Both the QOS and the association carry ``maxwall``, and a job has to satisfy
+both, so the smaller of the two is what it inherits.
+
+The limit is filled in at submit, so ``squeue`` and ``scontrol show job`` report
+it, and it is the job's own limit from then on: a later change to the QOS does
+not move it.
+
+Precedence for a job that requests nothing, first match winning:
+
+1. The partition's ``DefaultTime``, or the chain described under
+   ``default_time_limit_minutes`` in :doc:`configuration`.
+2. The smaller of the QOS and association ``maxwall``.
+3. Otherwise the job stays unbounded.
+
+So a partition ``DefaultTime`` shorter than ``maxwall`` still wins — ``maxwall``
+is a ceiling, and only supplies a default where nothing else does. The value
+filled in is also held under the requested partition's ``MaxTime``, above which
+the job would pend indefinitely on ``PartitionTimeLimit`` for a limit it never
+asked for. A ``maxwall`` of ``0`` blocks every job it governs
+(:ref:`limit-values`) and is never used as a default.
+
+.. note::
+
+   Jobs already running when this behaviour arrives keep the unbounded limit they
+   were submitted with; the QOS cap applies to submissions from then on. To bound
+   an existing job, set its limit directly with
+   ``scontrol update job <id> TimeLimit=<time>``.
 
 .. _grpwall-budgets:
 

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -388,7 +388,9 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
        flat value. Prior to this release the setting was inert (never applied);
        it now takes effect, and its default changed from ``60`` to ``0`` so
        ``-t``-less jobs stay unbounded exactly as before. A site that had set it
-       expecting an effect will now see that effect.
+       expecting an effect will now see that effect. A job the partitions leave
+       unbounded still takes its QOS or association ``MaxWall`` when one is set —
+       see :ref:`maxwall-default`.
    * - ``enforce_part_limits``
      - string
      - ``NO``

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -442,6 +442,77 @@ class TestQosLimitReasons:
         )
 
 
+# Deadline (1 min) + watchdog tick + SIGTERM grace + reap, with slack. The
+# smallest MaxWall is a minute, so this path costs roughly that in wall time.
+WALLCAP_FINISH_TIMEOUT = 240
+
+
+def _wait_time_limit(cluster, job_id: int, timeout: int = 30) -> str:
+    """Poll squeue until the job's TIME_LIMIT column is populated, then return it.
+
+    Defaulting runs synchronously at submit, so the row carries its limit the
+    first time it is visible. ``-t all`` keeps it readable even if the job has
+    already reached a terminal state.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        out = cluster.squeue(["-j", str(job_id), "-h", "-o", "%l", "-t", "all"]).strip()
+        if out:
+            return out
+        time.sleep(1)
+    raise AssertionError(f"job {job_id} never appeared in squeue within {timeout}s")
+
+
+class TestQosWallCapDefaulting:
+    """A job submitted without --time under a QOS with MaxWall must inherit that
+    MaxWall as its limit and actually be killed at the wall, not admitted
+    unbounded and left to run forever (the live incident where 31 jobs ran ~6x
+    past their cap). The QOS/account wall cap only becomes the default when the
+    partition imposes no DefaultTime/MaxTime of its own, so this runs on an
+    unbounded partition."""
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {
+            "partitions": [
+                {"name": "default", "state": "UP", "default": True, "nodes": "ALL"}
+            ]
+        }
+
+    def test_untimed_job_inherits_qos_maxwall_and_is_killed(self, accounting_cluster):
+        c = accounting_cluster
+
+        # MaxWall granularity is minutes; 1 is the smallest meaningful cap.
+        c.sacctmgr(["add", "qos", "name=wallcap", "maxwall=1"])
+        # Wait past the QOS cache refresh floor (10s) so the cap loads before submit.
+        time.sleep(15)
+
+        script = c.write_file("wallcap-untimed.sh", "#!/bin/bash\nsleep 600\n")
+        job_id = parse_job_id(
+            c.sbatch(["-J", "wallcap-untimed", "-N", "1", "-q", "wallcap", script])
+        )
+        assert job_id is not None
+
+        # Half one: the untimed job inherits MaxWall (1:00) as its limit rather
+        # than being admitted UNLIMITED — the bug this PR fixes.
+        limit = _wait_time_limit(c, job_id)
+        assert limit == "1:00", (
+            f"untimed job must inherit the QOS MaxWall as its limit, got {limit!r} "
+            f"(UNLIMITED means defaulting never fired)"
+        )
+
+        # Half two: the wall-clock watchdog actually terminates it at the cap
+        # instead of letting the 600s sleep run to completion.
+        state = wait_job(c, job_id, timeout=WALLCAP_FINISH_TIMEOUT)
+        assert state == "TO", (
+            f"a job killed by its inherited wall limit must report TIMEOUT, got "
+            f"{state}:\n{c.debug_job(job_id)}"
+        )
+        show = c.scontrol("show", "job", str(job_id))
+        assert "JobState=TIMEOUT" in show, show
+        assert "Reason=TimeLimit" in show, show
+
+
 class TestSacctmgrUserAssociationLimits:
     def test_maxjobs_set_via_add_user_blocks_a_second_job(self, accounting_cluster):
         c = accounting_cluster


### PR DESCRIPTION
## What this fixes

A job submitted without `-t` carried no time limit at all. It reported `UNLIMITED`, and the running-job watchdog acts on a job's own limit, so it had no deadline to enforce — a positive `maxwall` only ever held for jobs that named a limit themselves. Operators saw the split first-hand: jobs that passed `-t 12:00:00` were killed on time while jobs in the same QOS ran well past the cap.

Fixes #692.

## Approach

Wall-time defaulting now runs after QOS defaulting, so the governing QOS is known, and takes the job's per-job wall ceiling as the default when the partition chain supplies nothing. Precedence is unchanged where it already produced an answer: a partition `DefaultTime` (or the `default_time_limit_minutes` chain) still wins, because `maxwall` is a ceiling and only fills a gap.

Two clamps keep a filled-in limit from being worse than the unbounded job it replaces:

- The **account `maxwall`** rejects a submission outright, so defaulting above it would turn a job that runs today into one that cannot be submitted. The QOS and association caps both apply to a job, so the smaller is what it inherits.
- A requested partition's **`MaxTime`** blocks a job above it, so a default above `MaxTime` would pend forever on `PartitionTimeLimit` for a limit the user never asked for. The ceiling used is the most permissive requested partition's, since the job only has to be schedulable somewhere.

A `maxwall` of `0` is the block-all sentinel rather than a zero-length budget, so it is never used as a default — the existing breach checks still handle it.

## Design notes

- **The limit is the job's own from then on.** It is written into the spec at submit, so `squeue` and `scontrol show job` report a real value and a later QOS change does not move it. That is also why nothing here touches jobs that are already running: they keep the unbounded limit they were submitted with, so upgrading cannot mass-kill live work. Bounding an existing job stays an explicit `scontrol update job <id> TimeLimit=` action.
- **Unread limits default nothing.** `wall_caps` reports no ceiling while the QOS or association cache has not loaded, matching how `enforce_submit_limits` treats limits it cannot read yet. A cold controller does not invent deadlines.
- Moving the defaulting call after `apply_default_qos` is safe: nothing between the old and new call sites reads `time_limit`. The submit-time partition check stays keyed on `user_requested_time`, so an auto-filled value is still exempt from `EnforcePartLimits` rejection, as before.

## Tests

- Twelve unit tests around `apply_default_time_limit` covering the QOS-supplied default, an account-supplied one, the smaller of the two, partition `DefaultTime` still winning, both clamps, the multi-partition ceiling, an unlimited partition lifting it, and the zero sentinel on either cap.
- One test through the real `submit_job` path with a seeded QOS cache, asserting the persisted spec carries the limit.
- One test that `wall_caps` reports nothing before the caches load.
- An end-to-end test (`tests/native_host/e2e/test_accounting.py::TestQosWallCapDefaulting`) for the incident path: a `-t`-less job under a QOS with `maxwall` set, on an unbounded partition so defaulting reaches the wall cap. It asserts both halves — the job inherits the `MaxWall` as its limit (`squeue %l` is `1:00`, not `UNLIMITED`) and the watchdog actually kills it at the cap (`JobState=TIMEOUT`, `Reason=TimeLimit`) rather than running out its sleep.
- The eleven pre-existing defaulting tests are unchanged in behavior and still pass, pinning that the partition chain did not move.
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` clean; full `cargo test --locked` green.

## Docs

New "MaxWall as the default time limit" section in the accounting admin guide with the precedence list and the clamp reasoning, cross-referenced from both `maxwall` key tables and from `default_time_limit_minutes` in the configuration guide.

Made with [Cursor](https://cursor.com)