### PR TITLE
test: resolve flake8 lint violations in pytest e2e suite

### DIFF
--- a/tests/.flake8
+++ b/tests/.flake8
@@ -1,5 +1,0 @@
-# Line width matches the repo's existing style (not PEP 8's 79), so lint
-# noise tracks real problems instead of every moderately long assert/f-string.
-[flake8]
-max-line-length = 120
-exclude = __pycache__,manifests

--- a/tests/.flake8
+++ b/tests/.flake8
@@ -1,0 +1,5 @@
+# Line width matches the repo's existing style (not PEP 8's 79), so lint
+# noise tracks real problems instead of every moderately long assert/f-string.
+[flake8]
+max-line-length = 120
+exclude = __pycache__,manifests

--- a/tests/k8s/e2e/test_spurjob.py
+++ b/tests/k8s/e2e/test_spurjob.py
@@ -42,7 +42,7 @@ class TestSpurJobLifecycle:
         assert "custom=spur-ci-test" in logs, f"expected CUSTOM_VAR in logs:\n{logs}"
         job_idx = logs.find("job=")
         assert job_idx >= 0, f"expected SPUR_JOB_ID in logs:\n{logs}"
-        job_val = logs[job_idx + 4 :].split()[0] if logs[job_idx + 4 :] else ""
+        job_val = logs[job_idx + 4:].split()[0] if logs[job_idx + 4:] else ""
         assert job_val, f"expected non-empty SPUR_JOB_ID in logs:\n{logs}"
 
     def test_multinode_job_assigns_nodes(self, cluster):

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -8,7 +8,6 @@ See docs/developer/building.rst for full environment variable reference.
 """
 
 import os
-import time
 from pathlib import Path
 
 import pytest

--- a/tests/native_host/e2e/fixtures/distributed_test.py
+++ b/tests/native_host/e2e/fixtures/distributed_test.py
@@ -106,7 +106,7 @@ def main():
     hostname = socket.gethostname()
     num_gpus = torch.cuda.device_count()
 
-    print(f"=== Spur Distributed PyTorch Test ===")
+    print("=== Spur Distributed PyTorch Test ===")
     print(f"Host: {hostname} | Job: {env['job_id']} | Node rank: {env['node_rank']}/{env['num_nodes']}")
     print(f"Task offset: {env['task_offset']} | Peers: {env['peer_nodes']}")
     print(f"PyTorch: {torch.__version__} | HIP: {torch.version.hip}")

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -60,7 +60,7 @@ class TestSacctmgrShowQos:
     def test_default_output_shows_tres_columns(self, accounting_cluster):
         c = accounting_cluster
         c.sacctmgr(["add", "qos", "name=nodeqos", "priority=50",
-                     "grptres=node=4,cpu=16", "maxtresperjob=node=2"])
+                    "grptres=node=4,cpu=16", "maxtresperjob=node=2"])
         time.sleep(15)
         out = c.sacctmgr(["show", "qos"])
         assert "nodeqos" in out
@@ -70,14 +70,14 @@ class TestSacctmgrShowQos:
     def test_format_selects_specific_fields(self, accounting_cluster):
         c = accounting_cluster
         c.sacctmgr(["add", "qos", "name=fmtqos", "priority=10",
-                     "grptres=cpu=32", "maxtresperjob=cpu=8"])
+                    "grptres=cpu=32", "maxtresperjob=cpu=8"])
         time.sleep(15)
         out = c.sacctmgr(["show", "qos", "format=Name,GrpTRES,MaxTRES"])
         assert "fmtqos" in out
         assert "cpu=32" in out, f"GrpTRES missing: {out!r}"
         assert "cpu=8" in out, f"MaxTRES missing: {out!r}"
         # Priority should NOT appear since it was not in the format list.
-        lines = [l for l in out.splitlines() if "fmtqos" in l]
+        lines = [line for line in out.splitlines() if "fmtqos" in line]
         assert lines, f"no fmtqos row in output: {out!r}"
         assert "Priority" not in out.splitlines()[0], (
             f"Priority column should not appear: {out!r}")
@@ -141,7 +141,7 @@ class TestSacctmgrShowAccount:
     def test_default_output_shows_legacy_columns(self, accounting_cluster):
         c = accounting_cluster
         c.sacctmgr(["add", "account", "name=physics", "description=Physics",
-                     "organization=sciences", "grptres=cpu=16"])
+                    "organization=sciences", "grptres=cpu=16"])
         out = c.sacctmgr(["show", "account"])
         header = next(line for line in out.splitlines() if line.strip())
         for column in ("Account", "Descr", "Org", "Parent", "Share", "GrpTRES"):
@@ -151,7 +151,7 @@ class TestSacctmgrShowAccount:
     def test_format_selects_specific_fields(self, accounting_cluster):
         c = accounting_cluster
         c.sacctmgr(["add", "account", "name=fmtacct", "description=Formatted",
-                     "grptres=cpu=32"])
+                    "grptres=cpu=32"])
         out = c.sacctmgr(["show", "account", "format=Account,GrpTRES"])
         assert "fmtacct" in out
         assert "cpu=32" in out, f"GrpTRES missing: {out!r}"

--- a/tests/native_host/e2e/test_burst_qos.py
+++ b/tests/native_host/e2e/test_burst_qos.py
@@ -28,11 +28,11 @@ import pytest
 from cluster import job_state, parse_job_id, wait_job, wait_job_state
 
 _SLEEP_SCRIPT = "#!/bin/bash\nsleep 600\n"
-_QUICK_SCRIPT  = "#!/bin/bash\nsleep 5\n"
+_QUICK_SCRIPT = "#!/bin/bash\nsleep 5\n"
 
 _WAIT_PREEMPT = 60
-_WAIT_RESUME  = 90
-_GUARD_SECS   = 12
+_WAIT_RESUME = 90
+_GUARD_SECS = 12
 
 # Every cluster in this file uses the same base config:
 # preempt_type=qos_priority so the QoS allow-list is enforced, and

--- a/tests/native_host/e2e/test_container.py
+++ b/tests/native_host/e2e/test_container.py
@@ -257,8 +257,8 @@ class TestContainerMultiNode:
         assert "RANK=0" in all_output, f"missing RANK=0:\n{all_output}"
         assert "RANK=1" in all_output, f"missing RANK=1:\n{all_output}"
         assert any(
-            l.startswith("MASTER_ADDR=") and l != "MASTER_ADDR="
-            for l in all_output.splitlines()
+            line.startswith("MASTER_ADDR=") and line != "MASTER_ADDR="
+            for line in all_output.splitlines()
         ), f"MASTER_ADDR should be non-empty:\n{all_output}"
 
     def test_two_node_container_dns(self, multi_container_cluster):

--- a/tests/native_host/e2e/test_deregistration.py
+++ b/tests/native_host/e2e/test_deregistration.py
@@ -12,7 +12,7 @@ import time
 
 import pytest
 
-from cluster import parse_job_id, job_state, SpurCluster
+from cluster import parse_job_id, job_state
 
 
 def _wait_job_terminal(cluster, job_id, timeout=120):
@@ -88,7 +88,6 @@ class TestDrainAndRemove:
     def test_drain_and_remove(self, multi_node_cluster):
         cluster = multi_node_cluster
         node0 = cluster.node_names[0]
-        node1 = cluster.node_names[1]
 
         cluster.cli(["spur", "node", "drain", node0, "--reason", "maintenance"])
         _wait_node_state(cluster, node0, ["drain"])

--- a/tests/native_host/e2e/test_devices.py
+++ b/tests/native_host/e2e/test_devices.py
@@ -107,7 +107,6 @@ def _render_video_user(cluster: SpurCluster) -> str | None:
     return both[0] if both else None
 
 
-
 class TestCdiAutoDetect:
     def test_autodetect_and_metadata(self, gpu_cluster):
         cluster = gpu_cluster
@@ -133,7 +132,6 @@ class TestCdiAutoDetect:
         cluster.assert_spurd_registry(0, min_gpus=before)
         after = cluster.spurd_registry_gpu_count(0)
         assert after == before, f"GPU count changed after restart: {before} -> {after}"
-
 
 
 class TestGresScheduling:
@@ -223,7 +221,6 @@ class TestGresScheduling:
 
         _, _, content2 = _submit_probe(cluster, probe, f"gpu:{n}", job_name="gres-rel-2")
         assert "PROBE_OK" in content2
-
 
 
 class TestNativeInjection:
@@ -331,7 +328,6 @@ echo "SPUR_JOB_GPUS=$SPUR_JOB_GPUS" > '{rd}/hook-out/prolog-gpu.log'
         assert "SPUR_JOB_GPUS=" in hook_log, hook_log
         spur_gpus = hook_log.strip().split("=", 1)[1]
         assert len(spur_gpus.split(",")) == 2, hook_log
-
 
 
 class TestConcurrentAllocation:
@@ -447,7 +443,6 @@ class TestConcurrentAllocation:
         cluster.scancel(str(id_c))
 
 
-
 @pytest.fixture
 def gpu_container_cluster(gpu_cluster, tmp_path):
     cluster = gpu_cluster
@@ -490,8 +485,6 @@ class TestContainerInjection:
         assert parsed.get("RENDER_COUNT") == "2", (
             f"expected RENDER_COUNT=2 in container\n{content}"
         )
-
-
 
 
 class TestMultiNodeSpread:
@@ -569,7 +562,6 @@ class TestMultiNodeSpread:
         wait_job(cluster, job_id, timeout=300)
         content = cluster.read_output_all_nodes(out_path)
         assert content.count("PROBE_OK") >= 4, content
-
 
 
 # Every case asserts a real GPU device registry but uses the generic

--- a/tests/native_host/e2e/test_multi_node.py
+++ b/tests/native_host/e2e/test_multi_node.py
@@ -57,8 +57,8 @@ class TestMultiNodeDispatch:
         assert "SLURM_NNODES=2" in all_output, f"missing SLURM_NNODES=2:\n{all_output}"
         assert "SPUR_NODE_RANK=" in all_output, f"missing SPUR_NODE_RANK:\n{all_output}"
         assert any(
-            l.startswith("SPUR_PEER_NODES=") and len(l) > len("SPUR_PEER_NODES=")
-            for l in all_output.splitlines()
+            line.startswith("SPUR_PEER_NODES=") and len(line) > len("SPUR_PEER_NODES=")
+            for line in all_output.splitlines()
         ), f"SPUR_PEER_NODES should be non-empty:\n{all_output}"
         # SLURM twins for prefixed vars
         assert "SLURM_JOB_ID=" in all_output, f"missing SLURM_JOB_ID:\n{all_output}"
@@ -86,8 +86,8 @@ class TestMultiNodeDispatch:
         assert "RANK=1" in all_output
         assert "MASTER_PORT=29500" in all_output
         master_addr_lines = [
-            l for l in all_output.splitlines()
-            if l.startswith("MASTER_ADDR=") and l != "MASTER_ADDR="
+            line for line in all_output.splitlines()
+            if line.startswith("MASTER_ADDR=") and line != "MASTER_ADDR="
         ]
         assert len(master_addr_lines) >= 2, (
             f"MASTER_ADDR should be set on both ranks:\n{all_output}"

--- a/tests/native_host/e2e/test_partitions.py
+++ b/tests/native_host/e2e/test_partitions.py
@@ -868,7 +868,6 @@ class TestSlurmsyntax:
         """Full lifecycle using only Slurm-compatible scontrol syntax."""
         name = _unique("slurm-rt")
         nodes_list = ",".join(cluster.node_names)
-        node = cluster.node_names[0]
 
         # Create
         cluster.scontrol(

--- a/tests/native_host/e2e/test_preemption.py
+++ b/tests/native_host/e2e/test_preemption.py
@@ -10,8 +10,6 @@ separately from failure requeues (dispatch failure/Timeout/NodeFail) and are
 never checked against `max_batch_requeue`.
 """
 
-import time
-
 import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state

--- a/tests/native_host/e2e/test_preemption_modes.py
+++ b/tests/native_host/e2e/test_preemption_modes.py
@@ -33,9 +33,9 @@ from cluster import job_state, parse_job_id, wait_job, wait_job_state
 _SLEEP_SCRIPT = "#!/bin/bash\nsleep 600\n"
 _QUICK_SCRIPT = "#!/bin/bash\nsleep 5\n"
 
-_WAIT_PREEMPT = 30   # seconds to wait for preemption to fire
-_WAIT_RESUME  = 60   # seconds to wait for a suspended/requeued job to come back up
-_GUARD_SECS   = 10   # seconds to hold before asserting "nothing happened"
+_WAIT_PREEMPT = 30  # seconds to wait for preemption to fire
+_WAIT_RESUME = 60  # seconds to wait for a suspended/requeued job to come back up
+_GUARD_SECS = 10  # seconds to hold before asserting "nothing happened"
 
 _PARTITION = {
     "name": "default",

--- a/tests/native_host/e2e/test_preemption_multinode.py
+++ b/tests/native_host/e2e/test_preemption_multinode.py
@@ -26,7 +26,7 @@ _SLEEP_SCRIPT = "#!/bin/bash\nsleep 600\n"
 _QUICK_SCRIPT = "#!/bin/bash\nsleep 5\n"
 
 _WAIT_PREEMPT = 30
-_WAIT_RUN     = 60
+_WAIT_RUN = 60
 
 
 # Required when the test runner SSHes in as root: spurd refuses to execute jobs

--- a/tests/native_host/e2e/test_srun_multi_node.py
+++ b/tests/native_host/e2e/test_srun_multi_node.py
@@ -7,7 +7,7 @@ import re
 import shlex
 import time
 
-from cluster import job_state, parse_job_id, wait_job, wait_job_state
+from cluster import parse_job_id, wait_job, wait_job_state
 
 
 class TestStandaloneSrun:


### PR DESCRIPTION
## Summary
- Fixes all substantive flake8 findings in `tests/native_host/e2e` and `tests/k8s/e2e` (unused imports, unused locals, ambiguous `l` names, blank-line count, alignment whitespace, an f-string with no placeholders, and a slice-whitespace inconsistency).
- No behavior change: purely lint cleanup, no test logic touched.
- This is prep for a follow-up PR that adds a `flake8` config and CI job, so the job starts green instead of immediately failing on pre-existing debt.

## Approach
Ran `flake8 --max-line-length=120 tests/` (120 chosen because that's the line width the codebase already uses; a separate PR formalizes this in a checked-in config) and fixed each of the 31 reported issues by hand:
- Removed unused `import time` (x2), unused import (`SpurCluster`, `job_state`), and unused locals (`node1`, `node`).
- Renamed list-comprehension variable `l` -> `line` (ambiguous with `1`/`I`) in 4 spots.
- Normalized `=` alignment and continuation-line indentation to standard single-space/PEP8 style.
- Trimmed stray triple/quadruple blank lines down to two in `test_devices.py`.
- Dropped an f-string prefix with no placeholders and removed a redundant space before `:` in a slice.

## Test plan
- `flake8 --max-line-length=120 tests/` -> 0 issues (was 31).
- `pytest tests/k8s/e2e --collect-only` and `pytest tests/native_host/e2e --collect-only` both collect without import/syntax errors.