### PR TITLE
ci: prune spur-build-cache untagged image versions

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -12,11 +12,14 @@ permissions:
 jobs:
   prune:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [spur-ci, spur-build-cache]
     steps:
-      - name: Delete old CI images
+      - name: Delete old ${{ matrix.package }} images
         uses: actions/delete-package-versions@v5
         with:
-          package-name: spur-ci
+          package-name: ${{ matrix.package }}
           package-type: container
           min-versions-to-keep: 20
           ignore-versions: "^(latest|v\\d+)"

--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -13,6 +13,7 @@ jobs:
   prune:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         package: [spur-ci, spur-build-cache]
     steps:


### PR DESCRIPTION
## What

The weekly image cleanup job only pruned the `spur-ci` package. `spur-build-cache` was never touched, so its untagged versions accumulated unbounded.

## Why

The docker build cache is written with `cache-to type=registry,ref=ghcr.io/rocm/spur-build-cache:ci,mode=max` (in `ci.yml`, gated to `main`). Every main build pushes a fresh cache manifest and moves the `:ci` tag onto it. GHCR keys a package version by manifest digest and does not drop the old digest when the tag moves, so each build strands the previous manifest as an untagged version. With `mode=max` (all intermediate layers cached), these hold significant storage.

## Change

Extend the existing cleanup job to a matrix over both `spur-ci` and `spur-build-cache`, keeping the 20 most recent versions each. Retention stays count-based (the first-party `actions/delete-package-versions` has no age filter); 20 is generous headroom for ephemeral build artifacts. The live `:ci` cache is always the newest version, so `min-versions-to-keep` never deletes it.

## Test

Config-only change. Can be validated with a `workflow_dispatch` run (optionally a dry run first).