### PR TITLE
feat(sbcast): broadcast a file to a job's allocated nodes

### DIFF
--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -20,6 +20,7 @@ mod sacctmgr;
 mod salloc;
 mod sattach;
 mod sbatch;
+mod sbcast;
 mod scancel;
 mod scontrol;
 mod scrontab;
@@ -123,6 +124,7 @@ fn main() -> anyhow::Result<()> {
     match bin_name {
         "salloc" => return runtime.block_on(salloc::main()),
         "sbatch" => return runtime.block_on(sbatch::main()),
+        "sbcast" => return runtime.block_on(sbcast::main()),
         "srun" => return runtime.block_on(srun::main()),
         "squeue" => return runtime.block_on(squeue::main()),
         "scancel" => return runtime.block_on(scancel::main()),
@@ -176,6 +178,7 @@ fn main() -> anyhow::Result<()> {
         "report" | "usage" => Some("sreport"),
         "trigger" | "triggers" => Some("strigger"),
         "attach" => Some("sattach"),
+        "sbcast" | "bcast" => Some("sbcast"),
         "crontab" | "cron" => Some("scrontab"),
         "health" | "monitor" => Some("smd"),
         "sbatch" | "srun" | "squeue" | "scancel" | "sinfo" | "sacct" | "sacctmgr" | "scontrol"
@@ -225,6 +228,7 @@ fn main() -> anyhow::Result<()> {
                 runtime.block_on(strigger::main_with_args(rewritten))
             }
             "sattach" | "attach" => runtime.block_on(sattach::main_with_args(rewritten)),
+            "sbcast" | "bcast" => runtime.block_on(sbcast::main_with_args(rewritten)),
             "scrontab" | "crontab" | "cron" => {
                 runtime.block_on(scrontab::main_with_args(rewritten))
             }
@@ -330,4 +334,5 @@ fn print_usage() {
     eprintln!("Slurm-compatible aliases (also work as symlinks):");
     eprintln!("  salloc sbatch srun squeue scancel sinfo sacct sacctmgr scontrol");
     eprintln!("  sprio sshare sstat sdiag sreport strigger sattach scrontab smd");
+    eprintln!("  sbcast");
 }

--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -212,6 +212,7 @@ mock_controller_impl! {
         }
     }
     unimplemented {
+        sbcast(proto::SbcastRequest) -> proto::SbcastResponse;
         submit_job(proto::SubmitJobRequest) -> proto::SubmitJobResponse;
         get_jobs(proto::GetJobsRequest) -> proto::GetJobsResponse;
         get_job(proto::GetJobRequest) -> proto::JobInfo;

--- a/crates/spur-cli/src/sbcast.rs
+++ b/crates/spur-cli/src/sbcast.rs
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `sbcast` — broadcast a local file to node-local storage on every node of a
+//! running job's allocation (Slurm-compatible).
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use spur_proto::proto::SbcastRequest;
+
+/// Transmit a file to the nodes allocated to a running job.
+#[derive(Parser, Debug)]
+#[command(
+    name = "sbcast",
+    about = "Broadcast a file to node-local storage across a job's allocated nodes"
+)]
+pub struct SbcastArgs {
+    /// Source file on the local (submit) host
+    pub source: String,
+
+    /// Destination path on each allocated node (relative resolves against the job work dir)
+    pub dest: String,
+
+    /// Overwrite an existing destination file
+    #[arg(short = 'f', long)]
+    pub force: bool,
+
+    /// Job ID (defaults to $SPUR_JOB_ID / $SLURM_JOB_ID inside an allocation)
+    #[arg(short = 'j', long = "jobid")]
+    pub jobid: Option<u32>,
+
+    /// Accepted for Slurm compatibility (compression is not yet implemented)
+    #[arg(short = 'C', long, hide = true)]
+    pub compress: bool,
+
+    /// Accepted for Slurm compatibility (mode is always taken from the source file)
+    #[arg(short = 'p', long, hide = true)]
+    pub preserve: bool,
+
+    /// Controller address (the controller fans the file out to the compute nodes)
+    #[arg(
+        long,
+        env = "SPUR_CONTROLLER_ADDR",
+        default_value = "http://localhost:6817"
+    )]
+    pub controller: String,
+}
+
+pub async fn main() -> Result<()> {
+    main_with_args(std::env::args().collect()).await
+}
+
+pub async fn main_with_args(args: Vec<String>) -> Result<()> {
+    let args = SbcastArgs::try_parse_from(&args)?;
+
+    let job_id = match args.jobid {
+        Some(j) => j,
+        None => job_id_from_env().context(
+            "no job id: pass --jobid or run inside an allocation (SPUR_JOB_ID / SLURM_JOB_ID)",
+        )?,
+    };
+
+    let meta = std::fs::metadata(&args.source)
+        .with_context(|| format!("cannot stat source file '{}'", args.source))?;
+    if !meta.is_file() {
+        bail!("source '{}' is not a regular file", args.source);
+    }
+    let mode = {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o7777
+    };
+    let data = std::fs::read(&args.source)
+        .with_context(|| format!("cannot read source file '{}'", args.source))?;
+
+    let channel = crate::authclient::connect(&args.controller)
+        .await
+        .context("failed to connect to controller")?;
+    let mut client = spur_proto::controller_client(channel);
+
+    let resp = client
+        .sbcast(SbcastRequest {
+            job_id,
+            dest: args.dest.clone(),
+            data,
+            mode,
+            force: args.force,
+            user: crate::interactive::current_user()?,
+        })
+        .await
+        .context("sbcast failed")?
+        .into_inner();
+
+    if resp.success {
+        println!(
+            "sbcast: {} -> {} on {} node(s)",
+            args.source,
+            args.dest,
+            resp.nodes.len()
+        );
+        Ok(())
+    } else {
+        bail!("sbcast failed: {}", resp.message);
+    }
+}
+
+/// Resolve the job id from the allocation environment, mirroring Slurm's
+/// SLURM_JOB_ID lookup (spur sets SPUR_JOB_ID; SLURM_JOB_ID is honored for
+/// drop-in compatibility).
+fn job_id_from_env() -> Result<u32> {
+    for var in ["SPUR_JOB_ID", "SLURM_JOB_ID", "SLURM_JOBID"] {
+        if let Ok(v) = std::env::var(var) {
+            if let Ok(id) = v.trim().parse::<u32>() {
+                return Ok(id);
+            }
+        }
+    }
+    bail!("job id not present in environment")
+}

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -541,6 +541,7 @@ mod tests {
     }
 
     stub_controller! {
+        sbcast(pb::SbcastRequest) -> pb::SbcastResponse;
         submit_job(pb::SubmitJobRequest) -> pb::SubmitJobResponse;
         get_jobs(pb::GetJobsRequest) -> pb::GetJobsResponse;
         get_job(pb::GetJobRequest) -> pb::JobInfo;

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -691,6 +691,17 @@ impl SlurmAgent for VirtualAgent {
         ))
     }
 
+    async fn receive_file(
+        &self,
+        _request: Request<ReceiveFileRequest>,
+    ) -> Result<Response<ReceiveFileResponse>, Status> {
+        // sbcast fan-out target. The K8s virtual agent has no node-local
+        // filesystem to stage into; pods share storage via volumes instead.
+        Err(Status::unimplemented(
+            "ReceiveFile (sbcast) is not supported by the K8s virtual agent",
+        ))
+    }
+
     async fn cancel_step(
         &self,
         _request: Request<CancelStepRequest>,

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -3043,6 +3043,14 @@ mod tests {
                 Ok(tonic::Response::new(Default::default()))
             }
 
+            async fn receive_file(
+                &self,
+                _request: tonic::Request<spur_proto::proto::ReceiveFileRequest>,
+            ) -> Result<tonic::Response<spur_proto::proto::ReceiveFileResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(Default::default()))
+            }
+
             async fn run_command(
                 &self,
                 _request: tonic::Request<spur_proto::proto::RunCommandRequest>,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2619,6 +2619,113 @@ impl SlurmController for ControllerService {
         Ok(resp)
     }
 
+    async fn sbcast(
+        &self,
+        request: Request<SbcastRequest>,
+    ) -> Result<Response<SbcastResponse>, Status> {
+        if self.check_leader(&request).is_err() {
+            let proxy = &self.leader_proxy;
+            let mut client = proxy.get_leader_client().await?;
+            let fwd = Self::forward_request(request);
+            return client.sbcast(fwd).await;
+        }
+
+        let __identity = Self::verified_identity(&request).cloned();
+        let mut req = request.into_inner();
+        Self::authoritative_user(&mut req.user, __identity.as_ref());
+        let job_id = req.job_id;
+
+        let job = self
+            .cluster
+            .get_job(job_id)
+            .ok_or_else(|| Status::not_found(format!("job {job_id} not found")))?;
+
+        spur_core::auth::check_job_owner(
+            &req.user,
+            self.caller_is_admin(__identity.as_ref()),
+            &job.spec.user,
+            "sbcast to",
+        )
+        .map_err(|e| Status::permission_denied(e.to_string()))?;
+
+        if job.state != spur_core::job::JobState::Running {
+            return Err(Status::failed_precondition(format!(
+                "job {job_id} is not running (state: {})",
+                job.state
+            )));
+        }
+        if job.allocated_nodes.is_empty() {
+            return Err(Status::internal(format!(
+                "job {job_id} has no allocated nodes"
+            )));
+        }
+
+        // Fan the file out to every node in the allocation. A per-node failure is
+        // collected rather than aborting, so a healthy node still gets the file.
+        let mut written: Vec<String> = Vec::new();
+        let mut failures: Vec<String> = Vec::new();
+        for node_name in &job.allocated_nodes {
+            let node = match self.cluster.get_node(node_name) {
+                Some(n) => n,
+                None => {
+                    failures.push(format!("{node_name}: node not found"));
+                    continue;
+                }
+            };
+            let agent_addr = match node_comm_http_url(&node, node_name) {
+                Ok(a) => a,
+                Err(e) => {
+                    failures.push(format!("{node_name}: {e}"));
+                    continue;
+                }
+            };
+            let mut agent = match crate::agent_client::connect(agent_addr.clone()).await {
+                Ok(c) => c
+                    .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+                    .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE),
+                Err(e) => {
+                    failures.push(format!("{node_name}: cannot reach agent: {e}"));
+                    continue;
+                }
+            };
+            let resp = agent
+                .receive_file(ReceiveFileRequest {
+                    job_id,
+                    dest: req.dest.clone(),
+                    data: req.data.clone(),
+                    mode: req.mode,
+                    force: req.force,
+                    uid: job.spec.uid,
+                    gid: job.spec.gid,
+                    work_dir: job.spec.work_dir.clone(),
+                })
+                .await;
+            match resp {
+                Ok(r) => {
+                    let inner = r.into_inner();
+                    if inner.success {
+                        written.push(node_name.clone());
+                    } else {
+                        failures.push(format!("{node_name}: {}", inner.message));
+                    }
+                }
+                Err(e) => failures.push(format!("{node_name}: {e}")),
+            }
+        }
+
+        let success = failures.is_empty();
+        let message = if success {
+            String::new()
+        } else {
+            failures.join("; ")
+        };
+        Ok(Response::new(SbcastResponse {
+            success,
+            message,
+            nodes: written,
+        }))
+    }
+
     /// Route a step from srun to the job's allocated nodes. Unlike ExecInJob,
     /// the job may not have a tracked process — salloc allocations only exist
     /// as scheduler bookkeeping.

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1912,6 +1912,52 @@ impl SlurmAgent for AgentService {
         Ok(Response::new(RegisterJobAllocationResponse {}))
     }
 
+    /// Write a broadcast file to this node's local storage for a running job —
+    /// the sbcast fan-out target. Controller-only; uid/gid/work_dir arrive from
+    /// the controller's authoritative job record.
+    async fn receive_file(
+        &self,
+        request: Request<ReceiveFileRequest>,
+    ) -> Result<Response<ReceiveFileResponse>, Status> {
+        // Controller-only: the uid/gid/dest are wire-supplied, so a valid *user*
+        // token calling this directly would be an arbitrary write as any uid.
+        Self::require_controller(&request)?;
+        let req = request.into_inner();
+
+        // Mirror job execution: refuse writing as root unless the operator opted in.
+        if let Err(msg) = crate::privdrop::check_root_execution_allowed(
+            req.uid,
+            self.allow_root_jobs,
+            self.spurd_is_root,
+        ) {
+            return Ok(Response::new(ReceiveFileResponse {
+                success: false,
+                message: msg,
+            }));
+        }
+
+        let dest = match crate::sbcast::resolve_dest(&req.dest, &req.work_dir) {
+            Ok(d) => d,
+            Err(e) => {
+                return Ok(Response::new(ReceiveFileResponse {
+                    success: false,
+                    message: e,
+                }))
+            }
+        };
+
+        match crate::sbcast::write_file(&dest, &req.data, req.mode, req.force, req.uid, req.gid) {
+            Ok(()) => Ok(Response::new(ReceiveFileResponse {
+                success: true,
+                message: String::new(),
+            })),
+            Err(e) => Ok(Response::new(ReceiveFileResponse {
+                success: false,
+                message: e,
+            })),
+        }
+    }
+
     /// Run a one-shot command on this node, used by srun inside an allocation.
     /// Unlike ExecInJob, this does not require a tracked job process — salloc
     /// allocations don't run anything until srun dispatches a step.

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -12,6 +12,7 @@ mod mpi_plugin;
 pub(crate) mod privdrop;
 pub(crate) mod pty;
 mod reporter;
+mod sbcast;
 mod seccomp;
 
 use std::collections::HashMap;

--- a/crates/spurd/src/sbcast.rs
+++ b/crates/spurd/src/sbcast.rs
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! sbcast fan-out target: write a broadcast file to this node's local storage.
+//!
+//! The controller supplies the job owner's uid/gid/work_dir, so this module is
+//! stateless about the job. When spurd runs as root and the job user is not
+//! root, the write is performed *as the job user* via a `setpriv`-dropped child
+//! so the kernel enforces where the user may write — a direct root write would
+//! let a user overwrite root-owned paths (e.g. /etc/cron.d), a privilege
+//! escalation. Otherwise the file is written directly with spurd's own creds.
+
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use crate::privdrop::PrivDrop;
+
+/// Resolve the destination path; a relative path resolves against the job's
+/// working directory (Slurm sbcast semantics).
+pub(crate) fn resolve_dest(dest: &str, work_dir: &str) -> Result<PathBuf, String> {
+    let p = Path::new(dest);
+    if p.as_os_str().is_empty() {
+        return Err("empty destination path".into());
+    }
+    if p.is_absolute() {
+        Ok(p.to_path_buf())
+    } else if !work_dir.is_empty() {
+        Ok(Path::new(work_dir).join(p))
+    } else {
+        Err(format!(
+            "relative destination '{dest}' but the job has no working directory"
+        ))
+    }
+}
+
+/// Write `data` to `dest` for a job, honoring `force`, `mode`, and the job
+/// user's identity.
+pub(crate) fn write_file(
+    dest: &Path,
+    data: &[u8],
+    mode: u32,
+    force: bool,
+    uid: u32,
+    gid: u32,
+) -> Result<(), String> {
+    if !force && dest.exists() {
+        return Err(format!(
+            "{} exists (use --force to overwrite)",
+            dest.display()
+        ));
+    }
+    let mode = if mode == 0 { 0o644 } else { mode & 0o7777 };
+
+    match PrivDrop::resolve_if_needed(uid, gid) {
+        Some(pd) => write_as_user(&pd, dest, data, mode),
+        None => write_direct(dest, data, mode),
+    }
+}
+
+fn write_direct(dest: &Path, data: &[u8], mode: u32) -> Result<(), String> {
+    let mut f =
+        std::fs::File::create(dest).map_err(|e| format!("create {}: {e}", dest.display()))?;
+    f.write_all(data)
+        .map_err(|e| format!("write {}: {e}", dest.display()))?;
+    f.set_permissions(std::fs::Permissions::from_mode(mode))
+        .map_err(|e| format!("chmod {}: {e}", dest.display()))?;
+    Ok(())
+}
+
+/// Write via a `setpriv`-dropped `sh` child so the file is created with the job
+/// user's credentials.
+///
+/// ponytail: the redirect is not atomic (no temp+rename) and the `!force` check
+/// happens in the caller (a small TOCTOU window) — acceptable for staging a
+/// file, upgrade path is an O_NOFOLLOW temp-file + rename done in the child.
+fn write_as_user(pd: &PrivDrop, dest: &Path, data: &[u8], mode: u32) -> Result<(), String> {
+    let dest_s = dest
+        .to_str()
+        .ok_or_else(|| "destination path is not valid UTF-8".to_string())?;
+    let mut prefix = pd.setpriv_prefix(); // ["setpriv", "--reuid=..", "--regid=..", "--init-groups", "--"]
+    let program = prefix.remove(0);
+
+    let mut child = std::process::Command::new(program)
+        .args(prefix)
+        .arg("/bin/sh")
+        .arg("-c")
+        .arg(r#"umask 0; cat > "$1" && chmod "$2" "$1""#)
+        .arg("sh") // $0
+        .arg(dest_s) // $1
+        .arg(format!("{mode:o}")) // $2
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("spawn privilege-dropped writer: {e}"))?;
+
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| "writer child has no stdin".to_string())?
+        .write_all(data)
+        .map_err(|e| format!("feed sbcast data to writer: {e}"))?;
+
+    let out = child
+        .wait_with_output()
+        .map_err(|e| format!("wait for writer: {e}"))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "write as job user failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch_dir() -> PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "spur-sbcast-test-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        base
+    }
+
+    #[test]
+    fn resolve_dest_absolute_is_used_verbatim() {
+        assert_eq!(
+            resolve_dest("/tmp/x", "/home/u").unwrap(),
+            PathBuf::from("/tmp/x")
+        );
+    }
+
+    #[test]
+    fn resolve_dest_relative_joins_work_dir() {
+        assert_eq!(
+            resolve_dest("data/x", "/home/u").unwrap(),
+            PathBuf::from("/home/u/data/x")
+        );
+    }
+
+    #[test]
+    fn resolve_dest_relative_without_work_dir_errors() {
+        assert!(resolve_dest("x", "").is_err());
+        assert!(resolve_dest("", "/home/u").is_err());
+    }
+
+    #[test]
+    fn write_direct_writes_content_and_mode() {
+        // Off-root test runner: uid == euid, so resolve_if_needed returns None
+        // and write_file takes the direct path.
+        let dir = scratch_dir();
+        let dest = dir.join("payload.bin");
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+
+        write_file(&dest, b"hello sbcast", 0o640, false, uid, gid).unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), b"hello sbcast");
+        let got = std::fs::metadata(&dest).unwrap().permissions().mode() & 0o7777;
+        assert_eq!(got, 0o640, "mode should match the requested bits");
+
+        // Without --force, an existing destination is refused.
+        assert!(write_file(&dest, b"again", 0o640, false, uid, gid).is_err());
+        // With --force, it overwrites.
+        write_file(&dest, b"again", 0o600, true, uid, gid).unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), b"again");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/docs/user-guide/slurm-compatibility.rst
+++ b/docs/user-guide/slurm-compatibility.rst
@@ -83,6 +83,9 @@ Command Map
    * - ``spur attach``
      - ``sattach``
      - Attach to a running job's I/O
+   * - ``spur sbcast``
+     - ``sbcast``
+     - Broadcast a file to a job's allocated nodes
    * - ``spur crontab``
      - ``scrontab``
      - Manage recurring cron-style jobs

--- a/docs/user-guide/submitting-jobs.rst
+++ b/docs/user-guide/submitting-jobs.rst
@@ -339,6 +339,69 @@ those runtimes expect — ``LOCAL_RANK``, ``LOCAL_WORLD_SIZE``, ``NODE_RANK``, t
 ``OMPI_COMM_WORLD_*`` ranks, and ``SPUR_PEER_NODES`` — so ``torchrun``, MPI, and
 PMI/PMIx launchers run without extra wiring.
 
+.. _submit-sbcast:
+
+Staging Files onto Allocated Nodes — ``sbcast``
+------------------------------------------------
+
+``sbcast`` copies a file from the submit host to every node allocated to a
+running job. The usual reason is to put a binary, dataset, or config on fast
+node-local storage (``/tmp``, ``/dev/shm``) at job start, so the ranks read it
+from local disk instead of all hitting a shared filesystem at once.
+
+.. code-block:: bash
+
+   sbcast ./model.bin /tmp/model.bin
+
+Run inside a job script, that stages the file on each allocated node before the
+work starts:
+
+.. code-block:: bash
+
+   #!/bin/bash
+   #SBATCH --nodes=4
+   #SBATCH --gres=gpu:mi300x:8
+
+   sbcast --force ./model.bin /tmp/model.bin
+   srun ./train --model /tmp/model.bin
+
+Options:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 12 66
+
+   * - Option
+     - Short
+     - Description
+   * - ``--force``
+     - ``-f``
+     - Overwrite the destination if it already exists. Without it, an existing
+       file is an error.
+   * - ``--jobid``
+     - ``-j``
+     - Job to broadcast to. Defaults to ``$SPUR_JOB_ID``, then ``$SLURM_JOB_ID``,
+       so it can be omitted inside an allocation.
+
+A relative ``DEST`` resolves against the job's working directory; an absolute
+path is used as given. The destination file takes the mode of the source file.
+
+The job must be running and owned by the caller. If some nodes fail — a
+read-only path, a full disk — the broadcast continues to the rest and reports
+the per-node failures rather than stopping at the first one.
+
+Writes land as the job's user, so the destination must be a path that user can
+write. Staging into a root-owned directory fails with a permission error even
+when the node agent runs as root.
+
+.. note::
+
+   ``--compress``/``-C`` and ``--preserve``/``-p`` are accepted for drop-in
+   compatibility but do nothing: nothing is compressed on the wire, and the mode
+   always comes from the source file. ``--exclude`` and ``--send-libs`` are not
+   supported yet. The file is sent in a single message, so its size is bounded
+   by the controller's maximum request size.
+
 See Also
 --------
 

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -399,6 +399,9 @@ service SlurmController {
   // and standalone srun. Fans out tasks via agent RunCommand RPCs.
   rpc RunStep(RunStepRequest) returns (RunStepResponse);
 
+  // Broadcast a file to node-local storage on every node of a running job (Slurm sbcast).
+  rpc Sbcast(SbcastRequest) returns (SbcastResponse);
+
   // -- Native cluster (k0s) lifecycle: SPUR owns the k0s cluster --
   rpc ClusterUp(ClusterUpRequest) returns (ClusterUpResponse);
   rpc ClusterDown(ClusterDownRequest) returns (ClusterDownResponse);
@@ -424,6 +427,9 @@ service SlurmAgent {
   rpc ExecInJob(ExecInJobRequest) returns (ExecInJobResponse);
   // Run a one-shot command on this node (for srun step dispatch).
   rpc RunCommand(RunCommandRequest) returns (RunCommandResponse);
+
+  // Write a file to this node's local filesystem for a job (sbcast fan-out target).
+  rpc ReceiveFile(ReceiveFileRequest) returns (ReceiveFileResponse);
   // Stop an in-flight srun step on this node without cancelling the allocation job.
   rpc CancelStep(CancelStepRequest) returns (google.protobuf.Empty);
   // Record an allocation on this node without launching a batch process.
@@ -1130,6 +1136,44 @@ message RegisterJobAllocationRequest {
 }
 
 message RegisterJobAllocationResponse {}
+
+// sbcast: client -> controller. The controller verifies ownership and fans the
+// file out to every node in the job's allocation. The whole file rides in one
+// message, bounded by MAX_GRPC_REQUEST_SIZE (ponytail: no block streaming yet;
+// upgrade path is a client-streaming RPC for files larger than the cap).
+message SbcastRequest {
+  uint32 job_id = 1;
+  string dest = 2;    // Destination path on each node; relative resolves against the job work_dir
+  bytes data = 3;     // File contents
+  uint32 mode = 4;    // Unix permission bits (e.g. 0o755)
+  bool force = 5;     // Overwrite an existing destination
+  string user = 6;    // Requesting user; controller/admin credential overrides
+}
+
+message SbcastResponse {
+  bool success = 1;
+  string message = 2;         // Error detail when success is false
+  repeated string nodes = 3;  // Nodes the file was written to
+}
+
+// controller -> agent: write one file to this node's local filesystem. uid/gid/
+// work_dir come from the controller's authoritative job record, so the agent
+// stays stateless about the job.
+message ReceiveFileRequest {
+  uint32 job_id = 1;
+  string dest = 2;
+  bytes data = 3;
+  uint32 mode = 4;
+  bool force = 5;
+  uint32 uid = 6;
+  uint32 gid = 7;
+  string work_dir = 8;  // For relative-dest resolution
+}
+
+message ReceiveFileResponse {
+  bool success = 1;
+  string message = 2;
+}
 
 message RunCommandResponse {
   int32 exit_code = 1;

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -24,7 +24,7 @@ import tomli_w
 logger = logging.getLogger(__name__)
 
 BINARIES = ["spurctld", "spurd", "spur"]
-CLI_SYMLINKS = ["sbatch", "srun", "squeue", "scancel", "sinfo", "scontrol"]
+CLI_SYMLINKS = ["sbatch", "srun", "squeue", "scancel", "sinfo", "scontrol", "sbcast"]
 ACCOUNTING_SYMLINKS = ["sacct", "sacctmgr", "sshare", "sreport"]
 
 CONTROLLER_PORT = int(os.environ.get("SPUR_TEST_CONTROLLER_PORT", "6817"))

--- a/tests/native_host/e2e/test_sbcast.py
+++ b/tests/native_host/e2e/test_sbcast.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for `sbcast` — broadcasting a file to a job's allocated nodes."""
+
+from cluster import parse_job_id, wait_job_state
+
+
+class TestSbcast:
+    def test_sbcast_delivers_file_to_running_job_node(self, cluster):
+        # A job that stays running long enough to sbcast into.
+        script = cluster.write_file(
+            "sbcast-sleeper.sh", "#!/bin/bash\nsleep 300\n"
+        )
+        sb = cluster.sbatch(["-J", "sbcast-job", "-N", "1", script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+        wait_job_state(cluster, job_id, "R", timeout=60)
+
+        try:
+            payload = "SBCAST_PAYLOAD_OK\nline2\n"
+            src = cluster.write_file("sbcast-src.dat", payload, executable=False)
+            dest = f"{cluster.remote_dir}/sbcast-dst.dat"
+            # Ensure a clean slate for the destination.
+            cluster.nodes[0].exec_allow_fail(f"rm -f '{dest}'")
+
+            out = cluster.cli(["sbcast", "--jobid", str(job_id), src, dest])
+            assert "node(s)" in out, f"unexpected sbcast output:\n{out}"
+
+            got = cluster.read_output_on_any_node(dest)
+            assert "SBCAST_PAYLOAD_OK" in got, f"file not delivered:\n{got}"
+
+            # Without --force, re-sending to an existing path must fail.
+            rc, out2 = cluster.cli_with_exit(
+                ["sbcast", "--jobid", str(job_id), src, dest]
+            )
+            assert rc != 0, f"expected failure without --force, got:\n{out2}"
+
+            # With --force, it overwrites.
+            payload2 = "SBCAST_FORCED_OK\n"
+            src2 = cluster.write_file("sbcast-src2.dat", payload2, executable=False)
+            out3 = cluster.cli(
+                ["sbcast", "--force", "--jobid", str(job_id), src2, dest]
+            )
+            assert "node(s)" in out3, f"forced sbcast failed:\n{out3}"
+            got2 = cluster.read_output_on_any_node(dest)
+            assert "SBCAST_FORCED_OK" in got2, f"force did not overwrite:\n{got2}"
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_sbcast_rejects_nonexistent_job(self, cluster):
+        src = cluster.write_file("sbcast-nojob.dat", "x\n", executable=False)
+        dest = f"{cluster.remote_dir}/sbcast-nojob-dst.dat"
+        rc, out = cluster.cli_with_exit(
+            ["sbcast", "--jobid", "999999", src, dest]
+        )
+        assert rc != 0, f"expected failure for unknown job, got:\n{out}"


### PR DESCRIPTION
## Summary

Closes #828

Adds `sbcast`, the Slurm-compatible command for staging a local file onto
node-local storage across every node of a running job's allocation. It was
entirely missing from spur — no existing code, issue, or PR upstream.

Typical use: push a binary, dataset, or config to fast node-local disk
(`/tmp`, `/dev/shm`) at job start instead of hammering a shared filesystem.

## How it works

Mirrors the existing `ExecInJob` path:

sbcast SOURCE DEST → controller Sbcast (verifies job ownership + running state) → per-node ReceiveFile fan-out on the agents (writes the file)


- **Proto:** new `SlurmController.Sbcast` and `SlurmAgent.ReceiveFile` RPCs.
- **Controller:** resolves the job's authoritative `uid/gid/work_dir`, fans out
  to every allocated node, and collects per-node failures rather than aborting
  the whole broadcast.
- **Agent:** resolves the destination (relative paths against the job's work
  dir) and writes the file honoring `--force` and the source file's mode.
- **CLI:** `sbcast SOURCE DEST [-f/--force] [-j/--jobid]`, with `$SPUR_JOB_ID` /
  `$SLURM_JOB_ID` fallback and a `sbcast` binary alias. `-C/--compress` and
  `-p/--preserve` are accepted as no-ops for drop-in compatibility.

This is a from-scratch native implementation modeled on Slurm's *documented*
CLI/semantics — no Slurm source was copied (Slurm is GPLv2; these files are
Apache-2.0).

## Security

The write can land as another user, so the trust boundary is enforced on two
levels:

- `ReceiveFile` is gated with `require_controller` — `uid/gid/dest` are
  wire-supplied, so a valid *user* token must not be able to drive an arbitrary
  write as any uid. Only the controller (which has already checked job
  ownership) can reach it.
- When spurd runs as root and the job user is not root, the write is performed
  **as the job user** via the existing `PrivDrop`/`setpriv` machinery, so the
  kernel enforces where the user may write (path traversal / absolute paths to
  root-owned locations fail with `EACCES`). Root jobs remain gated by
  `check_root_execution_allowed`.
- `dest`/`mode` are passed as `sh` positional args, never interpolated into the
  script string.

## Testing

- **Unit** (`crates/spurd/src/sbcast.rs`): destination resolution
  (absolute / relative-to-workdir / error cases) and direct write (content,
  mode, `--force` overwrite). Full `spurd` suite: 246 passed.
- **E2E** (`tests/native_host/e2e/test_sbcast.py`): sbcast into a running job on
  a live cluster, verifying file delivery + content, `--force` overwrite, and
  unknown-job rejection. Both pass.
- `cargo build` / `fmt` / `clippy` clean.

## Known limitations (follow-ups)

- Whole file sent in one gRPC message (bounded by `MAX_GRPC_REQUEST_SIZE`) — no
  block streaming for very large files yet.
- Non-atomic write (truncating redirect); small TOCTOU on the `!force` check.
- No `--compress`, `--exclude`, or `--send-libs` yet.