### PR TITLE
fix(spur-cli): show planned job/start and composite State= for plnd nodes

### DIFF
--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -695,6 +695,9 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                 if !node.active_reservation.is_empty() {
                     println!("   ActiveReservation={}", node.active_reservation);
                 }
+                if let Some(line) = planned_reservation_line(&node) {
+                    println!("   {line}");
+                }
                 println!("   CpuLoad={}", node.cpu_load as f64 / 100.0);
                 println!();
             }
@@ -920,6 +923,19 @@ fn format_ts(ts: Option<&prost_types::Timestamp>) -> String {
         }
         _ => "N/A".into(),
     }
+}
+
+/// `PlannedJobId=/PlannedStartTime=` line for `scontrol show node`, or `None`
+/// when the node has no scheduler-held future reservation.
+fn planned_reservation_line(node: &spur_proto::proto::NodeInfo) -> Option<String> {
+    if node.planned_job_id == 0 {
+        return None;
+    }
+    Some(format!(
+        "PlannedJobId={} PlannedStartTime={}",
+        node.planned_job_id,
+        format_ts(node.planned_start.as_ref()),
+    ))
 }
 
 async fn requeue(controller: &str, job_id: u32, hold: bool) -> Result<()> {
@@ -1734,6 +1750,27 @@ mod tests {
     fn gpu_tres_label_total() {
         assert_eq!(gpu_tres_label("gpu:8"), "TresPerJob");
         assert_eq!(gpu_tres_label("gpu:mi300x:4"), "TresPerJob");
+    }
+
+    #[test]
+    fn planned_reservation_line_none_when_no_planned_job() {
+        let node = spur_proto::proto::NodeInfo::default();
+        assert_eq!(planned_reservation_line(&node), None);
+    }
+
+    #[test]
+    fn planned_reservation_line_shows_job_and_start() {
+        let node = spur_proto::proto::NodeInfo {
+            planned_job_id: 42,
+            planned_start: Some(prost_types::Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            }),
+            ..Default::default()
+        };
+        let line = planned_reservation_line(&node).unwrap();
+        assert!(line.contains("PlannedJobId=42"), "{line}");
+        assert!(line.contains("PlannedStartTime=2023-11-14"), "{line}");
     }
 
     #[test]

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -659,7 +659,7 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                 println!("NodeName={}", node.name);
                 println!(
                     "   State={} Reason={}",
-                    node_state_name(node.state),
+                    node_state_display(&node),
                     node.state_reason
                 );
                 if !node.partitions.is_empty() {
@@ -912,6 +912,22 @@ fn node_state_name(state: i32) -> &'static str {
     spur_core::node::NodeState::from_proto_i32(state)
         .map(|s| s.display_upper())
         .unwrap_or("UNKNOWN")
+}
+
+/// `State=` value for `scontrol show node`, composited the way real Slurm
+/// does (`IDLE+RESERVED`, `IDLE+MAINTENANCE+RESERVED`, `IDLE+PLANNED`).
+fn node_state_display(node: &spur_proto::proto::NodeInfo) -> String {
+    let base = node_state_name(node.state);
+    match spur_core::node::node_overlay(node) {
+        Some(spur_core::node::NodeOverlay::Reserved { maint: true }) => {
+            format!("{base}+MAINTENANCE+RESERVED")
+        }
+        Some(spur_core::node::NodeOverlay::Reserved { maint: false }) => {
+            format!("{base}+RESERVED")
+        }
+        Some(spur_core::node::NodeOverlay::Planned) => format!("{base}+PLANNED"),
+        None => base.to_string(),
+    }
 }
 
 fn format_ts(ts: Option<&prost_types::Timestamp>) -> String {
@@ -1785,6 +1801,48 @@ mod tests {
             planned_reservation_line(&node).unwrap(),
             "PlannedJobId=42 PlannedStartTime=N/A"
         );
+    }
+
+    fn idle_node() -> spur_proto::proto::NodeInfo {
+        spur_proto::proto::NodeInfo {
+            state: spur_proto::proto::NodeState::NodeIdle as i32,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn node_state_display_plain_idle() {
+        assert_eq!(node_state_display(&idle_node()), "IDLE");
+    }
+
+    #[test]
+    fn node_state_display_reserved() {
+        let mut node = idle_node();
+        node.active_reservation = "r1".into();
+        assert_eq!(node_state_display(&node), "IDLE+RESERVED");
+    }
+
+    #[test]
+    fn node_state_display_maintenance_reserved() {
+        let mut node = idle_node();
+        node.active_reservation = "r1".into();
+        node.reservation_maint = true;
+        assert_eq!(node_state_display(&node), "IDLE+MAINTENANCE+RESERVED");
+    }
+
+    #[test]
+    fn node_state_display_planned() {
+        let mut node = idle_node();
+        node.planned_job_id = 42;
+        assert_eq!(node_state_display(&node), "IDLE+PLANNED");
+    }
+
+    #[test]
+    fn node_state_display_non_idle_state_ignores_overlay_fields() {
+        let mut node = idle_node();
+        node.state = spur_proto::proto::NodeState::NodeAllocated as i32;
+        node.planned_job_id = 42;
+        assert_eq!(node_state_display(&node), "ALLOCATED");
     }
 
     #[test]

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -925,8 +925,8 @@ fn format_ts(ts: Option<&prost_types::Timestamp>) -> String {
     }
 }
 
-/// `PlannedJobId=/PlannedStartTime=` line for `scontrol show node`, or `None`
-/// when the node has no scheduler-held future reservation.
+/// `PlannedJobId=/PlannedStartTime=` line for `scontrol show node` (`None` if
+/// unset, `N/A` start if unknown); server only sets it while Idle, like sinfo's `plnd`.
 fn planned_reservation_line(node: &spur_proto::proto::NodeInfo) -> Option<String> {
     if node.planned_job_id == 0 {
         return None;
@@ -1768,9 +1768,23 @@ mod tests {
             }),
             ..Default::default()
         };
-        let line = planned_reservation_line(&node).unwrap();
-        assert!(line.contains("PlannedJobId=42"), "{line}");
-        assert!(line.contains("PlannedStartTime=2023-11-14"), "{line}");
+        assert_eq!(
+            planned_reservation_line(&node).unwrap(),
+            "PlannedJobId=42 PlannedStartTime=2023-11-14T22:13:20"
+        );
+    }
+
+    #[test]
+    fn planned_reservation_line_start_na_when_unset() {
+        let node = spur_proto::proto::NodeInfo {
+            planned_job_id: 42,
+            planned_start: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            planned_reservation_line(&node).unwrap(),
+            "PlannedJobId=42 PlannedStartTime=N/A"
+        );
     }
 
     #[test]

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -333,20 +333,14 @@ fn resolve_partition_field(
 }
 
 fn effective_state_str(node: &NodeInfo) -> String {
-    if node.state == spur_proto::proto::NodeState::NodeIdle as i32 {
-        if !node.active_reservation.is_empty() {
-            if node.reservation_maint {
-                return "maint".into();
-            }
-            return "resv".into();
-        }
-        if node.planned_job_id != 0 {
-            return "plnd".into();
-        }
+    match spur_core::node::node_overlay(node) {
+        Some(spur_core::node::NodeOverlay::Reserved { maint: true }) => "maint".into(),
+        Some(spur_core::node::NodeOverlay::Reserved { maint: false }) => "resv".into(),
+        Some(spur_core::node::NodeOverlay::Planned) => "plnd".into(),
+        None => spur_core::node::NodeState::from_proto_i32(node.state)
+            .map(|s| s.short().to_string())
+            .unwrap_or_else(|| "unk".into()),
     }
-    spur_core::node::NodeState::from_proto_i32(node.state)
-        .map(|s| s.short().to_string())
-        .unwrap_or_else(|| "unk".into())
 }
 
 #[cfg(test)]

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -212,6 +212,34 @@ impl std::fmt::Display for NodeState {
     }
 }
 
+/// A display-only condition layered on top of an Idle node — CLI-facing
+/// (sinfo/scontrol), not part of the persisted [`NodeState`] machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeOverlay {
+    /// Held by an active reservation; `maint` also carries the MAINT flag.
+    Reserved { maint: bool },
+    /// Idle now, but earmarked by backfill for a future job's start.
+    Planned,
+}
+
+/// Resolve the overlay for a node, matching Slurm's own precedence: an
+/// active reservation wins over a backfill plan, and both only apply while
+/// the node is otherwise Idle.
+pub fn node_overlay(node: &spur_proto::proto::NodeInfo) -> Option<NodeOverlay> {
+    if node.state != spur_proto::proto::NodeState::NodeIdle as i32 {
+        return None;
+    }
+    if !node.active_reservation.is_empty() {
+        return Some(NodeOverlay::Reserved {
+            maint: node.reservation_maint,
+        });
+    }
+    if node.planned_job_id != 0 {
+        return Some(NodeOverlay::Planned);
+    }
+    None
+}
+
 /// Where a node originates from.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -687,5 +715,64 @@ mod tests {
     fn node_state_from_short_or_name_rejects_unknown() {
         assert_eq!(NodeState::from_short_or_name("bogus"), None);
         assert_eq!(NodeState::from_short_or_name(""), None);
+    }
+
+    fn idle_node_info() -> spur_proto::proto::NodeInfo {
+        spur_proto::proto::NodeInfo {
+            state: spur_proto::proto::NodeState::NodeIdle as i32,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn node_overlay_none_when_plain_idle() {
+        assert_eq!(node_overlay(&idle_node_info()), None);
+    }
+
+    #[test]
+    fn node_overlay_none_when_not_idle_even_with_reservation() {
+        let mut node = idle_node_info();
+        node.state = spur_proto::proto::NodeState::NodeAllocated as i32;
+        node.active_reservation = "r1".into();
+        assert_eq!(node_overlay(&node), None);
+    }
+
+    #[test]
+    fn node_overlay_reserved_without_maint() {
+        let mut node = idle_node_info();
+        node.active_reservation = "r1".into();
+        assert_eq!(
+            node_overlay(&node),
+            Some(NodeOverlay::Reserved { maint: false })
+        );
+    }
+
+    #[test]
+    fn node_overlay_reserved_with_maint() {
+        let mut node = idle_node_info();
+        node.active_reservation = "r1".into();
+        node.reservation_maint = true;
+        assert_eq!(
+            node_overlay(&node),
+            Some(NodeOverlay::Reserved { maint: true })
+        );
+    }
+
+    #[test]
+    fn node_overlay_planned() {
+        let mut node = idle_node_info();
+        node.planned_job_id = 42;
+        assert_eq!(node_overlay(&node), Some(NodeOverlay::Planned));
+    }
+
+    #[test]
+    fn node_overlay_reservation_wins_over_planned() {
+        let mut node = idle_node_info();
+        node.active_reservation = "r1".into();
+        node.planned_job_id = 42;
+        assert_eq!(
+            node_overlay(&node),
+            Some(NodeOverlay::Reserved { maint: false })
+        );
     }
 }

--- a/tests/native_host/e2e/test_multi_node.py
+++ b/tests/native_host/e2e/test_multi_node.py
@@ -241,6 +241,9 @@ class TestBackfillReservation:
             f"n1 is idle-but-reserved for big_id={big_id}, "
             f"scontrol show node should report it:\n{n1_show}"
         )
+        assert "State=IDLE+PLANNED" in n1_show, (
+            f"n1's State= should carry the PLANNED overlay flag:\n{n1_show}"
+        )
 
         cluster.scancel(str(small_id))
 

--- a/tests/native_host/e2e/test_multi_node.py
+++ b/tests/native_host/e2e/test_multi_node.py
@@ -235,6 +235,13 @@ class TestBackfillReservation:
         assert job_state(sq, small_id) == "PD", (
             f"small job should stay pending, reserved capacity was taken:\n{sq}"
         )
+
+        n1_show = cluster.scontrol_show_node(n1)
+        assert f"PlannedJobId={big_id}" in n1_show, (
+            f"n1 is idle-but-reserved for big_id={big_id}, "
+            f"scontrol show node should report it:\n{n1_show}"
+        )
+
         cluster.scancel(str(small_id))
 
         wait_job(cluster, big_id, timeout=90)


### PR DESCRIPTION
## Summary

Since the backfill-starvation fix, an idle node the scheduler holds a future reservation for shows as `plnd` in `sinfo` (`NodeInfo.planned_job_id`/`planned_start`, already populated by the controller every scheduling pass). But `scontrol show node` gave no visibility into this at all: `State=` always printed the raw node state (e.g. `IDLE`), with no indication a reservation was in play, and no way to see which job was holding the node or when it was expected to start.

This PR:
1. Adds a `PlannedJobId=<id> PlannedStartTime=<ts>` line to `scontrol show node <name>`, shown only when the node has a scheduler-held reservation.
2. Makes `State=` itself carry the overlay, matching **real Slurm's own behavior** (verified live against a Slurm 25.11.6 cluster): `State=IDLE+RESERVED`, `State=IDLE+MAINTENANCE+RESERVED`, `State=IDLE+PLANNED`. Previously Spur's `scontrol show node` never reflected `resv`/`maint`/`plnd` in `State=` at all (only `sinfo` did) — this brings it in line with Slurm and fixes that gap for all three, not just `plnd`.

## Approach

- Extracted the Idle+active_reservation+planned_job_id branching (previously only in `sinfo.rs`'s `effective_state_str`) into a shared `spur_core::node::node_overlay()`, so `sinfo` and `scontrol` derive the same precedence instead of duplicating/drifting independently. `sinfo`'s existing 36 tests pass unchanged, confirming the refactor is behavior-preserving there.
- New `node_state_display()` in `scontrol.rs` composes `{base}+{overlay flags}` the same way Slurm does.
- Kept `ActiveReservation=`/`PlannedJobId=`/`PlannedStartTime=` as separate labeled lines in addition to the composited `State=` — redundant with the state string but non-breaking and still useful for anything already parsing those fields. Notably, real Slurm's own `scontrol show node` does NOT show which job or start time for a `PLANNED` node at all (you have to cross-reference `squeue --start`) — so this PR's `PlannedJobId=`/`PlannedStartTime=` lines are ahead of Slurm here, not just parity.
- Considered a `sinfo` long-format column for the job-id/start-time too, but `sinfo`'s default view groups multiple nodes per partition/state row — a single column doesn't fit when different nodes in the same group are held by different jobs. Left as a known limitation.

## Known limitations

- `format_ts` (pre-existing, shared helper) silently falls back to the Unix epoch rather than an explicit error if given a corrupt/out-of-range timestamp — not introduced by this change, out of scope here.
- No `sinfo` column for job-id/start-time (see above).
- `State=` output value changes for nodes already in `resv`/`maint` (previously just `IDLE`, now `IDLE+RESERVED`/`IDLE+MAINTENANCE+RESERVED`). This is a user-facing CLI output change, not a schema break — no field removed/renamed. No script/test in this repo currently asserts an exact `State=IDLE` string for these cases, but flagging in case any external Slurm-compat tooling parses it literally.

## Testing

- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` and `cargo fmt --all --check`: clean.
- `cargo test -p spur-core -p spur-cli --locked`: 618 + 434 tests pass, including new unit tests for `node_overlay()` (spur-core) and `node_state_display()` (spur-cli) covering plain-idle, reserved, maintenance+reserved, planned, and non-idle-ignores-overlay cases. Verified each new test fails against a stubbed-out version of the fix and passes once restored.
- Extended the existing `TestBackfillReservation` e2e test (`tests/native_host/e2e/test_multi_node.py`) — it already reproduces the exact `plnd` scenario — with assertions on both the new `PlannedJobId=` line and the composited `State=IDLE+PLANNED`. Ran it against the real 2-node lab: passes.
- Validated end-to-end on an isolated 2-node deployment, reproducing the scenario twice (once for each commit in this PR):

  ```
  $ sinfo -N
  NODELIST  NODES PARTITION       STATE CPUS   MEMORY GRES
  node2          1 iso        plnd    4    15989 (null)
  node1          1 iso       alloc   10    60267 (null)

  $ scontrol show node node2
  NodeName=node2
     State=IDLE+PLANNED Reason=
     Partitions=iso
     CPUTot=4 CPUAlloc=0 RealMemory=15989 FreeMem=15411
     Arch= OS=
     PlannedJobId=2 PlannedStartTime=2026-08-26T12:41:05
     CpuLoad=0

  $ scontrol show node node1
  NodeName=node1
     State=ALLOCATED Reason=
     ...
  ```

  Confirmed `State=` carries the overlay exactly when the node has a scheduler-held reservation and is otherwise raw for a non-idle node (`node1` above, busy with the filler job).