### PR TITLE
fix(spur-cli): parse --mem units (K/M/G/T) consistently across sbatch/srun/salloc

### DIFF
--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -395,17 +395,7 @@ fn resolve_salloc_env(matches: &ArgMatches, args: &mut SallocArgs) {
     );
 }
 
-fn parse_memory_mb(s: &str) -> Result<u64> {
-    let s = s.trim();
-    if let Some(gb) = s.strip_suffix('G').or_else(|| s.strip_suffix('g')) {
-        let val: f64 = gb.parse().context("invalid memory value")?;
-        Ok((val * 1024.0) as u64)
-    } else if let Some(mb) = s.strip_suffix('M').or_else(|| s.strip_suffix('m')) {
-        Ok(mb.parse().context("invalid memory value")?)
-    } else {
-        Ok(s.parse().context("invalid memory value")?)
-    }
-}
+use spur_core::resource::parse_memory_mb;
 
 #[cfg(test)]
 mod tests {

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -4,6 +4,7 @@
 use crate::env_defaults::{apply_csv, apply_flag, apply_str, apply_string};
 use anyhow::{Context, Result};
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
+use spur_core::resource::parse_memory_mb;
 use spur_core::spur_env::SpurEnv;
 use spur_proto::proto::{CancelJobRequest, GetJobRequest, JobSpec, SubmitJobRequest};
 use std::collections::HashMap;
@@ -394,8 +395,6 @@ fn resolve_salloc_env(matches: &ArgMatches, args: &mut SallocArgs) {
         &mut args.exclusive,
     );
 }
-
-use spur_core::resource::parse_memory_mb;
 
 #[cfg(test)]
 mod tests {

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -5,6 +5,7 @@ use crate::env_defaults::{apply_csv, apply_str, apply_string, env_first, was_cli
 use anyhow::{bail, Context, Result};
 use clap::parser::ValueSource;
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
+use spur_core::resource::parse_memory_mb;
 use spur_proto::proto::{JobSpec, SubmitJobRequest};
 use std::collections::HashMap;
 
@@ -635,9 +636,6 @@ fn parse_datetime_arg(s: &str) -> Result<chrono::DateTime<chrono::Utc>> {
         &chrono::Local::now(),
     )?)
 }
-
-/// Parse memory string (e.g., "4G", "4096M", "4096") into MB.
-use spur_core::resource::parse_memory_mb;
 
 /// Parse a GPU flag value ("4" or "mi300x:4") into a proto GpuRequest.
 pub(crate) fn parse_gpu_flag(value: Option<&str>) -> Result<Option<spur_proto::proto::GpuRequest>> {

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -637,21 +637,7 @@ fn parse_datetime_arg(s: &str) -> Result<chrono::DateTime<chrono::Utc>> {
 }
 
 /// Parse memory string (e.g., "4G", "4096M", "4096") into MB.
-fn parse_memory_mb(s: &str) -> Result<u64> {
-    let s = s.trim();
-    if let Some(gb) = s.strip_suffix('G').or_else(|| s.strip_suffix('g')) {
-        let val: f64 = gb.parse().context("invalid memory value")?;
-        Ok((val * 1024.0) as u64)
-    } else if let Some(mb) = s.strip_suffix('M').or_else(|| s.strip_suffix('m')) {
-        Ok(mb.parse().context("invalid memory value")?)
-    } else if let Some(kb) = s.strip_suffix('K').or_else(|| s.strip_suffix('k')) {
-        let val: u64 = kb.parse().context("invalid memory value")?;
-        Ok(val / 1024)
-    } else {
-        // Default: MB
-        Ok(s.parse().context("invalid memory value")?)
-    }
-}
+use spur_core::resource::parse_memory_mb;
 
 /// Parse a GPU flag value ("4" or "mi300x:4") into a proto GpuRequest.
 pub(crate) fn parse_gpu_flag(value: Option<&str>) -> Result<Option<spur_proto::proto::GpuRequest>> {

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -1348,17 +1348,7 @@ async fn run_as_step(
     .await;
 }
 
-fn parse_memory_mb(s: &str) -> Result<u64> {
-    let s = s.trim();
-    if let Some(gb) = s.strip_suffix('G').or_else(|| s.strip_suffix('g')) {
-        let val: f64 = gb.parse().context("invalid memory value")?;
-        Ok((val * 1024.0) as u64)
-    } else if let Some(mb) = s.strip_suffix('M').or_else(|| s.strip_suffix('m')) {
-        Ok(mb.parse().context("invalid memory value")?)
-    } else {
-        Ok(s.parse().context("invalid memory value")?)
-    }
-}
+use spur_core::resource::parse_memory_mb;
 
 fn load_hooks_config() -> HooksConfig {
     crate::spur_config::load_spur_config().hooks

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -7,6 +7,7 @@ use crate::env_defaults::{
 use anyhow::{Context, Result};
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
 use spur_core::config::HooksConfig;
+use spur_core::resource::parse_memory_mb;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
     CancelJobRequest, CompleteJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest,
@@ -1347,8 +1348,6 @@ async fn run_as_step(
     )
     .await;
 }
-
-use spur_core::resource::parse_memory_mb;
 
 fn load_hooks_config() -> HooksConfig {
     crate::spur_config::load_spur_config().hooks

--- a/crates/spur-core/src/resource.rs
+++ b/crates/spur-core/src/resource.rs
@@ -298,6 +298,30 @@ impl ResourceSet {
 /// The input is trimmed and empty strings are rejected, so callers that split a
 /// comma-list (CLI `--gres`, `SLURM_GRES`, REST, FFI) can pass raw segments
 /// without worrying about incidental whitespace or trailing commas.
+/// Parse a Slurm-style `--mem` size into MiB. Optional K/M/G/T suffix
+/// (case-insensitive), no suffix means MiB. Shared by sbatch/srun/salloc.
+pub fn parse_memory_mb(s: &str) -> anyhow::Result<u64> {
+    let s = s.trim();
+    if s.is_empty() {
+        anyhow::bail!("invalid memory value ''");
+    }
+    let (num, mult): (&str, f64) = match s.as_bytes()[s.len() - 1] {
+        b'K' | b'k' => (&s[..s.len() - 1], 1.0 / 1024.0),
+        b'M' | b'm' => (&s[..s.len() - 1], 1.0),
+        b'G' | b'g' => (&s[..s.len() - 1], 1024.0),
+        b'T' | b't' => (&s[..s.len() - 1], 1024.0 * 1024.0),
+        _ => (s, 1.0),
+    };
+    let val: f64 = num
+        .trim()
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid memory value '{s}'"))?;
+    if !val.is_finite() || val < 0.0 {
+        anyhow::bail!("invalid memory value '{s}'");
+    }
+    Ok((val * mult) as u64)
+}
+
 pub fn parse_gres(gres: &str) -> Option<(String, Option<String>, u32)> {
     let gres = gres.trim();
     if gres.is_empty() {
@@ -807,5 +831,45 @@ mod accounting_tests {
         assert_eq!(inv.total_gpus(), 3);
         assert_eq!(inv.gpu_counts().get("mi300x"), Some(&2));
         assert_eq!(ResourceSet::default().total_gpus(), 0);
+    }
+}
+
+#[cfg(test)]
+mod parse_memory_tests {
+    use super::parse_memory_mb;
+
+    #[test]
+    fn default_unit_is_mib() {
+        assert_eq!(parse_memory_mb("4096").unwrap(), 4096);
+    }
+
+    #[test]
+    fn all_suffixes_supported_case_insensitive() {
+        assert_eq!(parse_memory_mb("1024K").unwrap(), 1);
+        assert_eq!(parse_memory_mb("1024k").unwrap(), 1);
+        assert_eq!(parse_memory_mb("4096M").unwrap(), 4096);
+        assert_eq!(parse_memory_mb("4096m").unwrap(), 4096);
+        assert_eq!(parse_memory_mb("4G").unwrap(), 4096);
+        assert_eq!(parse_memory_mb("4g").unwrap(), 4096);
+        assert_eq!(parse_memory_mb("1T").unwrap(), 1024 * 1024);
+        assert_eq!(parse_memory_mb("1t").unwrap(), 1024 * 1024);
+    }
+
+    #[test]
+    fn fractional_gigabytes() {
+        assert_eq!(parse_memory_mb("1.5G").unwrap(), 1536);
+    }
+
+    #[test]
+    fn whitespace_trimmed() {
+        assert_eq!(parse_memory_mb("  2G  ").unwrap(), 2048);
+    }
+
+    #[test]
+    fn rejects_garbage_and_empty() {
+        assert!(parse_memory_mb("").is_err());
+        assert!(parse_memory_mb("abc").is_err());
+        assert!(parse_memory_mb("G").is_err());
+        assert!(parse_memory_mb("-5G").is_err());
     }
 }

--- a/docs/user-guide/submitting-jobs.rst
+++ b/docs/user-guide/submitting-jobs.rst
@@ -138,10 +138,12 @@ patterns for ``--output`` and ``--error``, the token expands to the job ID.
      - CPUs per task. Default ``1``.
    * - ``--mem``
      -
-     - Memory per node. ``512G`` and ``4096M`` use suffixes; a bare ``4096`` means MB.
+     - Memory per node. Takes a ``K``, ``M``, ``G``, or ``T`` suffix
+       (case-insensitive), e.g. ``512G`` or ``4096M``; a bare ``4096`` means MB.
+       ``sbatch``, ``srun``, and ``salloc`` accept the same set.
    * - ``--mem-per-cpu``
      -
-     - Memory per allocated CPU instead of per node.
+     - Memory per allocated CPU instead of per node. Same suffixes as ``--mem``.
    * - ``--gres``
      -
      - Generic resources, e.g. ``gpu:4`` or ``gpu:mi300x:8``. See


### PR DESCRIPTION
## Summary

Closes #827

The `--mem` flag accepted different unit suffixes depending on which submission
command you used. `sbatch --mem=1024K` submitted a job fine, but the same flag
under `srun` and `salloc` failed with `invalid memory value` — and none of the
three accepted a `T` (terabyte) suffix at all. This is a silent Slurm
incompatibility: a script that works under `sbatch` breaks when the identical
memory flag is passed to `srun` or `salloc`.

## Root cause

Each command carried its **own private copy** of the `parse_memory_mb` helper.
The copies drifted over time — when the helper was copy-pasted into `srun` and
`salloc`, the `K` (kilobyte) branch was dropped, and the `T` (terabyte) branch
was never added to any of them. Nothing in the code, tests, or docs justified
the difference; it was accidental copy-paste drift, not intentional design.

## Slurm comparison

Slurm's man pages for `sbatch`, `srun`, and `salloc` document `--mem`
identically: the size takes an optional `[K|M|G|T]` suffix, and in real Slurm all
three commands share a single option parser, so they are guaranteed to behave the
same. Spur's split implementations broke that guarantee: `K` worked only in
`sbatch`, and `T` worked nowhere. After this change all three accept the full
`K/M/G/T` set (case-insensitive, defaulting to MiB when no suffix is given),
matching Slurm.

## Fix

Instead of patching the missing branches into two more copies (which would leave
three implementations free to drift again), this PR removes all three copies and
routes every command through **one shared parser** in `spur-core`. `sbatch`,
`srun`, and `salloc` now import the same function, so their accepted units are
identical by construction and can never diverge in the future. The shared parser
also adds the previously-missing `T` support and rejects empty, non-numeric, and
negative input. Net effect is a reduction in code — three near-duplicate helpers
collapse into a single source of truth.

## Testing

- Unit tests (added in `spur-core`): K/M/G/T in both upper and lower case,
  fractional gigabytes, whitespace trimming, and rejection of empty/garbage/
  negative values.
- Full regression suites pass (`spur-core` and `spur-cli`), with `cargo fmt
  --check` and `cargo clippy --all-targets` clean.
- End-to-end against a live controller (run multiple times): `sbatch`, `srun`,
  and `salloc` all accept `--mem=1024K` and `--mem=1T`, while invalid values are
  still rejected by all three.