### PR TITLE
fix(spurctld)!: store job ids as 64-bit in the accounting database

### DIFF
--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -33,7 +33,7 @@ const SCHEMA_LOCK_OBJ: i32 = 1;
 
 const SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS jobs (
-    job_id          INTEGER PRIMARY KEY,
+    job_id          BIGINT PRIMARY KEY,
     name            TEXT NOT NULL DEFAULT '',
     user_name       TEXT NOT NULL,
     uid             INTEGER NOT NULL DEFAULT 0,
@@ -126,7 +126,7 @@ CREATE TABLE IF NOT EXISTS associations (
 );
 
 CREATE TABLE IF NOT EXISTS tres_usage (
-    job_id          INTEGER NOT NULL,
+    job_id          BIGINT NOT NULL,
     tres_type       TEXT NOT NULL,
     alloc_value     BIGINT NOT NULL DEFAULT 0,
     used_value      BIGINT NOT NULL DEFAULT 0,
@@ -158,9 +158,34 @@ ALTER TABLE associations ADD COLUMN IF NOT EXISTS grp_submit_jobs INTEGER;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS grp_tres TEXT;
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS preempt TEXT NOT NULL DEFAULT '';
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS preempt_exempt_time INTEGER;
-ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempted_by INTEGER;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempted_by BIGINT;
 ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempt_mode TEXT NOT NULL DEFAULT '';
 ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempt_qos TEXT NOT NULL DEFAULT '';
+
+-- Job ids are u32 in the scheduler but these columns were INTEGER, so an id above
+-- i32::MAX wrapped negative and could collide with an unrelated row instead of
+-- failing. Guarded on the current type because ALTER TYPE rewrites the table and
+-- takes ACCESS EXCLUSIVE: it must run once on upgrade, not on every start.
+DO $$
+DECLARE
+    target RECORD;
+BEGIN
+    FOR target IN
+        SELECT *
+        FROM (VALUES ('jobs', 'job_id'), ('jobs', 'preempted_by'), ('tres_usage', 'job_id'))
+             AS t(tbl, col)
+    LOOP
+        IF EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = target.tbl
+              AND column_name = target.col
+              AND data_type = 'integer'
+        ) THEN
+            EXECUTE format('ALTER TABLE %I ALTER COLUMN %I TYPE BIGINT', target.tbl, target.col);
+        END IF;
+    END LOOP;
+END $$;
 
 -- users.default_account is the single source of truth for a user's default
 -- account (the scheduler reads it via the association cache). associations
@@ -254,7 +279,7 @@ pub async fn record_job_start(conn: &mut PgConnection, rec: &JobStartRecord) -> 
             end_time = NULL
         "#,
     )
-    .bind(rec.job_id as i32)
+    .bind(rec.job_id as i64)
     .bind(&rec.name)
     .bind(&rec.user)
     .bind(&rec.account)
@@ -275,7 +300,7 @@ pub async fn record_job_start(conn: &mut PgConnection, rec: &JobStartRecord) -> 
     let row = sqlx::query(
         "SELECT user_name, account, start_time, num_tasks, cpus_per_task, end_time FROM jobs WHERE job_id = $1",
     )
-    .bind(rec.job_id as i32)
+    .bind(rec.job_id as i64)
     .fetch_one(&mut *conn)
     .await?;
 
@@ -292,13 +317,13 @@ pub async fn record_job_start(conn: &mut PgConnection, rec: &JobStartRecord) -> 
 #[allow(clippy::too_many_arguments)]
 pub async fn record_job_end(
     conn: &mut PgConnection,
-    job_id: i32,
+    job_id: i64,
     state: &str,
     exit_code: i32,
     end_time: DateTime<Utc>,
     exit_signal: i32,
     derived_exit_code: i32,
-    preempted_by: Option<i32>,
+    preempted_by: Option<i64>,
     preempt_mode: &str,
     preempt_qos: &str,
 ) -> anyhow::Result<()> {
@@ -352,8 +377,8 @@ pub struct AccountingRowState {
 /// by the reconciliation pass to detect jobs missing or stale in accounting.
 pub async fn job_accounting_states(
     pool: &PgPool,
-    job_ids: &[i32],
-) -> anyhow::Result<HashMap<i32, AccountingRowState>> {
+    job_ids: &[i64],
+) -> anyhow::Result<HashMap<i64, AccountingRowState>> {
     if job_ids.is_empty() {
         return Ok(HashMap::new());
     }
@@ -366,7 +391,7 @@ pub async fn job_accounting_states(
     Ok(rows
         .into_iter()
         .map(|r| {
-            let job_id: i32 = r.get("job_id");
+            let job_id: i64 = r.get("job_id");
             let user_name: String = r.get("user_name");
             let start_time: Option<DateTime<Utc>> = r.get("start_time");
             let row = AccountingRowState {
@@ -428,7 +453,7 @@ async fn update_usage(
 /// Job record returned from history queries.
 #[derive(Debug)]
 pub struct JobRecord {
-    pub job_id: i32,
+    pub job_id: i64,
     pub name: String,
     pub user_name: String,
     pub account: String,
@@ -444,7 +469,7 @@ pub struct JobRecord {
     pub start_time: Option<DateTime<Utc>>,
     pub end_time: Option<DateTime<Utc>>,
     pub reservation: String,
-    pub preempted_by: Option<i32>,
+    pub preempted_by: Option<i64>,
     pub preempt_mode: String,
     pub preempt_qos: String,
 }
@@ -1404,9 +1429,9 @@ mod job_history_tests {
     use super::*;
     use chrono::Duration;
 
-    fn test_job_id(slot: u32) -> i32 {
-        const BASE: i32 = 9_000_000;
-        BASE + (std::process::id() as i32 % 10_000) * 10 + slot as i32
+    fn test_job_id(slot: u32) -> i64 {
+        const BASE: i64 = 9_000_000;
+        BASE + (std::process::id() as i64 % 10_000) * 10 + slot as i64
     }
 
     async fn test_pool() -> anyhow::Result<PgPool> {
@@ -1419,7 +1444,7 @@ mod job_history_tests {
         Ok(pool)
     }
 
-    async fn delete_jobs(pool: &PgPool, ids: &[i32]) -> anyhow::Result<()> {
+    async fn delete_jobs(pool: &PgPool, ids: &[i64]) -> anyhow::Result<()> {
         for id in ids {
             sqlx::query("DELETE FROM jobs WHERE job_id = $1")
                 .bind(id)
@@ -1435,7 +1460,7 @@ mod job_history_tests {
     #[allow(clippy::too_many_arguments)]
     async fn start(
         pool: &PgPool,
-        job_id: i32,
+        job_id: i64,
         name: &str,
         user: &str,
         account: &str,
@@ -1470,7 +1495,7 @@ mod job_history_tests {
     #[allow(clippy::too_many_arguments)]
     async fn start_with_qos(
         pool: &PgPool,
-        job_id: i32,
+        job_id: i64,
         name: &str,
         user: &str,
         account: &str,
@@ -1508,7 +1533,7 @@ mod job_history_tests {
 
     async fn end(
         pool: &PgPool,
-        job_id: i32,
+        job_id: i64,
         state: &str,
         exit_code: i32,
         end_time: DateTime<Utc>,
@@ -1711,6 +1736,123 @@ mod job_history_tests {
 
         delete_jobs(&pool, &[id]).await?;
         Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn job_ids_past_i32_survive_the_accounting_round_trip() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        // The largest id the scheduler can hand out. Narrowed to i32 it arrived as
+        // -1 and, job_id being the primary key, landed on whatever row held that id
+        // rather than failing.
+        let id = i64::from(u32::MAX);
+        let preempter = id - 1;
+        let user = format!("spur_wide_id_{}", std::process::id());
+        delete_jobs(&pool, &[id, preempter]).await.ok();
+
+        let t0 = Utc::now() - Duration::hours(2);
+        start(&pool, id, "wide", &user, "", "", 1, 1, 1, 0, t0, t0, "").await?;
+
+        let mut conn = pool.acquire().await?;
+        record_job_end(
+            &mut conn,
+            id,
+            "PREEMPTED",
+            0,
+            Utc::now(),
+            0,
+            0,
+            Some(preempter),
+            "requeue",
+            "high",
+        )
+        .await?;
+        drop(conn);
+
+        let history = get_job_history(&pool, Some(&user), None, None, None, &[], 100).await?;
+        let row = history
+            .iter()
+            .find(|r| r.job_id == id)
+            .expect("a job id above i32::MAX must be queryable under that same id");
+        assert_eq!(
+            row.preempted_by,
+            Some(preempter),
+            "the preempting job's id is a job id too, so it must survive the same width"
+        );
+        assert!(
+            !history.iter().any(|r| r.job_id < 0),
+            "no id may arrive negative; that is the wrap this widening removes"
+        );
+
+        let states = job_accounting_states(&pool, &[id]).await?;
+        assert!(
+            states.contains_key(&id),
+            "the reconciler looks rows up by id, so its lookup must use the same width"
+        );
+
+        delete_jobs(&pool, &[id, preempter]).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn migrate_widens_pre_fix_integer_job_ids() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+
+        // Reconstruct a pre-fix database by narrowing the three id columns back,
+        // then let migrate() perform the upgrade an existing cluster would see.
+        sqlx::query("ALTER TABLE jobs ALTER COLUMN job_id TYPE INTEGER")
+            .execute(&pool)
+            .await?;
+        sqlx::query("ALTER TABLE jobs ALTER COLUMN preempted_by TYPE INTEGER")
+            .execute(&pool)
+            .await?;
+        sqlx::query("ALTER TABLE tres_usage ALTER COLUMN job_id TYPE INTEGER")
+            .execute(&pool)
+            .await?;
+        for (table, column) in id_columns() {
+            assert_eq!(
+                column_type(&pool, table, column).await?,
+                "integer",
+                "{table}.{column} must start narrow for this to test anything"
+            );
+        }
+
+        migrate(&pool).await?;
+
+        for (table, column) in id_columns() {
+            assert_eq!(
+                column_type(&pool, table, column).await?,
+                "bigint",
+                "migrate must widen {table}.{column} on an existing database"
+            );
+        }
+
+        // Idempotent: a second run leaves the widened columns alone.
+        migrate(&pool).await?;
+        for (table, column) in id_columns() {
+            assert_eq!(column_type(&pool, table, column).await?, "bigint");
+        }
+        Ok(())
+    }
+
+    fn id_columns() -> [(&'static str, &'static str); 3] {
+        [
+            ("jobs", "job_id"),
+            ("jobs", "preempted_by"),
+            ("tres_usage", "job_id"),
+        ]
+    }
+
+    async fn column_type(pool: &PgPool, table: &str, column: &str) -> anyhow::Result<String> {
+        Ok(sqlx::query_scalar::<_, String>(
+            "SELECT data_type FROM information_schema.columns \
+             WHERE table_schema = current_schema() AND table_name = $1 AND column_name = $2",
+        )
+        .bind(table)
+        .bind(column)
+        .fetch_one(pool)
+        .await?)
     }
 
     /// GrpWall attributes consumption by the QOS recorded on each job, so a start

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -317,13 +317,13 @@ pub async fn record_job_start(conn: &mut PgConnection, rec: &JobStartRecord) -> 
 #[allow(clippy::too_many_arguments)]
 pub async fn record_job_end(
     conn: &mut PgConnection,
-    job_id: i64,
+    job_id: JobId,
     state: &str,
     exit_code: i32,
     end_time: DateTime<Utc>,
     exit_signal: i32,
     derived_exit_code: i32,
-    preempted_by: Option<i64>,
+    preempted_by: Option<JobId>,
     preempt_mode: &str,
     preempt_qos: &str,
 ) -> anyhow::Result<()> {
@@ -345,13 +345,13 @@ pub async fn record_job_end(
         RETURNING user_name, account, start_time, num_tasks, cpus_per_task
         "#,
     )
-    .bind(job_id)
+    .bind(job_id as i64)
     .bind(state)
     .bind(exit_code)
     .bind(end_time)
     .bind(exit_signal)
     .bind(derived_exit_code)
-    .bind(preempted_by)
+    .bind(preempted_by.map(|id| id as i64))
     .bind(preempt_mode)
     .bind(preempt_qos)
     .fetch_one(&mut *conn)
@@ -377,28 +377,32 @@ pub struct AccountingRowState {
 /// by the reconciliation pass to detect jobs missing or stale in accounting.
 pub async fn job_accounting_states(
     pool: &PgPool,
-    job_ids: &[i64],
-) -> anyhow::Result<HashMap<i64, AccountingRowState>> {
+    job_ids: &[JobId],
+) -> anyhow::Result<HashMap<JobId, AccountingRowState>> {
     if job_ids.is_empty() {
         return Ok(HashMap::new());
     }
+    // Keyed by the stored form so a returned row is decoded by the id it was
+    // queried with, never by narrowing whatever the column holds.
+    let queried: HashMap<i64, JobId> = job_ids.iter().map(|&id| (id as i64, id)).collect();
+    let stored: Vec<i64> = queried.keys().copied().collect();
     let rows =
         sqlx::query("SELECT job_id, state, user_name, start_time FROM jobs WHERE job_id = ANY($1)")
-            .bind(job_ids)
+            .bind(&stored)
             .fetch_all(pool)
             .await?;
 
     Ok(rows
         .into_iter()
-        .map(|r| {
-            let job_id: i64 = r.get("job_id");
+        .filter_map(|r| {
+            let job_id = queried.get(&r.get::<i64, _>("job_id")).copied()?;
             let user_name: String = r.get("user_name");
             let start_time: Option<DateTime<Utc>> = r.get("start_time");
             let row = AccountingRowState {
                 state: r.get("state"),
                 needs_start_backfill: user_name.is_empty() || start_time.is_none(),
             };
-            (job_id, row)
+            Some((job_id, row))
         })
         .collect())
 }
@@ -450,10 +454,17 @@ async fn update_usage(
     Ok(())
 }
 
+/// A stored id back to the in-memory `JobId` it was written from. Rows written
+/// before the columns were widened hold the id narrowed to 32 bits, so a large id
+/// reads back negative; truncating to the low 32 bits recovers it either way.
+fn decode_job_id(stored: i64) -> JobId {
+    stored as JobId
+}
+
 /// Job record returned from history queries.
 #[derive(Debug)]
 pub struct JobRecord {
-    pub job_id: i64,
+    pub job_id: JobId,
     pub name: String,
     pub user_name: String,
     pub account: String,
@@ -469,7 +480,7 @@ pub struct JobRecord {
     pub start_time: Option<DateTime<Utc>>,
     pub end_time: Option<DateTime<Utc>>,
     pub reservation: String,
-    pub preempted_by: Option<i64>,
+    pub preempted_by: Option<JobId>,
     pub preempt_mode: String,
     pub preempt_qos: String,
 }
@@ -521,7 +532,7 @@ pub async fn get_job_history(
     let records = rows
         .iter()
         .map(|row| JobRecord {
-            job_id: row.get("job_id"),
+            job_id: decode_job_id(row.get("job_id")),
             name: row.get("name"),
             user_name: row.get("user_name"),
             account: row.get("account"),
@@ -537,7 +548,7 @@ pub async fn get_job_history(
             start_time: row.get("start_time"),
             end_time: row.get("end_time"),
             reservation: row.get("reservation"),
-            preempted_by: row.get("preempted_by"),
+            preempted_by: row.get::<Option<i64>, _>("preempted_by").map(decode_job_id),
             preempt_mode: row.get("preempt_mode"),
             preempt_qos: row.get("preempt_qos"),
         })
@@ -1429,9 +1440,9 @@ mod job_history_tests {
     use super::*;
     use chrono::Duration;
 
-    fn test_job_id(slot: u32) -> i64 {
-        const BASE: i64 = 9_000_000;
-        BASE + (std::process::id() as i64 % 10_000) * 10 + slot as i64
+    fn test_job_id(slot: u32) -> JobId {
+        const BASE: JobId = 9_000_000;
+        BASE + (std::process::id() % 10_000) * 10 + slot
     }
 
     async fn test_pool() -> anyhow::Result<PgPool> {
@@ -1444,10 +1455,10 @@ mod job_history_tests {
         Ok(pool)
     }
 
-    async fn delete_jobs(pool: &PgPool, ids: &[i64]) -> anyhow::Result<()> {
+    async fn delete_jobs(pool: &PgPool, ids: &[JobId]) -> anyhow::Result<()> {
         for id in ids {
             sqlx::query("DELETE FROM jobs WHERE job_id = $1")
-                .bind(id)
+                .bind(*id as i64)
                 .execute(pool)
                 .await?;
         }
@@ -1460,7 +1471,7 @@ mod job_history_tests {
     #[allow(clippy::too_many_arguments)]
     async fn start(
         pool: &PgPool,
-        job_id: i64,
+        job_id: JobId,
         name: &str,
         user: &str,
         account: &str,
@@ -1495,7 +1506,7 @@ mod job_history_tests {
     #[allow(clippy::too_many_arguments)]
     async fn start_with_qos(
         pool: &PgPool,
-        job_id: i64,
+        job_id: JobId,
         name: &str,
         user: &str,
         account: &str,
@@ -1513,7 +1524,7 @@ mod job_history_tests {
         record_job_start(
             &mut conn,
             &JobStartRecord {
-                job_id: job_id as JobId,
+                job_id,
                 name: name.to_string(),
                 user: user.to_string(),
                 account: account.to_string(),
@@ -1533,7 +1544,7 @@ mod job_history_tests {
 
     async fn end(
         pool: &PgPool,
-        job_id: i64,
+        job_id: JobId,
         state: &str,
         exit_code: i32,
         end_time: DateTime<Utc>,
@@ -1745,7 +1756,7 @@ mod job_history_tests {
         // The largest id the scheduler can hand out. Narrowed to i32 it arrived as
         // -1 and, job_id being the primary key, landed on whatever row held that id
         // rather than failing.
-        let id = i64::from(u32::MAX);
+        let id = u32::MAX;
         let preempter = id - 1;
         let user = format!("spur_wide_id_{}", std::process::id());
         delete_jobs(&pool, &[id, preempter]).await.ok();
@@ -1779,11 +1790,6 @@ mod job_history_tests {
             Some(preempter),
             "the preempting job's id is a job id too, so it must survive the same width"
         );
-        assert!(
-            !history.iter().any(|r| r.job_id < 0),
-            "no id may arrive negative; that is the wrap this widening removes"
-        );
-
         let states = job_accounting_states(&pool, &[id]).await?;
         assert!(
             states.contains_key(&id),
@@ -1791,6 +1797,43 @@ mod job_history_tests {
         );
 
         delete_jobs(&pool, &[id, preempter]).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn a_row_written_before_the_widening_reads_back_under_its_real_id() -> anyhow::Result<()>
+    {
+        let pool = test_pool().await?;
+        // What a pre-fix controller left behind: the id narrowed to 32 bits, which
+        // for u32::MAX was stored as -1. Widening the column does not rewrite it,
+        // so history has to keep decoding it to the id the job actually had.
+        let id = u32::MAX;
+        let user = format!("spur_legacy_id_{}", std::process::id());
+        delete_jobs(&pool, &[id]).await.ok();
+        sqlx::query(
+            "INSERT INTO jobs (job_id, name, user_name, state, submit_time, preempted_by) \
+             VALUES ($1, 'legacy', $2, 'COMPLETED', $3, $4)",
+        )
+        .bind(-1_i64)
+        .bind(&user)
+        .bind(Utc::now())
+        .bind(-2_i64)
+        .execute(&pool)
+        .await?;
+
+        let history = get_job_history(&pool, Some(&user), None, None, None, &[], 100).await?;
+        let row = history.first().expect("the legacy row must be returned");
+        assert_eq!(
+            row.job_id, id,
+            "a narrowed id must decode to its real value"
+        );
+        assert_eq!(row.preempted_by, Some(id - 1));
+
+        sqlx::query("DELETE FROM jobs WHERE user_name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
         Ok(())
     }
 

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -162,10 +162,8 @@ ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempted_by BIGINT;
 ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempt_mode TEXT NOT NULL DEFAULT '';
 ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempt_qos TEXT NOT NULL DEFAULT '';
 
--- Job ids are u32 in the scheduler but these columns were INTEGER, so an id above
--- i32::MAX wrapped negative and could collide with an unrelated row instead of
--- failing. Guarded on the current type because ALTER TYPE rewrites the table and
--- takes ACCESS EXCLUSIVE: it must run once on upgrade, not on every start.
+-- job_id is u32 but these columns were INTEGER, so ids above i32::MAX wrapped negative onto
+-- unrelated rows. Guarded: ALTER TYPE rewrites the table under ACCESS EXCLUSIVE.
 DO $$
 DECLARE
     target RECORD;
@@ -186,6 +184,21 @@ BEGIN
         END IF;
     END LOOP;
 END $$;
+
+-- Restore the true id of a row a pre-fix controller narrowed: the u32 wrapped to a
+-- negative int4, so add 2^32 back. Skip a row whose true id already exists so the
+-- rewrite can never violate the primary key. No-op (and cheap on the PK) once clean.
+UPDATE jobs SET job_id = job_id + 4294967296
+WHERE job_id < 0
+  AND NOT EXISTS (SELECT 1 FROM jobs j WHERE j.job_id = jobs.job_id + 4294967296);
+UPDATE jobs SET preempted_by = preempted_by + 4294967296
+WHERE preempted_by < 0;
+UPDATE tres_usage t SET job_id = job_id + 4294967296
+WHERE job_id < 0
+  AND NOT EXISTS (
+    SELECT 1 FROM tres_usage u
+    WHERE u.job_id = t.job_id + 4294967296 AND u.tres_type = t.tres_type
+  );
 
 -- users.default_account is the single source of truth for a user's default
 -- account (the scheduler reads it via the association cache). associations
@@ -382,10 +395,7 @@ pub async fn job_accounting_states(
     if job_ids.is_empty() {
         return Ok(HashMap::new());
     }
-    // Keyed by the stored form so a returned row is decoded by the id it was
-    // queried with, never by narrowing whatever the column holds.
-    let queried: HashMap<i64, JobId> = job_ids.iter().map(|&id| (id as i64, id)).collect();
-    let stored: Vec<i64> = queried.keys().copied().collect();
+    let stored: Vec<i64> = job_ids.iter().map(|&id| id as i64).collect();
     let rows =
         sqlx::query("SELECT job_id, state, user_name, start_time FROM jobs WHERE job_id = ANY($1)")
             .bind(&stored)
@@ -394,15 +404,15 @@ pub async fn job_accounting_states(
 
     Ok(rows
         .into_iter()
-        .filter_map(|r| {
-            let job_id = queried.get(&r.get::<i64, _>("job_id")).copied()?;
+        .map(|r| {
+            let job_id = r.get::<i64, _>("job_id") as JobId;
             let user_name: String = r.get("user_name");
             let start_time: Option<DateTime<Utc>> = r.get("start_time");
             let row = AccountingRowState {
                 state: r.get("state"),
                 needs_start_backfill: user_name.is_empty() || start_time.is_none(),
             };
-            Some((job_id, row))
+            (job_id, row)
         })
         .collect())
 }
@@ -452,13 +462,6 @@ async fn update_usage(
     .await?;
 
     Ok(())
-}
-
-/// A stored id back to the in-memory `JobId` it was written from. Rows written
-/// before the columns were widened hold the id narrowed to 32 bits, so a large id
-/// reads back negative; truncating to the low 32 bits recovers it either way.
-fn decode_job_id(stored: i64) -> JobId {
-    stored as JobId
 }
 
 /// Job record returned from history queries.
@@ -532,7 +535,7 @@ pub async fn get_job_history(
     let records = rows
         .iter()
         .map(|row| JobRecord {
-            job_id: decode_job_id(row.get("job_id")),
+            job_id: row.get::<i64, _>("job_id") as JobId,
             name: row.get("name"),
             user_name: row.get("user_name"),
             account: row.get("account"),
@@ -548,7 +551,9 @@ pub async fn get_job_history(
             start_time: row.get("start_time"),
             end_time: row.get("end_time"),
             reservation: row.get("reservation"),
-            preempted_by: row.get::<Option<i64>, _>("preempted_by").map(decode_job_id),
+            preempted_by: row
+                .get::<Option<i64>, _>("preempted_by")
+                .map(|id| id as JobId),
             preempt_mode: row.get("preempt_mode"),
             preempt_qos: row.get("preempt_qos"),
         })
@@ -1753,9 +1758,8 @@ mod job_history_tests {
     #[ignore = "requires DATABASE_URL and PostgreSQL"]
     async fn job_ids_past_i32_survive_the_accounting_round_trip() -> anyhow::Result<()> {
         let pool = test_pool().await?;
-        // The largest id the scheduler can hand out. Narrowed to i32 it arrived as
-        // -1 and, job_id being the primary key, landed on whatever row held that id
-        // rather than failing.
+        // The largest id the scheduler can hand out; as i32 it wrapped to -1 and,
+        // job_id being the primary key, overwrote whatever row already held -1.
         let id = u32::MAX;
         let preempter = id - 1;
         let user = format!("spur_wide_id_{}", std::process::id());
@@ -1802,38 +1806,97 @@ mod job_history_tests {
 
     #[tokio::test]
     #[ignore = "requires DATABASE_URL and PostgreSQL"]
-    async fn a_row_written_before_the_widening_reads_back_under_its_real_id() -> anyhow::Result<()>
-    {
+    async fn migrate_rewrites_a_legacy_narrowed_row_to_its_real_id() -> anyhow::Result<()> {
         let pool = test_pool().await?;
-        // What a pre-fix controller left behind: the id narrowed to 32 bits, which
-        // for u32::MAX was stored as -1. Widening the column does not rewrite it,
-        // so history has to keep decoding it to the id the job actually had.
+        // A pre-fix controller stored u32::MAX as -1 in the narrow columns; migrate
+        // must widen and rewrite it so reads and reconciler lookups agree on the id.
         let id = u32::MAX;
         let user = format!("spur_legacy_id_{}", std::process::id());
-        delete_jobs(&pool, &[id]).await.ok();
+        let outcome = migrate_rewrites_legacy_row_body(&pool, id, &user).await;
+        clear_user_rows(&pool, &user).await.ok();
+        let restore = widen_id_columns(&pool).await;
+        outcome.and(restore)
+    }
+
+    async fn migrate_rewrites_legacy_row_body(
+        pool: &PgPool,
+        id: JobId,
+        user: &str,
+    ) -> anyhow::Result<()> {
+        clear_user_rows(pool, user).await?;
+        narrow_id_columns(pool).await?;
         sqlx::query(
             "INSERT INTO jobs (job_id, name, user_name, state, submit_time, preempted_by) \
              VALUES ($1, 'legacy', $2, 'COMPLETED', $3, $4)",
         )
         .bind(-1_i64)
-        .bind(&user)
+        .bind(user)
         .bind(Utc::now())
         .bind(-2_i64)
-        .execute(&pool)
+        .execute(pool)
         .await?;
 
-        let history = get_job_history(&pool, Some(&user), None, None, None, &[], 100).await?;
-        let row = history.first().expect("the legacy row must be returned");
+        migrate(pool).await?;
+
+        let history = get_job_history(pool, Some(user), None, None, None, &[], 100).await?;
+        let row = history.first().expect("the migrated row must be returned");
         assert_eq!(
             row.job_id, id,
-            "a narrowed id must decode to its real value"
+            "the narrowed id must be rewritten to its real value"
         );
         assert_eq!(row.preempted_by, Some(id - 1));
 
-        sqlx::query("DELETE FROM jobs WHERE user_name = $1")
+        let states = job_accounting_states(pool, &[id]).await?;
+        assert!(
+            states.contains_key(&id),
+            "the reconciler looks the row up by its real id, so the rewrite must match it"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn migrate_skips_a_legacy_id_whose_real_id_already_exists() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        // Defensive: if the true id is already taken, the rewrite must skip the
+        // negative row rather than duplicate it or violate the primary key.
+        let user = format!("spur_guard_id_{}", std::process::id());
+        clear_user_rows(&pool, &user).await.ok();
+        for stored in [(u32::MAX as i64), -1_i64] {
+            sqlx::query(
+                "INSERT INTO jobs (job_id, name, user_name, state, submit_time) \
+                 VALUES ($1, 'row', $2, 'COMPLETED', $3)",
+            )
+            .bind(stored)
             .bind(&user)
+            .bind(Utc::now())
             .execute(&pool)
             .await?;
+        }
+
+        migrate(&pool).await?;
+
+        let negatives: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM jobs WHERE user_name = $1 AND job_id < 0")
+                .bind(&user)
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(
+            negatives, 1,
+            "the colliding negative row must be left untouched"
+        );
+        let at_true_id: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM jobs WHERE user_name = $1 AND job_id = $2")
+                .bind(&user)
+                .bind(u32::MAX as i64)
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(
+            at_true_id, 1,
+            "the pre-existing true-id row must be the only one"
+        );
+
+        clear_user_rows(&pool, &user).await?;
         Ok(())
     }
 
@@ -1841,40 +1904,39 @@ mod job_history_tests {
     #[ignore = "requires DATABASE_URL and PostgreSQL"]
     async fn migrate_widens_pre_fix_integer_job_ids() -> anyhow::Result<()> {
         let pool = test_pool().await?;
+        let outcome = migrate_widens_body(&pool).await;
+        // Restore the shared schema even on the failure path, so a serial `--ignored`
+        // run does not leave every later test on a narrow column.
+        let restore = widen_id_columns(&pool).await;
+        outcome.and(restore)
+    }
 
+    async fn migrate_widens_body(pool: &PgPool) -> anyhow::Result<()> {
         // Reconstruct a pre-fix database by narrowing the three id columns back,
         // then let migrate() perform the upgrade an existing cluster would see.
-        sqlx::query("ALTER TABLE jobs ALTER COLUMN job_id TYPE INTEGER")
-            .execute(&pool)
-            .await?;
-        sqlx::query("ALTER TABLE jobs ALTER COLUMN preempted_by TYPE INTEGER")
-            .execute(&pool)
-            .await?;
-        sqlx::query("ALTER TABLE tres_usage ALTER COLUMN job_id TYPE INTEGER")
-            .execute(&pool)
-            .await?;
+        narrow_id_columns(pool).await?;
         for (table, column) in id_columns() {
             assert_eq!(
-                column_type(&pool, table, column).await?,
+                column_type(pool, table, column).await?,
                 "integer",
                 "{table}.{column} must start narrow for this to test anything"
             );
         }
 
-        migrate(&pool).await?;
+        migrate(pool).await?;
 
         for (table, column) in id_columns() {
             assert_eq!(
-                column_type(&pool, table, column).await?,
+                column_type(pool, table, column).await?,
                 "bigint",
                 "migrate must widen {table}.{column} on an existing database"
             );
         }
 
         // Idempotent: a second run leaves the widened columns alone.
-        migrate(&pool).await?;
+        migrate(pool).await?;
         for (table, column) in id_columns() {
-            assert_eq!(column_type(&pool, table, column).await?, "bigint");
+            assert_eq!(column_type(pool, table, column).await?, "bigint");
         }
         Ok(())
     }
@@ -1885,6 +1947,36 @@ mod job_history_tests {
             ("jobs", "preempted_by"),
             ("tres_usage", "job_id"),
         ]
+    }
+
+    async fn narrow_id_columns(pool: &PgPool) -> anyhow::Result<()> {
+        for stmt in [
+            "ALTER TABLE jobs ALTER COLUMN job_id TYPE INTEGER",
+            "ALTER TABLE jobs ALTER COLUMN preempted_by TYPE INTEGER",
+            "ALTER TABLE tres_usage ALTER COLUMN job_id TYPE INTEGER",
+        ] {
+            sqlx::query(stmt).execute(pool).await?;
+        }
+        Ok(())
+    }
+
+    async fn widen_id_columns(pool: &PgPool) -> anyhow::Result<()> {
+        for stmt in [
+            "ALTER TABLE jobs ALTER COLUMN job_id TYPE BIGINT",
+            "ALTER TABLE jobs ALTER COLUMN preempted_by TYPE BIGINT",
+            "ALTER TABLE tres_usage ALTER COLUMN job_id TYPE BIGINT",
+        ] {
+            sqlx::query(stmt).execute(pool).await?;
+        }
+        Ok(())
+    }
+
+    async fn clear_user_rows(pool: &PgPool, user: &str) -> anyhow::Result<()> {
+        sqlx::query("DELETE FROM jobs WHERE user_name = $1")
+            .bind(user)
+            .execute(pool)
+            .await?;
+        Ok(())
     }
 
     async fn column_type(pool: &PgPool, table: &str, column: &str) -> anyhow::Result<String> {

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -206,7 +206,7 @@ impl SlurmAccounting for AccountingService {
             .map_err(|e| Status::internal(e.to_string()))?;
         db::record_job_end(
             &mut conn,
-            req.job_id as i64,
+            req.job_id,
             state_str,
             req.exit_code,
             end_time,
@@ -272,7 +272,7 @@ impl SlurmAccounting for AccountingService {
         let jobs = records
             .iter()
             .map(|r| JobInfo {
-                job_id: r.job_id as u32,
+                job_id: r.job_id,
                 name: r.name.clone(),
                 user: r.user_name.clone(),
                 uid: 0,
@@ -323,7 +323,7 @@ impl SlurmAccounting for AccountingService {
                 srun_step_dispatch: false,
                 req_gpus: 0,
                 req_gpus_detail: String::new(),
-                preempted_by: r.preempted_by.unwrap_or(0) as u32,
+                preempted_by: r.preempted_by.unwrap_or(0),
                 preempt_mode: r.preempt_mode.clone(),
                 preempt_qos: r.preempt_qos.clone(),
             })

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -206,7 +206,7 @@ impl SlurmAccounting for AccountingService {
             .map_err(|e| Status::internal(e.to_string()))?;
         db::record_job_end(
             &mut conn,
-            req.job_id as i32,
+            req.job_id as i64,
             state_str,
             req.exit_code,
             end_time,

--- a/crates/spurctld/src/accounting/notifier.rs
+++ b/crates/spurctld/src/accounting/notifier.rs
@@ -97,13 +97,13 @@ impl AccountingNotifier {
                 let mut conn = pool.acquire().await?;
                 super::db::record_job_end(
                     &mut conn,
-                    job_id as i32,
+                    job_id as i64,
                     &state_str,
                     exit_code,
                     end_time,
                     exit_signal,
                     derived_exit_code,
-                    preempted_by.map(|id| id as i32),
+                    preempted_by.map(|id| id as i64),
                     preempt_mode.as_deref().unwrap_or(""),
                     preempt_qos.as_deref().unwrap_or(""),
                 )

--- a/crates/spurctld/src/accounting/notifier.rs
+++ b/crates/spurctld/src/accounting/notifier.rs
@@ -97,13 +97,13 @@ impl AccountingNotifier {
                 let mut conn = pool.acquire().await?;
                 super::db::record_job_end(
                     &mut conn,
-                    job_id as i64,
+                    job_id,
                     &state_str,
                     exit_code,
                     end_time,
                     exit_signal,
                     derived_exit_code,
-                    preempted_by.map(|id| id as i64),
+                    preempted_by,
                     preempt_mode.as_deref().unwrap_or(""),
                     preempt_qos.as_deref().unwrap_or(""),
                 )

--- a/crates/spurctld/src/accounting/reconcile.rs
+++ b/crates/spurctld/src/accounting/reconcile.rs
@@ -93,15 +93,10 @@ async fn run_once(pool: &PgPool, cluster: &ClusterManager) {
         .map(|j| (j.job_id, accounting_expected_state(j.state)))
         .collect();
 
-    let job_ids: Vec<i64> = candidates.iter().map(|j| j.job_id as i64).collect();
+    let job_ids: Vec<JobId> = candidates.iter().map(|j| j.job_id).collect();
     let (accounting_states, unknown): (HashMap<JobId, AccountingRowState>, HashSet<JobId>) =
         match db::job_accounting_states(pool, &job_ids).await {
-            Ok(rows) => (
-                rows.into_iter()
-                    .map(|(id, row)| (id as JobId, row))
-                    .collect(),
-                HashSet::new(),
-            ),
+            Ok(rows) => (rows, HashSet::new()),
             Err(e) => {
                 // A failed read is not evidence the rows are absent. Treating
                 // it as "missing" would make resync_job call write_start,
@@ -252,13 +247,13 @@ async fn write_end(conn: &mut sqlx::PgConnection, job: &Job) -> anyhow::Result<(
     let end_time = job.end_time.unwrap_or_else(Utc::now);
     db::record_job_end(
         conn,
-        job.job_id as i64,
+        job.job_id,
         job.state.display(),
         job.exit_code.unwrap_or(0),
         end_time,
         job.exit_signal,
         job.derived_exit_code,
-        job.preempted_by.map(|id| id as i64),
+        job.preempted_by,
         job.preempt_mode.as_deref().unwrap_or(""),
         job.preempt_qos.as_deref().unwrap_or(""),
     )
@@ -453,9 +448,9 @@ mod tests {
         Ok(pool)
     }
 
-    async fn delete_job(pool: &PgPool, job_id: i64) {
+    async fn delete_job(pool: &PgPool, job_id: JobId) {
         let _ = sqlx::query("DELETE FROM jobs WHERE job_id = $1")
-            .bind(job_id)
+            .bind(job_id as i64)
             .execute(pool)
             .await;
     }
@@ -469,7 +464,7 @@ mod tests {
     async fn resync_job_backfills_bare_row_left_by_a_missed_job_start() -> anyhow::Result<()> {
         let pool = test_pool().await?;
         let job_id = test_job_id(0);
-        delete_job(&pool, job_id as i64).await;
+        delete_job(&pool, job_id).await;
 
         let job = test_job(job_id, JobState::Completed);
 
@@ -477,7 +472,7 @@ mod tests {
         let mut conn = pool.acquire().await?;
         db::record_job_end(
             &mut conn,
-            job_id as i64,
+            job_id,
             job.state.display(),
             0,
             job.end_time.unwrap(),
@@ -490,9 +485,9 @@ mod tests {
         .await?;
         drop(conn);
 
-        let bare = db::job_accounting_states(&pool, &[job_id as i64])
+        let bare = db::job_accounting_states(&pool, &[job_id])
             .await?
-            .remove(&(job_id as i64))
+            .remove(&job_id)
             .expect("bare row exists");
         assert!(bare.needs_start_backfill);
         assert_eq!(bare.state, "COMPLETED");
@@ -532,7 +527,7 @@ mod tests {
             "usage must be backfilled along with the row"
         );
 
-        delete_job(&pool, job_id as i64).await;
+        delete_job(&pool, job_id).await;
         sqlx::query("DELETE FROM usage WHERE user_name = $1")
             .bind(&job.spec.user)
             .execute(&pool)
@@ -548,15 +543,15 @@ mod tests {
     async fn suspended_job_is_not_flagged_stale_against_a_running_row() -> anyhow::Result<()> {
         let pool = test_pool().await?;
         let job_id = test_job_id(1);
-        delete_job(&pool, job_id as i64).await;
+        delete_job(&pool, job_id).await;
 
         let running_job = test_job(job_id, JobState::Running);
         resync_job(&pool, &running_job, true, false).await;
 
         let suspended_job = test_job(job_id, JobState::Suspended);
-        let row = db::job_accounting_states(&pool, &[job_id as i64])
+        let row = db::job_accounting_states(&pool, &[job_id])
             .await?
-            .remove(&(job_id as i64))
+            .remove(&job_id)
             .expect("row exists");
         let expected = vec![(job_id, accounting_expected_state(suspended_job.state))];
         let mut accounting = HashMap::new();
@@ -568,7 +563,7 @@ mod tests {
             "a suspended job matching a RUNNING row must not be flagged stale"
         );
 
-        delete_job(&pool, job_id as i64).await;
+        delete_job(&pool, job_id).await;
         Ok(())
     }
 
@@ -591,7 +586,7 @@ mod tests {
     async fn resync_job_transaction_rolls_back_a_partial_backfill() -> anyhow::Result<()> {
         let pool = test_pool().await?;
         let job_id = test_job_id(2);
-        delete_job(&pool, job_id as i64).await;
+        delete_job(&pool, job_id).await;
 
         // Seed a correct, complete terminal record, as if a prior pass had
         // already recorded it successfully.
@@ -619,7 +614,7 @@ mod tests {
             .await?;
             db::record_job_end(
                 &mut conn,
-                job_id as i64,
+                job_id,
                 "COMPLETED",
                 0,
                 job.end_time.unwrap(),
@@ -669,7 +664,7 @@ mod tests {
             "a rolled-back backfill must never wipe out end_time"
         );
 
-        delete_job(&pool, job_id as i64).await;
+        delete_job(&pool, job_id).await;
         Ok(())
     }
 }

--- a/crates/spurctld/src/accounting/reconcile.rs
+++ b/crates/spurctld/src/accounting/reconcile.rs
@@ -93,7 +93,7 @@ async fn run_once(pool: &PgPool, cluster: &ClusterManager) {
         .map(|j| (j.job_id, accounting_expected_state(j.state)))
         .collect();
 
-    let job_ids: Vec<i32> = candidates.iter().map(|j| j.job_id as i32).collect();
+    let job_ids: Vec<i64> = candidates.iter().map(|j| j.job_id as i64).collect();
     let (accounting_states, unknown): (HashMap<JobId, AccountingRowState>, HashSet<JobId>) =
         match db::job_accounting_states(pool, &job_ids).await {
             Ok(rows) => (
@@ -252,13 +252,13 @@ async fn write_end(conn: &mut sqlx::PgConnection, job: &Job) -> anyhow::Result<(
     let end_time = job.end_time.unwrap_or_else(Utc::now);
     db::record_job_end(
         conn,
-        job.job_id as i32,
+        job.job_id as i64,
         job.state.display(),
         job.exit_code.unwrap_or(0),
         end_time,
         job.exit_signal,
         job.derived_exit_code,
-        job.preempted_by.map(|id| id as i32),
+        job.preempted_by.map(|id| id as i64),
         job.preempt_mode.as_deref().unwrap_or(""),
         job.preempt_qos.as_deref().unwrap_or(""),
     )
@@ -453,7 +453,7 @@ mod tests {
         Ok(pool)
     }
 
-    async fn delete_job(pool: &PgPool, job_id: i32) {
+    async fn delete_job(pool: &PgPool, job_id: i64) {
         let _ = sqlx::query("DELETE FROM jobs WHERE job_id = $1")
             .bind(job_id)
             .execute(pool)
@@ -469,7 +469,7 @@ mod tests {
     async fn resync_job_backfills_bare_row_left_by_a_missed_job_start() -> anyhow::Result<()> {
         let pool = test_pool().await?;
         let job_id = test_job_id(0);
-        delete_job(&pool, job_id as i32).await;
+        delete_job(&pool, job_id as i64).await;
 
         let job = test_job(job_id, JobState::Completed);
 
@@ -477,7 +477,7 @@ mod tests {
         let mut conn = pool.acquire().await?;
         db::record_job_end(
             &mut conn,
-            job_id as i32,
+            job_id as i64,
             job.state.display(),
             0,
             job.end_time.unwrap(),
@@ -490,9 +490,9 @@ mod tests {
         .await?;
         drop(conn);
 
-        let bare = db::job_accounting_states(&pool, &[job_id as i32])
+        let bare = db::job_accounting_states(&pool, &[job_id as i64])
             .await?
-            .remove(&(job_id as i32))
+            .remove(&(job_id as i64))
             .expect("bare row exists");
         assert!(bare.needs_start_backfill);
         assert_eq!(bare.state, "COMPLETED");
@@ -507,7 +507,7 @@ mod tests {
         resync_job(&pool, &job, false, true).await;
 
         let row = sqlx::query("SELECT user_name, start_time, state FROM jobs WHERE job_id = $1")
-            .bind(job_id as i32)
+            .bind(job_id as i64)
             .fetch_one(&pool)
             .await?;
         let user_name: String = row.get("user_name");
@@ -532,7 +532,7 @@ mod tests {
             "usage must be backfilled along with the row"
         );
 
-        delete_job(&pool, job_id as i32).await;
+        delete_job(&pool, job_id as i64).await;
         sqlx::query("DELETE FROM usage WHERE user_name = $1")
             .bind(&job.spec.user)
             .execute(&pool)
@@ -548,15 +548,15 @@ mod tests {
     async fn suspended_job_is_not_flagged_stale_against_a_running_row() -> anyhow::Result<()> {
         let pool = test_pool().await?;
         let job_id = test_job_id(1);
-        delete_job(&pool, job_id as i32).await;
+        delete_job(&pool, job_id as i64).await;
 
         let running_job = test_job(job_id, JobState::Running);
         resync_job(&pool, &running_job, true, false).await;
 
         let suspended_job = test_job(job_id, JobState::Suspended);
-        let row = db::job_accounting_states(&pool, &[job_id as i32])
+        let row = db::job_accounting_states(&pool, &[job_id as i64])
             .await?
-            .remove(&(job_id as i32))
+            .remove(&(job_id as i64))
             .expect("row exists");
         let expected = vec![(job_id, accounting_expected_state(suspended_job.state))];
         let mut accounting = HashMap::new();
@@ -568,7 +568,7 @@ mod tests {
             "a suspended job matching a RUNNING row must not be flagged stale"
         );
 
-        delete_job(&pool, job_id as i32).await;
+        delete_job(&pool, job_id as i64).await;
         Ok(())
     }
 
@@ -591,7 +591,7 @@ mod tests {
     async fn resync_job_transaction_rolls_back_a_partial_backfill() -> anyhow::Result<()> {
         let pool = test_pool().await?;
         let job_id = test_job_id(2);
-        delete_job(&pool, job_id as i32).await;
+        delete_job(&pool, job_id as i64).await;
 
         // Seed a correct, complete terminal record, as if a prior pass had
         // already recorded it successfully.
@@ -619,7 +619,7 @@ mod tests {
             .await?;
             db::record_job_end(
                 &mut conn,
-                job_id as i32,
+                job_id as i64,
                 "COMPLETED",
                 0,
                 job.end_time.unwrap(),
@@ -641,7 +641,7 @@ mod tests {
         // corrupted shape the pre-fix bug used to leave committed: RUNNING
         // with end_time wiped out.
         let mid_row = sqlx::query("SELECT state, end_time FROM jobs WHERE job_id = $1")
-            .bind(job_id as i32)
+            .bind(job_id as i64)
             .fetch_one(&mut *tx)
             .await?;
         let mid_state: String = mid_row.get("state");
@@ -655,7 +655,7 @@ mod tests {
         drop(tx); // never committed: sqlx issues ROLLBACK
 
         let row = sqlx::query("SELECT state, end_time FROM jobs WHERE job_id = $1")
-            .bind(job_id as i32)
+            .bind(job_id as i64)
             .fetch_one(&pool)
             .await?;
         let state: String = row.get("state");
@@ -669,7 +669,7 @@ mod tests {
             "a rolled-back backfill must never wipe out end_time"
         );
 
-        delete_job(&pool, job_id as i32).await;
+        delete_job(&pool, job_id as i64).await;
         Ok(())
     }
 }

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -189,9 +189,10 @@ and Raft high-availability topology.
      - integer
      - ``999999999``
      - Not implemented
-     - Intended as the job-ID wrap point. No code consumes it; the counter does
-       not wrap. Job IDs are 32-bit unsigned and stored as 64-bit in the
-       accounting database, so the full range is usable without one.
+     - Intended as the job-ID wrap point. No code consumes it. Job IDs are 32-bit
+       unsigned and stored as 64-bit in the accounting database, so ids above
+       ``i32::MAX`` are recorded correctly; the counter still wraps to zero past
+       ``u32::MAX`` and would re-issue ids that collide with existing rows.
    * - ``first_job_id``
      - integer
      - ``1``

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -190,7 +190,8 @@ and Raft high-availability topology.
      - ``999999999``
      - Not implemented
      - Intended as the job-ID wrap point. No code consumes it; the counter does
-       not wrap.
+       not wrap. Job IDs are 32-bit unsigned and stored as 64-bit in the
+       accounting database, so the full range is usable without one.
    * - ``first_job_id``
      - integer
      - ``1``

--- a/docs/deployment/upgrading.rst
+++ b/docs/deployment/upgrading.rst
@@ -239,6 +239,15 @@ Follow this order for any cluster upgrade:
 5. **HA membership is fixed at init** in Spur 0.3.0. You can roll new binaries onto the
    existing controller set freely, but changing *which* hosts are controllers requires
    ``deploy.yml -e spur_wipe_state=true``.
+6. **Only roll forward across an accounting schema migration.** The first upgraded
+   controller applies pending PostgreSQL migrations on startup, so upgrade controllers
+   before agents and let each migration finish before the next controller starts. One
+   such migration widens the ``jobs`` job-id columns to 64-bit: it rewrites the table
+   under an ``ACCESS EXCLUSIVE`` lock, so its duration scales with the row count and
+   accounting writes block until it completes. **Rolling back to a pre-migration
+   controller is not supported** — an older controller reads the widened columns as
+   32-bit and its accounting queries fail against a migrated database. Take a database
+   backup before upgrading if you need a recovery path.
 
 See Also
 --------


### PR DESCRIPTION
Closes #749.

Job ids are `u32` in the scheduler (`JobId`), but the accounting schema stored them in `INTEGER` columns — signed 32-bit. Every write narrowed with an unchecked `as i32`, so an id above `i32::MAX` arrived negative. Since `job_id` is the primary key, such a write did not fail; it landed on whatever row already held the wrapped id, and `record_job_end` and the reconciler would then act on the wrong job.

`controller.max_job_id` would have kept ids inside the column's range at its default of 999,999,999, but nothing reads it — the docs already say so.

## Approach

Widen the three id columns to `BIGINT` (`jobs.job_id`, `jobs.preempted_by`, `tres_usage.job_id`) and carry `i64` through the accounting path, so the stored width covers the full `u32` range and no cast can wrap.

I chose widening over the two alternatives because it leaves job id semantics alone. Enforcing the ceiling instead would mean a cluster that reaches it stops accepting jobs. Implementing `max_job_id` as the wrap point the docs describe would be a much larger change than it appears, because the codebase currently treats id order as time order:

```rust
// crates/spurctld/src/server.rs
None => job_id < cluster.peek_next_job_id(),
```

That is how the controller decides a node-reported id was issued at some point and may therefore be released. Under a wrapping counter, an id that *was* issued compares as never-issued after the wrap and is spared forever, leaking node-side state. Allocation is a bare `next_job_id.fetch_add(1)` with no live-id skipping, so wrapping would also need that, plus an audit of every other place ordering is assumed. Worth doing only if the ceiling is actually wanted; it is not needed to fix this.

## Legacy rows are rewritten, not decoded

A pre-fix controller could have already stored an id above `i32::MAX` as its negative wrap. Rather than heal those at read time, the migration repairs the data once, right after each `ALTER ... TYPE BIGINT`:

```sql
UPDATE jobs SET job_id = job_id + 4294967296
WHERE job_id < 0
  AND NOT EXISTS (SELECT 1 FROM jobs j WHERE j.job_id = jobs.job_id + 4294967296);
-- plus jobs.preempted_by and tres_usage.job_id
```

The `NOT EXISTS` guard skips a negative row whose true id already exists so the rewrite can never violate the primary key (defensive — a genuine pre-fix `INTEGER` column cannot itself hold the true id, so this only matters for a hand-corrupted table). The rewrite runs inside the same transaction as the widening, so a partial apply rolls back cleanly and never leaves the table half-migrated.

This removes the read/lookup asymmetry an earlier revision had: decoding at read time meant `get_job_history` healed a stored `-1` back to `u32::MAX` while `job_accounting_states` bound the positive id and missed the row, so the reconciler inserted a duplicate at the positive id and double-charged usage on its end write. With the data rewritten, `decode_job_id` is gone and both paths are plain `i64` → `u32` conversions. `job_accounting_states` also drops its now-unreachable `HashMap` inversion — every returned `job_id` is by construction an element of the bound list.

## Upgrade behaviour — **breaking, roll forward only**

Existing databases are migrated in place by the first upgraded controller. The type change is guarded on the column's current type, so it runs once rather than on every start. `ALTER COLUMN TYPE` from `INTEGER` to `BIGINT` is not binary-coercible, so it rewrites the table and holds `ACCESS EXCLUSIVE` on `jobs` for the duration — writes to that table block while the migration runs, and the duration scales with the row count.

**Rolling back to a pre-migration controller is not supported.** An older binary decodes `job_id` as `i32` and binds `&[i32]`, so `get_job_history` and `job_accounting_states` fail outright against a migrated database (writes survive, since Postgres widens an `int4` parameter). Because that breaks an older client against a migrated DB, the title now carries `!` (`fix(spurctld)!:`). This is documented in `docs/deployment/upgrading.rst` under "Safe Upgrade Order".

No proto change: `RecordJobStartRequest.job_id` stays `uint32`, matching `JobId`.

## Testing

DB integration tests (in the `DB tests (accounting)` job), seeded against real legacy negative rows before migrating:

- `job_ids_past_i32_survive_the_accounting_round_trip` — writes `u32::MAX` through `record_job_start`/`record_job_end`, reads it back through `get_job_history` and `job_accounting_states`, asserting the id and `preempted_by` survive.
- `migrate_rewrites_a_legacy_narrowed_row_to_its_real_id` — seeds a `-1` row in a narrowed schema, runs `migrate`, and asserts it reads back under `u32::MAX` and that the reconciler's lookup finds it.
- `migrate_skips_a_legacy_id_whose_real_id_already_exists` — seeds both a `-1` row and a row already at the true id, and asserts the guard leaves the negative row untouched rather than duplicating or colliding.
- `migrate_widens_pre_fix_integer_job_ids` — reconstructs a pre-fix schema, asserts all three columns widen, and re-runs to pin idempotency. Its schema restore now runs on the failure path too, so a local `--ignored` run that fails midway does not leave the shared DB narrow.

`cargo clippy --workspace --exclude spur-ffi --all-targets --locked` warning-free, full `cargo test --locked` green, and all accounting DB tests pass against a local Postgres.

Also: corrected the `max_job_id` configuration note (the counter still wraps past `u32::MAX`, so it does not make the full range safe on its own), and trimmed the migration/test comment blocks per repo style.

## Deferred

`SET LOCAL lock_timeout` inside the migration transaction (so the rewrite fails fast instead of queueing behind an older replica's open transaction) is left as a follow-up. It changes startup failure semantics and picking the timeout is a policy call; keeping this PR focused on the correctness fix. The rewrite makes that pre-existing behaviour more expensive but does not introduce it.
