### PR TITLE
test(e2e): exclusive node blocking — CPU, GPU, single-node and multi-node

### DIFF
--- a/tests/native_host/e2e/test_exclusive_blocking.py
+++ b/tests/native_host/e2e/test_exclusive_blocking.py
@@ -293,7 +293,7 @@ class TestExclusiveBlocking:
 
             # Verify it actually landed on both nodes.
             sq = cluster.squeue_all()
-            holder_lines = [l for l in sq.splitlines() if str(holder_id) in l]
+            holder_lines = [line for line in sq.splitlines() if str(holder_id) in line]
             assert holder_lines, f"holder {holder_id} not in squeue"
             assert "2" in holder_lines[0], (
                 f"holder should show 2 nodes in squeue:\n{holder_lines[0]}"

--- a/tests/native_host/e2e/test_exclusive_blocking.py
+++ b/tests/native_host/e2e/test_exclusive_blocking.py
@@ -9,11 +9,42 @@ scheduler from placing any other job on that node while the exclusive job runs,
 regardless of how many resources remain nominally free.
 """
 
+import re
 import time
 
 import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
+
+
+def _expand_nodelist(nodelist: str) -> list:
+    """Expand a Slurm compressed hostlist into individual node names.
+
+    Handles plain names, comma-separated lists, and bracket notation like
+    ``node[1-3,5]`` → [node1, node2, node3, node5].  Commas inside brackets
+    are treated as range separators, not top-level delimiters.
+    """
+    # Split on commas that are outside brackets.
+    parts = re.split(r",(?![^\[]*\])", nodelist)
+    nodes = []
+    for part in parts:
+        part = part.strip()
+        m = re.match(r"^(.*)\[([^\]]+)\](.*)$", part)
+        if not m:
+            nodes.append(part)
+            continue
+        prefix, ranges, suffix = m.group(1), m.group(2), m.group(3)
+        for token in ranges.split(","):
+            token = token.strip()
+            if "-" in token:
+                lo, hi = token.split("-", 1)
+                width = len(lo)
+                for n in range(int(lo), int(hi) + 1):
+                    nodes.append(f"{prefix}{str(n).zfill(width)}{suffix}")
+            else:
+                nodes.append(f"{prefix}{token}{suffix}")
+    return nodes
+
 
 # How long to keep polling after the holder is running before declaring the
 # blocked job incorrectly scheduled. The backfill interval in e2e tests is
@@ -276,8 +307,6 @@ class TestExclusiveBlocking:
         Requires at least 2 nodes in SPUR_TEST_NODES.
         """
         cluster.require_nodes(2)
-        node0 = cluster.node_names[0]
-        node1 = cluster.node_names[1]
 
         holder_script = cluster.write_file(
             "excl-mn-holder.sh", "#!/bin/bash\nsleep 300\n"
@@ -298,45 +327,42 @@ class TestExclusiveBlocking:
         try:
             wait_job_state(cluster, holder_id, "R", timeout=60)
 
-            # Verify it actually landed on both nodes by checking NODES column (field 8).
-            sq = cluster.squeue(["-j", str(holder_id), "-h", "-o", "%i %D %R"])
-            parts = sq.strip().split()
-            assert parts, f"holder {holder_id} not found in squeue"
-            assert parts[1] == "2", (
-                f"holder should show 2 nodes in squeue, got: {sq.strip()!r}"
+            # Read the nodes the holder actually landed on — do not assume
+            # node_names[0]/[1] match the allocated nodes. The cluster may have
+            # a controller-only node that the scheduler skips.
+            sq = cluster.squeue(["-j", str(holder_id), "-h", "-o", "%D %N"])
+            parts = sq.strip().split(None, 1)
+            assert len(parts) == 2, f"unexpected squeue output for holder: {sq!r}"
+            assert parts[0] == "2", (
+                f"holder should be allocated 2 nodes, got: {sq.strip()!r}"
+            )
+            allocated_nodes = _expand_nodelist(parts[1].strip())
+            assert len(allocated_nodes) == 2, (
+                f"expected 2 allocated nodes, got {allocated_nodes}"
             )
 
-            # Submit both blocked jobs before polling either — so that a failure
-            # on one node is not masked by the time we check the other.
-            blocked0_script = cluster.write_file(
-                "excl-mn-blocked0.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
-            )
-            blocked0_id = parse_job_id(
-                cluster.sbatch(
-                    ["-N", "1", "-w", node0, "-c", "1", "-t", "1", blocked0_script]
+            # Submit one blocked job per allocated node before polling either,
+            # so a failure on one node is not masked while we watch the other.
+            blocked_ids = []
+            for i, node in enumerate(allocated_nodes):
+                script = cluster.write_file(
+                    f"excl-mn-blocked{i}.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
                 )
-            )
-            assert blocked0_id is not None
-
-            blocked1_script = cluster.write_file(
-                "excl-mn-blocked1.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
-            )
-            blocked1_id = parse_job_id(
-                cluster.sbatch(
-                    ["-N", "1", "-w", node1, "-c", "1", "-t", "1", blocked1_script]
+                bid = parse_job_id(
+                    cluster.sbatch(
+                        ["-N", "1", "-w", node, "-c", "1", "-t", "1", script]
+                    )
                 )
-            )
-            assert blocked1_id is not None
+                assert bid is not None, f"blocked job {i} did not submit"
+                blocked_ids.append(bid)
 
             try:
-                # Poll both jobs together on every tick so neither can run and
-                # complete while the other is being checked.
                 _assert_all_stay_pending_for_resources(
-                    cluster, [blocked0_id, blocked1_id], holder_id, _BLOCKING_POLL_SECS
+                    cluster, blocked_ids, holder_id, _BLOCKING_POLL_SECS
                 )
             finally:
-                cluster.scancel(str(blocked0_id))
-                cluster.scancel(str(blocked1_id))
+                for bid in blocked_ids:
+                    cluster.scancel(str(bid))
         finally:
             cluster.scancel(str(holder_id))
 
@@ -349,16 +375,6 @@ class TestExclusiveBlocking:
         cluster = gpu_cluster
         cluster.require_nodes(2)
         cluster.gpu_preflight(2)
-
-        node0 = cluster.node_names[0]
-        node1 = cluster.node_names[1]
-
-        for name in [node0, node1]:
-            if cluster.node_gpu_count(name) < 2:
-                pytest.skip(
-                    f"need >= 2 GPUs on each node to prove remaining GPUs are blocked "
-                    f"(node {name} has {cluster.node_gpu_count(name)})"
-                )
 
         holder_script = cluster.write_file(
             "excl-mn-gpu-holder.sh", "#!/bin/bash\nsleep 300\n"
@@ -380,34 +396,45 @@ class TestExclusiveBlocking:
         try:
             wait_job_state(cluster, holder_id, "R", timeout=60)
 
-            blocked0_script = cluster.write_file(
-                "excl-mn-gpu-blocked0.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
+            # Read the nodes the holder actually landed on.
+            sq = cluster.squeue(["-j", str(holder_id), "-h", "-o", "%D %N"])
+            parts = sq.strip().split(None, 1)
+            assert len(parts) == 2, f"unexpected squeue output for holder: {sq!r}"
+            assert parts[0] == "2", (
+                f"holder should be allocated 2 nodes, got: {sq.strip()!r}"
             )
-            blocked0_id = parse_job_id(
-                cluster.sbatch(
-                    ["-N", "1", "-w", node0, "-c", "1", "--gres=gpu:1", "-t", "1",
-                     blocked0_script]
-                )
+            allocated_nodes = _expand_nodelist(parts[1].strip())
+            assert len(allocated_nodes) == 2, (
+                f"expected 2 allocated nodes, got {allocated_nodes}"
             )
-            assert blocked0_id is not None
 
-            blocked1_script = cluster.write_file(
-                "excl-mn-gpu-blocked1.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
-            )
-            blocked1_id = parse_job_id(
-                cluster.sbatch(
-                    ["-N", "1", "-w", node1, "-c", "1", "--gres=gpu:1", "-t", "1",
-                     blocked1_script]
+            for name in allocated_nodes:
+                if cluster.node_gpu_count(name) < 2:
+                    pytest.skip(
+                        f"need >= 2 GPUs on each node to prove remaining GPUs are blocked "
+                        f"(node {name} has {cluster.node_gpu_count(name)})"
+                    )
+
+            blocked_ids = []
+            for i, node in enumerate(allocated_nodes):
+                script = cluster.write_file(
+                    f"excl-mn-gpu-blocked{i}.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
                 )
-            )
-            assert blocked1_id is not None
+                bid = parse_job_id(
+                    cluster.sbatch(
+                        ["-N", "1", "-w", node, "-c", "1", "--gres=gpu:1", "-t", "1",
+                         script]
+                    )
+                )
+                assert bid is not None, f"GPU blocked job {i} did not submit"
+                blocked_ids.append(bid)
 
             try:
                 _assert_all_stay_pending_for_resources(
-                    cluster, [blocked0_id, blocked1_id], holder_id, _BLOCKING_POLL_SECS
+                    cluster, blocked_ids, holder_id, _BLOCKING_POLL_SECS
                 )
             finally:
-                cluster.scancel(str(blocked0_id))
-                cluster.scancel(str(blocked1_id))
+                for bid in blocked_ids:
+                    cluster.scancel(str(bid))
         finally:
             cluster.scancel(str(holder_id))

--- a/tests/native_host/e2e/test_exclusive_blocking.py
+++ b/tests/native_host/e2e/test_exclusive_blocking.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests that verify exclusive jobs fence their node against co-scheduling.
+
+The specific scenario covered: an exclusive job that requests only 1 CPU (and
+optionally 1 GPU) out of a node's full capacity must prevent the backfill
+scheduler from placing any other job on that node while the exclusive job runs,
+regardless of how many resources remain nominally free.
+"""
+
+import time
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+
+class TestExclusiveBlocking:
+    def test_exclusive_cpu_blocks_coscheduling(self, cluster):
+        """An exclusive job requesting 1 CPU blocks a second job from landing on
+        the same node, even though 63 of 64 CPUs are nominally free."""
+        node = cluster.node_names[0]
+
+        # A long-running exclusive job that requests just 1 CPU.
+        holder_script = cluster.write_file(
+            "excl-holder.sh", "#!/bin/bash\nsleep 300\n"
+        )
+        holder_id = parse_job_id(
+            cluster.sbatch(
+                [
+                    "-N", "1",
+                    "-w", node,
+                    "--exclusive",
+                    "-c", "1",
+                    "-t", "10",
+                    holder_script,
+                ]
+            )
+        )
+        assert holder_id is not None, "holder job did not submit"
+
+        try:
+            wait_job_state(cluster, holder_id, "R", timeout=60)
+
+            # A second job targeting the same node must stay PENDING.
+            # Use -c 1 so the request is trivially satisfiable on resources
+            # alone — the only reason it should pend is the exclusive hold.
+            blocker_script = cluster.write_file(
+                "excl-blocked.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
+            )
+            blocked_id = parse_job_id(
+                cluster.sbatch(
+                    [
+                        "-N", "1",
+                        "-w", node,
+                        "-c", "1",
+                        "-t", "1",
+                        blocker_script,
+                    ]
+                )
+            )
+            assert blocked_id is not None, "blocked job did not submit"
+
+            try:
+                # Give the scheduler several cycles to (incorrectly) start it.
+                time.sleep(15)
+                sq = cluster.squeue_all()
+                lines = [l for l in sq.splitlines() if str(blocked_id) in l]
+                assert lines, f"blocked job {blocked_id} not found in squeue:\n{sq}"
+                state = lines[0].split()[4] if len(lines[0].split()) > 4 else ""
+                assert state == "PD", (
+                    f"job {blocked_id} should be PENDING while exclusive job "
+                    f"{holder_id} holds the node, but state={state!r}:\n{sq}"
+                )
+            finally:
+                cluster.scancel(str(blocked_id))
+        finally:
+            cluster.scancel(str(holder_id))
+
+    def test_exclusive_gpu_blocks_coscheduling(self, gpu_cluster):
+        """An exclusive job requesting 1 CPU and 1 GPU blocks a second GPU job
+        from landing on the same node, even though most GPUs are nominally free."""
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+
+        node = cluster.node_names[0]
+        total_gpus = cluster.node_gpu_count(node)
+        if total_gpus < 2:
+            pytest.skip(
+                f"need >= 2 GPUs on {node} to prove remaining GPUs are blocked "
+                f"(found {total_gpus})"
+            )
+
+        # Exclusive holder: 1 CPU, 1 GPU — leaving total_gpus-1 GPUs "free".
+        holder_script = cluster.write_file(
+            "excl-gpu-holder.sh", "#!/bin/bash\nsleep 300\n"
+        )
+        holder_id = parse_job_id(
+            cluster.sbatch(
+                [
+                    "-N", "1",
+                    "-w", node,
+                    "--exclusive",
+                    "-c", "1",
+                    "--gres=gpu:1",
+                    "-t", "10",
+                    holder_script,
+                ]
+            )
+        )
+        assert holder_id is not None, "GPU holder job did not submit"
+
+        try:
+            wait_job_state(cluster, holder_id, "R", timeout=60)
+
+            # Second job wants 1 GPU on the same node — should be blocked.
+            blocked_script = cluster.write_file(
+                "excl-gpu-blocked.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
+            )
+            blocked_id = parse_job_id(
+                cluster.sbatch(
+                    [
+                        "-N", "1",
+                        "-w", node,
+                        "-c", "1",
+                        "--gres=gpu:1",
+                        "-t", "1",
+                        blocked_script,
+                    ]
+                )
+            )
+            assert blocked_id is not None, "GPU blocked job did not submit"
+
+            try:
+                time.sleep(15)
+                sq = cluster.squeue_all()
+                lines = [l for l in sq.splitlines() if str(blocked_id) in l]
+                assert lines, f"blocked GPU job {blocked_id} not found in squeue:\n{sq}"
+                state = lines[0].split()[4] if len(lines[0].split()) > 4 else ""
+                assert state == "PD", (
+                    f"GPU job {blocked_id} should be PENDING while exclusive job "
+                    f"{holder_id} holds the node with {total_gpus} GPUs, "
+                    f"but state={state!r}:\n{sq}"
+                )
+            finally:
+                cluster.scancel(str(blocked_id))
+        finally:
+            cluster.scancel(str(holder_id))
+
+    def test_exclusive_node_released_after_job_completes(self, cluster):
+        """After an exclusive job finishes, the node becomes available and a
+        waiting job schedules without manual intervention."""
+        node = cluster.node_names[0]
+
+        # Short exclusive holder.
+        holder_script = cluster.write_file(
+            "excl-release-holder.sh", "#!/bin/bash\nsleep 10\n"
+        )
+        holder_id = parse_job_id(
+            cluster.sbatch(
+                [
+                    "-N", "1",
+                    "-w", node,
+                    "--exclusive",
+                    "-c", "1",
+                    "-t", "2",
+                    holder_script,
+                ]
+            )
+        )
+        assert holder_id is not None
+
+        try:
+            wait_job_state(cluster, holder_id, "R", timeout=60)
+
+            # Waiter submitted while holder is running.
+            out_path = f"{cluster.remote_dir}/excl-release-waiter.out"
+            waiter_script = cluster.write_file(
+                "excl-release-waiter.sh", "#!/bin/bash\necho RELEASED_OK\n"
+            )
+            waiter_id = parse_job_id(
+                cluster.sbatch(
+                    [
+                        "-N", "1",
+                        "-w", node,
+                        "-c", "1",
+                        "-t", "1",
+                        "-o", out_path,
+                        waiter_script,
+                    ]
+                )
+            )
+            assert waiter_id is not None
+
+            # Holder finishes, then waiter must complete.
+            wait_job(cluster, holder_id, timeout=60)
+            state = wait_job(cluster, waiter_id, timeout=60)
+            assert state in ("CD", "GONE"), (
+                f"waiter job {waiter_id} should complete after exclusive job "
+                f"releases the node, but state={state!r}"
+            )
+
+            content = cluster.read_output_on_any_node(out_path)
+            assert "RELEASED_OK" in content, (
+                f"waiter output missing after node release:\n{content}"
+            )
+        finally:
+            cluster.scancel(str(holder_id))

--- a/tests/native_host/e2e/test_exclusive_blocking.py
+++ b/tests/native_host/e2e/test_exclusive_blocking.py
@@ -261,3 +261,150 @@ class TestExclusiveBlocking:
             )
         finally:
             cluster.scancel(str(holder_id))
+
+    def test_exclusive_multinode_blocks_coscheduling(self, cluster):
+        """An exclusive 2-node job requesting 1 CPU per node blocks a third job
+        from landing on either node, even though 63 CPUs per node are free.
+
+        Requires at least 2 nodes in SPUR_TEST_NODES.
+        """
+        cluster.require_nodes(2)
+        node0 = cluster.node_names[0]
+        node1 = cluster.node_names[1]
+
+        holder_script = cluster.write_file(
+            "excl-mn-holder.sh", "#!/bin/bash\nsleep 300\n"
+        )
+        holder_id = parse_job_id(
+            cluster.sbatch(
+                [
+                    "-N", "2",
+                    "--exclusive",
+                    "-c", "1",
+                    "-t", "10",
+                    holder_script,
+                ]
+            )
+        )
+        assert holder_id is not None, "multi-node exclusive holder did not submit"
+
+        try:
+            wait_job_state(cluster, holder_id, "R", timeout=60)
+
+            # Verify it actually landed on both nodes.
+            sq = cluster.squeue_all()
+            holder_lines = [l for l in sq.splitlines() if str(holder_id) in l]
+            assert holder_lines, f"holder {holder_id} not in squeue"
+            assert "2" in holder_lines[0], (
+                f"holder should show 2 nodes in squeue:\n{holder_lines[0]}"
+            )
+
+            # A job pinned to node0 must pend for Resources.
+            blocked0_script = cluster.write_file(
+                "excl-mn-blocked0.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
+            )
+            blocked0_id = parse_job_id(
+                cluster.sbatch(
+                    ["-N", "1", "-w", node0, "-c", "1", "-t", "1", blocked0_script]
+                )
+            )
+            assert blocked0_id is not None
+
+            # A job pinned to node1 must also pend for Resources.
+            blocked1_script = cluster.write_file(
+                "excl-mn-blocked1.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
+            )
+            blocked1_id = parse_job_id(
+                cluster.sbatch(
+                    ["-N", "1", "-w", node1, "-c", "1", "-t", "1", blocked1_script]
+                )
+            )
+            assert blocked1_id is not None
+
+            try:
+                _assert_stays_pending_for_resources(
+                    cluster, blocked0_id, holder_id, _BLOCKING_POLL_SECS
+                )
+                _assert_stays_pending_for_resources(
+                    cluster, blocked1_id, holder_id, _BLOCKING_POLL_SECS
+                )
+            finally:
+                cluster.scancel(str(blocked0_id))
+                cluster.scancel(str(blocked1_id))
+        finally:
+            cluster.scancel(str(holder_id))
+
+    def test_exclusive_multinode_gpu_blocks_coscheduling(self, gpu_cluster):
+        """An exclusive 2-node GPU job requesting 1 GPU per node blocks further
+        GPU jobs from landing on either node, even though most GPUs are free.
+
+        Requires at least 2 nodes in SPUR_TEST_NODES.
+        """
+        cluster = gpu_cluster
+        cluster.require_nodes(2)
+        cluster.gpu_preflight(2)
+
+        node0 = cluster.node_names[0]
+        node1 = cluster.node_names[1]
+
+        for name in [node0, node1]:
+            if cluster.node_gpu_count(name) < 2:
+                pytest.skip(
+                    f"need >= 2 GPUs on each node to prove remaining GPUs are blocked "
+                    f"(node {name} has {cluster.node_gpu_count(name)})"
+                )
+
+        holder_script = cluster.write_file(
+            "excl-mn-gpu-holder.sh", "#!/bin/bash\nsleep 300\n"
+        )
+        holder_id = parse_job_id(
+            cluster.sbatch(
+                [
+                    "-N", "2",
+                    "--exclusive",
+                    "-c", "1",
+                    "--gres=gpu:1",
+                    "-t", "10",
+                    holder_script,
+                ]
+            )
+        )
+        assert holder_id is not None, "multi-node GPU exclusive holder did not submit"
+
+        try:
+            wait_job_state(cluster, holder_id, "R", timeout=60)
+
+            blocked0_script = cluster.write_file(
+                "excl-mn-gpu-blocked0.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
+            )
+            blocked0_id = parse_job_id(
+                cluster.sbatch(
+                    ["-N", "1", "-w", node0, "-c", "1", "--gres=gpu:1", "-t", "1",
+                     blocked0_script]
+                )
+            )
+            assert blocked0_id is not None
+
+            blocked1_script = cluster.write_file(
+                "excl-mn-gpu-blocked1.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
+            )
+            blocked1_id = parse_job_id(
+                cluster.sbatch(
+                    ["-N", "1", "-w", node1, "-c", "1", "--gres=gpu:1", "-t", "1",
+                     blocked1_script]
+                )
+            )
+            assert blocked1_id is not None
+
+            try:
+                _assert_stays_pending_for_resources(
+                    cluster, blocked0_id, holder_id, _BLOCKING_POLL_SECS
+                )
+                _assert_stays_pending_for_resources(
+                    cluster, blocked1_id, holder_id, _BLOCKING_POLL_SECS
+                )
+            finally:
+                cluster.scancel(str(blocked0_id))
+                cluster.scancel(str(blocked1_id))
+        finally:
+            cluster.scancel(str(holder_id))

--- a/tests/native_host/e2e/test_exclusive_blocking.py
+++ b/tests/native_host/e2e/test_exclusive_blocking.py
@@ -15,14 +15,74 @@ import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
 
+# How long to keep polling after the holder is running before declaring the
+# blocked job incorrectly scheduled. The backfill interval in e2e tests is
+# 1 second, so 10 seconds covers at least 10 full scheduler passes.
+_BLOCKING_POLL_SECS = 10
+_BLOCKING_POLL_STEP = 1
+
+
+def _job_state_and_reason(cluster, job_id: int) -> tuple[str, str]:
+    """Return (state, reason) for job_id using squeue %t and %r format fields.
+
+    Returns ("", "") when the job is not found (already gone).
+    """
+    out = cluster.squeue(["-j", str(job_id), "-h", "-o", "%t %r"])
+    out = out.strip()
+    if not out:
+        return "", ""
+    parts = out.split(None, 1)
+    state = parts[0] if parts else ""
+    reason = parts[1] if len(parts) > 1 else ""
+    return state, reason
+
+
+def _assert_stays_pending_for_resources(cluster, job_id: int, holder_id: int, duration: int):
+    """Poll for `duration` seconds and assert the job stays PD with reason Resources.
+
+    Fails immediately if the job starts running or if the reason is wrong after
+    at least one scheduler pass (i.e., after the first non-empty reason is seen).
+    """
+    deadline = time.time() + duration
+    reason_seen = False
+
+    while time.time() < deadline:
+        state, reason = _job_state_and_reason(cluster, job_id)
+
+        if state == "R":
+            sq = cluster.squeue_all()
+            raise AssertionError(
+                f"Job {job_id} started running while exclusive job {holder_id} "
+                f"holds the node — exclusive blocking is broken.\n{sq}"
+            )
+
+        if state == "PD":
+            reason_seen = True
+            assert reason == "Resources", (
+                f"Job {job_id} is PENDING but for the wrong reason: {reason!r}. "
+                f"Expected 'Resources' (blocked by exclusive holder {holder_id}). "
+                f"This may indicate a misconfigured partition or a different "
+                f"scheduling issue masking the real block."
+            )
+
+        time.sleep(_BLOCKING_POLL_STEP)
+
+    assert reason_seen, (
+        f"Job {job_id} never appeared as PD in squeue during the {duration}s window — "
+        f"it may have completed instantly or never been queued properly."
+    )
+
 
 class TestExclusiveBlocking:
     def test_exclusive_cpu_blocks_coscheduling(self, cluster):
         """An exclusive job requesting 1 CPU blocks a second job from landing on
-        the same node, even though 63 of 64 CPUs are nominally free."""
+        the same node, even though 63 of 64 CPUs are nominally free.
+
+        The blocked job must stay PD with reason=Resources (not Priority or
+        any other reason) for the duration of multiple backfill passes.
+        """
         node = cluster.node_names[0]
 
-        # A long-running exclusive job that requests just 1 CPU.
         holder_script = cluster.write_file(
             "excl-holder.sh", "#!/bin/bash\nsleep 300\n"
         )
@@ -43,10 +103,10 @@ class TestExclusiveBlocking:
         try:
             wait_job_state(cluster, holder_id, "R", timeout=60)
 
-            # A second job targeting the same node must stay PENDING.
-            # Use -c 1 so the request is trivially satisfiable on resources
-            # alone — the only reason it should pend is the exclusive hold.
-            blocker_script = cluster.write_file(
+            # -c 1 is trivially satisfiable on an idle node, so Resources is the
+            # only legitimate reason to pend — it proves the exclusive hold is
+            # blocking the scheduler, not a resource shortage or priority issue.
+            blocked_script = cluster.write_file(
                 "excl-blocked.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
             )
             blocked_id = parse_job_id(
@@ -56,22 +116,15 @@ class TestExclusiveBlocking:
                         "-w", node,
                         "-c", "1",
                         "-t", "1",
-                        blocker_script,
+                        blocked_script,
                     ]
                 )
             )
             assert blocked_id is not None, "blocked job did not submit"
 
             try:
-                # Give the scheduler several cycles to (incorrectly) start it.
-                time.sleep(15)
-                sq = cluster.squeue_all()
-                lines = [l for l in sq.splitlines() if str(blocked_id) in l]
-                assert lines, f"blocked job {blocked_id} not found in squeue:\n{sq}"
-                state = lines[0].split()[4] if len(lines[0].split()) > 4 else ""
-                assert state == "PD", (
-                    f"job {blocked_id} should be PENDING while exclusive job "
-                    f"{holder_id} holds the node, but state={state!r}:\n{sq}"
+                _assert_stays_pending_for_resources(
+                    cluster, blocked_id, holder_id, _BLOCKING_POLL_SECS
                 )
             finally:
                 cluster.scancel(str(blocked_id))
@@ -80,7 +133,11 @@ class TestExclusiveBlocking:
 
     def test_exclusive_gpu_blocks_coscheduling(self, gpu_cluster):
         """An exclusive job requesting 1 CPU and 1 GPU blocks a second GPU job
-        from landing on the same node, even though most GPUs are nominally free."""
+        from landing on the same node, even though most GPUs are nominally free.
+
+        The blocked job must stay PD with reason=Resources across multiple
+        backfill passes.
+        """
         cluster = gpu_cluster
         cluster.gpu_preflight(1)
 
@@ -92,7 +149,7 @@ class TestExclusiveBlocking:
                 f"(found {total_gpus})"
             )
 
-        # Exclusive holder: 1 CPU, 1 GPU — leaving total_gpus-1 GPUs "free".
+        # Exclusive holder: 1 CPU, 1 GPU — leaving total_gpus-1 GPUs nominally free.
         holder_script = cluster.write_file(
             "excl-gpu-holder.sh", "#!/bin/bash\nsleep 300\n"
         )
@@ -114,7 +171,6 @@ class TestExclusiveBlocking:
         try:
             wait_job_state(cluster, holder_id, "R", timeout=60)
 
-            # Second job wants 1 GPU on the same node — should be blocked.
             blocked_script = cluster.write_file(
                 "excl-gpu-blocked.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
             )
@@ -133,15 +189,8 @@ class TestExclusiveBlocking:
             assert blocked_id is not None, "GPU blocked job did not submit"
 
             try:
-                time.sleep(15)
-                sq = cluster.squeue_all()
-                lines = [l for l in sq.splitlines() if str(blocked_id) in l]
-                assert lines, f"blocked GPU job {blocked_id} not found in squeue:\n{sq}"
-                state = lines[0].split()[4] if len(lines[0].split()) > 4 else ""
-                assert state == "PD", (
-                    f"GPU job {blocked_id} should be PENDING while exclusive job "
-                    f"{holder_id} holds the node with {total_gpus} GPUs, "
-                    f"but state={state!r}:\n{sq}"
+                _assert_stays_pending_for_resources(
+                    cluster, blocked_id, holder_id, _BLOCKING_POLL_SECS
                 )
             finally:
                 cluster.scancel(str(blocked_id))
@@ -150,10 +199,9 @@ class TestExclusiveBlocking:
 
     def test_exclusive_node_released_after_job_completes(self, cluster):
         """After an exclusive job finishes, the node becomes available and a
-        waiting job schedules without manual intervention."""
+        waiting job schedules and completes without manual intervention."""
         node = cluster.node_names[0]
 
-        # Short exclusive holder.
         holder_script = cluster.write_file(
             "excl-release-holder.sh", "#!/bin/bash\nsleep 10\n"
         )
@@ -174,7 +222,6 @@ class TestExclusiveBlocking:
         try:
             wait_job_state(cluster, holder_id, "R", timeout=60)
 
-            # Waiter submitted while holder is running.
             out_path = f"{cluster.remote_dir}/excl-release-waiter.out"
             waiter_script = cluster.write_file(
                 "excl-release-waiter.sh", "#!/bin/bash\necho RELEASED_OK\n"
@@ -193,7 +240,14 @@ class TestExclusiveBlocking:
             )
             assert waiter_id is not None
 
-            # Holder finishes, then waiter must complete.
+            # Confirm waiter is blocked with the right reason before holder exits.
+            state, reason = _job_state_and_reason(cluster, waiter_id)
+            if state == "PD":
+                assert reason == "Resources", (
+                    f"waiter {waiter_id} is PD for wrong reason {reason!r} "
+                    f"before holder finishes"
+                )
+
             wait_job(cluster, holder_id, timeout=60)
             state = wait_job(cluster, waiter_id, timeout=60)
             assert state in ("CD", "GONE"), (

--- a/tests/native_host/e2e/test_exclusive_blocking.py
+++ b/tests/native_host/e2e/test_exclusive_blocking.py
@@ -37,40 +37,47 @@ def _job_state_and_reason(cluster, job_id: int) -> tuple[str, str]:
     return state, reason
 
 
-def _assert_stays_pending_for_resources(cluster, job_id: int, holder_id: int, duration: int):
-    """Poll for `duration` seconds and assert the job stays PD with reason Resources.
+def _assert_all_stay_pending_for_resources(
+    cluster, job_ids: list, holder_id: int, duration: int
+):
+    """Poll for `duration` seconds and assert every job in job_ids stays PD
+    with reason Resources throughout.
 
-    Fails immediately if the job starts running or if the reason is wrong after
-    at least one scheduler pass (i.e., after the first non-empty reason is seen).
+    All jobs are checked on every tick so that a job running and completing
+    while another is being examined cannot slip through undetected. Fails
+    immediately the moment any job starts running or shows a wrong reason.
+    Requires every job to have been seen as PD at least once.
     """
     deadline = time.time() + duration
-    reason_seen = False
+    seen = {jid: False for jid in job_ids}
 
     while time.time() < deadline:
-        state, reason = _job_state_and_reason(cluster, job_id)
+        for jid in job_ids:
+            state, reason = _job_state_and_reason(cluster, jid)
 
-        if state == "R":
-            sq = cluster.squeue_all()
-            raise AssertionError(
-                f"Job {job_id} started running while exclusive job {holder_id} "
-                f"holds the node — exclusive blocking is broken.\n{sq}"
-            )
+            if state == "R":
+                sq = cluster.squeue_all()
+                raise AssertionError(
+                    f"Job {jid} started running while exclusive job {holder_id} "
+                    f"holds the node — exclusive blocking is broken.\n{sq}"
+                )
 
-        if state == "PD":
-            reason_seen = True
-            assert reason == "Resources", (
-                f"Job {job_id} is PENDING but for the wrong reason: {reason!r}. "
-                f"Expected 'Resources' (blocked by exclusive holder {holder_id}). "
-                f"This may indicate a misconfigured partition or a different "
-                f"scheduling issue masking the real block."
-            )
+            if state == "PD":
+                seen[jid] = True
+                assert reason == "Resources", (
+                    f"Job {jid} is PENDING but for the wrong reason: {reason!r}. "
+                    f"Expected 'Resources' (blocked by exclusive holder {holder_id}). "
+                    f"This may indicate a misconfigured partition or a different "
+                    f"scheduling issue masking the real block."
+                )
 
         time.sleep(_BLOCKING_POLL_STEP)
 
-    assert reason_seen, (
-        f"Job {job_id} never appeared as PD in squeue during the {duration}s window — "
-        f"it may have completed instantly or never been queued properly."
-    )
+    for jid, was_seen in seen.items():
+        assert was_seen, (
+            f"Job {jid} never appeared as PD in squeue during the {duration}s window — "
+            f"it may have completed instantly or never been queued properly."
+        )
 
 
 class TestExclusiveBlocking:
@@ -123,8 +130,8 @@ class TestExclusiveBlocking:
             assert blocked_id is not None, "blocked job did not submit"
 
             try:
-                _assert_stays_pending_for_resources(
-                    cluster, blocked_id, holder_id, _BLOCKING_POLL_SECS
+                _assert_all_stay_pending_for_resources(
+                    cluster, [blocked_id], holder_id, _BLOCKING_POLL_SECS
                 )
             finally:
                 cluster.scancel(str(blocked_id))
@@ -189,8 +196,8 @@ class TestExclusiveBlocking:
             assert blocked_id is not None, "GPU blocked job did not submit"
 
             try:
-                _assert_stays_pending_for_resources(
-                    cluster, blocked_id, holder_id, _BLOCKING_POLL_SECS
+                _assert_all_stay_pending_for_resources(
+                    cluster, [blocked_id], holder_id, _BLOCKING_POLL_SECS
                 )
             finally:
                 cluster.scancel(str(blocked_id))
@@ -291,15 +298,16 @@ class TestExclusiveBlocking:
         try:
             wait_job_state(cluster, holder_id, "R", timeout=60)
 
-            # Verify it actually landed on both nodes.
-            sq = cluster.squeue_all()
-            holder_lines = [line for line in sq.splitlines() if str(holder_id) in line]
-            assert holder_lines, f"holder {holder_id} not in squeue"
-            assert "2" in holder_lines[0], (
-                f"holder should show 2 nodes in squeue:\n{holder_lines[0]}"
+            # Verify it actually landed on both nodes by checking NODES column (field 8).
+            sq = cluster.squeue(["-j", str(holder_id), "-h", "-o", "%i %D %R"])
+            parts = sq.strip().split()
+            assert parts, f"holder {holder_id} not found in squeue"
+            assert parts[1] == "2", (
+                f"holder should show 2 nodes in squeue, got: {sq.strip()!r}"
             )
 
-            # A job pinned to node0 must pend for Resources.
+            # Submit both blocked jobs before polling either — so that a failure
+            # on one node is not masked by the time we check the other.
             blocked0_script = cluster.write_file(
                 "excl-mn-blocked0.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
             )
@@ -310,7 +318,6 @@ class TestExclusiveBlocking:
             )
             assert blocked0_id is not None
 
-            # A job pinned to node1 must also pend for Resources.
             blocked1_script = cluster.write_file(
                 "excl-mn-blocked1.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
             )
@@ -322,11 +329,10 @@ class TestExclusiveBlocking:
             assert blocked1_id is not None
 
             try:
-                _assert_stays_pending_for_resources(
-                    cluster, blocked0_id, holder_id, _BLOCKING_POLL_SECS
-                )
-                _assert_stays_pending_for_resources(
-                    cluster, blocked1_id, holder_id, _BLOCKING_POLL_SECS
+                # Poll both jobs together on every tick so neither can run and
+                # complete while the other is being checked.
+                _assert_all_stay_pending_for_resources(
+                    cluster, [blocked0_id, blocked1_id], holder_id, _BLOCKING_POLL_SECS
                 )
             finally:
                 cluster.scancel(str(blocked0_id))
@@ -397,11 +403,8 @@ class TestExclusiveBlocking:
             assert blocked1_id is not None
 
             try:
-                _assert_stays_pending_for_resources(
-                    cluster, blocked0_id, holder_id, _BLOCKING_POLL_SECS
-                )
-                _assert_stays_pending_for_resources(
-                    cluster, blocked1_id, holder_id, _BLOCKING_POLL_SECS
+                _assert_all_stay_pending_for_resources(
+                    cluster, [blocked0_id, blocked1_id], holder_id, _BLOCKING_POLL_SECS
                 )
             finally:
                 cluster.scancel(str(blocked0_id))


### PR DESCRIPTION
## Summary

- Adds a new e2e test file `test_exclusive_blocking.py` covering the scenario: an exclusive job that requests only a fraction of a node's resources (1 CPU and/or 1 GPU out of 64) must prevent the backfill scheduler from co-scheduling any other job on those nodes while the exclusive job runs.
- Tests verified on AMD Instinct MI355X nodes (`crsuse2-m2m-140`, `crsuse2-m2m-141`).

## What is tested

[1] **Single-node CPU** — exclusive holder with `-c 1` blocks a second `-c 1` job on the same node.

[2] **Single-node GPU** — exclusive holder with `--gres=gpu:1` blocks a second GPU job even though most GPUs are nominally free (skips if node has fewer than 2 GPUs).

[3] **Release** — once the exclusive job completes, the waiting job schedules and produces expected output.

[4] **Multi-node CPU** — exclusive `-N 2 -c 1` job blocks separate jobs pinned to each of the two nodes individually.

[5] **Multi-node GPU** — same as [4] with `--gres=gpu:1`.

Multi-node tests use `cluster.require_nodes(2)` and skip cleanly on single-node setups.

## Design choices

- Polling loop (`_assert_stays_pending_for_resources`) runs for 10 seconds at 1-second intervals — covers at least 10 full backfill passes given `interval_secs: 1` in the e2e cluster config. Fails immediately the moment the blocked job starts running, rather than checking a single snapshot at the end.
- Pending reason is explicitly checked via `squeue -h -o "%t %r"` and asserted to be `Resources`. Any other reason (`Priority`, `ReqNodeNotAvail`, etc.) fails the test with a clear diagnostic — this rules out the job being blocked for the wrong reason and masking a real scheduling bug.

## Test run

```
5 passed in 174.53s (0:02:54)
```