### PR TITLE
feat(scontrol): add show hostnames/hostlist/hostnamestr

### DIFF
--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -31,7 +31,7 @@ pub struct ScontrolArgs {
 pub enum ScontrolCommand {
     /// Show detailed information
     Show {
-        /// Entity type: job, node, partition, reservation, assoc_mgr, federation, config
+        /// Entity type: job, node, partition, reservation, assoc_mgr, federation, config, hostnames, hostlist
         entity: String,
         /// Entity name or ID
         name: Option<String>,
@@ -567,6 +567,15 @@ fn format_config(controller: &str, ping: &spur_proto::proto::PingResponse) -> St
 }
 
 async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> {
+    // Offline hostlist utilities resolve locally — no controller round-trip,
+    // matching Slurm (these work outside an allocation and while ctld is down).
+    match entity.to_lowercase().as_str() {
+        "hostnames" | "hostname" => return show_hostnames(name),
+        "hostlist" | "hostlistsorted" => return show_hostlist(name),
+        "hostnamestr" => return show_hostnamestr(name),
+        _ => {}
+    }
+
     let channel = crate::authclient::connect(controller)
         .await
         .context("failed to connect to spurctld")?;
@@ -840,12 +849,72 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
         }
         other => {
             bail!(
-                "scontrol: unknown entity type '{}'. Use: job, node, partition, reservation, assoc_mgr, federation, config",
+                "scontrol: unknown entity type '{}'. Use: job, node, partition, reservation, assoc_mgr, federation, config, hostnames, hostlist",
                 other
             );
         }
     }
 
+    Ok(())
+}
+
+/// Resolve the hostlist argument for the offline `scontrol show hostnames`
+/// family. Falls back to `$SLURM_JOB_NODELIST` / `$SLURM_NODELIST` like Slurm
+/// so `scontrol show hostnames` works with no argument inside a job.
+fn resolve_hostlist(name: Option<&str>) -> Result<String> {
+    if let Some(value) = name {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+    for var in ["SLURM_JOB_NODELIST", "SLURM_NODELIST"] {
+        if let Ok(value) = std::env::var(var) {
+            if !value.trim().is_empty() {
+                return Ok(value);
+            }
+        }
+    }
+    bail!(
+        "scontrol show hostnames: no hostlist given and neither \
+         SLURM_JOB_NODELIST nor SLURM_NODELIST is set"
+    )
+}
+
+/// Expand a hostlist and return it sorted + de-duplicated in Slurm's natural
+/// (numeric) order. The compress/expand round-trip reuses the controller's own
+/// hostlist codec so ordering matches `compress` exactly (node10 after node2).
+fn normalized_hosts(pattern: &str) -> Result<Vec<String>> {
+    let hosts = spur_core::hostlist::expand(pattern)
+        .map_err(|e| anyhow::anyhow!("invalid hostlist '{pattern}': {e}"))?;
+    let compact = spur_core::hostlist::compress(&hosts);
+    spur_core::hostlist::expand(&compact)
+        .map_err(|e| anyhow::anyhow!("invalid hostlist '{compact}': {e}"))
+}
+
+/// `scontrol show hostnames [HOSTLIST]` — expand to one hostname per line.
+fn show_hostnames(name: Option<&str>) -> Result<()> {
+    let pattern = resolve_hostlist(name)?;
+    for host in normalized_hosts(&pattern)? {
+        println!("{host}");
+    }
+    Ok(())
+}
+
+/// `scontrol show hostlist HOSTLIST` — collapse hostnames into a compact
+/// bracketed expression on a single line.
+fn show_hostlist(name: Option<&str>) -> Result<()> {
+    let pattern = resolve_hostlist(name)?;
+    let hosts = spur_core::hostlist::expand(&pattern)
+        .map_err(|e| anyhow::anyhow!("invalid hostlist '{pattern}': {e}"))?;
+    println!("{}", spur_core::hostlist::compress(&hosts));
+    Ok(())
+}
+
+/// `scontrol show hostnamestr HOSTLIST` — expand to one comma-separated line.
+fn show_hostnamestr(name: Option<&str>) -> Result<()> {
+    let pattern = resolve_hostlist(name)?;
+    println!("{}", normalized_hosts(&pattern)?.join(","));
     Ok(())
 }
 
@@ -2218,6 +2287,32 @@ mod tests {
         assert!(!out.contains("ClusterName=spur"), "{out}");
         assert!(out.contains("SlurmctldAddr=http://ctld:6817"), "{out}");
         assert!(out.contains("Version=9.9.9"), "{out}");
+    }
+
+    #[test]
+    fn show_hostnames_expands_sorted_unique() {
+        assert_eq!(
+            normalized_hosts("node[1-3]").unwrap(),
+            vec!["node1", "node2", "node3"]
+        );
+        // numeric (not lexical) sort and de-duplication, matching Slurm
+        assert_eq!(
+            normalized_hosts("node[2,10,1],node1").unwrap(),
+            vec!["node1", "node2", "node10"]
+        );
+        assert_eq!(
+            normalized_hosts("gpu[1-2],cpu[1-2]").unwrap(),
+            vec!["cpu1", "cpu2", "gpu1", "gpu2"]
+        );
+    }
+
+    #[test]
+    fn resolve_hostlist_prefers_explicit_arg_then_errors() {
+        assert_eq!(resolve_hostlist(Some("node[1-2]")).unwrap(), "node[1-2]");
+        std::env::remove_var("SLURM_JOB_NODELIST");
+        std::env::remove_var("SLURM_NODELIST");
+        assert!(resolve_hostlist(Some("   ")).is_err());
+        assert!(resolve_hostlist(None).is_err());
     }
 
     #[test]

--- a/docs/user-guide/monitoring-jobs.rst
+++ b/docs/user-guide/monitoring-jobs.rst
@@ -606,6 +606,61 @@ scopes the view to the caller and lists only the QOS and accounts they take part
 in. Administrators see every scope, and may pass ``users=<name>`` to inspect one
 user.
 
+Expanding Node Lists — ``scontrol show hostnames``
+--------------------------------------------------
+
+Allocations report their nodes as a compact expression such as ``node[1-4]``.
+Distributed launchers need the individual hostnames behind it — most often to
+pick a rendezvous host. ``scontrol show hostnames`` expands one:
+
+.. code-block:: bash
+
+   scontrol show hostnames node[1-4]
+   # node1
+   # node2
+   # node3
+   # node4
+
+Three forms are available:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Subcommand
+     - Output
+   * - ``show hostnames``
+     - One hostname per line. ``hostname`` is accepted as an alias.
+   * - ``show hostlist``
+     - The hostnames collapsed back into a compact bracketed expression, on one
+       line. ``hostlistsorted`` is accepted as an alias.
+   * - ``show hostnamestr``
+     - The hostnames on a single comma-separated line.
+
+``hostlist`` is the inverse of ``hostnames``:
+
+.. code-block:: bash
+
+   scontrol show hostlist node1,node2,node3,node4
+   # node[1-4]
+
+Output is sorted in natural numeric order with duplicates removed, so ``node10``
+sorts after ``node9`` rather than after ``node1``.
+
+With no argument the list is read from ``$SLURM_JOB_NODELIST``, then
+``$SLURM_NODELIST``. Both are set inside a job, so a job script can omit it:
+
+.. code-block:: bash
+
+   MASTER_ADDR=$(scontrol show hostnames | head -n1)
+
+If no argument is given and neither variable is set, the command errors rather
+than printing nothing.
+
+Unlike the other ``scontrol show`` entities, these three are resolved by the CLI
+itself. They need no allocation and keep working while the controller is
+unreachable.
+
 Cluster Metrics — ``/metrics``
 ------------------------------
 


### PR DESCRIPTION
## Summary

Closes #824

Adds Slurm's `scontrol show hostnames [NODELIST]` and the `hostlist` /
`hostnamestr` variants, which were missing from spur. These are the idiomatic
way distributed jobs discover their nodes, e.g.
`MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)`.

## What
- `hostnames`   — expand a hostlist to one hostname per line
- `hostlist`    — collapse hostnames into a compact bracketed expression
- `hostnamestr` — expand to a single comma-separated line

Resolved locally with no controller round-trip (matches Slurm: works outside an
allocation and while ctld is down), falling back to `$SLURM_JOB_NODELIST` /
`$SLURM_NODELIST` when no argument is given. Output is sorted + de-duplicated in
natural numeric order by reusing `spur_core::hostlist` expand/compress.

## Testing
- Unit tests: expansion (sort/dedup/multi-prefix) and argument resolution.
- Manual: verified `hostnames`/`hostlist`/`hostnamestr`, env fallback, and the
  no-arg error path against the built binary.
- `cargo build` / `fmt` / `clippy -D warnings` clean.