### PR TITLE
ci: cache docker builds in ghcr registry instead of the actions cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,11 +203,28 @@ jobs:
   build-docker-image:
     name: Build Docker Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Registry cache avoids the 10 GB Actions cache budget shared with the cargo jobs; writes are gated to main so PRs read-only.
+      - name: Compute build cache ref
+        id: cacheref
+        run: |
+          owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "ref=ghcr.io/${owner}/spur-build-cache:ci" >> "$GITHUB_OUTPUT"
 
       - name: Build Docker image
         uses: docker/build-push-action@v7
@@ -218,8 +235,8 @@ jobs:
           push: false
           tags: spur:ci
           outputs: type=docker,dest=/tmp/spur-image.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ steps.cacheref.outputs.ref }}
+          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=registry,ref={0},mode=max,ignore-error=true', steps.cacheref.outputs.ref) || '' }}
 
       - name: Upload Docker image
         uses: actions/upload-artifact@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,11 +68,11 @@ RUN if [ "$BUILD_MPI_PLUGIN" = "1" ]; then \
         printf '%s\n' /usr/local/lib /usr/local/lib64 > /etc/ld.so.conf.d/openpmix.conf && \
         ldconfig && \
         rm -rf "/tmp/pmix-${OPENPMIX_VERSION}" && \
-        dnf clean all; \
-    fi && \
-    cd /build && \
-    PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:${PKG_CONFIG_PATH:-}" \
-    cargo build --release --locked -p spur-mpi-pmix
+        dnf clean all && \
+        cd /build && \
+        PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:${PKG_CONFIG_PATH:-}" \
+        cargo build --release --locked -p spur-mpi-pmix; \
+    fi
 
 RUN mkdir -p /dist/lib/spur && \
     if [ "$BUILD_MPI_PLUGIN" = "1" ]; then \


### PR DESCRIPTION
## What this fixes

The `build-docker-image` job took ~10 min even with cargo-chef. The `type=gha` cache backend shares one 10 GB per-repo Actions cache budget with the five cargo `actions/cache` entries (`clippy`, `build`, `test`, `test-db`, `coverage`), each caching a multi-GB `target/`. They evict each other, so the cargo-chef dependency layer was routinely cold and every dependency recompiled from scratch.

## Approach

- Move the Docker build cache to a ghcr registry cache (`ghcr.io/<owner>/spur-build-cache:ci`). It lives outside the Actions cache budget and pulls faster, so the cook layer survives across runs.
- Gate `cache-to` to `main` only. PRs read the cache but never write it, which prevents cache poisoning from untrusted PRs and matches GitHub's read-only-cache-for-untrusted-triggers model.
- Gate the second `spur-mpi-pmix` release build behind `BUILD_MPI_PLUGIN=1`. It ran on every image build for a stub artifact that is never copied to dist.

The cache ref is derived from `github.repository_owner` (lowercased) so it resolves correctly on both the upstream repo and forks.

## Trade-offs

- Fork PRs cannot read a private ghcr package, so they build cold unless `spur-build-cache` is made public. That package contains only compiled OSS artifacts (the build passes no secrets), so making it public is safe. Same-repo PRs and `main` are unaffected.

## Results (measured on a fork)

- Cold build (cache miss, seeds cache): 10m26s
- Warm build (source-only change): 4m31s

Roughly 57% faster on the common case. The remaining ~3 min is the first-party workspace compile, which cargo-chef cannot cache.

## Testing

Pushed to a fork and ran CI twice: run 1 seeded `spur-build-cache:ci` (`cache-from` miss confirmed in logs), run 2 imported the manifest and restored the cook layer, rebuilding only the workspace crates. The `BUILD_MPI_PLUGIN=0` path was confirmed to skip the plugin build (`RUN if [ "0" = "1" ]` no-op).