### PR TITLE
ci: apply no-e2e-on-draft label to release-please PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
       "draft-pull-request": true,
       "prerelease": true,
       "bump-minor-pre-major": true,
+      "extra-label": "no-e2e-on-draft",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
Because it is okay to test a release PR just before a release is made, i.e., when the release PR is marked ready. 

## Summary
- Release-please opens its release PRs as drafts, but `e2e.yml`'s draft-skip logic only fires for drafts carrying the `no-e2e-on-draft` label.
- Adds `extra-label: no-e2e-on-draft` to `release-please-config.json` so release PRs get it automatically. This is additive and independent of the `autorelease: pending` / `autorelease: tagged` labels release-please uses to track its own state.
- Created the `no-e2e-on-draft` label on the repo (it was referenced by `e2e.yml` but never existed).

