### PR TITLE
fix(spurctld): hold jobs whose QOS or association limits cannot be read

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -297,3 +297,5 @@ MiB
 OOM
 pluggable
 torchrun
+backoff
+unapplied

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -329,6 +329,12 @@ pub enum PendingReason {
     /// Replaces `BeginTime` as the pending reason for preempted-requeued jobs so the
     /// reason string is unambiguous.
     Preempted,
+
+    /// Accounting is enabled but its caches hold no snapshot, so the job's QOS or
+    /// association limits cannot be read. Has no Slurm counterpart: Slurm keeps its
+    /// association state on disk and refuses to start without it, so it never
+    /// schedules in this state to begin with.
+    AccountingUnavailable,
 }
 
 impl PendingReason {
@@ -417,6 +423,7 @@ impl PendingReason {
             Self::QosMaxSubmitJobPerAccountLimit => "MaxSubmitJobsPerAccount",
             Self::K8sReserved => "ReqNodeNotAvail, Reserved for Kubernetes cluster",
             Self::Preempted => "Preempted",
+            Self::AccountingUnavailable => "AccountingUnavailable",
         }
     }
 

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -2346,6 +2346,21 @@ mod tests {
         );
     }
 
+    // The variant reaches the Raft log through `WalOperation`, so its serialized
+    // name is a compatibility surface: renaming or reordering must fail here rather
+    // than on a controller replaying a log it cannot parse.
+    #[test]
+    fn accounting_unavailable_reason_displays_and_roundtrips() {
+        assert_eq!(
+            PendingReason::AccountingUnavailable.display(),
+            "AccountingUnavailable"
+        );
+        let json = serde_json::to_string(&PendingReason::AccountingUnavailable).unwrap();
+        assert_eq!(json, "\"AccountingUnavailable\"");
+        let back: PendingReason = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, PendingReason::AccountingUnavailable);
+    }
+
     #[test]
     fn pending_reason_exit_vocabulary_display() {
         assert_eq!(PendingReason::NonZeroExitCode.display(), "NonZeroExitCode");

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -97,26 +97,61 @@ fn require_admin<T>(request: &Request<T>, op: &str) -> Result<(), Status> {
     }
 }
 
-pub(crate) enum AccountingService {
-    Available(PgPool),
-    Unavailable { reason: &'static str },
+/// The accounting gRPC service. The pool is held behind a shared, swappable
+/// slot so a controller that boots while the database is unreachable can
+/// install the pool later, once the background bring-up connects — the same
+/// handle keeps serving `Unavailable` until then. Cloning shares that slot, so
+/// the copy handed to the gRPC server and the copy the bring-up keeps see each
+/// other's writes.
+pub(crate) struct AccountingService {
+    inner: std::sync::Arc<AccountingInner>,
+}
+
+struct AccountingInner {
+    pool: parking_lot::RwLock<Option<PgPool>>,
+    reason: parking_lot::RwLock<&'static str>,
+}
+
+impl Clone for AccountingService {
+    fn clone(&self) -> Self {
+        Self {
+            inner: std::sync::Arc::clone(&self.inner),
+        }
+    }
 }
 
 impl AccountingService {
-    pub(crate) fn available(pool: PgPool) -> Self {
-        Self::Available(pool)
-    }
-
     pub(crate) fn unavailable(reason: &'static str) -> Self {
-        Self::Unavailable { reason }
+        Self {
+            inner: std::sync::Arc::new(AccountingInner {
+                pool: parking_lot::RwLock::new(None),
+                reason: parking_lot::RwLock::new(reason),
+            }),
+        }
     }
 
-    fn pool(&self) -> Result<&PgPool, Status> {
-        match self {
-            Self::Available(pool) => Ok(pool),
-            Self::Unavailable { reason } => Err(Status::unavailable(format!(
-                "accounting service is not available ({reason})"
-            ))),
+    /// Install the pool once the background bring-up connects, flipping every
+    /// clone of this service from `Unavailable` to serving live queries.
+    pub(crate) fn install_pool(&self, pool: PgPool) {
+        *self.inner.pool.write() = Some(pool);
+    }
+
+    /// Record why the service is still unavailable, so a client hitting it
+    /// during the connect-retry window sees the latest cause rather than a
+    /// stale one.
+    pub(crate) fn mark_unavailable(&self, reason: &'static str) {
+        *self.inner.reason.write() = reason;
+    }
+
+    fn pool(&self) -> Result<PgPool, Status> {
+        match self.inner.pool.read().as_ref() {
+            Some(pool) => Ok(pool.clone()),
+            None => {
+                let reason = *self.inner.reason.read();
+                Err(Status::unavailable(format!(
+                    "accounting service is not available ({reason})"
+                )))
+            }
         }
     }
 }
@@ -135,6 +170,7 @@ impl SlurmAccounting for AccountingService {
         request: Request<RecordJobStartRequest>,
     ) -> Result<Response<()>, Status> {
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
         let start_time = req
             .start_time
@@ -184,6 +220,7 @@ impl SlurmAccounting for AccountingService {
         request: Request<RecordJobEndRequest>,
     ) -> Result<Response<()>, Status> {
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
         let end_time = req
             .end_time
@@ -227,6 +264,7 @@ impl SlurmAccounting for AccountingService {
         request: Request<GetJobHistoryRequest>,
     ) -> Result<Response<GetJobHistoryResponse>, Status> {
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
 
         let start_after = timestamp_to_utc(req.start_after)?;
@@ -359,6 +397,7 @@ impl SlurmAccounting for AccountingService {
         request: Request<GetUsageRequest>,
     ) -> Result<Response<GetUsageResponse>, Status> {
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
 
         let since = req
@@ -416,6 +455,7 @@ impl SlurmAccounting for AccountingService {
     ) -> Result<Response<()>, Status> {
         require_admin(&request, "create account")?;
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
         if let Some(g) = &req.grp_tres {
             validate_tres("grptres", g)?;
@@ -440,6 +480,7 @@ impl SlurmAccounting for AccountingService {
     ) -> Result<Response<()>, Status> {
         require_admin(&request, "delete account")?;
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
         db::delete_account(pool, &req.name)
             .await
@@ -452,6 +493,7 @@ impl SlurmAccounting for AccountingService {
         _request: Request<ListAccountsRequest>,
     ) -> Result<Response<ListAccountsResponse>, Status> {
         let pool = self.pool()?;
+        let pool = &pool;
         let records = db::list_accounts(pool)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
@@ -475,6 +517,7 @@ impl SlurmAccounting for AccountingService {
     async fn add_user(&self, request: Request<AddUserRequest>) -> Result<Response<()>, Status> {
         require_admin(&request, "add user")?;
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
         let admin_level = req
             .admin_level
@@ -563,6 +606,7 @@ impl SlurmAccounting for AccountingService {
     ) -> Result<Response<()>, Status> {
         require_admin(&request, "remove user")?;
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
         let deleted = db::remove_user(pool, &req.user, &req.account)
             .await
@@ -583,6 +627,7 @@ impl SlurmAccounting for AccountingService {
         request: Request<ListUsersRequest>,
     ) -> Result<Response<ListUsersResponse>, Status> {
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
         let account = if req.account.is_empty() {
             None
@@ -622,6 +667,7 @@ impl SlurmAccounting for AccountingService {
     async fn create_qos(&self, request: Request<CreateQosRequest>) -> Result<Response<()>, Status> {
         require_admin(&request, "create qos")?;
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
         if let Some(t) = &req.max_tres_per_job {
             validate_tres("maxtresperjob", t)?;
@@ -697,6 +743,7 @@ impl SlurmAccounting for AccountingService {
     async fn delete_qos(&self, request: Request<DeleteQosRequest>) -> Result<Response<()>, Status> {
         require_admin(&request, "delete qos")?;
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
         db::delete_qos(pool, &req.name)
             .await
@@ -709,6 +756,7 @@ impl SlurmAccounting for AccountingService {
         _request: Request<ListQosRequest>,
     ) -> Result<Response<ListQosResponse>, Status> {
         let pool = self.pool()?;
+        let pool = &pool;
         let records = db::list_qos(pool)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
@@ -744,6 +792,7 @@ impl SlurmAccounting for AccountingService {
         request: Request<GetFairshareFactorsRequest>,
     ) -> Result<Response<GetFairshareFactorsResponse>, Status> {
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
         let halflife_days = if req.halflife_days == 0 {
             14
@@ -789,6 +838,7 @@ impl SlurmAccounting for AccountingService {
         // Ungated, consistent with get_job_history and the rest of this service.
         // Confidentiality of the audit log requires auth.mode = required.
         let pool = self.pool()?;
+        let pool = &pool;
         let req = request.into_inner();
 
         let start_after = timestamp_to_utc(req.start_after)?;
@@ -944,6 +994,43 @@ mod tests {
         assert_eq!(
             status.message(),
             "accounting service is not available (database migration failed at startup)"
+        );
+    }
+
+    // The core of the cold-start recovery: a service that boots unavailable must
+    // start serving once the background bring-up installs the pool, and every
+    // clone must see that install through the shared slot (the gRPC server holds
+    // one clone, the bring-up task another). `connect_lazy` yields a real
+    // `PgPool` without touching a database, so this exercises the actual
+    // install/read path rather than a stand-in.
+    #[tokio::test]
+    async fn install_pool_recovers_a_cloned_unavailable_service() {
+        let service = AccountingService::unavailable("connecting to accounting database");
+        let server_copy = service.clone();
+        assert!(
+            server_copy.pool().is_err(),
+            "must report unavailable before the pool is installed"
+        );
+
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://spur:spur@127.0.0.1:5433/does-not-connect")
+            .expect("lazy pool builds without connecting");
+        service.install_pool(pool);
+
+        assert!(
+            server_copy.pool().is_ok(),
+            "the server's clone must observe the pool the bring-up installed"
+        );
+    }
+
+    #[test]
+    fn mark_unavailable_updates_the_reported_reason() {
+        let service = AccountingService::unavailable("connecting to accounting database");
+        service.mark_unavailable("database migration failed");
+        let status = service.pool().unwrap_err();
+        assert_eq!(
+            status.message(),
+            "accounting service is not available (database migration failed)"
         );
     }
 

--- a/crates/spurctld/src/accounting/mod.rs
+++ b/crates/spurctld/src/accounting/mod.rs
@@ -17,10 +17,175 @@ pub use reconcile::RECONCILE_INTERVAL_SECS;
 pub(crate) use txn::{TxnAction, TxnEntity, TxnOutcome, TxnRecord, TxnSource};
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
 
 use sqlx::PgPool;
 
 use spur_core::accounting::{AccountLimits, TresRecord};
+use spur_core::config::SlurmConfig;
+
+use crate::cluster::ClusterManager;
+use crate::raft::RaftHandle;
+
+/// Start accounting for the controller.
+///
+/// Returns the gRPC service to register (`None` when accounting is disabled).
+/// The database connect, migration, and everything downstream of them — the
+/// job notifier, the reconcile and purge loops, and the four cache-refresh
+/// loops — run in a background task so startup never blocks on the database and,
+/// crucially, so a controller that boots while the database is unreachable
+/// keeps retrying and wires everything up once it returns. Without that retry a
+/// cold start with the database down would leave every cache unloaded for the
+/// life of the process, holding every inherited job that names a QOS or account
+/// (see `ClusterManager::accounting_block`).
+pub(crate) fn start(
+    config: &SlurmConfig,
+    cluster: Arc<ClusterManager>,
+    raft: Arc<RaftHandle>,
+) -> Option<AccountingService> {
+    if config.accounting.database_url.is_empty() {
+        tracing::info!("accounting disabled (database_url not configured)");
+        return None;
+    }
+
+    let service = AccountingService::unavailable("connecting to accounting database");
+    let bringup = service.clone();
+    let url = config.accounting.database_url.clone();
+    let params = ActivationParams::from_config(config);
+    tokio::spawn(async move {
+        let pool = connect_with_retry(&url, &bringup).await;
+        activate(pool, &bringup, &cluster, &raft, &params);
+    });
+    Some(service)
+}
+
+/// The config values `activate` needs, copied out so the bring-up task does not
+/// have to hold the whole `SlurmConfig`.
+struct ActivationParams {
+    fairshare_halflife_days: u32,
+    refresh_secs: u64,
+    grp_wall_window_days: u32,
+    txn_retention_days: Option<u32>,
+}
+
+impl ActivationParams {
+    fn from_config(config: &SlurmConfig) -> Self {
+        Self {
+            fairshare_halflife_days: config.scheduler.fairshare_halflife_days,
+            refresh_secs: config.accounting.fairshare_refresh_secs as u64,
+            grp_wall_window_days: config.accounting.grp_wall_window_days,
+            txn_retention_days: config.accounting.txn_retention_days.filter(|d| *d > 0),
+        }
+    }
+}
+
+/// Which phase of bring-up failed, so the service can report a specific cause
+/// while it keeps retrying.
+enum BringupError {
+    Connect(sqlx::Error),
+    Migrate(anyhow::Error),
+}
+
+impl BringupError {
+    fn reason(&self) -> &'static str {
+        match self {
+            Self::Connect(_) => "database connection failed",
+            Self::Migrate(_) => "database migration failed",
+        }
+    }
+}
+
+impl std::fmt::Display for BringupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connect(e) => write!(f, "{e}"),
+            Self::Migrate(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+async fn connect_and_migrate(url: &str) -> Result<PgPool, BringupError> {
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(8)
+        .acquire_timeout(Duration::from_secs(5))
+        .connect(url)
+        .await
+        .map_err(BringupError::Connect)?;
+    db::migrate(&pool).await.map_err(BringupError::Migrate)?;
+    Ok(pool)
+}
+
+/// Connect and migrate, retrying with capped exponential backoff until it
+/// succeeds. Each failure updates the service's unavailability reason so a
+/// client hitting accounting mid-outage sees the current cause.
+async fn connect_with_retry(url: &str, service: &AccountingService) -> PgPool {
+    const FIRST_BACKOFF: Duration = Duration::from_secs(1);
+    const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+    let mut backoff = FIRST_BACKOFF;
+    loop {
+        match connect_and_migrate(url).await {
+            Ok(pool) => {
+                tracing::info!("accounting database connected");
+                return pool;
+            }
+            Err(e) => {
+                service.mark_unavailable(e.reason());
+                tracing::warn!(
+                    error = %e,
+                    retry_in_secs = backoff.as_secs(),
+                    "accounting database unavailable; retrying in background"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
+        }
+    }
+}
+
+/// Wire a freshly connected pool into the controller: install it into the gRPC
+/// service, set the job notifier, and spawn the reconcile, purge, and
+/// cache-refresh loops. Runs once per successful connect — at startup when the
+/// database is up, or later when a cold-start outage clears.
+fn activate(
+    pool: PgPool,
+    service: &AccountingService,
+    cluster: &Arc<ClusterManager>,
+    raft: &Arc<RaftHandle>,
+    params: &ActivationParams,
+) {
+    service.install_pool(pool.clone());
+    cluster.set_accounting(AccountingNotifier::new(pool.clone()));
+
+    spawn_reconcile_loop(
+        pool.clone(),
+        cluster.clone(),
+        raft.clone(),
+        Duration::from_secs(RECONCILE_INTERVAL_SECS),
+    );
+
+    if let Some(days) = params.txn_retention_days {
+        spawn_txn_purge_loop(pool.clone(), raft.clone(), days, Duration::from_secs(3600));
+    }
+
+    cluster.fairshare_cache().spawn_refresh_loop(
+        pool.clone(),
+        params.fairshare_halflife_days,
+        params.refresh_secs,
+    );
+    cluster
+        .qos_cache()
+        .spawn_refresh_loop(pool.clone(), params.refresh_secs);
+    cluster
+        .association_cache()
+        .spawn_refresh_loop(pool.clone(), params.refresh_secs);
+    cluster.grp_wall_cache().spawn_refresh_loop(
+        pool,
+        params.refresh_secs,
+        params.grp_wall_window_days,
+    );
+}
 
 /// Compute fairshare factors directly from the database.
 ///
@@ -253,5 +418,13 @@ mod tests {
     fn account_limits_pass_through_positive() {
         let limits = super::account_limits_from_record(record_with_submit(Some(5)));
         assert_eq!(limits.grp_submit_jobs, Some(5));
+    }
+
+    #[test]
+    fn bringup_error_reason_names_the_failed_phase() {
+        let connect = super::BringupError::Connect(sqlx::Error::PoolClosed);
+        assert_eq!(connect.reason(), "database connection failed");
+        let migrate = super::BringupError::Migrate(anyhow::anyhow!("bad migration"));
+        assert_eq!(migrate.reason(), "database migration failed");
     }
 }

--- a/crates/spurctld/src/association_cache.rs
+++ b/crates/spurctld/src/association_cache.rs
@@ -11,6 +11,7 @@ use tracing::{info, warn};
 
 use spur_core::accounting::AccountLimits;
 
+#[derive(Default)]
 struct Snapshot {
     default_qos: HashMap<(String, String), String>,
     default_account: HashMap<String, String>,
@@ -192,6 +193,13 @@ impl AssociationCache {
             admin_level,
             loaded: true,
         };
+    }
+
+    /// Test-only seam: returns the cache to its pre-first-fetch state, as a freshly
+    /// started controller sees it while its predecessor's queue is already durable.
+    #[cfg(test)]
+    pub(crate) fn reset(&self) {
+        *self.snapshot.write() = Snapshot::default();
     }
 
     /// Test-only seam: populates the cache without a database.

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3315,11 +3315,6 @@ impl ClusterManager {
             }
         });
 
-        let qos_by_job: HashMap<JobId, Qos> = candidates
-            .iter()
-            .map(|candidate| (candidate.job.job_id, self.resolve_qos(&candidate.job)))
-            .collect();
-
         let reservations = self.get_reservations();
         retain_unblocked(&mut candidates, &mut reason_updates, |job| {
             reservation_block(job, &reservations, now)
@@ -3375,9 +3370,23 @@ impl ClusterManager {
             *count += 1;
         }
 
-        retain_unblocked(&mut candidates, &mut reason_updates, |job| {
-            self.accounting_block(job)
+        // Eligible-only: an unreadable cap is transient, not structural, so it must
+        // not claim a begin-deferred job and report itself in place of BeginTime.
+        // Nothing is admitted past the gate either way — ineligible candidates leave
+        // the schedulable set below.
+        retain_eligible(&mut candidates, &mut reason_updates, |job| {
+            match self.accounting_block(job) {
+                Some(reason) => GateOutcome::Block(reason),
+                None => GateOutcome::Keep,
+            }
         });
+
+        // Built after the accounting gate so a held job never gets the limitless
+        // default `resolve_qos` warns about.
+        let qos_by_job: HashMap<JobId, Qos> = candidates
+            .iter()
+            .map(|candidate| (candidate.job.job_id, self.resolve_qos(&candidate.job)))
+            .collect();
 
         {
             let mut reserved = PassReservations::default();
@@ -4798,12 +4807,7 @@ impl ClusterManager {
     /// Holds a candidate whose accounting limits cannot be read. Admission is the
     /// last point at which a cap can still be applied — a running job is never
     /// re-checked — so a cold cache pends the job rather than gating it against a
-    /// limitless default. Mirrors the submit-time fail-closed gate; with accounting
-    /// disabled there are no limits to read and nothing is held.
-    ///
-    /// The window is real despite submit validating the QOS: the queue is durable
-    /// and the caches are not, so a restarted controller inherits its predecessor's
-    /// pending jobs before its first fetch completes.
+    /// limitless default.
     fn accounting_block(&self, job: &Job) -> Option<PendingReason> {
         if !self.config().accounting.enabled() {
             return None;
@@ -17544,8 +17548,8 @@ mod tests {
     }
 
     fn admitted_of(cm: &ClusterManager, ids: &[JobId]) -> usize {
-        let pending: Vec<JobId> = cm.pending_jobs().iter().map(|j| j.job_id).collect();
-        ids.iter().filter(|id| pending.contains(id)).count()
+        let admitted: Vec<JobId> = cm.pending_jobs().iter().map(|j| j.job_id).collect();
+        ids.iter().filter(|id| admitted.contains(id)).count()
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -17585,6 +17589,33 @@ mod tests {
         assert_eq!(
             cm.get_job(ids[0]).unwrap().pending_reason,
             PendingReason::AccountingUnavailable
+        );
+    }
+
+    // A job waiting on its start time is not waiting on the cache: the cold-cache
+    // hold gates admission, and a begin-deferred job is not up for admission, so
+    // BeginTime stays its reason.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cold_cache_does_not_claim_a_begin_deferred_job() {
+        let dir = TempDir::new().unwrap();
+        let cm = accounting_cluster(&dir).await;
+        register_node(&cm, "n1", 64, 128000);
+        cm.qos_cache().insert(Qos {
+            name: "cnt".into(),
+            ..Default::default()
+        });
+
+        let mut spec = basic_spec("later");
+        spec.qos = Some("cnt".into());
+        spec.begin_time = Some(Utc::now() + chrono::Duration::hours(1));
+        let id = submit_and_wait(&cm, spec);
+
+        cm.qos_cache().reset();
+        cm.refresh_pending_reasons();
+
+        assert_eq!(
+            cm.get_job(id).unwrap().pending_reason,
+            PendingReason::BeginTime
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3375,6 +3375,10 @@ impl ClusterManager {
             *count += 1;
         }
 
+        retain_unblocked(&mut candidates, &mut reason_updates, |job| {
+            self.accounting_block(job)
+        });
+
         {
             let mut reserved = PassReservations::default();
             let grp_wall_usage = self.grp_wall_cache.usage();
@@ -4754,6 +4758,9 @@ impl ClusterManager {
     }
 
     /// Resolve a job's QoS from the cache; unknown/absent name → limitless default.
+    /// Callers that gate admission must go through `accounting_block` first: the
+    /// limitless default is only safe where a missing QOS costs nothing (priority
+    /// and preemption comparisons), never where a limit is being applied.
     pub(crate) fn resolve_qos(&self, job: &Job) -> Qos {
         match job.spec.qos.as_deref() {
             Some(name) => self.qos_cache.get(name).unwrap_or_default(),
@@ -4786,6 +4793,39 @@ impl ClusterManager {
             qos_minutes,
             account_minutes,
         }
+    }
+
+    /// Holds a candidate whose accounting limits cannot be read. Admission is the
+    /// last point at which a cap can still be applied — a running job is never
+    /// re-checked — so a cold cache pends the job rather than gating it against a
+    /// limitless default. Mirrors the submit-time fail-closed gate; with accounting
+    /// disabled there are no limits to read and nothing is held.
+    ///
+    /// The window is real despite submit validating the QOS: the queue is durable
+    /// and the caches are not, so a restarted controller inherits its predecessor's
+    /// pending jobs before its first fetch completes.
+    fn accounting_block(&self, job: &Job) -> Option<PendingReason> {
+        if !self.config().accounting.enabled() {
+            return None;
+        }
+
+        if let Some(name) = job.spec.qos.as_deref().filter(|n| !n.is_empty()) {
+            if !self.qos_cache.is_loaded() {
+                return Some(PendingReason::AccountingUnavailable);
+            }
+            // Loaded and still absent means the QOS was removed after the job
+            // queued, which Slurm reports the same way.
+            if self.qos_cache.get(name).is_none() {
+                return Some(PendingReason::InvalidQOS);
+            }
+        }
+
+        let has_account = job.spec.account.as_deref().is_some_and(|a| !a.is_empty());
+        if has_account && !self.association_cache.is_loaded() {
+            return Some(PendingReason::AccountingUnavailable);
+        }
+
+        None
     }
 
     /// Submit-time limit gate (Slurm's `acct_policy_validate`). Submit-count
@@ -17475,6 +17515,156 @@ mod tests {
             granted, 2,
             "pending_jobs() returned {granted} jobs but max_jobs_per_user=2 allows 2"
         );
+    }
+
+    /// A cluster with accounting configured, ready to be given a cold cache.
+    async fn accounting_cluster(dir: &TempDir) -> Arc<ClusterManager> {
+        let mut cfg = test_config();
+        cfg.accounting.database_url = "postgres://unused-in-test".into();
+        test_cluster_with_config(dir, cfg).await
+    }
+
+    /// Three jobs from one user under a QOS capped at two, returned in submit order.
+    fn submit_three_under_capped_qos(cm: &ClusterManager) -> Vec<JobId> {
+        cm.qos_cache().insert(Qos {
+            name: "cnt".into(),
+            limits: spur_core::accounting::QosLimits {
+                max_jobs_per_user: Some(2),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        (0..3)
+            .map(|i| {
+                let mut s = basic_spec(&format!("c{i}"));
+                s.qos = Some("cnt".into());
+                submit_and_wait(cm, s)
+            })
+            .collect()
+    }
+
+    fn admitted_of(cm: &ClusterManager, ids: &[JobId]) -> usize {
+        let pending: Vec<JobId> = cm.pending_jobs().iter().map(|j| j.job_id).collect();
+        ids.iter().filter(|id| pending.contains(id)).count()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_jobs_keeps_qos_limits_across_a_controller_restart() {
+        // Submit accepts a `--qos` only while the cache knows the name, so a queued
+        // job always carries a real QOS. A restarting controller starts with an
+        // empty cache and its predecessor's queue already durable, and that queue
+        // must not be admitted past the QOS's caps just because the limits are not
+        // readable yet.
+        let dir = TempDir::new().unwrap();
+        let cm = accounting_cluster(&dir).await;
+        register_node(&cm, "n1", 64, 128000);
+        let ids = submit_three_under_capped_qos(&cm);
+
+        cm.qos_cache().reset();
+
+        let granted = admitted_of(&cm, &ids);
+        assert_eq!(
+            granted, 0,
+            "pending_jobs() admitted {granted} of 3 jobs under max_jobs_per_user=2 \
+             while the QOS cache was unreadable"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_jobs_reports_a_cold_cache_as_the_hold_reason() {
+        // The hold has to be legible: an operator seeing these jobs pend needs the
+        // cold cache named, not a generic Resources or Priority wait.
+        let dir = TempDir::new().unwrap();
+        let cm = accounting_cluster(&dir).await;
+        register_node(&cm, "n1", 64, 128000);
+        let ids = submit_three_under_capped_qos(&cm);
+
+        cm.qos_cache().reset();
+        cm.refresh_pending_reasons();
+
+        assert_eq!(
+            cm.get_job(ids[0]).unwrap().pending_reason,
+            PendingReason::AccountingUnavailable
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_jobs_holds_a_job_whose_qos_was_deleted() {
+        // A loaded cache that does not know the name is a QOS removed after the job
+        // queued, not an unreadable one — the same limitless-default hazard, and the
+        // case Slurm reports as InvalidQOS.
+        let dir = TempDir::new().unwrap();
+        let cm = accounting_cluster(&dir).await;
+        register_node(&cm, "n1", 64, 128000);
+        let ids = submit_three_under_capped_qos(&cm);
+
+        // A later refresh that no longer carries "cnt": loaded, but without it.
+        cm.qos_cache().reset();
+        cm.qos_cache().insert(Qos {
+            name: "other".into(),
+            ..Default::default()
+        });
+        cm.refresh_pending_reasons();
+
+        assert_eq!(admitted_of(&cm, &ids), 0);
+        assert_eq!(
+            cm.get_job(ids[0]).unwrap().pending_reason,
+            PendingReason::InvalidQOS
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_jobs_holds_account_jobs_while_the_association_cache_is_cold() {
+        // The association cache carries the same caps one layer up and starts just
+        // as empty, so an account-scoped job gets the same hold.
+        let dir = TempDir::new().unwrap();
+        let cm = accounting_cluster(&dir).await;
+        register_node(&cm, "n1", 64, 128000);
+        let mut spec = basic_spec("acct");
+        spec.account = Some("tenant-a".into());
+        // Submit has its own cold-cache gate, so the association is seeded to get
+        // the job queued; the scheduling pass then faces a cache that went cold.
+        cm.association_cache()
+            .insert_association(&spec.user, "tenant-a");
+        let id = submit_and_wait(&cm, spec);
+        cm.association_cache().reset();
+
+        assert_eq!(admitted_of(&cm, &[id]), 0);
+        cm.refresh_pending_reasons();
+        assert_eq!(
+            cm.get_job(id).unwrap().pending_reason,
+            PendingReason::AccountingUnavailable
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_jobs_admits_freely_when_accounting_is_disabled() {
+        // Without accounting there are no limits to read, so an empty cache means
+        // "no caps exist" rather than "caps are unreadable" and must not hold work.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 64, 128000);
+        let ids = submit_three_under_capped_qos(&cm);
+
+        cm.qos_cache().reset();
+
+        assert_eq!(
+            admitted_of(&cm, &ids),
+            3,
+            "a cold cache must not gate scheduling on a cluster that runs no accounting"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_jobs_still_enforces_the_cap_once_the_cache_is_warm() {
+        // The guard must not swallow the limit it protects: with the cache loaded
+        // the cap applies exactly as before.
+        let dir = TempDir::new().unwrap();
+        let cm = accounting_cluster(&dir).await;
+        register_node(&cm, "n1", 64, 128000);
+        let ids = submit_three_under_capped_qos(&cm);
+
+        assert_eq!(admitted_of(&cm, &ids), 2);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4804,6 +4804,22 @@ impl ClusterManager {
         }
     }
 
+    /// Whether QOS limits can be *read* right now: either accounting is off (no
+    /// caps exist to read) or the QOS cache has loaded at least one snapshot.
+    /// This is the canonical per-cache verdict `accounting_block` gates on; it
+    /// is exposed so operator-facing surfaces report the same thing rather than
+    /// re-deriving a weaker `loaded`-only check that misreports both the
+    /// accounting-disabled case (no caps) and a split cache (one cache warm).
+    pub(crate) fn qos_limits_readable(&self) -> bool {
+        !self.config().accounting.enabled() || self.qos_cache.is_loaded()
+    }
+
+    /// Whether association limits can be read right now; the association-cache
+    /// counterpart of [`qos_limits_readable`](Self::qos_limits_readable).
+    pub(crate) fn association_limits_readable(&self) -> bool {
+        !self.config().accounting.enabled() || self.association_cache.is_loaded()
+    }
+
     /// Holds a candidate whose accounting limits cannot be read. Admission is the
     /// last point at which a cap can still be applied — a running job is never
     /// re-checked — so a cold cache pends the job rather than gating it against a
@@ -4814,7 +4830,7 @@ impl ClusterManager {
         }
 
         if let Some(name) = job.spec.qos.as_deref().filter(|n| !n.is_empty()) {
-            if !self.qos_cache.is_loaded() {
+            if !self.qos_limits_readable() {
                 return Some(PendingReason::AccountingUnavailable);
             }
             // Loaded and still absent means the QOS was removed after the job
@@ -4825,7 +4841,7 @@ impl ClusterManager {
         }
 
         let has_account = job.spec.account.as_deref().is_some_and(|a| !a.is_empty());
-        if has_account && !self.association_cache.is_loaded() {
+        if has_account && !self.association_limits_readable() {
             return Some(PendingReason::AccountingUnavailable);
         }
 
@@ -17696,6 +17712,80 @@ mod tests {
         let ids = submit_three_under_capped_qos(&cm);
 
         assert_eq!(admitted_of(&cm, &ids), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cold_cache_hold_clears_once_the_qos_cache_reloads() {
+        // The fail-closed hold must be self-clearing. A controller that boots
+        // with the database down keeps the cache cold and holds every job; once
+        // the background bring-up connects and a refresh lands, the same
+        // scheduling pass that held these jobs must admit them — no operator
+        // release. This mirrors that transition at the cache boundary the
+        // scheduler reads.
+        let dir = TempDir::new().unwrap();
+        let cm = accounting_cluster(&dir).await;
+        register_node(&cm, "n1", 64, 128000);
+        let ids = submit_three_under_capped_qos(&cm);
+
+        cm.qos_cache().reset();
+        assert_eq!(admitted_of(&cm, &ids), 0, "a cold cache holds every job");
+        cm.refresh_pending_reasons();
+        assert_eq!(
+            cm.get_job(ids[0]).unwrap().pending_reason,
+            PendingReason::AccountingUnavailable
+        );
+
+        cm.qos_cache().insert(Qos {
+            name: "cnt".into(),
+            limits: spur_core::accounting::QosLimits {
+                max_jobs_per_user: Some(2),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(
+            admitted_of(&cm, &ids),
+            2,
+            "once the cache reloads the hold clears and the cap applies"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn limits_readable_tracks_enabled_and_per_cache_state() {
+        // The canonical "can limits be read?" verdict is per cache: a cold cache
+        // on an accounting cluster is unreadable, and a warm QOS cache does not
+        // make the still-cold association cache readable. This split is exactly
+        // what a conjoined loaded-only check gets wrong.
+        let dir = TempDir::new().unwrap();
+        let cm = accounting_cluster(&dir).await;
+        assert!(!cm.qos_limits_readable());
+        assert!(!cm.association_limits_readable());
+
+        cm.qos_cache().insert(Qos {
+            name: "any".into(),
+            ..Default::default()
+        });
+        assert!(cm.qos_limits_readable());
+        assert!(
+            !cm.association_limits_readable(),
+            "a warm QOS cache must not vouch for a cold association cache"
+        );
+
+        cm.association_cache()
+            .insert_association("alice", "research");
+        assert!(cm.association_limits_readable());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn limits_readable_is_true_when_accounting_is_disabled() {
+        // With no database there are no caps to read, so both caches read as
+        // "readable" even cold — the accounting-disabled case a loaded-only
+        // check misreports as "unreadable" forever.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        assert!(cm.qos_limits_readable());
+        assert!(cm.association_limits_readable());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -59,6 +59,16 @@ impl QosCache {
         snap.loaded = true;
     }
 
+    /// Test-only seam: returns the cache to its pre-first-fetch state, as a
+    /// freshly started controller sees it while jobs submitted by its
+    /// predecessor are already queued.
+    #[cfg(test)]
+    pub(crate) fn reset(&self) {
+        let mut snap = self.snapshot.write();
+        snap.qos.clear();
+        snap.loaded = false;
+    }
+
     pub fn spawn_refresh_loop(self: &Arc<Self>, pool: PgPool, refresh_interval_secs: u64) {
         let cache = Arc::clone(self);
         let interval = Duration::from_secs(refresh_interval_secs.max(10));

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -187,82 +187,12 @@ async fn main() -> anyhow::Result<()> {
     cluster.set_sched_stats(sched_stats.clone());
 
     // Accounting stays best-effort so a database outage does not stop scheduling.
-    let accounting_service = if config.accounting.database_url.is_empty() {
-        info!("accounting disabled (database_url not configured)");
-        None
-    } else {
-        match sqlx::postgres::PgPoolOptions::new()
-            .max_connections(8)
-            .acquire_timeout(std::time::Duration::from_secs(5))
-            .connect(&config.accounting.database_url)
-            .await
-        {
-            Ok(pool) => {
-                if let Err(e) = accounting::db::migrate(&pool).await {
-                    tracing::error!(
-                        error = %e,
-                        "accounting migration failed; accounting service will report unavailable"
-                    );
-                    Some(accounting::AccountingService::unavailable(
-                        "database migration failed at startup",
-                    ))
-                } else {
-                    info!("accounting database connected");
-                    let notifier = accounting::AccountingNotifier::new(pool.clone());
-                    cluster.set_accounting(notifier);
-
-                    accounting::spawn_reconcile_loop(
-                        pool.clone(),
-                        cluster.clone(),
-                        raft_handle.clone(),
-                        std::time::Duration::from_secs(accounting::RECONCILE_INTERVAL_SECS),
-                    );
-
-                    if let Some(days) = config.accounting.txn_retention_days.filter(|d| *d > 0) {
-                        accounting::spawn_txn_purge_loop(
-                            pool.clone(),
-                            raft_handle.clone(),
-                            days,
-                            std::time::Duration::from_secs(3600),
-                        );
-                    }
-
-                    cluster.fairshare_cache().spawn_refresh_loop(
-                        pool.clone(),
-                        config.scheduler.fairshare_halflife_days,
-                        config.accounting.fairshare_refresh_secs as u64,
-                    );
-
-                    cluster.qos_cache().spawn_refresh_loop(
-                        pool.clone(),
-                        config.accounting.fairshare_refresh_secs as u64,
-                    );
-
-                    cluster.association_cache().spawn_refresh_loop(
-                        pool.clone(),
-                        config.accounting.fairshare_refresh_secs as u64,
-                    );
-
-                    cluster.grp_wall_cache().spawn_refresh_loop(
-                        pool.clone(),
-                        config.accounting.fairshare_refresh_secs as u64,
-                        config.accounting.grp_wall_window_days,
-                    );
-
-                    Some(accounting::AccountingService::available(pool))
-                }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "failed to connect to accounting database; accounting service will report unavailable"
-                );
-                Some(accounting::AccountingService::unavailable(
-                    "database connection failed at startup",
-                ))
-            }
-        }
-    };
+    // The connect, migration, notifier, and refresh loops are brought up in a
+    // background task that retries until the database is reachable, so a
+    // controller that boots with the database down converges on its own — its
+    // caches load once the database returns and the fail-closed hold on
+    // QOS/account jobs clears without operator action.
+    let accounting_service = accounting::start(&config, cluster.clone(), raft_handle.clone());
 
     // Start scheduler loop (only schedules when this node is Raft leader)
     let sched_cluster = cluster.clone();

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -610,6 +610,34 @@ applied over it.
    an existing job, set its limit directly with
    ``scontrol update job <id> TimeLimit=<time>``.
 
+.. _limits-unreadable:
+
+When limits cannot be read
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Limits are served from caches that ``spurctld`` refreshes from the accounting
+database, and a freshly started controller has none until its first fetch
+completes. The job queue, by contrast, is durable — a controller that restarts or
+takes over as leader inherits its predecessor's pending jobs immediately.
+
+While accounting is enabled and a cache holds no snapshot, jobs that name a QOS
+or an account are **not scheduled**. They pend with reason
+``AccountingUnavailable`` and start normally once the cache loads. The
+alternative is worse: a running job is never re-checked against limits, so a job
+admitted during that window stays over the cap for its entire run.
+
+Two related cases:
+
+- A job whose QOS no longer exists — deleted or renamed while the job sat in the
+  queue — pends with ``InvalidQOS``, as in Slurm.
+- With accounting disabled (an empty ``database_url``) there are no limits to
+  read, so an empty cache means "no caps exist" and nothing is held.
+
+``AccountingUnavailable`` has no Slurm counterpart, because Slurm keeps its
+association state on disk and declines to schedule without it rather than
+reaching this state. Jobs pending with it point at one thing: ``spurctld`` cannot
+reach the accounting database. The controller log carries the fetch failure.
+
 .. _grpwall-budgets:
 
 Group wall-clock budgets (GrpWall)

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -622,9 +622,21 @@ takes over as leader inherits its predecessor's pending jobs immediately.
 
 While accounting is enabled and a cache holds no snapshot, jobs that name a QOS
 or an account are **not scheduled**. They pend with reason
-``AccountingUnavailable`` and start normally once the cache loads. The
+``AccountingUnavailable`` and start on their own once the cache loads. The
 alternative is worse: a running job is never re-checked against limits, so a job
 admitted during that window stays over the cap for its entire run.
+
+The hold is **self-clearing**, including on a cold start. If the accounting
+database is unreachable when ``spurctld`` starts, the controller does not give
+up: it retries the connection in the background with backoff and, once the
+database returns, connects, migrates, and starts the cache-refresh loops. The
+next scheduling pass then reads a loaded cache and admits the held jobs. No
+operator action is needed — there is deliberately no manual override, because
+``AccountingUnavailable`` is not an administrative hold (``scontrol release``
+does not apply to it) and clearing it by hand would admit jobs against the very
+limits that could not be read. The only operator lever is the configuration
+itself: fix ``database_url`` (or clear it to disable accounting) and the hold
+resolves accordingly.
 
 Related cases:
 

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -626,12 +626,16 @@ or an account are **not scheduled**. They pend with reason
 alternative is worse: a running job is never re-checked against limits, so a job
 admitted during that window stays over the cap for its entire run.
 
-Two related cases:
+Related cases:
 
 - A job whose QOS no longer exists — deleted or renamed while the job sat in the
   queue — pends with ``InvalidQOS``, as in Slurm.
 - With accounting disabled (an empty ``database_url``) there are no limits to
   read, so an empty cache means "no caps exist" and nothing is held.
+- The hold covers QOS and association limits. Consumption figures for
+  :ref:`grpwall-budgets` load separately, and a ``grpwall`` cap is unapplied
+  until the first figure is read — so do not assume every accounting limit fails
+  closed on restart.
 
 ``AccountingUnavailable`` has no Slurm counterpart, because Slurm keeps its
 association state on disk and declines to schedule without it rather than

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -635,8 +635,8 @@ operator action is needed — there is deliberately no manual override, because
 ``AccountingUnavailable`` is not an administrative hold (``scontrol release``
 does not apply to it) and clearing it by hand would admit jobs against the very
 limits that could not be read. The only operator lever is the configuration
-itself: fix ``database_url`` (or clear it to disable accounting) and the hold
-resolves accordingly.
+itself: fix ``database_url`` so the retry succeeds, or clear it to disable
+accounting — the latter is read at startup, so it takes a controller restart.
 
 Related cases:
 

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -334,7 +334,8 @@ in-process inside ``spurctld`` (served on port 6817) — there is no separate
      - Restart
      - PostgreSQL connection string. A non-empty value enables accounting; empty
        disables it entirely. Example: ``"postgresql://spur:spur@localhost/spur"``.
-       The connection pool is built at startup.
+       The controller connects in the background and retries with backoff, so an
+       unreachable database at startup does not stop it from connecting later.
    * - ``fairshare_refresh_secs``
      - integer
      - ``300``

--- a/docs/deployment/upgrading.rst
+++ b/docs/deployment/upgrading.rst
@@ -248,6 +248,11 @@ Follow this order for any cluster upgrade:
    controller is not supported** — an older controller reads the widened columns as
    32-bit and its accounting queries fail against a migrated database. Take a database
    backup before upgrading if you need a recovery path.
+7. **Roll forward, not back.** The Raft log gains entries — new job states, pending
+   reasons, operations — as Spur evolves, and a controller replaying a log written by a
+   newer build cannot parse them. A newer controller reads older logs fine, so the
+   supported recovery from a bad upgrade is to roll forward, not to reinstall the
+   previous version over a log the new one has already written.
 
 Behavior Changes Between Releases
 ---------------------------------


### PR DESCRIPTION
Fixes #745

## What this fixes

The scheduling gate resolved a job's QOS through the controller's QOS cache and fell back to a **limitless** default whenever the cache could not produce the name:

```rust
Some(name) => self.qos_cache.get(name).unwrap_or_default(),
```

A job carrying a QOS the cache does not hold was therefore gated against no limits at all, and since a running job is never re-checked, it stayed over the cap for its whole run. The association path had the same shape — account limits come from a cache that also starts empty.

Submit-time validation does not close this. It rejects an unknown `--qos` and already fails closed on a cold association cache, but the queue is durable while the caches are not: a controller that restarts or takes over as leader inherits its predecessor's pending jobs and starts scheduling before its first accounting fetch completes. Every pass in that window admitted them unmetered. If the accounting database is unreachable, the window lasts as long as the outage.

## Approach

One `retain_unblocked` pass, `accounting_block`, runs immediately before the existing QOS and account limit gates. When accounting is enabled and a cache holds no snapshot, a job naming a QOS or an account pends with a new `AccountingUnavailable` reason instead of being admitted. A QOS the loaded cache does not know — deleted or renamed after the job queued — pends with `InvalidQOS`, as in Slurm.

`qos_block_with` and `account_block_with` are untouched, so nothing that already enforced correctly changed shape. `resolve_qos` keeps its limitless fallback: its remaining callers compare priority and preempt mode, where a missing QOS costs nothing, and the constraint is now documented on the function.

## The hold is self-clearing, including on a cold start

A fail-closed hold is only acceptable if it recovers on its own. Previously the accounting connect, the notifier, the reconcile/purge loops, and the four cache-refresh loops all sat on the connect-success arm in `main.rs`; the connect-error and migration-error arms spawned nothing and never retried. So a controller that booted while the database was down had `enabled() == true` and `is_loaded() == false` permanently, holding every inherited QOS/account job for the life of the process.

Accounting bring-up now lives in `accounting::start`, which spawns a background task that retries connect + migrate with capped backoff and, on the first success, calls `activate` to install the pool and spawn every loop. `main.rs` is a single flat call. Once the database returns, the caches load and the next scheduling pass admits the held jobs — no operator action. The gRPC `AccountingService` was made recoverable through a shared, swappable pool slot, so `sacct`/`sacctmgr` also come back after a cold-start outage, not just scheduling.

There is deliberately **no manual override**. `AccountingUnavailable` is not added to `is_scheduling_hold()` and there is no opt-out knob: `scontrol release` clearing it would admit jobs against the very limits that could not be read, which is the hazard the hold exists to prevent. The only operator lever is the config — fix `database_url`, or clear it to disable accounting — and both resolve the hold correctly.

## The "can limits be read?" predicate

`accounting_block` is the canonical definition of whether a cache's limits are readable. It is now exposed as two `pub(crate)` helpers on `ClusterManager`, each returning the per-cache `!enabled() || is_loaded()` verdict, and `accounting_block` consumes them:

```rust
pub(crate) fn qos_limits_readable(&self) -> bool {
    !self.config().accounting.enabled() || self.qos_cache.is_loaded()
}
pub(crate) fn association_limits_readable(&self) -> bool {
    !self.config().accounting.enabled() || self.association_cache.is_loaded()
}
```

This lets a limits-readable operator banner (see #746) adopt the same verdict instead of re-deriving a weaker `qos_loaded && assoc_loaded`, which misreports both the accounting-disabled case (no caps exist) and a split cache (one warm, one cold).

## Design choices

- **Fail closed, matching the submit gate.** Admission is the last point at which a cap can still be applied. The trade-off is bounded now that the hold self-clears: with the database unreachable at start, QOS/account jobs pend *until the database returns*, then start on their own. Slurm reaches the pend-not-start outcome by different means — it keeps association state on disk and declines to schedule without it.
- **Accounting-disabled clusters are unaffected.** With an empty `database_url` there are no limits to read, so an empty cache means "no caps exist" rather than "caps are unreadable". A guard test pins this, since getting it wrong would stall every account-scoped job on clusters that run no accounting.
- **`AccountingUnavailable` has no Slurm counterpart**, because Slurm never schedules in this state. Reusing `InvalidQOS` for it would have been misleading: the QOS is fine, it just cannot be read.

## Upgrade note

`PendingReason` travels inside `WalOperation`, so the new variant reaches the Raft log. A new controller replaying an old log is fine; an **old** controller replaying an entry that contains `AccountingUnavailable` would fail to deserialize, so this is forward-only and would bite on a rollback or in a mixed-version HA cluster. This follows the additive pattern the enum already took for the Slurm reason-code parity batch (`Preempted` in #700, `QosGrpWallLimit` in #675) rather than setting a new one.

## Follow-ups

Operators still cannot see per-user usage against a QOS's caps without inferring it from `squeue`; a read-only `scontrol show assoc_mgr` view is the natural next step and is left out of here deliberately. Separately, an association whose `(user, account)` pair is absent from a loaded cache still reads as limitless — the association twin of the `InvalidQOS` case, not addressed here because telling "no limits set" from "no such association" needs more than the current cache API exposes.

## Testing

Through the real scheduling pass and the real bring-up seams:

- the reproduction — three jobs under `maxjobsperuser=2` with a cold cache admit **zero**, where they previously all started;
- the hold reports `AccountingUnavailable` through `tag_blocked_pending_reasons`;
- a deleted QOS reports `InvalidQOS`;
- the association twin holds the same way;
- an accounting-disabled cluster still admits all three on a cold cache;
- a warm cache still enforces the cap at exactly two;
- **self-clearing** — a held job is admitted (under its cap) once the QOS cache reloads;
- the per-cache readable predicate across enabled/disabled and split-cache states;
- `AccountingService` flips from unavailable to serving once the bring-up installs the pool, observed through a clone's shared slot, and reports the latest failure reason while retrying.

`cargo test --locked` (full workspace, plus the ignored PostgreSQL-backed suite), `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` warning-free, `cargo fmt --all` clean. Docs: the "When limits cannot be read" subsection now describes the self-clearing behaviour and the absence of a manual override.
