### PR TITLE
perf(spurctld): index the GrpWall consumption window

### DIFF
--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -138,6 +138,13 @@ CREATE INDEX IF NOT EXISTS idx_jobs_account ON jobs(account);
 CREATE INDEX IF NOT EXISTS idx_jobs_state ON jobs(state);
 CREATE INDEX IF NOT EXISTS idx_jobs_submit_time ON jobs(submit_time);
 CREATE INDEX IF NOT EXISTS idx_jobs_start_time ON jobs(start_time);
+-- Serves the GrpWall consumption aggregate, which otherwise scans the whole job
+-- history on every cache refresh; a refresh slow enough to time out leaves the
+-- budget unenforced. end_time leads because it carries the window predicate and
+-- is the only selective one: ordering by qos instead leaves nothing to narrow,
+-- and the planner then prefers a full scan.
+CREATE INDEX IF NOT EXISTS idx_jobs_grp_wall_window ON jobs(end_time, qos, start_time)
+    WHERE qos <> '' AND start_time IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_usage_period ON usage(period_start, period_end);
 CREATE INDEX IF NOT EXISTS idx_assoc_user ON associations(user_name);
 CREATE INDEX IF NOT EXISTS idx_assoc_account ON associations(account);
@@ -705,11 +712,10 @@ pub async fn get_usage(
 /// be written by callers outside the controller and can skew, and a single
 /// end-before-start row would otherwise cancel real consumption in the same QOS
 /// and under-report the budget.
-pub async fn consumed_wall_minutes_by_qos(
-    pool: &PgPool,
-    window_days: u32,
-) -> anyhow::Result<HashMap<String, u64>> {
-    let rows = sqlx::query(
+/// A macro rather than a `const` so the test can prefix it with `EXPLAIN` via
+/// `concat!`: sqlx 0.9 accepts only statically known SQL.
+macro_rules! consumed_wall_minutes_sql {
+    () => {
         r#"
         SELECT qos,
                SUM(GREATEST(
@@ -724,11 +730,18 @@ pub async fn consumed_wall_minutes_by_qos(
           AND start_time IS NOT NULL
           AND (end_time IS NULL OR end_time > now() - make_interval(days => $1))
         GROUP BY qos
-        "#,
-    )
-    .bind(window_days as i32)
-    .fetch_all(pool)
-    .await?;
+        "#
+    };
+}
+
+pub async fn consumed_wall_minutes_by_qos(
+    pool: &PgPool,
+    window_days: u32,
+) -> anyhow::Result<HashMap<String, u64>> {
+    let rows = sqlx::query(consumed_wall_minutes_sql!())
+        .bind(window_days as i32)
+        .fetch_all(pool)
+        .await?;
 
     let consumed = rows
         .iter()
@@ -1897,6 +1910,42 @@ mod job_history_tests {
         );
 
         delete_jobs(&pool, &ids).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn grp_wall_aggregate_is_servable_from_its_index() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let mut tx = pool.begin().await?;
+
+        // A partial index qualifies only if its predicate is implied by the query's
+        // WHERE, which is the part that rots silently when either side is edited.
+        // Forcing seqscan off makes the planner say whether the pairing still holds
+        // on a table too small for it to prefer the index on cost alone.
+        sqlx::query("SET LOCAL enable_seqscan = off")
+            .execute(&mut *tx)
+            .await?;
+        let plan = sqlx::query(concat!("EXPLAIN ", consumed_wall_minutes_sql!()))
+            .bind(14i32)
+            .fetch_all(&mut *tx)
+            .await?
+            .iter()
+            .map(|row| row.get::<String, _>(0))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            plan.contains("idx_jobs_grp_wall_window"),
+            "GrpWall consumption must be servable from idx_jobs_grp_wall_window; plan was:\n{plan}"
+        );
+        assert!(
+            plan.contains("end_time"),
+            "the window predicate must reach the index, or its cost tracks total \
+             history instead of the window; plan was:\n{plan}"
+        );
+
+        tx.rollback().await?;
         Ok(())
     }
 

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -138,11 +138,8 @@ CREATE INDEX IF NOT EXISTS idx_jobs_account ON jobs(account);
 CREATE INDEX IF NOT EXISTS idx_jobs_state ON jobs(state);
 CREATE INDEX IF NOT EXISTS idx_jobs_submit_time ON jobs(submit_time);
 CREATE INDEX IF NOT EXISTS idx_jobs_start_time ON jobs(start_time);
--- Serves the GrpWall consumption aggregate, which otherwise scans the whole job
--- history on every cache refresh; a refresh slow enough to time out leaves the
--- budget unenforced. end_time leads because it carries the window predicate and
--- is the only selective one: ordering by qos instead leaves nothing to narrow,
--- and the planner then prefers a full scan.
+-- Serves the GrpWall aggregate, which otherwise scans all job history per refresh;
+-- a first-refresh timeout leaves the budget unapplied. end_time leads: it bounds the window.
 CREATE INDEX IF NOT EXISTS idx_jobs_grp_wall_window ON jobs(end_time, qos, start_time)
     WHERE qos <> '' AND start_time IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_usage_period ON usage(period_start, period_end);
@@ -1544,6 +1541,41 @@ mod job_history_tests {
         .await
     }
 
+    /// Seeds one job through the real start/end path on `conn`, so the EXPLAIN test
+    /// can build its fixture inside a transaction that rolls back. `end = None`
+    /// leaves the job running with a NULL end_time.
+    async fn seed_job(
+        conn: &mut PgConnection,
+        job_id: i32,
+        qos: &str,
+        start_time: DateTime<Utc>,
+        end: Option<DateTime<Utc>>,
+    ) -> anyhow::Result<()> {
+        record_job_start(
+            conn,
+            &JobStartRecord {
+                job_id: job_id as JobId,
+                name: "fixture".to_string(),
+                user: "root".to_string(),
+                account: String::new(),
+                partition: String::new(),
+                qos: qos.to_string(),
+                num_nodes: 1,
+                num_tasks: 1,
+                cpus_per_task: 1,
+                memory_mb: 0,
+                submit_time: start_time,
+                start_time,
+                reservation: Some(String::new()),
+            },
+        )
+        .await?;
+        if let Some(end_time) = end {
+            record_job_end(conn, job_id, "COMPLETED", 0, end_time, 0, 0, None, "", "").await?;
+        }
+        Ok(())
+    }
+
     #[tokio::test]
     #[ignore = "requires DATABASE_URL and PostgreSQL"]
     async fn get_job_history_query_builder() -> anyhow::Result<()> {
@@ -1918,6 +1950,48 @@ mod job_history_tests {
     async fn grp_wall_aggregate_is_servable_from_its_index() -> anyhow::Result<()> {
         let pool = test_pool().await?;
         let mut tx = pool.begin().await?;
+        let now = Utc::now();
+
+        // Seed a known shape inside the transaction so the plan is chosen from these
+        // rows, not from ambient statistics left by sibling tests: two in-window,
+        // one out-of-window, one still running (NULL end_time, the branch the
+        // predicate deliberately omits), one with no QOS. ANALYZE makes it visible
+        // to the planner; everything rolls back.
+        let base = 9_100_000 + (std::process::id() as i32 % 10_000) * 10;
+        seed_job(
+            &mut tx,
+            base,
+            "gw",
+            now - Duration::minutes(60),
+            Some(now - Duration::minutes(30)),
+        )
+        .await?;
+        seed_job(
+            &mut tx,
+            base + 1,
+            "gw",
+            now - Duration::days(5),
+            Some(now - Duration::days(2)),
+        )
+        .await?;
+        seed_job(
+            &mut tx,
+            base + 2,
+            "gw",
+            now - Duration::days(365),
+            Some(now - Duration::days(364)),
+        )
+        .await?;
+        seed_job(&mut tx, base + 3, "gw", now - Duration::minutes(15), None).await?;
+        seed_job(
+            &mut tx,
+            base + 4,
+            "",
+            now - Duration::minutes(45),
+            Some(now - Duration::minutes(20)),
+        )
+        .await?;
+        sqlx::query("ANALYZE jobs").execute(&mut *tx).await?;
 
         // A partial index qualifies only if its predicate is implied by the query's
         // WHERE, which is the part that rots silently when either side is edited.
@@ -1935,19 +2009,17 @@ mod job_history_tests {
             .collect::<Vec<_>>()
             .join("\n");
 
-        // The scan node varies with table statistics — index-only on a populated
-        // table, a bitmap OR over the two end_time branches on a small one — so the
-        // pairing is asserted by which relation is read, not by node shape. With
-        // seqscan off, a full scan is what the planner falls back to when the index
-        // predicate is no longer implied, which is the rot this test is here for.
         assert!(
             plan.contains("idx_jobs_grp_wall_window"),
             "GrpWall consumption must be servable from idx_jobs_grp_wall_window; plan was:\n{plan}"
         );
+        // A broken predicate degrades to idx_jobs_start_time (start_time IS NOT NULL is
+        // indexable), not a seq scan — enable_seqscan = off is a cost penalty, not a
+        // prohibition. That index scans all history, so its absence is what ties cost to the window.
         assert!(
-            !plan.contains("Seq Scan on jobs"),
-            "the index no longer covers this query, so its cost tracks total history \
-             instead of the window; plan was:\n{plan}"
+            !plan.contains("idx_jobs_start_time"),
+            "the window predicate no longer reaches idx_jobs_grp_wall_window, so the plan \
+             degraded to the non-selective start_time index; plan was:\n{plan}"
         );
 
         tx.rollback().await?;

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -704,16 +704,8 @@ pub async fn get_usage(
     Ok(records)
 }
 
-/// Wall-clock minutes consumed per QOS inside the trailing `window_days`, for
-/// `GrpWall` enforcement. Running jobs count their elapsed time so far, and a job
-/// that started before the window contributes only the part inside it.
-///
-/// Each row is clamped at zero inside the `SUM`, not after it: start/end times can
-/// be written by callers outside the controller and can skew, and a single
-/// end-before-start row would otherwise cancel real consumption in the same QOS
-/// and under-report the budget.
-/// A macro rather than a `const` so the test can prefix it with `EXPLAIN` via
-/// `concat!`: sqlx 0.9 accepts only statically known SQL.
+// A macro rather than a `const` so the EXPLAIN test can build its statement with
+// `concat!`, which needs a literal on both sides.
 macro_rules! consumed_wall_minutes_sql {
     () => {
         r#"
@@ -734,6 +726,14 @@ macro_rules! consumed_wall_minutes_sql {
     };
 }
 
+/// Wall-clock minutes consumed per QOS inside the trailing `window_days`, for
+/// `GrpWall` enforcement. Running jobs count their elapsed time so far, and a job
+/// that started before the window contributes only the part inside it.
+///
+/// Each row is clamped at zero inside the `SUM`, not after it: start/end times can
+/// be written by callers outside the controller and can skew, and a single
+/// end-before-start row would otherwise cancel real consumption in the same QOS
+/// and under-report the budget.
 pub async fn consumed_wall_minutes_by_qos(
     pool: &PgPool,
     window_days: u32,
@@ -1935,14 +1935,19 @@ mod job_history_tests {
             .collect::<Vec<_>>()
             .join("\n");
 
+        // The scan node varies with table statistics — index-only on a populated
+        // table, a bitmap OR over the two end_time branches on a small one — so the
+        // pairing is asserted by which relation is read, not by node shape. With
+        // seqscan off, a full scan is what the planner falls back to when the index
+        // predicate is no longer implied, which is the rot this test is here for.
         assert!(
             plan.contains("idx_jobs_grp_wall_window"),
             "GrpWall consumption must be servable from idx_jobs_grp_wall_window; plan was:\n{plan}"
         );
         assert!(
-            plan.contains("end_time"),
-            "the window predicate must reach the index, or its cost tracks total \
-             history instead of the window; plan was:\n{plan}"
+            !plan.contains("Seq Scan on jobs"),
+            "the index no longer covers this query, so its cost tracks total history \
+             instead of the window; plan was:\n{plan}"
         );
 
         tx.rollback().await?;


### PR DESCRIPTION
Closes #748.

`consumed_wall_minutes_by_qos` had no index to stand on, so QOS `GrpWall` consumption was computed by scanning the entire accumulated job history on every cache refresh. Cost tracked total retention rather than the window being measured, and `GrpWallCache` bounds its first read at 5 seconds and later reads at 10 — past that it logs `grpwall usage refresh timed out, retaining last figure` and keeps the previous snapshot, so only the first refresh timing out leaves the budget unapplied.

## Approach

One partial index on `jobs(end_time, qos, start_time)` where `qos <> '' AND start_time IS NOT NULL`, so the aggregate's cost follows the window instead of the history.

Column order is the whole point, and I got it wrong first. My initial attempt led with `qos` and carried `end_time` as an `INCLUDE` payload, on the reasoning that the query groups by `qos`. Measured, that index was never chosen — the planner kept the sequential scan, because `qos <> ''` and `start_time IS NOT NULL` match nearly every row and leave nothing to narrow. The selective predicate is the window on `end_time`, so `end_time` has to lead. With that order the planner picks it unprompted and builds a `BitmapOr` across the two branches of `end_time IS NULL OR end_time > cutoff`.

The SQL moved into a `consumed_wall_minutes_sql!` macro rather than staying an inline literal so the test can prefix it with `EXPLAIN` and cannot drift from the query that actually runs. It is a macro and not a `const` because sqlx 0.9 accepts only statically known SQL.

## Measurements

Postgres 16, 400k jobs spanning ~700 days, 12 QOS, 14-day window, 8,008 rows qualifying, `EXPLAIN (ANALYZE, BUFFERS)`:

| | plan | execution |
|---|---|---|
| before | parallel sequential scan over all 400k rows | 60.4 / 61.0 / 63.8 ms |
| after | `BitmapOr` of two index scans, 8,023 rows | 8.4 / 9.2 ms |

Roughly 7x here, but the ratio is not the interesting part — before, the work grew with everything the cluster had ever run; after, it grows with the window. On the first fixture I generated, the gain was only 1.4x, because I had given 5% of jobs a NULL `end_time` scattered across two years. Real clusters only have recently-started jobs still running, and correcting the fixture to match is what exposed the true difference.

Index size is 17 MB against a 57 MB heap at 400k rows, and it adds one more index to maintain on job insert and update. `end_time` leads the index and `record_job_end` writes it on every completion, so each job end now churns an index entry and that update can no longer be HOT — almost certainly fine on a table already carrying five indexes, but worth stating.

## Trade-offs

`migrate` applies the schema inside a transaction, so `CREATE INDEX CONCURRENTLY` is not available here. The `CREATE INDEX` itself takes `SHARE` on `jobs` — it blocks writers, not readers — for the duration of the build (seconds at 400k rows, longer on a large history). In practice the first boot already holds `ACCESS EXCLUSIVE` on `jobs`, taken earlier in the same transaction by the existing `ALTER TABLE jobs ADD COLUMN IF NOT EXISTS` statements and held until commit, so writers are blocked either way on that first start. This matches the indexes already created the same way in this schema, and `CREATE INDEX IF NOT EXISTS` makes it a no-op on every subsequent start.

## Testing

New DB integration test `grp_wall_aggregate_is_servable_from_its_index` asserts the plan reaches the index and that the window predicate gets there, which is what keeps cost tied to the window. It seeds a small deterministic fixture inside a rolled-back transaction — two in-window rows, one out-of-window, one still running with a NULL `end_time` (the branch the predicate deliberately omits), one with no QOS — then runs `ANALYZE jobs` before the `EXPLAIN`, so the plan is chosen from a known shape rather than whatever statistics the database happens to carry. With `enable_seqscan` off the planner is forced to say whether the partial index's predicate is still implied by the query's `WHERE` — the pairing that rots silently when either side is edited. The negative assertion checks the plan does not fall to `idx_jobs_start_time`: `enable_seqscan = off` is a cost penalty, not a prohibition, so a broken predicate degrades to an index scan on that index (which scans all history), not to the seq scan the earlier assertion looked for. Removing `qos <> ''` from the query confirms the assertion fires.

Full suite green: `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` warning-free, `cargo test --locked` passing, and all 24 accounting DB tests passing against a local Postgres 16 (`cargo test -p spurctld -- --ignored --test-threads=1`), with the same plan observed against a freshly created database.
