### PR TITLE
fix(spur-sched): protect large multi-node jobs from backfill starvation

### DIFF
--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -329,13 +329,16 @@ fn resolve_partition_field(
 }
 
 fn effective_state_str(node: &NodeInfo) -> String {
-    if !node.active_reservation.is_empty()
-        && node.state == spur_proto::proto::NodeState::NodeIdle as i32
-    {
-        if node.reservation_maint {
-            return "maint".into();
+    if node.state == spur_proto::proto::NodeState::NodeIdle as i32 {
+        if !node.active_reservation.is_empty() {
+            if node.reservation_maint {
+                return "maint".into();
+            }
+            return "resv".into();
         }
-        return "resv".into();
+        if node.planned_job_id != 0 {
+            return "plnd".into();
+        }
     }
     spur_core::node::NodeState::from_proto_i32(node.state)
         .map(|s| s.short().to_string())
@@ -805,6 +808,27 @@ mod tests {
     #[test]
     fn test_effective_state_mixed_reserved() {
         let node = make_reserved_node("n1", NodeState::NodeMixed, "p", "maint");
+        assert_eq!(effective_state_str(&node), "mix");
+    }
+
+    #[test]
+    fn test_effective_state_idle_with_planned_reservation_shows_plnd() {
+        let mut node = make_node("n1", NodeState::NodeIdle, "p");
+        node.planned_job_id = 42;
+        assert_eq!(effective_state_str(&node), "plnd");
+    }
+
+    #[test]
+    fn test_effective_state_active_reservation_wins_over_planned() {
+        let mut node = make_reserved_node("n1", NodeState::NodeIdle, "p", "resv1");
+        node.planned_job_id = 42;
+        assert_eq!(effective_state_str(&node), "resv");
+    }
+
+    #[test]
+    fn test_effective_state_planned_only_applies_when_idle() {
+        let mut node = make_node("n1", NodeState::NodeMixed, "p");
+        node.planned_job_id = 42;
         assert_eq!(effective_state_str(&node), "mix");
     }
 

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -117,14 +117,14 @@ impl BackfillScheduler {
 
     /// Resolve concrete per-node CPU and GPU allocations for non-uniform demand.
     /// CPU counts are positional (aligned to task launch order); a GPU total is
-    /// packed greedily onto the most-available nodes. `None` if it cannot fit now.
+    /// packed greedily onto the most-available nodes. `None` if it cannot fit at `at_time`.
     fn plan_per_node_alloc(
         &self,
         job: &Job,
         demand: &GpuDemand,
         assigned_nodes: &[(usize, chrono::DateTime<Utc>)],
         nodes: &[Node],
-        now: chrono::DateTime<Utc>,
+        at_time: chrono::DateTime<Utc>,
     ) -> Option<HashMap<String, ResourceAllocations>> {
         let base = base_node_request(job);
         let cpu_counts = cpu_per_node_counts(job);
@@ -147,7 +147,7 @@ impl BackfillScheduler {
                 // Capacity-sorted greedy: pack GPUs onto most-available nodes.
                 let mut caps: Vec<(usize, u32)> = assigned_nodes
                     .iter()
-                    .map(|(ni, _)| (*ni, self.free_gpus_at(*ni, &nodes[*ni], gpu_type, now)))
+                    .map(|(ni, _)| (*ni, self.free_gpus_at(*ni, &nodes[*ni], gpu_type, at_time)))
                     .collect();
                 caps.sort_by_key(|(_, cap)| std::cmp::Reverse(*cap));
                 let cap_values: Vec<u32> = caps.iter().map(|(_, c)| *c).collect();
@@ -162,7 +162,7 @@ impl BackfillScheduler {
         let mut per_node_alloc = HashMap::new();
         for (idx, (ni, _)) in assigned_nodes.iter().enumerate() {
             let node = &nodes[*ni];
-            let current = self.timelines[*ni].accumulated_at(now);
+            let current = self.timelines[*ni].accumulated_at(at_time);
 
             let mut req = base.clone();
             let cpus = cpu_counts.get(idx).copied().unwrap_or(base.cpus).max(1);
@@ -418,16 +418,17 @@ impl Scheduler for BackfillScheduler {
             let mut per_node_alloc = HashMap::new();
             if heterogeneous {
                 // Non-uniform per-node CPU or GPU counts: resolve concrete
-                // per-node allocations against current free capacity. We only
-                // place these when the job can start now (no heterogeneous
-                // future shadow reservation yet); otherwise leave it pending for
-                // a later cycle.
-                if earliest > now {
-                    continue;
-                }
-                match self.plan_per_node_alloc(job, &demand, &assigned_nodes, cluster.nodes, now) {
+                // per-node allocations against free capacity at the job's
+                // actual (possibly future) start time, same as the uniform path.
+                match self.plan_per_node_alloc(
+                    job,
+                    &demand,
+                    &assigned_nodes,
+                    cluster.nodes,
+                    earliest,
+                ) {
                     Some(allocs) => per_node_alloc = allocs,
-                    None => continue, // not enough free capacity right now
+                    None => continue, // not enough free capacity at that time
                 }
             } else {
                 for (ni, _) in &assigned_nodes {
@@ -1326,6 +1327,105 @@ mod tests {
         big.spec.exclusive = true;
         let mut small = make_job(2, 1, 1);
         small.spec.time_limit = Some(Duration::seconds(5));
+
+        let mut busy_until = std::collections::HashMap::new();
+        busy_until.insert("node002".to_string(), Utc::now() + Duration::seconds(20));
+        let cluster = ClusterState {
+            busy_until: &busy_until,
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&[big, small], &cluster);
+        assert_eq!(assignments.len(), 1);
+        assert_eq!(assignments[0].job_id, 2);
+        assert_eq!(assignments[0].nodes, vec!["node001".to_string()]);
+    }
+
+    // Heterogeneous (uneven per-node CPU split) jobs get the same future
+    // reservation protection as exclusive/uniform jobs, not just the ones
+    // that can start immediately. node001 is sized to exactly match big's
+    // real per-node share (4 cpus) so this is sensitive to reservation size,
+    // not just reservation existence: an under-counted reservation would
+    // leave spare capacity a non-exclusive small job could wrongly claim.
+    #[test]
+    fn heterogeneous_job_reservation_blocks_an_overlapping_smaller_job() {
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes = make_nodes(2);
+        nodes[0].total_resources.cpus = 4;
+        nodes[1].state = NodeState::Allocated;
+        nodes[1].alloc_resources = ResourceAllocations::with_scalar(64, 256_000);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let big = Job::new(
+            1,
+            JobSpec {
+                name: "uneven".into(),
+                partition: Some("default".into()),
+                user: "test".into(),
+                num_nodes: 2,
+                num_tasks: 7,
+                cpus_per_task: 1,
+                time_limit: Some(Duration::hours(1)),
+                ..Default::default()
+            },
+        );
+        // Non-exclusive: only conflicts if the reservation correctly claims
+        // all 4 of node001's cpus, not merely if *some* reservation exists.
+        let small = make_job(2, 1, 1);
+
+        let mut busy_until = std::collections::HashMap::new();
+        busy_until.insert("node002".to_string(), Utc::now() + Duration::seconds(20));
+        let cluster = ClusterState {
+            busy_until: &busy_until,
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&[big, small], &cluster);
+        assert!(
+            assignments.is_empty(),
+            "the uneven-split job's 4-cpu reservation on node001 must hold, {assignments:?}"
+        );
+    }
+
+    // Complement: a heterogeneous job's own future reservation must not block
+    // a smaller job that genuinely finishes first, even on the same
+    // exactly-sized node.
+    #[test]
+    fn heterogeneous_job_reservation_does_not_block_a_non_overlapping_smaller_job() {
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes = make_nodes(2);
+        nodes[0].total_resources.cpus = 4;
+        nodes[1].state = NodeState::Allocated;
+        nodes[1].alloc_resources = ResourceAllocations::with_scalar(64, 256_000);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let big = Job::new(
+            1,
+            JobSpec {
+                name: "uneven".into(),
+                partition: Some("default".into()),
+                user: "test".into(),
+                num_nodes: 2,
+                num_tasks: 7,
+                cpus_per_task: 1,
+                time_limit: Some(Duration::hours(1)),
+                ..Default::default()
+            },
+        );
+        let mut small = make_job(2, 1, 1);
+        small.spec.time_limit = Some(Duration::seconds(5)); // finishes before node002's 20s window.
 
         let mut busy_until = std::collections::HashMap::new();
         busy_until.insert("node002".to_string(), Utc::now() + Duration::seconds(20));

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -41,6 +41,25 @@ impl BackfillScheduler {
         }
     }
 
+    /// Nodes that are idle right now but hold a future reservation for a
+    /// specific pending job, as of the last `schedule()` call. Call
+    /// immediately after `schedule()`; the timelines are rebuilt every cycle.
+    pub fn planned_starts(&self) -> HashMap<String, (JobId, chrono::DateTime<Utc>)> {
+        let now = Utc::now();
+        self.timelines
+            .iter()
+            .filter(|tl| tl.accumulated_at(now).is_empty())
+            .filter_map(|tl| {
+                tl.intervals
+                    .iter()
+                    .filter(|iv| iv.start > now)
+                    .filter_map(|iv| iv.job_id.map(|id| (id, iv.start)))
+                    .min_by_key(|(_, start)| *start)
+                    .map(|(job_id, start)| (tl.node_name.clone(), (job_id, start)))
+            })
+            .collect()
+    }
+
     /// Initialize or reset timelines from current cluster state.
     fn init_timelines(&mut self, nodes: &[Node]) {
         self.timelines = nodes
@@ -456,7 +475,12 @@ impl Scheduler for BackfillScheduler {
                         .get(&cluster.nodes[*ni].name)
                         .cloned()
                         .unwrap_or_default();
-                    self.timelines[*ni].reserve(now, now + duration, node_alloc);
+                    self.timelines[*ni].reserve_for_job(
+                        now,
+                        now + duration,
+                        node_alloc,
+                        Some(job.job_id),
+                    );
                 }
 
                 debug!(
@@ -476,7 +500,12 @@ impl Scheduler for BackfillScheduler {
                         .get(&cluster.nodes[*ni].name)
                         .cloned()
                         .unwrap_or_default();
-                    self.timelines[*ni].reserve(earliest, earliest + duration, node_alloc);
+                    self.timelines[*ni].reserve_for_job(
+                        earliest,
+                        earliest + duration,
+                        node_alloc,
+                        Some(job.job_id),
+                    );
                 }
             }
         }
@@ -1443,6 +1472,44 @@ mod tests {
         assert_eq!(assignments.len(), 1);
         assert_eq!(assignments[0].job_id, 2);
         assert_eq!(assignments[0].nodes, vec!["node001".to_string()]);
+    }
+
+    #[test]
+    fn planned_starts_reports_the_job_holding_an_idle_nodes_future_reservation() {
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes = make_nodes(2);
+        nodes[1].state = NodeState::Allocated;
+        nodes[1].alloc_resources = ResourceAllocations::with_scalar(64, 256_000);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let mut big = make_job(7, 2, 1);
+        big.spec.exclusive = true;
+
+        let mut busy_until = std::collections::HashMap::new();
+        busy_until.insert("node002".to_string(), Utc::now() + Duration::seconds(20));
+        let cluster = ClusterState {
+            busy_until: &busy_until,
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&[big], &cluster);
+        assert!(assignments.is_empty(), "big job can't start yet");
+
+        let planned = sched.planned_starts();
+        let (job_id, start) = planned
+            .get("node001")
+            .copied()
+            .expect("node001 is idle now but reserved for the pending job");
+        assert_eq!(job_id, 7);
+        assert!(start > Utc::now());
+        // node002 is not idle right now, so it must not show up as "planned".
+        assert!(!planned.contains_key("node002"));
     }
 
     fn make_job_with_nodelist(

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -75,10 +75,7 @@ impl BackfillScheduler {
         let now = Utc::now();
 
         let suitable = |node: &Node| {
-            if !placement.matches(node, reservations, now) {
-                return false;
-            }
-            if !node.has_free_cpu_capacity() {
+            if !placement.matches_for_reservation(node, reservations, now) {
                 return false;
             }
             node.total_resources.can_satisfy(&required)
@@ -199,14 +196,16 @@ impl Scheduler for BackfillScheduler {
         let now = Utc::now();
         self.init_timelines(cluster.nodes);
 
-        // Add current allocations to timelines
+        // Add current allocations to timelines. Real per-node end times (from
+        // busy_until) replace the flat placeholder wherever known.
         for (i, node) in cluster.nodes.iter().enumerate() {
             if node.alloc_resources.cpus > 0 || node.alloc_resources.has_devices() {
-                self.timelines[i].reserve(
-                    now,
-                    now + Duration::hours(24),
-                    node.alloc_resources.clone(),
-                );
+                let free_at = cluster
+                    .busy_until
+                    .get(&node.name)
+                    .copied()
+                    .unwrap_or(now + Duration::hours(24));
+                self.timelines[i].reserve(now, free_at, node.alloc_resources.clone());
             }
             debug!(
                 node = %node.name,
@@ -295,11 +294,17 @@ impl Scheduler for BackfillScheduler {
                     .collect()
             };
 
-            // Find earliest start across needed_nodes
+            // Find earliest start across needed_nodes. Exclusive jobs time
+            // against the node's full capacity, not their own modest share.
             let mut node_starts: Vec<(usize, chrono::DateTime<Utc>)> = suitable
                 .iter()
                 .map(|&ni| {
-                    let start = self.timelines[ni].earliest_start(&required, duration, now);
+                    let timing_request: &ResourceSet = if job.spec.exclusive {
+                        &cluster.nodes[ni].total_resources
+                    } else {
+                        &required
+                    };
+                    let start = self.timelines[ni].earliest_start(timing_request, duration, now);
                     debug!(
                         job_id = job.job_id,
                         node = %cluster.nodes[ni].name,
@@ -430,7 +435,7 @@ impl Scheduler for BackfillScheduler {
                     let node_alloc = if job.spec.exclusive {
                         build_exclusive_allocation(&node.total_resources, required.memory_mb)
                     } else {
-                        let current = self.timelines[*ni].accumulated_at(now);
+                        let current = self.timelines[*ni].accumulated_at(earliest);
                         build_node_allocation(&node.total_resources, &current, &required)
                     };
                     per_node_alloc.insert(node.name.clone(), node_alloc);
@@ -647,6 +652,7 @@ mod tests {
 
         let pending = vec![make_job(1, 2, 32)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -670,6 +676,7 @@ mod tests {
 
         let pending = vec![make_job(1, 2, 32), make_job(2, 2, 32)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -706,6 +713,7 @@ mod tests {
             },
         );
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -753,6 +761,7 @@ mod tests {
             },
         );
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -810,6 +819,7 @@ mod tests {
             },
         );
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -851,6 +861,7 @@ mod tests {
             None,
         )];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -924,6 +935,7 @@ mod tests {
 
         let pending = vec![make_gpu_job(1, 4), make_gpu_job(2, 4)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -993,6 +1005,7 @@ mod tests {
         }];
         let pending = vec![total_gpu_job(1, 4, 8)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1016,6 +1029,7 @@ mod tests {
         }];
         let pending = vec![total_gpu_job(1, 2, 5)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1043,6 +1057,7 @@ mod tests {
         }];
         let pending = vec![total_gpu_job(1, 4, 8)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1065,6 +1080,7 @@ mod tests {
         }];
         let pending = vec![total_gpu_job(1, 2, 6)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1101,6 +1117,7 @@ mod tests {
             },
         )];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1143,6 +1160,7 @@ mod tests {
             },
         )];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1168,6 +1186,7 @@ mod tests {
         // Request 4 nodes but only 2 available
         let pending = vec![make_job(1, 4, 32)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1176,6 +1195,152 @@ mod tests {
 
         let assignments = sched.schedule(&pending, &cluster);
         assert_eq!(assignments.len(), 0);
+    }
+
+    // A job needing more nodes than are currently free must still reserve its
+    // eventual start against saturated nodes, so a later smaller job can't steal one.
+    #[test]
+    fn large_job_reservation_blocks_an_overlapping_smaller_job() {
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes = make_nodes(2);
+        nodes[1].state = NodeState::Allocated;
+        nodes[1].alloc_resources = ResourceAllocations::with_scalar(64, 256_000);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let mut big = make_job(1, 2, 1);
+        big.spec.exclusive = true;
+        let mut small = make_job(2, 1, 1);
+        small.spec.time_limit = Some(Duration::days(30));
+
+        let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&[big, small], &cluster);
+        assert!(
+            assignments.is_empty(),
+            "neither job can start now: node002 is saturated and node001 is \
+             reserved for the pending big job's eventual start, {assignments:?}"
+        );
+    }
+
+    // A non-overreach guard: this passes whether or not the reservation fix is
+    // present, since node001 was never contended for. It exists to confirm the
+    // fix doesn't turn into a blanket "anyone pending blocks everyone" hold.
+    #[test]
+    fn large_job_reservation_does_not_block_a_non_overlapping_smaller_job() {
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes = make_nodes(2);
+        nodes[1].state = NodeState::Allocated;
+        nodes[1].alloc_resources = ResourceAllocations::with_scalar(64, 256_000);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let mut big = make_job(1, 2, 1);
+        big.spec.exclusive = true;
+        let small = make_job(2, 1, 1); // default 1h, ends long before the big job's window.
+
+        let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&[big, small], &cluster);
+        assert_eq!(assignments.len(), 1);
+        assert_eq!(assignments[0].job_id, 2);
+        assert_eq!(assignments[0].nodes, vec!["node001".to_string()]);
+
+        // Confirm the big job's own future reservation was recorded internally
+        // even though it produced no Assignment yet.
+        assert!(
+            sched.timelines[1]
+                .intervals
+                .iter()
+                .any(|iv| iv.start > Utc::now()),
+            "node002 should carry the big job's future reservation"
+        );
+    }
+
+    // The realistic case: node002's running job actually ends in ~20s (via
+    // busy_until), not the flat 24h placeholder. A perfectly ordinary 1h job
+    // now correctly overlaps that near-term reservation and gets deferred.
+    #[test]
+    fn busy_until_protects_a_realistic_duration_reservation() {
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes = make_nodes(2);
+        nodes[1].state = NodeState::Allocated;
+        nodes[1].alloc_resources = ResourceAllocations::with_scalar(64, 256_000);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let mut big = make_job(1, 2, 1);
+        big.spec.exclusive = true;
+        let small = make_job(2, 1, 1); // ordinary default 1h duration, no artificial trick.
+
+        let mut busy_until = std::collections::HashMap::new();
+        busy_until.insert("node002".to_string(), Utc::now() + Duration::seconds(20));
+        let cluster = ClusterState {
+            busy_until: &busy_until,
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&[big, small], &cluster);
+        assert!(
+            assignments.is_empty(),
+            "a normal-duration job must not slip onto node001 ahead of the \
+             big job's near-term (20s) reservation, {assignments:?}"
+        );
+    }
+
+    // Complement: a small job whose own short duration finishes before
+    // node002's real (busy_until) completion time must still run now.
+    #[test]
+    fn busy_until_does_not_block_a_job_finishing_before_the_real_completion() {
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes = make_nodes(2);
+        nodes[1].state = NodeState::Allocated;
+        nodes[1].alloc_resources = ResourceAllocations::with_scalar(64, 256_000);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let mut big = make_job(1, 2, 1);
+        big.spec.exclusive = true;
+        let mut small = make_job(2, 1, 1);
+        small.spec.time_limit = Some(Duration::seconds(5));
+
+        let mut busy_until = std::collections::HashMap::new();
+        busy_until.insert("node002".to_string(), Utc::now() + Duration::seconds(20));
+        let cluster = ClusterState {
+            busy_until: &busy_until,
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&[big, small], &cluster);
+        assert_eq!(assignments.len(), 1);
+        assert_eq!(assignments[0].job_id, 2);
+        assert_eq!(assignments[0].nodes, vec!["node001".to_string()]);
     }
 
     fn make_job_with_nodelist(
@@ -1214,6 +1379,7 @@ mod tests {
 
         let pending = vec![make_job_with_nodelist(1, 1, Some("node001"), None)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1236,6 +1402,7 @@ mod tests {
 
         let pending = vec![make_job_with_nodelist(1, 2, Some("node001,node002"), None)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1260,6 +1427,7 @@ mod tests {
 
         let pending = vec![make_job_with_nodelist(1, 3, Some("node001"), None)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1288,6 +1456,7 @@ mod tests {
             None,
         )];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1315,6 +1484,7 @@ mod tests {
 
         let pending = vec![make_job_with_nodelist(1, 3, Some("node001"), None)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1356,6 +1526,7 @@ mod tests {
         job.spec.topology = Some("tree".into());
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1382,6 +1553,7 @@ mod tests {
         job.spec.num_tasks = 6;
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1404,6 +1576,7 @@ mod tests {
 
         let pending = vec![make_job_with_nodelist(1, 3, Some("node001"), None)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1431,6 +1604,7 @@ mod tests {
         job.spec.constraint = Some("mi300x".into());
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1461,6 +1635,7 @@ mod tests {
             None,
         )];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1491,6 +1666,7 @@ mod tests {
 
         let pending = vec![make_job_with_nodelist(1, 3, Some("node001"), None)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &reservations,
@@ -1527,6 +1703,7 @@ mod tests {
 
         let pending = vec![make_job_with_nodelist(1, 3, Some("node001"), None)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &reservations,
@@ -1549,6 +1726,7 @@ mod tests {
         // "nodeXXX" does not exist in the cluster
         let pending = vec![make_job_with_nodelist(1, 1, Some("nodeXXX"), None)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1571,6 +1749,7 @@ mod tests {
         // Exclude node001 and node002 → only node003 and node004 remain
         let pending = vec![make_job_with_nodelist(1, 2, None, Some("node001,node002"))];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1603,6 +1782,7 @@ mod tests {
 
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1630,6 +1810,7 @@ mod tests {
 
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1656,6 +1837,7 @@ mod tests {
 
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1678,6 +1860,7 @@ mod tests {
         // Exclude both → 2-node job can't schedule
         let pending = vec![make_job_with_nodelist(1, 2, None, Some("node001,node002"))];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1699,6 +1882,7 @@ mod tests {
 
         let pending = vec![make_job_with_nodelist(1, 2, Some("node[001-002]"), None)];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1723,6 +1907,7 @@ mod tests {
 
         let pending = vec![make_job_with_nodelist(1, 2, None, Some("node[001-002]"))];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1765,6 +1950,7 @@ mod tests {
 
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1799,6 +1985,7 @@ mod tests {
 
         let pending = vec![comp0, comp1];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1845,6 +2032,7 @@ mod tests {
 
         let pending = vec![comp0, comp1];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1878,6 +2066,7 @@ mod tests {
 
         let pending = vec![comp0, comp1];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1915,6 +2104,7 @@ mod tests {
 
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1939,6 +2129,7 @@ mod tests {
         }];
         let pending: Vec<Job> = (1..=8).map(|id| make_job(id, 1, 1)).collect();
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1974,6 +2165,7 @@ mod tests {
         for id in 1..=8 {
             let pending = vec![make_job(id, 1, 1)];
             let cluster = ClusterState {
+                busy_until: &std::collections::HashMap::new(),
                 nodes: &nodes,
                 partitions: &partitions,
                 reservations: &[],
@@ -2014,6 +2206,7 @@ mod tests {
 
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -2061,6 +2254,7 @@ mod tests {
         let job = make_job(1, 1, 1);
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &reservations,
@@ -2095,6 +2289,7 @@ mod tests {
 
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &reservations,
@@ -2129,6 +2324,7 @@ mod tests {
 
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &reservations,
@@ -2165,6 +2361,7 @@ mod tests {
         let job = make_job(1, 1, 1);
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[future_reservation],
@@ -2203,6 +2400,7 @@ mod tests {
 
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[future_reservation],

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -1544,6 +1544,70 @@ mod tests {
     }
 
     #[test]
+    fn heterogeneous_job_future_reservation_does_not_land_inside_another_reservation() {
+        // Same shape as the uniform common-window tests above, but through
+        // the heterogeneous (uneven per-node CPU split) allocation path,
+        // which was never exercised together with a reservation before.
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes = make_nodes(2);
+        nodes[0].total_resources.cpus = 4;
+        nodes[1].state = NodeState::Allocated;
+        nodes[1].alloc_resources = ResourceAllocations::with_scalar(64, 256_000);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let now = Utc::now();
+        let reservation = Reservation {
+            name: "upcoming".into(),
+            start_time: now + Duration::minutes(90),
+            end_time: now + Duration::minutes(150),
+            nodes: vec!["node001".into()],
+            accounts: Vec::new(),
+            users: vec!["alice".into()],
+            flags: Default::default(),
+            owner: String::new(),
+        };
+
+        let big = Job::new(
+            1,
+            JobSpec {
+                name: "uneven".into(),
+                partition: Some("default".into()),
+                user: "test".into(),
+                num_nodes: 2,
+                num_tasks: 7,
+                cpus_per_task: 1,
+                time_limit: Some(Duration::hours(1)),
+                ..Default::default()
+            },
+        );
+
+        let mut busy_until = std::collections::HashMap::new();
+        busy_until.insert("node002".to_string(), now + Duration::minutes(120));
+        let cluster = ClusterState {
+            busy_until: &busy_until,
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[reservation],
+            topology: None,
+        };
+
+        sched.schedule(&[big], &cluster);
+
+        let node001_conflict = sched.timelines[0].intervals.iter().any(|iv| {
+            iv.job_id == Some(1)
+                && iv.start < now + Duration::minutes(150)
+                && iv.end > now + Duration::minutes(90)
+        });
+        assert!(
+            !node001_conflict,
+            "heterogeneous job's shifted reservation on node001 must not land inside the unauthorized reservation window"
+        );
+    }
+
+    #[test]
     fn planned_starts_reports_the_job_holding_an_idle_nodes_future_reservation() {
         let mut sched = BackfillScheduler::new(100);
         let mut nodes = make_nodes(2);

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -278,22 +278,6 @@ impl Scheduler for BackfillScheduler {
             let heterogeneous = !job.spec.exclusive
                 && (homogeneous_per_node(&demand).is_none() || cpu_is_heterogeneous(job));
 
-            // Free GPUs of the requested type per candidate, used to pack the
-            // job onto the most-available nodes.
-            let free_gpu: HashMap<usize, u32> = if demand.is_none() {
-                HashMap::new()
-            } else {
-                suitable
-                    .iter()
-                    .map(|&ni| {
-                        (
-                            ni,
-                            self.free_gpus_at(ni, &cluster.nodes[ni], gpu_type.as_deref(), now),
-                        )
-                    })
-                    .collect()
-            };
-
             // Find earliest start across needed_nodes. Exclusive jobs time
             // against the node's full capacity, not their own modest share.
             let mut node_starts: Vec<(usize, chrono::DateTime<Utc>)> = suitable
@@ -315,6 +299,24 @@ impl Scheduler for BackfillScheduler {
                     (ni, start)
                 })
                 .collect();
+
+            // Free GPUs of the requested type per candidate, used to pack the
+            // job onto the most-available nodes. Evaluated at each node's own
+            // earliest_start, not `now` — a node's present-moment GPU count
+            // can be stale by the time this job would actually land there.
+            let free_gpu: HashMap<usize, u32> = if demand.is_none() {
+                HashMap::new()
+            } else {
+                node_starts
+                    .iter()
+                    .map(|&(ni, start)| {
+                        (
+                            ni,
+                            self.free_gpus_at(ni, &cluster.nodes[ni], gpu_type.as_deref(), start),
+                        )
+                    })
+                    .collect()
+            };
 
             node_starts.retain(|(ni, start)| {
                 !Self::start_overlaps_reservation(

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -50,8 +50,8 @@ impl BackfillScheduler {
         }
     }
 
-    /// Nodes that are idle right now but hold a future reservation for a
-    /// specific pending job, as of the last `schedule()` call. Call
+    /// Nodes with no resources currently allocated but a future reservation
+    /// for a specific pending job, as of the last `schedule()` call. Call
     /// immediately after `schedule()`; the timelines are rebuilt every cycle.
     pub fn planned_starts(&self) -> HashMap<String, (JobId, chrono::DateTime<Utc>)> {
         let now = Utc::now();
@@ -100,10 +100,8 @@ impl BackfillScheduler {
             .max()
     }
 
-    /// Earliest time `node` is free of both resource conflicts and reservation
-    /// conflicts for `duration`, searching forward from `floor`. Unlike a plain
-    /// `earliest_start` call, this stays valid even when combined with other
-    /// nodes' own (possibly later) start times in a common-window search.
+    /// Earliest time `node` is free of both resource and reservation
+    /// conflicts for `duration`, searching forward from `floor`.
     fn earliest_valid_start(
         &self,
         ni: usize,
@@ -349,10 +347,9 @@ impl Scheduler for BackfillScheduler {
                 }
             };
 
-            // Find earliest start across needed_nodes, folding both resource
-            // and reservation conflicts into one forward search per node.
-            // Exclusive jobs time against the node's full capacity, not
-            // their own modest share.
+            // Earliest start per node, folding resource and reservation
+            // conflicts into one search. Exclusive jobs time against the
+            // node's full capacity, not their own modest share.
             let mut node_starts: Vec<(usize, chrono::DateTime<Utc>)> = suitable
                 .iter()
                 .map(|&ni| {
@@ -374,10 +371,8 @@ impl Scheduler for BackfillScheduler {
                 })
                 .collect();
 
-            // Free GPUs of the requested type per candidate, used to pack the
-            // job onto the most-available nodes. Evaluated at each node's own
-            // earliest_start, not `now` — a node's present-moment GPU count
-            // can be stale by the time this job would actually land there.
+            // Free GPUs per candidate, evaluated at each node's own
+            // earliest_start (not `now`, which can be stale by then).
             let free_gpu: HashMap<usize, u32> = if demand.is_none() {
                 HashMap::new()
             } else {
@@ -503,10 +498,14 @@ impl Scheduler for BackfillScheduler {
                     })
                     .max()
                     .unwrap_or(earliest);
-                if next == earliest || earliest >= common_horizon {
+                // Advance before checking the horizon: the horizon only
+                // bounds iteration count, it must never discard a freshly
+                // computed (more accurate) value.
+                let converged = next == earliest;
+                earliest = next;
+                if converged || earliest >= common_horizon {
                     break;
                 }
-                earliest = next;
             }
 
             let mut per_node_alloc = HashMap::new();
@@ -2783,13 +2782,9 @@ mod tests {
 
     #[test]
     fn multi_node_future_reservation_does_not_land_inside_another_reservation() {
-        // node001 is free right now, but has an unauthorized reservation from
-        // +90m to +150m. node002 is busy until +120m. A 2-node job's own
-        // earliest_start on node001 alone is `now` (its 1h duration doesn't
-        // reach the +90m reservation), so the per-node overlap check at that
-        // candidate start passes — but the job's actual placement is shifted
-        // to node002's later availability (+120m), landing it at
-        // [+120m, +180m), which DOES overlap node001's reservation.
+        // node001 is idle but reserved +90m to +150m; node002 is busy until
+        // +120m, shifting the job's actual placement to [+120m, +180m) —
+        // which overlaps node001's reservation unless revalidated.
         let mut sched = BackfillScheduler::new(100);
         let mut nodes = make_nodes(2);
         nodes[1].state = NodeState::Allocated;

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -1375,12 +1375,8 @@ mod tests {
         assert_eq!(assignments[0].nodes, vec!["node001".to_string()]);
     }
 
-    // Heterogeneous (uneven per-node CPU split) jobs get the same future
-    // reservation protection as exclusive/uniform jobs, not just the ones
-    // that can start immediately. node001 is sized to exactly match big's
-    // real per-node share (4 cpus) so this is sensitive to reservation size,
-    // not just reservation existence: an under-counted reservation would
-    // leave spare capacity a non-exclusive small job could wrongly claim.
+    // node001 is sized to exactly match big's real per-node share (4 cpus),
+    // so this is sensitive to reservation size, not just existence.
     #[test]
     fn heterogeneous_job_reservation_blocks_an_overlapping_smaller_job() {
         let mut sched = BackfillScheduler::new(100);

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -1508,6 +1508,71 @@ mod tests {
         assert!(!planned.contains_key("node002"));
     }
 
+    #[test]
+    fn planned_starts_is_empty_when_nothing_is_reserved() {
+        let mut sched = BackfillScheduler::new(100);
+        let nodes = make_nodes(2);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+        let busy_until = std::collections::HashMap::new();
+        let cluster = ClusterState {
+            busy_until: &busy_until,
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        // Every node is idle and unclaimed with nothing pending.
+        sched.schedule(&[], &cluster);
+        assert!(sched.planned_starts().is_empty());
+    }
+
+    #[test]
+    fn planned_starts_picks_the_earliest_of_several_reservations_on_one_node() {
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes = make_nodes(2);
+        nodes[1].state = NodeState::Allocated;
+        nodes[1].alloc_resources = ResourceAllocations::with_scalar(64, 256_000);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let mut earlier = make_job(7, 2, 1);
+        earlier.spec.exclusive = true;
+        earlier.spec.time_limit = Some(Duration::minutes(5));
+        let mut later = make_job(8, 2, 1);
+        later.spec.exclusive = true;
+
+        let mut busy_until = std::collections::HashMap::new();
+        busy_until.insert("node002".to_string(), Utc::now() + Duration::seconds(20));
+        let cluster = ClusterState {
+            busy_until: &busy_until,
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        // Both need node001+node002; job 8 is queued behind job 7's reservation
+        // on node002, so it lands on a later slot on node001 too.
+        let assignments = sched.schedule(&[earlier, later], &cluster);
+        assert!(assignments.is_empty(), "neither job can start yet");
+
+        let (job_id, _start) = sched
+            .planned_starts()
+            .get("node001")
+            .copied()
+            .expect("node001 is idle now but reserved");
+        assert_eq!(
+            job_id, 7,
+            "must report the earlier reservation, not the later one"
+        );
+    }
+
     fn make_job_with_nodelist(
         id: u32,
         nodes: u32,

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -2775,6 +2775,62 @@ mod tests {
     }
 
     #[test]
+    fn multi_node_gpu_future_reservation_does_not_land_inside_another_reservation() {
+        // Same shape as the CPU version above, but with GPU nodes and an
+        // exclusive multi-node GPU job, to prove the common-window fix
+        // isn't CPU-only.
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes = vec![
+            make_named_gpu_node("node001", 8),
+            make_named_gpu_node("node002", 8),
+        ];
+        nodes[1].state = NodeState::Allocated;
+        nodes[1].alloc_resources = ResourceAllocations::with_scalar(64, 256_000);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let now = Utc::now();
+        let reservation = Reservation {
+            name: "upcoming".into(),
+            start_time: now + Duration::minutes(90),
+            end_time: now + Duration::minutes(150),
+            nodes: vec!["node001".into()],
+            accounts: Vec::new(),
+            users: vec!["alice".into()],
+            flags: Default::default(),
+            owner: String::new(),
+        };
+
+        let mut big = total_gpu_job(1, 2, 8);
+        big.spec.exclusive = true;
+        big.spec.time_limit = Some(Duration::hours(1));
+
+        let mut busy_until = std::collections::HashMap::new();
+        busy_until.insert("node002".to_string(), now + Duration::minutes(120));
+        let cluster = ClusterState {
+            busy_until: &busy_until,
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[reservation],
+            topology: None,
+        };
+
+        sched.schedule(&[big], &cluster);
+
+        let node001_conflict = sched.timelines[0].intervals.iter().any(|iv| {
+            iv.job_id == Some(1)
+                && iv.start < now + Duration::minutes(150)
+                && iv.end > now + Duration::minutes(90)
+        });
+        assert!(
+            !node001_conflict,
+            "GPU job's shifted reservation on node001 must not land inside the unauthorized reservation window"
+        );
+    }
+
+    #[test]
     fn test_job_resource_request_includes_countable_gres() {
         let job = Job::new(
             1,

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -15,7 +15,7 @@ use spur_core::resource::{
 };
 
 use crate::node_match::NodePlacement;
-use crate::timeline::NodeTimeline;
+use crate::timeline::{NodeTimeline, UNLIMITED_JOB_DURATION};
 use crate::traits::{Assignment, ClusterState, Scheduler};
 
 /// Backfill scheduler.
@@ -31,6 +31,15 @@ pub struct BackfillScheduler {
     timelines: Vec<NodeTimeline>,
     /// Max jobs to consider per cycle.
     max_jobs: usize,
+}
+
+/// Bundles the reservation-authorization inputs shared by every candidate
+/// node check for one job, to keep `earliest_valid_start` under clippy's arg limit.
+#[derive(Clone, Copy)]
+struct ReservationCheck<'a> {
+    job: &'a Job,
+    node: &'a str,
+    reservations: &'a [Reservation],
 }
 
 impl BackfillScheduler {
@@ -68,18 +77,53 @@ impl BackfillScheduler {
             .collect();
     }
 
-    /// Returns true when `[start, start+duration)` intersects a reservation on `node`
-    /// and the job is not authorized for that reservation.
-    fn start_overlaps_reservation(
-        job: &Job,
-        node: &str,
-        reservations: &[Reservation],
+    /// Latest end time among reservations on `node` that `[start, start+duration)`
+    /// would intersect without authorization, or `None` if clear.
+    fn reservation_blocker(
+        res_check: ReservationCheck<'_>,
         start: chrono::DateTime<Utc>,
         duration: chrono::Duration,
-    ) -> bool {
-        reservations
+    ) -> Option<chrono::DateTime<Utc>> {
+        res_check
+            .reservations
             .iter()
-            .any(|res| reservation::prospective_overlap_at(job, res, node, start, duration))
+            .filter(|res| {
+                reservation::prospective_overlap_at(
+                    res_check.job,
+                    res,
+                    res_check.node,
+                    start,
+                    duration,
+                )
+            })
+            .map(|res| res.end_time)
+            .max()
+    }
+
+    /// Earliest time `node` is free of both resource conflicts and reservation
+    /// conflicts for `duration`, searching forward from `floor`. Unlike a plain
+    /// `earliest_start` call, this stays valid even when combined with other
+    /// nodes' own (possibly later) start times in a common-window search.
+    fn earliest_valid_start(
+        &self,
+        ni: usize,
+        res_check: ReservationCheck<'_>,
+        request: &ResourceSet,
+        duration: chrono::Duration,
+        floor: chrono::DateTime<Utc>,
+    ) -> chrono::DateTime<Utc> {
+        let max_check = floor + chrono::Duration::days(365);
+        let mut candidate = floor;
+        loop {
+            if candidate > max_check {
+                return max_check;
+            }
+            candidate = self.timelines[ni].earliest_start(request, duration, candidate);
+            match Self::reservation_blocker(res_check, candidate, duration) {
+                Some(end) => candidate = end,
+                None => return candidate,
+            }
+        }
     }
 
     /// Find nodes that satisfy a job's resource requirements.
@@ -285,7 +329,7 @@ impl Scheduler for BackfillScheduler {
                 .filter(|ni| placement.is_listed(&cluster.nodes[**ni].name))
                 .count();
             let required = job_resource_request(job);
-            let duration = job.spec.time_limit.unwrap_or(Duration::hours(1));
+            let duration = job.spec.time_limit.unwrap_or(UNLIMITED_JOB_DURATION);
             let needed_nodes = (job.spec.num_nodes as usize).max(1);
 
             let demand = resolve_gpu_demand(&job.spec).unwrap_or(GpuDemand::None);
@@ -297,17 +341,28 @@ impl Scheduler for BackfillScheduler {
             let heterogeneous = !job.spec.exclusive
                 && (homogeneous_per_node(&demand).is_none() || cpu_is_heterogeneous(job));
 
-            // Find earliest start across needed_nodes. Exclusive jobs time
-            // against the node's full capacity, not their own modest share.
+            let timing_request = |ni: usize| -> &ResourceSet {
+                if job.spec.exclusive {
+                    &cluster.nodes[ni].total_resources
+                } else {
+                    &required
+                }
+            };
+
+            // Find earliest start across needed_nodes, folding both resource
+            // and reservation conflicts into one forward search per node.
+            // Exclusive jobs time against the node's full capacity, not
+            // their own modest share.
             let mut node_starts: Vec<(usize, chrono::DateTime<Utc>)> = suitable
                 .iter()
                 .map(|&ni| {
-                    let timing_request: &ResourceSet = if job.spec.exclusive {
-                        &cluster.nodes[ni].total_resources
-                    } else {
-                        &required
+                    let res_check = ReservationCheck {
+                        job,
+                        node: &cluster.nodes[ni].name,
+                        reservations: cluster.reservations,
                     };
-                    let start = self.timelines[ni].earliest_start(timing_request, duration, now);
+                    let start =
+                        self.earliest_valid_start(ni, res_check, timing_request(ni), duration, now);
                     debug!(
                         job_id = job.job_id,
                         node = %cluster.nodes[ni].name,
@@ -336,16 +391,6 @@ impl Scheduler for BackfillScheduler {
                     })
                     .collect()
             };
-
-            node_starts.retain(|(ni, start)| {
-                !Self::start_overlaps_reservation(
-                    job,
-                    &cluster.nodes[*ni].name,
-                    cluster.reservations,
-                    *start,
-                    duration,
-                )
-            });
 
             if placement.nodelist_is_additive()
                 && node_starts
@@ -434,7 +479,35 @@ impl Scheduler for BackfillScheduler {
             let assigned_nodes: Vec<(usize, chrono::DateTime<Utc>)> =
                 node_starts.into_iter().take(needed_nodes).collect();
 
-            let earliest = assigned_nodes.iter().map(|(_, t)| *t).max().unwrap();
+            // Converge on a start every assigned node is simultaneously free
+            // at — an independently-computed per-node start can be stale
+            // once shifted forward to match the slowest node in the set.
+            let mut earliest = assigned_nodes.iter().map(|(_, t)| *t).max().unwrap_or(now);
+            let common_horizon = now + chrono::Duration::days(365);
+            loop {
+                let next = assigned_nodes
+                    .iter()
+                    .map(|&(ni, _)| {
+                        let res_check = ReservationCheck {
+                            job,
+                            node: &cluster.nodes[ni].name,
+                            reservations: cluster.reservations,
+                        };
+                        self.earliest_valid_start(
+                            ni,
+                            res_check,
+                            timing_request(ni),
+                            duration,
+                            earliest,
+                        )
+                    })
+                    .max()
+                    .unwrap_or(earliest);
+                if next == earliest || earliest >= common_horizon {
+                    break;
+                }
+                earliest = next;
+            }
 
             let mut per_node_alloc = HashMap::new();
             if heterogeneous {
@@ -2641,6 +2714,63 @@ mod tests {
         assert!(
             assignments.is_empty(),
             "job that would overlap upcoming reservation must not schedule"
+        );
+    }
+
+    #[test]
+    fn multi_node_future_reservation_does_not_land_inside_another_reservation() {
+        // node001 is free right now, but has an unauthorized reservation from
+        // +90m to +150m. node002 is busy until +120m. A 2-node job's own
+        // earliest_start on node001 alone is `now` (its 1h duration doesn't
+        // reach the +90m reservation), so the per-node overlap check at that
+        // candidate start passes — but the job's actual placement is shifted
+        // to node002's later availability (+120m), landing it at
+        // [+120m, +180m), which DOES overlap node001's reservation.
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes = make_nodes(2);
+        nodes[1].state = NodeState::Allocated;
+        nodes[1].alloc_resources = ResourceAllocations::with_scalar(64, 256_000);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let now = Utc::now();
+        let reservation = Reservation {
+            name: "upcoming".into(),
+            start_time: now + Duration::minutes(90),
+            end_time: now + Duration::minutes(150),
+            nodes: vec!["node001".into()],
+            accounts: Vec::new(),
+            users: vec!["alice".into()],
+            flags: Default::default(),
+            owner: String::new(),
+        };
+
+        let mut big = make_job(1, 2, 1);
+        big.spec.exclusive = true;
+        big.spec.time_limit = Some(Duration::hours(1));
+
+        let mut busy_until = std::collections::HashMap::new();
+        busy_until.insert("node002".to_string(), now + Duration::minutes(120));
+        let cluster = ClusterState {
+            busy_until: &busy_until,
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[reservation],
+            topology: None,
+        };
+
+        sched.schedule(&[big], &cluster);
+
+        let node001_conflict = sched.timelines[0].intervals.iter().any(|iv| {
+            iv.job_id == Some(1)
+                && iv.start < now + Duration::minutes(150)
+                && iv.end > now + Duration::minutes(90)
+        });
+        assert!(
+            !node001_conflict,
+            "job's shifted reservation on node001 must not land inside the unauthorized reservation window"
         );
     }
 

--- a/crates/spur-sched/src/lib.rs
+++ b/crates/spur-sched/src/lib.rs
@@ -7,3 +7,5 @@ pub mod node_match;
 pub mod priority;
 pub mod timeline;
 pub mod traits;
+
+pub use timeline::UNLIMITED_JOB_DURATION;

--- a/crates/spur-sched/src/node_match.rs
+++ b/crates/spur-sched/src/node_match.rs
@@ -186,6 +186,17 @@ impl<'a> NodePlacement<'a> {
         true
     }
 
+    /// Like [`matches`](Self::matches), but admits a busy-yet-up node as a
+    /// candidate for a *future* reservation instead of excluding it outright.
+    pub fn matches_for_reservation(
+        &self,
+        node: &Node,
+        reservations: &[Reservation],
+        now: DateTime<Utc>,
+    ) -> bool {
+        !node.is_k0s_reserved() && self.eligible(node, reservations, now) && node.state.is_up()
+    }
+
     fn reservation_ok(
         &self,
         node: &Node,
@@ -308,6 +319,38 @@ mod tests {
             n.k0s_role = Some(role);
             assert!(!p.matches(&n, &[], now), "{role:?} must be excluded");
         }
+    }
+
+    #[test]
+    fn matches_for_reservation_admits_a_fully_busy_but_healthy_node() {
+        let job = job_with(base_spec());
+        let p = NodePlacement::new(&job);
+        let now = Utc::now();
+
+        let mut n = node("n1");
+        n.state = NodeState::Allocated;
+        n.alloc_resources = spur_core::resource::ResourceAllocations::with_scalar(64, 256_000);
+
+        assert!(!p.matches(&n, &[], now), "matches() still excludes it");
+        assert!(
+            p.matches_for_reservation(&n, &[], now),
+            "a fully-busy Allocated node is still a valid future-reservation candidate"
+        );
+    }
+
+    #[test]
+    fn matches_for_reservation_still_excludes_down_and_k0s_nodes() {
+        let job = job_with(base_spec());
+        let p = NodePlacement::new(&job);
+        let now = Utc::now();
+
+        let mut down = node("n1");
+        down.state = NodeState::Down;
+        assert!(!p.matches_for_reservation(&down, &[], now));
+
+        let mut k0s = node("n2");
+        k0s.k0s_role = Some(spur_core::k0s::K0sRole::Worker);
+        assert!(!p.matches_for_reservation(&k0s, &[], now));
     }
 
     #[test]

--- a/crates/spur-sched/src/timeline.rs
+++ b/crates/spur-sched/src/timeline.rs
@@ -7,6 +7,10 @@ use std::collections::BinaryHeap;
 use chrono::{DateTime, Duration, Utc};
 use spur_core::resource::{ResourceAllocations, ResourceSet};
 
+/// Assumed occupancy for a job with no explicit time limit, shared by
+/// backfill sizing and spurctld's running-job busy_until estimate.
+pub const UNLIMITED_JOB_DURATION: Duration = Duration::days(365);
+
 /// Per-node resource timeline for backfill scheduling.
 ///
 /// Tracks when resources become available on a node by maintaining
@@ -141,20 +145,15 @@ impl NodeTimeline {
     }
 
     /// Find the earliest time at which `request` resources are available
-    /// for `duration` contiguous time.
+    /// for `duration` contiguous time. `after` may itself be in the future
+    /// (e.g. a reservation's end time) — already-elapsed intervals relative
+    /// to `after` are handled correctly by the sweep, not a staleness bug.
     pub fn earliest_start(
         &self,
         request: &ResourceSet,
         duration: Duration,
         after: DateTime<Utc>,
     ) -> DateTime<Utc> {
-        #[cfg(debug_assertions)]
-        debug_assert!(
-            self.intervals.iter().all(|i| i.end > after),
-            "stale interval in timeline for {}",
-            self.node_name,
-        );
-
         let mut candidate = after;
         let max_check = after + Duration::days(365);
         let mut sweep = AllocationSweep::new(&self.intervals, after);

--- a/crates/spur-sched/src/timeline.rs
+++ b/crates/spur-sched/src/timeline.rs
@@ -24,6 +24,9 @@ pub struct Interval {
     pub start: DateTime<Utc>,
     pub end: DateTime<Utc>,
     pub resources: ResourceAllocations,
+    /// The job this reservation belongs to, if attributable to exactly one
+    /// (e.g. `None` for the aggregate "current allocation" seed interval).
+    pub job_id: Option<u32>,
 }
 
 /// Incremental sweep over sorted interval start/end events.
@@ -186,10 +189,23 @@ impl NodeTimeline {
         end: DateTime<Utc>,
         resources: ResourceAllocations,
     ) {
+        self.reserve_for_job(start, end, resources, None);
+    }
+
+    /// Like [`reserve`](Self::reserve), attributing the interval to a job so
+    /// callers can later report which pending job a future reservation is for.
+    pub fn reserve_for_job(
+        &mut self,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        resources: ResourceAllocations,
+        job_id: Option<u32>,
+    ) {
         self.intervals.push(Interval {
             start,
             end,
             resources,
+            job_id,
         });
         self.intervals.sort_by_key(|i| i.start);
     }

--- a/crates/spur-sched/src/traits.rs
+++ b/crates/spur-sched/src/traits.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 
+use chrono::{DateTime, Utc};
 use spur_core::job::{Job, JobId};
 use spur_core::node::Node;
 use spur_core::partition::Partition;
@@ -26,6 +27,9 @@ pub struct ClusterState<'a> {
     pub reservations: &'a [Reservation],
     /// Fabric topology (switch hierarchy). None if topology is not configured.
     pub topology: Option<&'a TopologyTree>,
+    /// Node name -> real time its last currently-running job is expected to
+    /// end. Absent entries fall back to a conservative placeholder.
+    pub busy_until: &'a HashMap<String, DateTime<Utc>>,
 }
 
 /// Trait for pluggable scheduler implementations.

--- a/crates/spur-tests/src/t07_sched.rs
+++ b/crates/spur-tests/src/t07_sched.rs
@@ -27,6 +27,7 @@ mod tests {
         let pending = vec![make_job_with_resources("train", 2, 64, 1, Some(60))];
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -51,6 +52,7 @@ mod tests {
         ];
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -74,6 +76,7 @@ mod tests {
         let pending = vec![make_job_with_resources("big", 4, 128, 1, Some(60))];
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -93,6 +96,7 @@ mod tests {
         let pending = vec![make_job_with_resources("cpu_heavy", 1, 64, 1, Some(60))];
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -115,6 +119,7 @@ mod tests {
         let pending = vec![make_job_with_resources("job", 2, 32, 1, Some(60))];
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -140,6 +145,7 @@ mod tests {
         let pending = vec![make_job_with_resources("job", 1, 32, 1, Some(60))];
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -169,6 +175,7 @@ mod tests {
         job.spec.partition = Some("gpu".into());
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -312,6 +319,7 @@ mod tests {
         job.spec.exclusive = true;
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -338,6 +346,7 @@ mod tests {
         job.spec.exclusive = true;
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -362,6 +371,7 @@ mod tests {
         let job = make_job_with_resources("normal", 1, 1, 1, Some(60));
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -387,6 +397,7 @@ mod tests {
         job.spec.constraint = Some("gpu".into());
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -416,6 +427,7 @@ mod tests {
         job.spec.constraint = Some("gpu".into());
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -480,6 +492,7 @@ mod tests {
         let partitions = vec![make_partition("default", 2)];
         let job = make_job_with_resources("train", 1, 1, 1, Some(60));
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -500,6 +513,7 @@ mod tests {
         let partitions = vec![make_partition("default", 2)];
         let job = make_job_with_resources("train", 1, 1, 1, Some(60));
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -559,6 +573,7 @@ mod tests {
         // A job with no reservation spec should NOT land on node001.
         let job = make_job_with_resources("regular-job", 1, 1, 1, Some(60));
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[res],
@@ -596,6 +611,7 @@ mod tests {
         job.spec.user = "bob".into();
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[res],
@@ -617,6 +633,7 @@ mod tests {
         let partitions = vec![make_partition("default", 4)];
         let job = make_job_with_resources("free-job", 1, 1, 1, Some(60));
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -639,6 +656,7 @@ mod tests {
         job.spec.num_nodes = 0;
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -660,6 +678,7 @@ mod tests {
         let job = make_job("simple");
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -685,6 +704,7 @@ mod tests {
         job.spec.constraint = Some("gpu".into());
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -711,6 +731,7 @@ mod tests {
         job.spec.exclusive = true;
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -738,6 +759,7 @@ mod tests {
         job.spec.num_tasks = 1;
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -767,6 +789,7 @@ mod tests {
         job.spec.num_tasks = 1;
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -816,6 +839,7 @@ mod tests {
         ]);
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -879,6 +903,7 @@ mod tests {
         ]);
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -921,6 +946,7 @@ mod tests {
         ]);
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -963,6 +989,7 @@ mod tests {
         ]);
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1014,6 +1041,7 @@ mod tests {
         let pending = vec![make_job("test-immediate")];
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -1039,6 +1067,7 @@ mod tests {
         let pending = vec![job];
 
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],

--- a/crates/spur-tests/src/t39_gpu.rs
+++ b/crates/spur-tests/src/t39_gpu.rs
@@ -238,6 +238,7 @@ mod tests {
 
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -304,6 +305,7 @@ mod tests {
 
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],
@@ -367,6 +369,7 @@ mod tests {
 
         let pending = vec![job];
         let cluster = ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -1168,6 +1168,7 @@ address = "http://peer-a:6817"
         job.spec.num_nodes = 0;
 
         let cluster = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &[],

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -425,6 +425,11 @@ pub struct ClusterManager {
     /// Wake signal for the scheduler loop.
     pub(crate) scheduler_notify: Arc<Notify>,
     sched_stats: OnceLock<Arc<SchedStatsCollector>>,
+    /// Node -> (job_id, start_time) for a node that's idle right now but
+    /// holds a future backfill reservation, refreshed every scheduling cycle.
+    /// Ephemeral like the scheduler's own timelines: never persisted, cheap
+    /// to lose and recompute on restart/failover.
+    planned_reservations: RwLock<HashMap<String, (JobId, DateTime<Utc>)>>,
     /// Last keepalive time per interactive allocation, used by the InactiveLimit
     /// reaper. Ephemeral soft state (like `Node::last_heartbeat`): keepalives
     /// arrive too often to persist, and on failover the reaper reseeds lazily.
@@ -522,6 +527,7 @@ impl ClusterManager {
             association_cache,
             scheduler_notify: Arc::new(Notify::new()),
             sched_stats: OnceLock::new(),
+            planned_reservations: RwLock::new(HashMap::new()),
             interactive_last_seen: RwLock::new(HashMap::new()),
             node_dispatch_cooldowns: RwLock::new(HashMap::new()),
         };
@@ -4600,6 +4606,19 @@ impl ClusterManager {
 
     pub fn set_sched_stats(&self, stats: Arc<SchedStatsCollector>) {
         let _ = self.sched_stats.set(stats);
+    }
+
+    pub(crate) fn set_planned_reservations(
+        &self,
+        planned: HashMap<String, (JobId, DateTime<Utc>)>,
+    ) {
+        *self.planned_reservations.write() = planned;
+    }
+
+    /// `(job_id, start_time)` if `node` is idle right now but the scheduler
+    /// holds a future reservation for a specific pending job on it.
+    pub fn planned_reservation(&self, node: &str) -> Option<(JobId, DateTime<Utc>)> {
+        self.planned_reservations.read().get(node).copied()
     }
 
     pub(crate) fn record_sched_cycle(
@@ -9560,6 +9579,26 @@ mod tests {
 
         let node = cm.get_node("worker1").unwrap();
         assert_eq!(node.alloc_resources.cpus, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn planned_reservation_round_trips_and_defaults_to_none() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        assert_eq!(cm.planned_reservation("node001"), None);
+
+        let now = Utc::now();
+        let mut planned = HashMap::new();
+        planned.insert("node001".to_string(), (7u32, now));
+        cm.set_planned_reservations(planned);
+
+        assert_eq!(cm.planned_reservation("node001"), Some((7, now)));
+        assert_eq!(cm.planned_reservation("node002"), None);
+
+        // A later cycle with nothing planned clears the stale entry.
+        cm.set_planned_reservations(HashMap::new());
+        assert_eq!(cm.planned_reservation("node001"), None);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -6394,7 +6394,10 @@ fn reservation_fence_reason(
     }
 
     let now = Utc::now();
-    let duration = job.spec.time_limit.unwrap_or(chrono::Duration::hours(1));
+    let duration = job
+        .spec
+        .time_limit
+        .unwrap_or(spur_sched::UNLIMITED_JOB_DURATION);
     let mut maint_block = false;
     let mut blocked = 0;
     let mut listed_blocked = false;

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4424,8 +4424,7 @@ impl ClusterManager {
                 && eligible.iter().any(|node| {
                     placement.is_listed(&node.name)
                         && node.total_resources.can_satisfy(&required)
-                        && (!placement.matches(node, cluster_state.reservations, now)
-                            || !node.can_satisfy_request(&required))
+                        && !placement.matches_for_reservation(node, cluster_state.reservations, now)
                 })
             {
                 job_entry.set_pending_reason(PendingReason::ReqNodeNotAvail);
@@ -11548,6 +11547,7 @@ mod tests {
         // The guard site in update_pending_reasons. An empty cluster_state would
         // otherwise force Resources/NodeDown.
         let empty_state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &[],
             partitions: &[],
             reservations: &[],
@@ -11585,6 +11585,7 @@ mod tests {
         assert!(cm.get_job(job_id).unwrap().is_begin_held(Utc::now()));
 
         let empty_state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &[],
             partitions: &[],
             reservations: &[],
@@ -12321,6 +12322,7 @@ mod tests {
             jobs.get_mut(&job_id).unwrap().pending_reason = PendingReason::DeadLine;
         }
         let empty_state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &[],
             partitions: &[],
             reservations: &[],
@@ -12351,6 +12353,7 @@ mod tests {
         node.alloc_resources = scalar_alloc(4, 8000);
         let nodes = vec![node];
         let state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &[],
             reservations: &[],
@@ -12367,6 +12370,7 @@ mod tests {
         down.state = NodeState::Down;
         let nodes = vec![down];
         let state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &[],
             reservations: &[],
@@ -12395,6 +12399,7 @@ mod tests {
         node.k0s_role = Some(K0sRole::Worker);
         let nodes = vec![node];
         let state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &[],
             reservations: &[],
@@ -12414,6 +12419,7 @@ mod tests {
         busy.state = NodeState::Mixed;
         let nodes = vec![busy];
         let state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &[],
             reservations: &[],
@@ -12451,6 +12457,7 @@ mod tests {
         let n2 = cm.get_node("n2").unwrap();
         let nodes = vec![n1, n2];
         let state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &[],
             reservations: &[],
@@ -12485,6 +12492,7 @@ mod tests {
             cm.get_node("n3").unwrap(),
         ];
         let state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &[],
             reservations: &[],
@@ -12523,6 +12531,7 @@ mod tests {
             cm.get_node("n4").unwrap(),
         ];
         let state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &[],
             reservations: &[],
@@ -12572,6 +12581,7 @@ mod tests {
             owner: String::new(),
         }];
         let state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &[],
             reservations: &reservations,
@@ -12621,6 +12631,7 @@ mod tests {
             owner: String::new(),
         }];
         let state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &[],
             reservations: &reservations,
@@ -12651,6 +12662,7 @@ mod tests {
 
         let nodes = vec![cm.get_node("n1").unwrap(), cm.get_node("n2").unwrap()];
         let state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &[],
             reservations: &[],
@@ -12678,6 +12690,7 @@ mod tests {
         // Node has no features.
         let nodes = vec![cm.get_node("n1").unwrap()];
         let state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &[],
             reservations: &[],
@@ -12854,6 +12867,7 @@ mod tests {
 
         // An empty cluster forces a real wait reason, which must win.
         let empty_state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &[],
             partitions: &[],
             reservations: &[],
@@ -15796,6 +15810,7 @@ mod tests {
         let partitions = cm.get_partitions();
         let reservations = cm.get_reservations();
         let cluster_state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &reservations,
@@ -16129,6 +16144,7 @@ mod tests {
         let partitions = cm.get_partitions();
         let reservations = cm.get_reservations();
         let cluster_state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &reservations,
@@ -16207,6 +16223,7 @@ mod tests {
         let partitions = cm.get_partitions();
         let reservations = cm.get_reservations();
         let cluster_state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &partitions,
             reservations: &reservations,
@@ -17481,6 +17498,7 @@ mod tests {
         let job = submit_and_wait(&cm, basic_spec("post-teardown"));
         let nodes = vec![cm.get_node("n1").unwrap()];
         let state = spur_sched::traits::ClusterState {
+            busy_until: &std::collections::HashMap::new(),
             nodes: &nodes,
             partitions: &[],
             reservations: &[],

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -425,10 +425,8 @@ pub struct ClusterManager {
     /// Wake signal for the scheduler loop.
     pub(crate) scheduler_notify: Arc<Notify>,
     sched_stats: OnceLock<Arc<SchedStatsCollector>>,
-    /// Node -> (job_id, start_time) for a node that's idle right now but
-    /// holds a future backfill reservation, refreshed every scheduling cycle.
-    /// Ephemeral like the scheduler's own timelines: never persisted, cheap
-    /// to lose and recompute on restart/failover.
+    /// Node -> (job_id, start_time) for a future backfill reservation,
+    /// refreshed every cycle. Ephemeral: never persisted, cheap to recompute.
     planned_reservations: RwLock<HashMap<String, (JobId, DateTime<Utc>)>>,
     /// Last keepalive time per interactive allocation, used by the InactiveLimit
     /// reaper. Ephemeral soft state (like `Node::last_heartbeat`): keepalives

--- a/crates/spurctld/src/rest/convert.rs
+++ b/crates/spurctld/src/rest/convert.rs
@@ -40,7 +40,10 @@ pub fn job_to_json(job: &Job) -> serde_json::Value {
     })
 }
 
-pub fn node_to_json(node: &Node) -> serde_json::Value {
+pub fn node_to_json(
+    node: &Node,
+    planned: Option<(spur_core::job::JobId, chrono::DateTime<chrono::Utc>)>,
+) -> serde_json::Value {
     serde_json::json!({
         "name": node.name,
         "state": node.state.display(),
@@ -53,6 +56,8 @@ pub fn node_to_json(node: &Node) -> serde_json::Value {
         "cpu_load": node.cpu_load,
         "architecture": node.arch,
         "operating_system": node.os,
+        "planned_job_id": planned.map(|(id, _)| id),
+        "planned_start": planned.map(|(_, start)| start.timestamp()),
     })
 }
 

--- a/crates/spurctld/src/rest/handlers.rs
+++ b/crates/spurctld/src/rest/handlers.rs
@@ -188,7 +188,10 @@ pub async fn get_nodes(
     State(state): State<Arc<RestState>>,
 ) -> Result<Json<ApiResponse<NodesData>>, RestError> {
     let nodes = state.cluster.get_nodes();
-    let json_nodes: Vec<serde_json::Value> = nodes.iter().map(node_to_json).collect();
+    let json_nodes: Vec<serde_json::Value> = nodes
+        .iter()
+        .map(|n| node_to_json(n, planned_reservation_if_idle(&state.cluster, n)))
+        .collect();
 
     Ok(ApiResponse::ok(NodesData { nodes: json_nodes }))
 }
@@ -202,9 +205,22 @@ pub async fn get_node(
         .get_node(&name)
         .ok_or_else(|| not_found_response(&format!("node {name} not found")))?;
 
+    let planned = planned_reservation_if_idle(&state.cluster, &node);
     Ok(ApiResponse::ok(NodesData {
-        nodes: vec![node_to_json(&node)],
+        nodes: vec![node_to_json(&node, planned)],
     }))
+}
+
+/// Only meaningful while idle — a node that has since gone
+/// Allocated/Down must not report a stale planned reservation.
+fn planned_reservation_if_idle(
+    cluster: &crate::cluster::ClusterManager,
+    node: &spur_core::node::Node,
+) -> Option<(spur_core::job::JobId, chrono::DateTime<chrono::Utc>)> {
+    if node.state != spur_core::node::NodeState::Idle {
+        return None;
+    }
+    cluster.planned_reservation(&node.name)
 }
 
 pub async fn get_partitions(

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -532,11 +532,8 @@ pub(crate) fn compute_job_allocation(
     }
 }
 
-/// Real per-node "free again at" times, computed once per cycle from actual
-/// running jobs (falls back to a flat placeholder in the caller for nodes
-/// with no entry) instead of guessing at every busy node's remaining time.
-/// Folds in suspended time and the kill grace period so the estimate isn't
-/// optimistic; saturates on overflow instead of panicking on a bad time_limit.
+/// Real per-node "free again at" times derived from running jobs, so backfill
+/// doesn't fall back to a flat placeholder for every busy node.
 fn running_jobs_busy_until(cluster: &ClusterManager) -> HashMap<String, DateTime<Utc>> {
     let running = cluster.get_jobs(&JobFilter {
         states: &[spur_core::job::JobState::Running],
@@ -557,19 +554,25 @@ fn busy_until_from_running_jobs(running: &[spur_core::job::Job]) -> HashMap<Stri
         let start = job.start_time.unwrap_or(now);
         let mut suspended = job.suspended_secs;
         if let Some(since) = job.suspended_at {
-            suspended += (now - since).num_seconds().max(0);
+            suspended = suspended.saturating_add((now - since).num_seconds().max(0));
         }
-        // Clamp first: an oversized time_limit would overflow the Duration
-        // arithmetic below before checked_add_signed ever gets a chance to guard it.
-        let time_limit = job
+        // Saturating i64 math, clamped once at the end: avoids the panicking
+        // Duration + Duration path (a huge suspended_secs alone can overflow it).
+        let time_limit_secs = job
             .spec
             .time_limit
-            .unwrap_or(UNLIMITED_FALLBACK)
-            .min(UNLIMITED_FALLBACK);
-        let slack = time_limit
-            + chrono::Duration::seconds(suspended)
-            + chrono::Duration::seconds(GRACE_PERIOD_SECS);
-        let end = start.checked_add_signed(slack).unwrap_or(far_future);
+            .map(|d| d.num_seconds())
+            .unwrap_or(UNLIMITED_FALLBACK.num_seconds());
+        let slack_secs = time_limit_secs
+            .saturating_add(suspended)
+            .saturating_add(GRACE_PERIOD_SECS)
+            .min(UNLIMITED_FALLBACK.num_seconds());
+        // A long-unbounded job outliving UNLIMITED_FALLBACK would otherwise
+        // compute an `end` already in the past, producing a backwards interval.
+        let end = start
+            .checked_add_signed(chrono::Duration::seconds(slack_secs))
+            .unwrap_or(far_future)
+            .max(now);
         for node in &job.allocated_nodes {
             busy_until
                 .entry(node.clone())
@@ -2421,13 +2424,28 @@ mod tests {
     }
 
     #[test]
-    fn busy_until_saturates_instead_of_panicking_on_an_extreme_time_limit() {
+    fn busy_until_saturates_instead_of_panicking_on_an_extreme_suspended_secs() {
         let now = Utc::now();
-        let mut job = running_job_on("node001", now, 0);
-        job.spec.time_limit = Some(chrono::Duration::MAX);
+        let mut job = running_job_on("node001", now, 60);
+        job.suspended_secs = i64::MAX / 1000;
 
         let busy_until = busy_until_from_running_jobs(&[job]);
-        assert!(busy_until.contains_key("node001"));
+        let got = busy_until["node001"];
+        assert!(got > now, "expected a sane future timestamp, got {got}");
+    }
+
+    #[test]
+    fn busy_until_does_not_go_backwards_for_a_long_unbounded_job() {
+        let now = Utc::now();
+        let mut job = running_job_on("node001", now - chrono::Duration::days(400), 0);
+        job.spec.time_limit = None;
+
+        let busy_until = busy_until_from_running_jobs(&[job]);
+        let got = busy_until["node001"];
+        assert!(
+            got >= now,
+            "busy_until must never be in the past relative to now, got {got}, now {now}"
+        );
     }
 
     fn node_total(cpus: u32, memory_mb: u64, gpus: Vec<GpuResource>) -> ResourceSet {

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -157,11 +157,13 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
 
         let cycle_start = Instant::now();
 
+        let busy_until = running_jobs_busy_until(&cluster);
         let cluster_state = ClusterState {
             nodes: &nodes,
             partitions: &partitions,
             reservations: &reservations,
             topology: topology.as_ref(),
+            busy_until: &busy_until,
         };
 
         // Catch panics in the scheduler so that a single bad job doesn't kill
@@ -518,6 +520,54 @@ pub(crate) fn compute_job_allocation(
                 .filter_map(|name| per_node_alloc.get(name).cloned()),
         )
     }
+}
+
+/// Real per-node "free again at" times, computed once per cycle from actual
+/// running jobs (falls back to a flat placeholder in the caller for nodes
+/// with no entry) instead of guessing at every busy node's remaining time.
+/// Folds in suspended time and the kill grace period so the estimate isn't
+/// optimistic; saturates on overflow instead of panicking on a bad time_limit.
+fn running_jobs_busy_until(cluster: &ClusterManager) -> HashMap<String, DateTime<Utc>> {
+    let running = cluster.get_jobs(&JobFilter {
+        states: &[spur_core::job::JobState::Running],
+        ..Default::default()
+    });
+    busy_until_from_running_jobs(&running)
+}
+
+/// Pure core of [`running_jobs_busy_until`], split out so it's testable
+/// without a full `ClusterManager` harness.
+fn busy_until_from_running_jobs(running: &[spur_core::job::Job]) -> HashMap<String, DateTime<Utc>> {
+    const UNLIMITED_FALLBACK: chrono::Duration = chrono::Duration::days(365);
+
+    let now = Utc::now();
+    let far_future = now + UNLIMITED_FALLBACK;
+    let mut busy_until: HashMap<String, DateTime<Utc>> = HashMap::new();
+    for job in running {
+        let start = job.start_time.unwrap_or(now);
+        let mut suspended = job.suspended_secs;
+        if let Some(since) = job.suspended_at {
+            suspended += (now - since).num_seconds().max(0);
+        }
+        // Clamp first: an oversized time_limit would overflow the Duration
+        // arithmetic below before checked_add_signed ever gets a chance to guard it.
+        let time_limit = job
+            .spec
+            .time_limit
+            .unwrap_or(UNLIMITED_FALLBACK)
+            .min(UNLIMITED_FALLBACK);
+        let slack = time_limit
+            + chrono::Duration::seconds(suspended)
+            + chrono::Duration::seconds(GRACE_PERIOD_SECS);
+        let end = start.checked_add_signed(slack).unwrap_or(far_future);
+        for node in &job.allocated_nodes {
+            busy_until
+                .entry(node.clone())
+                .and_modify(|e| *e = (*e).max(end))
+                .or_insert(end);
+        }
+    }
+    busy_until
 }
 
 /// Resolve the effective PreemptMode for a job: QoS override wins if set
@@ -2328,6 +2378,46 @@ mod tests {
         spec.num_tasks = spec.num_tasks.max(1);
         spec.num_nodes = spec.num_nodes.max(1);
         Job::new(1, spec)
+    }
+
+    fn running_job_on(node: &str, start: DateTime<Utc>, minutes: i64) -> Job {
+        let mut job = job_with_spec(JobSpec {
+            time_limit: Some(chrono::Duration::minutes(minutes)),
+            ..Default::default()
+        });
+        job.state = spur_core::job::JobState::Running;
+        job.start_time = Some(start);
+        job.allocated_nodes = vec![node.to_string()];
+        job
+    }
+
+    #[test]
+    fn busy_until_takes_the_max_across_jobs_sharing_a_node() {
+        let now = Utc::now();
+        let sooner = running_job_on("node001", now, 10);
+        let later = running_job_on("node001", now, 60);
+
+        // Larger-ending job processed first: a "last wins" bug (instead of a
+        // true max) would incorrectly keep the smaller value here.
+        let busy_until = busy_until_from_running_jobs(&[later, sooner]);
+
+        let expected =
+            now + chrono::Duration::minutes(60) + chrono::Duration::seconds(GRACE_PERIOD_SECS);
+        let got = busy_until["node001"];
+        assert!(
+            (got - expected).num_seconds().abs() < 2,
+            "expected the later job's end time to win, got {got}, expected ~{expected}"
+        );
+    }
+
+    #[test]
+    fn busy_until_saturates_instead_of_panicking_on_an_extreme_time_limit() {
+        let now = Utc::now();
+        let mut job = running_job_on("node001", now, 0);
+        job.spec.time_limit = Some(chrono::Duration::MAX);
+
+        let busy_until = busy_until_from_running_jobs(&[job]);
+        assert!(busy_until.contains_key("node001"));
     }
 
     fn node_total(cpus: u32, memory_mb: u64, gpus: Vec<GpuResource>) -> ResourceSet {

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -122,6 +122,9 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
 
         if !raft.is_leader() {
+            // A former leader must not keep serving planned-reservation info
+            // from before it lost leadership.
+            cluster.set_planned_reservations(HashMap::new());
             continue;
         }
 
@@ -142,6 +145,8 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         // even with nothing schedulable.
         let pending = cluster.pending_jobs_and_tag_reasons();
         if pending.is_empty() {
+            // Nothing pending means nothing can be planned either.
+            cluster.set_planned_reservations(HashMap::new());
             continue;
         }
         let hit_depth_limit = pending.len() > max_jobs;
@@ -152,6 +157,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
 
         if nodes.is_empty() {
             debug!("no schedulable nodes, skipping scheduling cycle");
+            cluster.set_planned_reservations(HashMap::new());
             continue;
         }
 
@@ -186,10 +192,14 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 let schedule_time_us =
                     schedule_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
                 cluster.record_sched_cycle(cycle_time_us, schedule_time_us, 0, hit_depth_limit);
+                // Fail safe: a scheduler that just panicked can't be trusted
+                // to have produced a valid plan, planned or otherwise.
+                cluster.set_planned_reservations(HashMap::new());
                 continue;
             }
         };
         let schedule_time_us = schedule_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
+        cluster.set_planned_reservations(sched_ref.planned_starts());
 
         // Preemption: if high-priority jobs couldn't be scheduled,
         // cancel lower-priority running jobs to free resources.

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -545,7 +545,7 @@ fn running_jobs_busy_until(cluster: &ClusterManager) -> HashMap<String, DateTime
 /// Pure core of [`running_jobs_busy_until`], split out so it's testable
 /// without a full `ClusterManager` harness.
 fn busy_until_from_running_jobs(running: &[spur_core::job::Job]) -> HashMap<String, DateTime<Utc>> {
-    const UNLIMITED_FALLBACK: chrono::Duration = chrono::Duration::days(365);
+    use spur_sched::UNLIMITED_JOB_DURATION as UNLIMITED_FALLBACK;
 
     let now = Utc::now();
     let far_future = now + UNLIMITED_FALLBACK;

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -2427,7 +2427,7 @@ mod tests {
     fn busy_until_saturates_instead_of_panicking_on_an_extreme_suspended_secs() {
         let now = Utc::now();
         let mut job = running_job_on("node001", now, 60);
-        job.suspended_secs = i64::MAX / 1000;
+        job.suspended_secs = i64::MAX;
 
         let busy_until = busy_until_from_running_jobs(&[job]);
         let got = busy_until["node001"];

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -2448,6 +2448,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn busy_until_accounts_for_currently_suspended_time() {
+        let now = Utc::now();
+        let mut job = running_job_on("node001", now, 10);
+        job.suspended_at = Some(now - chrono::Duration::minutes(5));
+
+        let busy_until = busy_until_from_running_jobs(&[job]);
+        let expected = now
+            + chrono::Duration::minutes(10)
+            + chrono::Duration::minutes(5)
+            + chrono::Duration::seconds(GRACE_PERIOD_SECS);
+        let got = busy_until["node001"];
+        assert!(
+            (got - expected).num_seconds().abs() < 2,
+            "expected suspended time folded in, got {got}, expected ~{expected}"
+        );
+    }
+
+    #[test]
+    fn busy_until_falls_back_to_now_when_start_time_is_missing() {
+        let now = Utc::now();
+        let mut job = running_job_on("node001", now, 10);
+        job.start_time = None;
+
+        let busy_until = busy_until_from_running_jobs(&[job]);
+        let expected =
+            now + chrono::Duration::minutes(10) + chrono::Duration::seconds(GRACE_PERIOD_SECS);
+        let got = busy_until["node001"];
+        assert!(
+            (got - expected).num_seconds().abs() < 2,
+            "expected now-based fallback, got {got}, expected ~{expected}"
+        );
+    }
+
     fn node_total(cpus: u32, memory_mb: u64, gpus: Vec<GpuResource>) -> ResourceSet {
         ResourceSet {
             cpus,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1265,6 +1265,7 @@ impl SlurmController for ControllerService {
 
         let reservations = self.cluster.get_reservations();
         annotate_nodes_with_reservations(&mut proto_nodes, &reservations, Utc::now());
+        annotate_nodes_with_planned_reservations(&mut proto_nodes, &self.cluster);
         Ok(Response::new(GetNodesResponse { nodes: proto_nodes }))
     }
 
@@ -1298,6 +1299,10 @@ impl SlurmController for ControllerService {
             std::slice::from_mut(&mut proto_node),
             &reservations,
             Utc::now(),
+        );
+        annotate_nodes_with_planned_reservations(
+            std::slice::from_mut(&mut proto_node),
+            &self.cluster,
         );
         Ok(Response::new(proto_node))
     }
@@ -3966,6 +3971,8 @@ fn node_to_proto(node: &spur_core::node::Node) -> NodeInfo {
         labels: node.labels.clone(),
         reservation_maint: false,
         features: node.features.clone(),
+        planned_job_id: 0,
+        planned_start: None,
     }
 }
 
@@ -4134,6 +4141,21 @@ fn annotate_nodes_with_reservations(
                     node_info.reservation_maint = true;
                 }
             }
+        }
+    }
+}
+
+fn annotate_nodes_with_planned_reservations(nodes: &mut [NodeInfo], cluster: &ClusterManager) {
+    for node_info in nodes.iter_mut() {
+        // Only meaningful while idle, matching how sinfo displays "plnd" —
+        // a node that has since gone Allocated/Down must not report a
+        // planned reservation left over from an earlier, staler read.
+        if node_info.state != spur_core::node::NodeState::Idle.to_proto_i32() {
+            continue;
+        }
+        if let Some((job_id, start)) = cluster.planned_reservation(&node_info.name) {
+            node_info.planned_job_id = job_id;
+            node_info.planned_start = Some(datetime_to_proto(start));
         }
     }
 }

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -489,6 +489,22 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
    will preempt a lower-priority running job holding the capacity it needs,
    rather than waiting for it to finish on its own.
 
+.. note::
+
+   Backfill protection for a large multi-node job (holding a node against
+   smaller jobs until the job it's waiting on can start) is only as good as
+   the wall-time information available for the jobs already running. A job
+   with no wall-time is assumed to run for up to a year, but that number is
+   only a placeholder used to size the *reservation itself*; it is not
+   compared against how long an incoming job actually needs the node, so a
+   fully unbounded cluster gets little practical protection from this
+   mechanism — a large job can still be starved by a continuous stream of
+   equally unbounded smaller jobs. Setting ``default_time_limit_minutes``
+   (or a per-partition ``DefaultTime``/``MaxTime``) so jobs carry real
+   wall-time information makes backfill reservations meaningful. For a job
+   that must not be starved by anything wall-time can't bound, use
+   preemption (``preempt_type``, above) instead.
+
 ``[auth]``
 ----------
 

--- a/docs/user-guide/monitoring-jobs.rst
+++ b/docs/user-guide/monitoring-jobs.rst
@@ -233,7 +233,9 @@ accepting jobs), ``drng`` (draining), ``err`` (error), ``unk``
 (unknown/unreachable), ``susp`` (suspended), and — all three only shown while
 the node is currently idle — ``resv`` or ``maint`` for a node held by an admin
 reservation, else ``plnd`` for a node currently held by the scheduler for a
-specific pending job's upcoming start.
+specific pending job's upcoming start. The idle gate is checked live, but the
+job and start time shown for ``plnd`` reflect the most recent scheduling
+cycle (``scheduler.interval_secs``), not the current instant.
 
 Accounting History — ``sacct``
 -------------------------------

--- a/docs/user-guide/monitoring-jobs.rst
+++ b/docs/user-guide/monitoring-jobs.rst
@@ -230,10 +230,10 @@ PARTITION STATE CPUS MEMORY GRES``.
 Node states are shown as short abbreviations: ``idle`` (free), ``alloc`` (fully
 allocated), ``mix`` (partly allocated), ``down``, ``drain`` (offline, not
 accepting jobs), ``drng`` (draining), ``err`` (error), ``unk``
-(unknown/unreachable), ``susp`` (suspended), ``resv`` or ``maint`` for a node
-held by an admin reservation, and — when no reservation applies — ``plnd`` for
-a node that was idle as of the last scheduling cycle but held by the scheduler
-for a specific pending job's upcoming start.
+(unknown/unreachable), ``susp`` (suspended), and — all three only shown while
+the node is currently idle — ``resv`` or ``maint`` for a node held by an admin
+reservation, else ``plnd`` for a node currently held by the scheduler for a
+specific pending job's upcoming start.
 
 Accounting History — ``sacct``
 -------------------------------

--- a/docs/user-guide/monitoring-jobs.rst
+++ b/docs/user-guide/monitoring-jobs.rst
@@ -230,8 +230,10 @@ PARTITION STATE CPUS MEMORY GRES``.
 Node states are shown as short abbreviations: ``idle`` (free), ``alloc`` (fully
 allocated), ``mix`` (partly allocated), ``down``, ``drain`` (offline, not
 accepting jobs), ``drng`` (draining), ``err`` (error), ``unk``
-(unknown/unreachable), ``susp`` (suspended), and ``resv`` or ``maint`` for a node
-held by a reservation.
+(unknown/unreachable), ``susp`` (suspended), ``resv`` or ``maint`` for a node
+held by an admin reservation, and — when no reservation applies — ``plnd`` for
+a node that was idle as of the last scheduling cycle but held by the scheduler
+for a specific pending job's upcoming start.
 
 Accounting History — ``sacct``
 -------------------------------

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -280,6 +280,11 @@ message NodeInfo {
   map<string, string> labels = 51;
   bool reservation_maint = 52;
   repeated string features = 53;
+
+  // Set when the node is idle right now but the scheduler holds a future
+  // reservation for a specific pending job (0 = no planned reservation).
+  uint32 planned_job_id = 54;
+  google.protobuf.Timestamp planned_start = 55;
 }
 
 message PartitionInfo {

--- a/tests/native_host/e2e/test_multi_node.py
+++ b/tests/native_host/e2e/test_multi_node.py
@@ -200,13 +200,16 @@ class TestBackfillReservation:
         assert filler_id is not None
         wait_job_state(cluster, filler_id, "R", timeout=30)
 
+        # Pinned to n0/n1 specifically: a >2-node cluster (e.g. CI's default 4)
+        # would otherwise let this dispatch immediately onto other free nodes.
         big_out = f"{cluster.remote_dir}/backfill-big.out"
         big_script = cluster.write_file(
             "backfill-big.sh", "#!/bin/bash\necho BIG_RAN\n"
         )
         big_id = parse_job_id(
             cluster.sbatch(
-                ["-J", "backfill-big", "-N", "2", "-o", big_out, big_script]
+                ["-J", "backfill-big", "-N", "2", f"--nodelist={n0},{n1}",
+                 "-o", big_out, big_script]
             )
         )
         assert big_id is not None

--- a/tests/native_host/e2e/test_multi_node.py
+++ b/tests/native_host/e2e/test_multi_node.py
@@ -9,7 +9,7 @@ The multi_node_cluster fixture validates this and skips if insufficient.
 
 import time
 
-from cluster import parse_job_id, job_state, wait_job
+from cluster import parse_job_id, job_state, wait_job, wait_job_state
 
 
 def _wait_node_state(cluster, node_name, target_states, timeout=60):
@@ -176,6 +176,67 @@ class TestMultiNodeScheduling:
         c2 = cluster.read_output_on_any_node(out2)
         assert "CONCURRENT_DONE" in c1, f"job1 missing CONCURRENT_DONE:\n{c1}"
         assert "CONCURRENT_DONE" in c2, f"job2 missing CONCURRENT_DONE:\n{c2}"
+
+
+class TestBackfillReservation:
+    """A pending 2-node job must reserve its second node instead of letting
+    a smaller job dispatch onto it once the node frees up."""
+
+    def test_large_multinode_job_is_not_starved_by_a_smaller_job(
+        self, multi_node_cluster
+    ):
+        cluster = multi_node_cluster
+        n0, n1 = cluster.node_names[0], cluster.node_names[1]
+
+        filler_script = cluster.write_file(
+            "backfill-filler.sh", "#!/bin/bash\nsleep 8\n"
+        )
+        filler_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "filler", "-N", "1", f"--nodelist={n0}",
+                 "--exclusive", "--time=00:01:00", filler_script]
+            )
+        )
+        assert filler_id is not None
+        wait_job_state(cluster, filler_id, "R", timeout=30)
+
+        big_out = f"{cluster.remote_dir}/backfill-big.out"
+        big_script = cluster.write_file(
+            "backfill-big.sh", "#!/bin/bash\necho BIG_RAN\n"
+        )
+        big_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "backfill-big", "-N", "2", "-o", big_out, big_script]
+            )
+        )
+        assert big_id is not None
+        wait_job_state(cluster, big_id, "PD", timeout=15)
+
+        # small requests a duration long enough to still be occupying n1 when
+        # big's reservation (~90s out, from filler's 1-min time_limit + grace)
+        # would need it — a short-lived small job wouldn't overlap at all and
+        # SHOULD be free to backfill into the gap, so this must outlast it.
+        small_script = cluster.write_file(
+            "backfill-small.sh", "#!/bin/bash\nsleep 200\necho SMALL_RAN\n"
+        )
+        small_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "backfill-small", "-N", "1", f"--nodelist={n1}",
+                 "--exclusive", "--time=00:05:00", small_script]
+            )
+        )
+        assert small_id is not None
+
+        time.sleep(10)
+        sq = cluster.squeue_all()
+        assert job_state(sq, small_id) == "PD", (
+            f"small job should stay pending, reserved capacity was taken:\n{sq}"
+        )
+        cluster.scancel(str(small_id))
+
+        wait_job(cluster, big_id, timeout=90)
+        big_content = cluster.read_output_on_any_node(big_out)
+        assert "BIG_RAN" in big_content, f"big job missing BIG_RAN:\n{big_content}"
 
 
 class TestMultiNodeStateUpdate:


### PR DESCRIPTION
## Summary

A job requesting more nodes than currently have any free capacity could be starved indefinitely by a stream of smaller jobs, regardless of priority — it was silently skipped every scheduling cycle with no forward reservation recorded at all, so any node that later freed up went to whichever smaller job asked for it first.

Several changes close this:

- `find_suitable_nodes()` gated candidacy on `Node::has_free_cpu_capacity()`, excluding fully-saturated (but healthy) nodes before the timeline/reservation machinery ever ran. A new `NodePlacement::matches_for_reservation()` admits them as valid future-reservation candidates instead. Extended to heterogeneous jobs too (uneven per-node CPU/GPU splits) — they previously bailed out before reaching the reservation path at all if they couldn't start immediately.
- Even with candidacy fixed, the scheduler had no way to know when an already-running job actually finishes — any busy node was modeled as occupied for a flat 24h placeholder. `ClusterState` now carries a `busy_until` map (node → real expected free time, built once per scheduling tick from running jobs' `start_time` + `time_limit`, adjusted for suspended time and the kill grace period) replacing the flat placeholder wherever real data is available. A job with no time limit at all now assumes a shared 365-day sentinel (`UNLIMITED_JOB_DURATION`) instead of a flat 1-hour guess — both for its own backfill sizing and for a running job's remaining-time estimate — so an unbounded job can no longer slip into a gap ahead of a protected reservation just because it was assumed short-lived.
- A multi-node job's placement previously computed each candidate node's earliest start *independently*, took the max across the set, and reserved every node at that shifted time without re-validating it — a node whose own earliest start was earlier than the shifted common time could end up reserved on top of an unauthorized admin reservation. Replaced with a fixed-point search that converges on a start every selected node is simultaneously and genuinely free at, folding resource and reservation conflicts into one forward search per node.
- Adds a small observability feature: a node that's idle right now but held by the scheduler for a specific pending job's future start previously looked plain `idle`. `spur nodes`/`sinfo` now shows this as `plnd` (matching Slurm's own convention), and the same info is available via the gRPC and REST node APIs (new append-only `NodeInfo.planned_job_id`/`planned_start` fields). Purely ephemeral/display-layer — nothing here touches the persisted `NodeState` or the WAL.
- Documents the priority-gap preemption formula in detail (worked examples, what can and can't fire, comparison with Slurm) in `docs/admin-guide/accounting.rst`, and adds a caveat in `docs/admin-guide/configuration.rst` that backfill's protection is only as good as the wall-time information available — a fully unconfigured cluster (no time limits anywhere) gets little practical benefit from it, and preemption is the right tool for jobs that must not be starved regardless of duration.

## Known limitations

- Heterogeneous jobs' coarse per-node timing estimate can still occasionally diverge from the exact per-node plan resolved later, causing a job to be dropped from a cycle with no reservation rather than deferred to the correct future time. Self-healing on the next cycle, pre-existing behavior widened rather than introduced by this PR.
- `plnd` tells you a node is held but not which job or when — the data is fully available via gRPC/REST, just not yet rendered in a CLI long-format column.
- `reservation_fence_reason` (the user-facing pending-reason diagnostic) checks each candidate node independently at `now` and doesn't know about the scheduler's multi-node common-window shift, so it could occasionally report the wrong reason for a job blocked only after that shift. Diagnostic-accuracy gap only — backfill's own scheduling decision is correct regardless.

## Testing

- New unit tests for every behavioral change (CPU, GPU, and heterogeneous variants of the common-window fix), each proven to fail against the prior behavior and pass against the fix.
- New e2e test (`TestBackfillReservation`) reproducing the original starvation scenario end-to-end, verified against the real fix and against pre-fix binaries.
- Full workspace `cargo clippy`/`cargo fmt` clean; `spur-sched`, `spurctld`, `spur-cli`, and `spur-tests` suites all green.
- Validated end-to-end on an isolated 2-node deployment.
