### PR TITLE
fix(spurctld): tag array-throttle pending jobs with JobArrayTaskLimit

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -328,6 +328,10 @@ pub enum PendingReason {
     /// Replaces `BeginTime` as the pending reason for preempted-requeued jobs so the
     /// reason string is unambiguous.
     Preempted,
+
+    /// Array task held back by the job's own `%N` concurrency throttle
+    /// (`array_max_concurrent`), not by cluster contention.
+    JobArrayTaskLimit,
 }
 
 impl PendingReason {
@@ -415,6 +419,7 @@ impl PendingReason {
             Self::QosMaxSubmitJobPerAccountLimit => "MaxSubmitJobsPerAccount",
             Self::K8sReserved => "ReqNodeNotAvail, Reserved for Kubernetes cluster",
             Self::Preempted => "Preempted",
+            Self::JobArrayTaskLimit => "JobArrayTaskLimit",
         }
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3283,23 +3283,20 @@ impl ClusterManager {
         });
 
         let mut array_counts = running_array_counts;
-        for candidate in &mut candidates {
-            if !candidate.scheduling_eligible {
-                continue;
-            }
-            let (Some(array_id), Some(max)) = (
-                candidate.job.spec.array_job_id,
-                candidate.job.spec.array_max_concurrent,
-            ) else {
-                continue;
+        retain_eligible(&mut candidates, &mut blocked, |job| {
+            let (Some(array_id), Some(max)) =
+                (job.spec.array_job_id, job.spec.array_max_concurrent)
+            else {
+                return GateOutcome::Keep;
             };
             let count = array_counts.entry(array_id).or_insert(0);
             if *count >= max {
-                candidate.scheduling_eligible = false;
+                GateOutcome::Block(PendingReason::JobArrayTaskLimit)
             } else {
                 *count += 1;
+                GateOutcome::Keep
             }
-        }
+        });
 
         {
             let mut reserved = PassReservations::default();
@@ -16596,6 +16593,41 @@ mod tests {
             .collect();
         let admitted = task_ids.iter().filter(|id| pending.contains(id)).count();
         assert_eq!(admitted, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn array_throttle_tags_job_array_task_limit_reason() {
+        // A task held by its own %N throttle used to report Reason=None,
+        // indistinguishable from a genuine scheduling stall.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        let mut spec = basic_spec("arr-throttle-reason");
+        spec.array_spec = Some("0-2%1".into());
+        let parent_id = cm.submit_job(spec).unwrap().job_id;
+        let task_ids: Vec<JobId> = (1..=3).map(|offset| parent_id + offset).collect();
+        for id in &task_ids {
+            wait_for(&format!("array task {id}"), || cm.get_job(*id).is_some());
+        }
+
+        cm.pending_jobs_and_tag_reasons();
+        let throttled: Vec<JobId> = task_ids
+            .iter()
+            .filter(|id| {
+                cm.get_job(**id).unwrap().pending_reason == PendingReason::JobArrayTaskLimit
+            })
+            .copied()
+            .collect();
+        assert_eq!(
+            throttled.len(),
+            2,
+            "the two tasks held back by %1 must be tagged JobArrayTaskLimit"
+        );
+        assert!(
+            !throttled.contains(&task_ids[0]),
+            "the one admitted task must not carry the throttle reason"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

Job array tasks held back by their own `%N` concurrency throttle (`array_max_concurrent`) were reporting `Reason=None` in `squeue`/`scontrol show job`, indistinguishable from a genuine scheduling stall. Slurm's equivalent case reports `JobArrayTaskLimit`.

Root cause: the array throttle in `classify_pending_jobs()` ran as a raw loop that flipped `candidate.scheduling_eligible = false` directly, outside the `GateOutcome`/`retain_eligible` framework the other scheduling gates (QOS, account, burst-buffer, dependency, reservation) already use to record a `PendingReason` when they drop a candidate. Without a recorded reason, the job fell through to a final catch-all that only tags `BeginTime`-held jobs, leaving everything else silently untagged.

## Approach

- Added `PendingReason::JobArrayTaskLimit` with the Slurm-compatible display string `"JobArrayTaskLimit"`.
- Rewrote the array-throttle loop to go through the existing `retain_eligible()` / `GateOutcome::Block(...)` pattern instead of a bespoke flag mutation, bringing it in line with every sibling gate in the same function.

No other call sites needed changes — the only place matching `PendingReason` exhaustively is its `display()` method, and the compiler caught it.

## Testing

- Added a unit test asserting array tasks held back by `%N` are tagged `JobArrayTaskLimit` (and the admitted task is not). Verified it fails against the pre-fix code and passes with the fix.
- All pre-existing array-throttle tests still pass unchanged.
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`: clean.
- `cargo test -p spur-core -p spurctld --locked`: all pass.
- Validated end-to-end on an isolated single-node deployment: submitted a `--array=0-2%1` job, confirmed the two throttled tasks show `Reason=JobArrayTaskLimit` via both `squeue` and `scontrol show job` while the admitted task runs.