### PR TITLE
fix(auth): align step RPC caller identity with JWT-bound job owner

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -24,6 +24,8 @@ hyperconverged
 InfiniBand
 JSON
 JWT
+keepalive
+keepalives
 Kubernetes
 kubeconfig
 kubelet

--- a/crates/spur-cli/src/exec.rs
+++ b/crates/spur-cli/src/exec.rs
@@ -42,11 +42,13 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .context("failed to connect to controller")?;
     let mut client = spur_proto::controller_client(channel);
 
+    let user = crate::interactive::job_caller_user(&mut client, args.job_id, None).await?;
+
     let resp = client
         .exec_in_job(ExecInJobRequest {
             job_id: args.job_id,
             command: args.command.clone(),
-            user: crate::interactive::current_user()?,
+            user,
         })
         .await
         .context("exec failed")?;

--- a/crates/spur-cli/src/interactive.rs
+++ b/crates/spur-cli/src/interactive.rs
@@ -5,7 +5,8 @@ use anyhow::{Context, Result};
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
-    interactive_input, interactive_output, InitSession, InteractiveInput, JobKeepaliveRequest,
+    interactive_input, interactive_output, GetJobRequest, InitSession, InteractiveInput,
+    JobKeepaliveRequest,
 };
 use std::collections::HashMap;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -87,6 +88,81 @@ pub async fn connect_agent(addr: &str) -> Result<SlurmAgentClient<crate::authcli
 /// with a later exec/attach request.
 pub fn current_user() -> Result<String> {
     whoami::username().context("failed to determine current username")
+}
+
+/// Username to send with step and keepalive RPCs for a job in the current shell.
+///
+/// Prefer the allocation owner exported by salloc (`SPUR_JOB_USER` / `SLURM_JOB_USER`)
+/// when `SPUR_JOB_ID` / `SLURM_JOB_ID` matches *job_id*; otherwise use *known_owner*
+/// when the caller already fetched the job, then `GetJob`; fall back to the local login name.
+pub async fn job_caller_user(
+    client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
+    job_id: u32,
+    known_owner: Option<&str>,
+) -> Result<String> {
+    if let Some(user) = allocation_env_job_user(job_id) {
+        return Ok(user);
+    }
+    if let Some(owner) = known_owner.map(str::trim).filter(|o| !o.is_empty()) {
+        return Ok(owner.to_string());
+    }
+    let resp = client
+        .get_job(GetJobRequest { job_id })
+        .await
+        .context("failed to look up job owner for step RPC")?;
+    let user = resp.into_inner().user;
+    if !user.is_empty() {
+        return Ok(user);
+    }
+    current_user()
+}
+
+/// Owner from allocation env vars when the exported job id matches *job_id*.
+fn allocation_env_job_user(job_id: u32) -> Option<String> {
+    let env_job_id = std::env::var("SPUR_JOB_ID")
+        .or_else(|_| std::env::var("SLURM_JOB_ID"))
+        .ok()?;
+    if env_job_id.trim().parse::<u32>().ok()? != job_id {
+        return None;
+    }
+    let user = std::env::var("SPUR_JOB_USER")
+        .or_else(|_| std::env::var("SLURM_JOB_USER"))
+        .ok()?;
+    let user = user.trim().to_string();
+    (!user.is_empty()).then_some(user)
+}
+
+/// Username for cancel RPCs when submit-time ``whoami`` may differ from the
+/// controller's bound owner (for example after JWT submit).
+pub async fn resolve_job_owner_for_cancel(
+    client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
+    job_id: u32,
+    submit_user: &str,
+) -> String {
+    match client.get_job(GetJobRequest { job_id }).await {
+        Ok(resp) => {
+            let owner = resp.into_inner().user;
+            if owner.is_empty() {
+                submit_user.to_string()
+            } else {
+                owner
+            }
+        }
+        Err(_) => submit_user.to_string(),
+    }
+}
+
+/// Propagate the caller's auth token into a child process (allocation shell).
+pub fn inherit_auth_token(cmd: &mut tokio::process::Command) {
+    if let Ok(token) = std::env::var("SPUR_AUTH_TOKEN") {
+        if !token.trim().is_empty() {
+            cmd.env("SPUR_AUTH_TOKEN", token);
+            return;
+        }
+    }
+    if let Some(token) = crate::authclient::load_token() {
+        cmd.env("SPUR_AUTH_TOKEN", token);
+    }
 }
 
 pub fn get_terminal_size() -> spur_proto::proto::WindowSize {
@@ -244,9 +320,9 @@ pub async fn run_interactive_session(
     argv: Vec<String>,
     winsize: spur_proto::proto::WindowSize,
     overlap: bool,
+    user: &str,
 ) -> Result<i32> {
-    let user = current_user()?;
-    let handle = open_interactive_session(agent, job_id, step_id, argv, winsize, overlap, &user)
+    let handle = open_interactive_session(agent, job_id, step_id, argv, winsize, overlap, user)
         .await
         .map_err(|status| anyhow::anyhow!("InteractiveSession RPC failed: {}", status.message()))?;
     drive_interactive_session(handle).await
@@ -265,5 +341,148 @@ impl RawModeGuard {
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
         let _ = crossterm::terminal::disable_raw_mode();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env_defaults::EnvGuard;
+    use crate::mock_controller;
+    use serial_test::serial;
+    use tonic::Code;
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn job_caller_user_prefers_spur_job_user_env() {
+        let _env = EnvGuard::new();
+        std::env::set_var("SPUR_JOB_ID", "42");
+        std::env::set_var("SPUR_JOB_USER", "jwt-owner");
+        let (addr, capture) = mock_controller::spawn().await;
+        let mut client = mock_controller::client(addr).await;
+        let user = job_caller_user(&mut client, 42, None)
+            .await
+            .expect("env owner");
+        assert_eq!(user, "jwt-owner");
+        assert_eq!(capture.get_job_calls(), 0);
+    }
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn job_caller_user_slurm_job_user_alias() {
+        let _env = EnvGuard::new();
+        std::env::set_var("SLURM_JOB_ID", "42");
+        std::env::set_var("SLURM_JOB_USER", "slurm-owner");
+        let (addr, capture) = mock_controller::spawn().await;
+        let mut client = mock_controller::client(addr).await;
+        let user = job_caller_user(&mut client, 42, None)
+            .await
+            .expect("slurm env owner");
+        assert_eq!(user, "slurm-owner");
+        assert_eq!(capture.get_job_calls(), 0);
+    }
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn job_caller_user_ignores_stale_allocation_env() {
+        let _env = EnvGuard::new();
+        std::env::set_var("SPUR_JOB_ID", "1");
+        std::env::set_var("SPUR_JOB_USER", "stale-owner");
+        let (addr, capture) = mock_controller::spawn().await;
+        let mut client = mock_controller::client(addr).await;
+        let user = job_caller_user(&mut client, 99, Some("controller-owner"))
+            .await
+            .expect("known owner");
+        assert_eq!(user, "controller-owner");
+        assert_eq!(capture.get_job_calls(), 0);
+    }
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn job_caller_user_uses_known_owner_without_get_job() {
+        let _env = EnvGuard::new();
+        let (addr, capture) = mock_controller::spawn().await;
+        let mut client = mock_controller::client(addr).await;
+        let user = job_caller_user(&mut client, 7, Some("controller-owner"))
+            .await
+            .expect("known owner");
+        assert_eq!(user, "controller-owner");
+        assert_eq!(capture.get_job_calls(), 0);
+    }
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn job_caller_user_fetches_owner_from_get_job() {
+        let _env = EnvGuard::new();
+        let (addr, capture) = mock_controller::spawn().await;
+        capture.set_get_job_user("from-controller");
+        let mut client = mock_controller::client(addr).await;
+        let user = job_caller_user(&mut client, 9, None)
+            .await
+            .expect("get_job owner");
+        assert_eq!(user, "from-controller");
+        assert_eq!(capture.get_job_calls(), 1);
+    }
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn job_caller_user_propagates_get_job_failure() {
+        let _env = EnvGuard::new();
+        let (addr, capture) = mock_controller::spawn().await;
+        capture.set_get_job_error(Code::Unavailable);
+        let mut client = mock_controller::client(addr).await;
+        let err = job_caller_user(&mut client, 9, None)
+            .await
+            .expect_err("get_job failure must not fall back to whoami");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("failed to look up job owner"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn resolve_job_owner_for_cancel_uses_controller_owner() {
+        let _env = EnvGuard::new();
+        let (addr, capture) = mock_controller::spawn().await;
+        capture.set_get_job_user("bound-owner");
+        let mut client = mock_controller::client(addr).await;
+        let user = resolve_job_owner_for_cancel(&mut client, 3, "submit-wire-name").await;
+        assert_eq!(user, "bound-owner");
+    }
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn resolve_job_owner_for_cancel_falls_back_on_get_job_error() {
+        let _env = EnvGuard::new();
+        let (addr, capture) = mock_controller::spawn().await;
+        capture.set_get_job_error(Code::Unavailable);
+        let mut client = mock_controller::client(addr).await;
+        let user = resolve_job_owner_for_cancel(&mut client, 3, "submit-wire-name").await;
+        assert_eq!(user, "submit-wire-name");
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn inherit_auth_token_exports_env_token() {
+        let _env = EnvGuard::new();
+        std::env::set_var("SPUR_AUTH_TOKEN", "test-jwt-token");
+        let mut cmd = tokio::process::Command::new("/bin/true");
+        inherit_auth_token(&mut cmd);
+        let envs: std::collections::HashMap<_, _> = cmd
+            .as_std()
+            .get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.map(|s| s.to_string_lossy().into_owned()),
+                )
+            })
+            .collect();
+        assert_eq!(
+            envs.get("SPUR_AUTH_TOKEN").and_then(|v| v.as_deref()),
+            Some("test-jwt-token")
+        );
     }
 }

--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -31,6 +31,9 @@ pub(crate) const MOCK_EXIT_CODE: i32 = 7;
 /// What the mock controller actually received, shared with the test body.
 #[derive(Clone, Default)]
 pub(crate) struct StepCapture {
+    get_job_calls: Arc<AtomicU32>,
+    /// When set, `get_job` returns `JobInfo { user: ... }` or the configured error.
+    get_job_response: Arc<Mutex<Option<Result<String, tonic::Code>>>>,
     create_step_num_tasks: Arc<AtomicU32>,
     run_step_step_id: Arc<AtomicU32>,
     run_step_calls: Arc<AtomicU32>,
@@ -44,6 +47,18 @@ pub(crate) struct StepCapture {
 }
 
 impl StepCapture {
+    pub(crate) fn get_job_calls(&self) -> u32 {
+        self.get_job_calls.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn set_get_job_user(&self, user: impl Into<String>) {
+        *self.get_job_response.lock().unwrap() = Some(Ok(user.into()));
+    }
+
+    pub(crate) fn set_get_job_error(&self, code: tonic::Code) {
+        *self.get_job_response.lock().unwrap() = Some(Err(code));
+    }
+
     /// Task count carried by the most recent `CreateJobStep`.
     pub(crate) fn create_step_num_tasks(&self) -> u32 {
         self.create_step_num_tasks.load(Ordering::SeqCst)
@@ -126,6 +141,21 @@ mock_controller_impl! {
                 step_id: MOCK_STEP_ID,
                 node_addr: String::new(),
             }))
+        }
+
+        async fn get_job(
+            &self,
+            _request: tonic::Request<proto::GetJobRequest>,
+        ) -> Result<tonic::Response<proto::JobInfo>, tonic::Status> {
+            self.capture.get_job_calls.fetch_add(1, Ordering::SeqCst);
+            match self.capture.get_job_response.lock().unwrap().clone() {
+                Some(Ok(user)) => Ok(tonic::Response::new(proto::JobInfo {
+                    user,
+                    ..Default::default()
+                })),
+                Some(Err(code)) => Err(tonic::Status::new(code, "mock get_job failure")),
+                None => Err(tonic::Status::unimplemented("get_job")),
+            }
         }
 
         async fn run_step(
@@ -214,7 +244,6 @@ mock_controller_impl! {
     unimplemented {
         submit_job(proto::SubmitJobRequest) -> proto::SubmitJobResponse;
         get_jobs(proto::GetJobsRequest) -> proto::GetJobsResponse;
-        get_job(proto::GetJobRequest) -> proto::JobInfo;
         cancel_job(proto::CancelJobRequest) -> ();
         complete_job(proto::CompleteJobRequest) -> ();
         job_keepalive(proto::JobKeepaliveRequest) -> proto::JobKeepaliveResponse;

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -119,7 +119,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     let controller = args.controller.clone();
     let job_spec = build_salloc_job_spec(&args, nodelist)?;
-    let user = job_spec.user.clone();
+    let submit_user = job_spec.user.clone();
 
     let channel = crate::authclient::connect(&controller)
         .await
@@ -142,11 +142,17 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     // Set up Ctrl+C handler to cancel the job on interrupt
     let cancel_client = client.clone();
-    let cancel_user = user.clone();
+    let cancel_submit_user = submit_user.clone();
     tokio::spawn(async move {
         let mut cancel_client = cancel_client;
         if tokio::signal::ctrl_c().await.is_ok() {
             eprintln!("\nsalloc: cancelling job {}...", job_id);
+            let cancel_user = crate::interactive::resolve_job_owner_for_cancel(
+                &mut cancel_client,
+                job_id,
+                &cancel_submit_user,
+            )
+            .await;
             let _ = cancel_client
                 .cancel_job(CancelJobRequest {
                     job_id,
@@ -171,11 +177,14 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 "salloc: timed out waiting for job {} to start (last reason: {})",
                 job_id, last_reason
             );
+            let cancel_user =
+                crate::interactive::resolve_job_owner_for_cancel(&mut client, job_id, &submit_user)
+                    .await;
             let _ = client
                 .cancel_job(CancelJobRequest {
                     job_id,
                     signal: 0,
-                    user: user.clone(),
+                    user: cancel_user,
                 })
                 .await;
             std::process::exit(1);
@@ -214,9 +223,15 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     eprintln!("salloc: Nodes {} are ready for job {}", nodelist, job_id);
     eprintln!("salloc: Granted job allocation {}", job_id);
 
+    let owner = job_info.user.clone();
+    if owner.is_empty() {
+        anyhow::bail!("salloc: job {} has no owner after allocation", job_id);
+    }
+
     let mut env = SpurEnv::new();
     env.set_with_slurm_twin("SPUR_JOB_ID", job_id);
     env.set_with_slurm_twin("SPUR_JOBID", job_id);
+    env.set_with_slurm_twin("SPUR_JOB_USER", &owner);
     env.set_with_slurm_twin("SPUR_JOB_NAME", &job_info.name);
     env.set_with_slurm_twin("SPUR_JOB_PARTITION", &job_info.partition);
     env.set_with_slurm_twin("SPUR_JOB_ACCOUNT", &job_info.account);
@@ -234,13 +249,14 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     // pings past the controller's InactiveLimit is what lets it reap an
     // abandoned allocation. The guard stops the pings on drop.
     let _keepalive =
-        crate::interactive::spawn_keepalive(client.clone(), job_id, user.clone(), "salloc");
+        crate::interactive::spawn_keepalive(client.clone(), job_id, owner.clone(), "salloc");
 
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".into());
     let mut cmd = tokio::process::Command::new(&shell);
     for (k, v) in env.into_map() {
         cmd.env(k, v);
     }
+    crate::interactive::inherit_auth_token(&mut cmd);
     let status = cmd
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
@@ -257,7 +273,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .cancel_job(CancelJobRequest {
             job_id,
             signal: 0,
-            user,
+            user: owner,
         })
         .await;
 

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -72,6 +72,8 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         anyhow::bail!("sattach: job {} has no allocated nodes", job_id);
     }
 
+    let user = crate::interactive::job_caller_user(&mut client, job_id, Some(&job.user)).await?;
+
     // Connect to the first node's agent. The controller reports a compressed
     // hostlist (e.g. `node[001-002]`), so expand it rather than comma-splitting.
     let first_node = crate::nodelist::first_allocated_node(nodelist).with_context(|| {
@@ -81,9 +83,9 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let mut agent = crate::interactive::connect_agent(&agent_addr).await?;
 
     if args.output_only {
-        stream_output_only(&mut agent, job_id, &args.output).await
+        stream_output_only(&mut agent, job_id, &args.output, &user).await
     } else {
-        let exit_code = interactive_attach(&mut agent, job_id).await?;
+        let exit_code = interactive_attach(&mut agent, job_id, &user).await?;
         std::process::exit(exit_code);
     }
 }
@@ -93,12 +95,13 @@ async fn stream_output_only(
     agent: &mut SlurmAgentClient<crate::authclient::AuthChannel>,
     job_id: u32,
     stream_name: &str,
+    user: &str,
 ) -> Result<()> {
     let mut stream = agent
         .stream_job_output(StreamJobOutputRequest {
             job_id,
             stream: stream_name.to_string(),
-            user: crate::interactive::current_user()?,
+            user: user.to_string(),
         })
         .await
         .context("failed to start output stream")?
@@ -135,9 +138,11 @@ async fn stream_output_only(
 async fn interactive_attach(
     agent: &mut SlurmAgentClient<crate::authclient::AuthChannel>,
     job_id: u32,
+    user: &str,
 ) -> Result<i32> {
     let winsize = crate::interactive::get_terminal_size();
-    crate::interactive::run_interactive_session(agent, job_id, 0, Vec::new(), winsize, true).await
+    crate::interactive::run_interactive_session(agent, job_id, 0, Vec::new(), winsize, true, user)
+        .await
 }
 
 fn state_name(state: i32) -> &'static str {

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -221,7 +221,17 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     // --jobid --overlap: exec into a running job (interactive PTY session)
     if let Some(job_id) = args.jobid {
         let node = first_node(args.nodelist.as_deref().unwrap_or_default());
-        let user = crate::interactive::current_user()?;
+        let channel = crate::authclient::connect(&args.controller)
+            .await
+            .context("cannot connect to controller")?;
+        let mut ctrl = spur_proto::controller_client(channel);
+        let job = ctrl
+            .get_job(GetJobRequest { job_id })
+            .await
+            .context("failed to get job info")?
+            .into_inner();
+        let known_owner = (!job.user.is_empty()).then_some(job.user.as_str());
+        let user = crate::interactive::job_caller_user(&mut ctrl, job_id, known_owner).await?;
         let exit_code =
             run_interactive_pty(&args.controller, job_id, args.command.clone(), node, &user)
                 .await?;
@@ -613,17 +623,20 @@ fn build_srun_job_spec(
 fn install_ctrl_c_cancel(
     client: SlurmControllerClient<crate::authclient::AuthChannel>,
     job_id: u32,
-    user: String,
+    submit_user: String,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut client = client;
         if tokio::signal::ctrl_c().await.is_ok() {
             eprintln!("\nsrun: cancelling job {}...", job_id);
+            let cancel_user =
+                crate::interactive::resolve_job_owner_for_cancel(&mut client, job_id, &submit_user)
+                    .await;
             let _ = client
                 .cancel_job(CancelJobRequest {
                     job_id,
                     signal: 2,
-                    user,
+                    user: cancel_user,
                 })
                 .await;
             std::process::exit(130);
@@ -631,10 +644,15 @@ fn install_ctrl_c_cancel(
     })
 }
 
+struct RunningAllocation {
+    nodelist: String,
+    user: String,
+}
+
 async fn wait_for_job_running(
     client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
     job_id: u32,
-) -> Result<String> {
+) -> Result<RunningAllocation> {
     let mut poll_interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
     let mut warned_unknown_state = false;
 
@@ -648,7 +666,10 @@ async fn wait_for_job_running(
 
         match JobState::try_from(job.state) {
             Ok(JobState::JobRunning) if !job.nodelist.is_empty() => {
-                return Ok(job.nodelist);
+                return Ok(RunningAllocation {
+                    nodelist: job.nodelist,
+                    user: job.user,
+                });
             }
             Ok(JobState::JobRunning) => {}
             Ok(
@@ -732,6 +753,7 @@ async fn dispatch_step(
             winsize: None,
             node: String::new(),
             user: params.user.to_string(),
+            uid: nix::unistd::geteuid().as_raw(),
         })
         .await
         .context("failed to create job step")?
@@ -841,7 +863,7 @@ async fn run_standalone_srun(
         .context("failed to connect to spurctld")?;
     let mut client = SlurmControllerClient::new(channel);
     let job_spec = build_srun_job_spec(args, work_dir, &io, mpi)?;
-    let user = job_spec.user.clone();
+    let submit_user = job_spec.user.clone();
     let submit_resp = client
         .submit_job(SubmitJobRequest {
             spec: Some(job_spec),
@@ -856,32 +878,39 @@ async fn run_standalone_srun(
 
     eprintln!("srun: Pending job allocation {}...", job_id);
 
-    let ctrl_c_handle = install_ctrl_c_cancel(client.clone(), job_id, user.clone());
+    let ctrl_c_handle = install_ctrl_c_cancel(client.clone(), job_id, submit_user.clone());
+
+    let running = wait_for_job_running(&mut client, job_id).await?;
+    if !running.nodelist.is_empty() {
+        eprintln!("srun: job {} running on {}", job_id, running.nodelist);
+    }
+
+    let known_owner = (!running.user.is_empty()).then_some(running.user.as_str());
+    let owner = crate::interactive::job_caller_user(&mut client, job_id, known_owner).await?;
+    if owner.is_empty() {
+        anyhow::bail!("srun: job {} has no owner after allocation", job_id);
+    }
+
     // Guard drops (and stops pinging) on every return path, including `?`.
     let _keepalive =
-        crate::interactive::spawn_keepalive(client.clone(), job_id, user.clone(), "srun");
-
-    let nodelist = wait_for_job_running(&mut client, job_id).await?;
-    if !nodelist.is_empty() {
-        eprintln!("srun: job {} running on {}", job_id, nodelist);
-    }
+        crate::interactive::spawn_keepalive(client.clone(), job_id, owner.clone(), "srun");
 
     if args.pty {
         ctrl_c_handle.abort();
-        eprintln!("srun: opening interactive session on {}", nodelist);
+        eprintln!("srun: opening interactive session on {}", running.nodelist);
         let result = run_interactive_pty(
             &args.controller,
             job_id,
             args.command.clone(),
             String::new(),
-            &user,
+            &owner,
         )
         .await;
         let _ = client
             .cancel_job(CancelJobRequest {
                 job_id,
                 signal: 0,
-                user: user.clone(),
+                user: owner.clone(),
             })
             .await;
         std::process::exit(result?);
@@ -899,7 +928,7 @@ async fn run_standalone_srun(
             work_dir,
             io: &io,
             mpi,
-            user: &user,
+            user: &owner,
         };
         let dispatch_result =
             dispatch_step_cancellable(&mut client, job_id, &step_params, true).await;
@@ -907,7 +936,7 @@ async fn run_standalone_srun(
             Ok(result) => result.exit_code,
             Err(_) => 1,
         };
-        release_srun_allocation(&mut client, job_id, &user, exit_code).await;
+        release_srun_allocation(&mut client, job_id, &owner, exit_code).await;
         let result = dispatch_result?;
         let state = if result.exit_code == 0 {
             JobState::JobCompleted
@@ -927,7 +956,7 @@ async fn run_standalone_srun(
     }
 
     let output_streamed = if io.stdout.is_empty() {
-        try_stream_output(&mut client, &nodelist, job_id, &user).await
+        try_stream_output(&mut client, &running.nodelist, job_id, &owner).await
     } else {
         false
     };
@@ -1236,6 +1265,7 @@ async fn run_interactive_pty(
                     winsize: Some(winsize),
                     node: node.clone(),
                     user: user.to_string(),
+                    uid: nix::unistd::geteuid().as_raw(),
                 })
                 .await
             {
@@ -1319,7 +1349,7 @@ async fn run_as_step(
     }
 
     let io = resolve_io_paths(args);
-    let user = crate::interactive::current_user()?;
+    let user = crate::interactive::job_caller_user(&mut client, job_id, None).await?;
 
     let step_params = StepDispatchParams {
         args,

--- a/crates/spur-core/src/auth.rs
+++ b/crates/spur-core/src/auth.rs
@@ -144,6 +144,51 @@ pub fn check_job_owner(
     })
 }
 
+/// Ownership gate for user-initiated RPCs that may carry a Unix uid (e.g. `RunStep`).
+///
+/// When a verified identity is present, only that subject (or an admin/internal caller) may
+/// act on the job — a matching uid alone cannot bypass a mismatched JWT. When unauthenticated
+/// (`auth.mode = permissive` without a credential), the owner username or a matching `caller_uid`
+/// against the job's submit-time uid is accepted (Slurm Munge-like same-session semantics).
+pub fn check_job_caller(
+    user: &str,
+    caller_uid: Option<u32>,
+    is_internal: bool,
+    owner: &str,
+    owner_uid: u32,
+    identity: Option<&Identity>,
+    action: &str,
+) -> Result<(), AuthError> {
+    if is_internal {
+        return Ok(());
+    }
+    if let Some(id) = identity {
+        if id.is_admin || id.user == owner {
+            return Ok(());
+        }
+        return Err(AuthError::NotJobOwner {
+            user: id.user.clone(),
+            owner: owner.into(),
+            action: action.into(),
+        });
+    }
+    if !user.is_empty() && user == owner {
+        return Ok(());
+    }
+    // Proto defaults and RPCs without a uid field (keepalive) send 0; treat that as
+    // absent rather than a root-caller match.
+    if let Some(uid) = caller_uid.filter(|&u| u != 0) {
+        if uid == owner_uid {
+            return Ok(());
+        }
+    }
+    Err(AuthError::NotJobOwner {
+        user: user.into(),
+        owner: owner.into(),
+        action: action.into(),
+    })
+}
+
 /// JWT token claims.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TokenClaims {
@@ -394,6 +439,73 @@ mod tests {
             check_job_owner("alice", false, "k8s", "exec").is_err(),
             "a placeholder owner denies every named user; record the real \
              submitter or leave the owner empty instead"
+        );
+    }
+
+    #[test]
+    fn check_job_caller_uid_fallback_when_unauthenticated() {
+        assert!(check_job_caller(
+            "localname",
+            Some(1000),
+            false,
+            "jwt-subject",
+            1000,
+            None,
+            "run a step in"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn check_job_caller_jwt_subject_must_match_owner() {
+        let id = Identity {
+            user: "jwt-subject".into(),
+            uid: 1000,
+            gid: 1000,
+            is_admin: false,
+        };
+        assert!(check_job_caller(
+            "jwt-subject",
+            Some(1000),
+            false,
+            "jwt-subject",
+            1000,
+            Some(&id),
+            "run a step in"
+        )
+        .is_ok());
+        let other = Identity {
+            user: "other-jwt-user".into(),
+            uid: 1000,
+            gid: 1000,
+            is_admin: false,
+        };
+        assert!(
+            check_job_caller(
+                "localname",
+                Some(1000),
+                false,
+                "jwt-subject",
+                1000,
+                Some(&other),
+                "run a step in"
+            )
+            .is_err(),
+            "uid alone must not bypass a JWT for a different owner"
+        );
+    }
+
+    #[test]
+    fn check_job_caller_rejects_mismatched_unauthenticated_user_and_uid() {
+        assert!(
+            check_job_caller("bob", Some(2000), false, "alice", 1000, None, "attach to").is_err()
+        );
+    }
+
+    #[test]
+    fn check_job_caller_uid_zero_does_not_bypass_username_check() {
+        assert!(
+            check_job_caller("bob", Some(0), false, "alice", 0, None, "run a step in").is_err()
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1003,8 +1003,7 @@ impl SlurmController for ControllerService {
         let mut req = request.into_inner();
         Self::authoritative_user(&mut req.user, __identity.as_ref());
         // A real keepalive always carries the caller's username. Reject an empty
-        // one explicitly: `check_job_owner` treats empty as authorized, which
-        // would let anyone hold any allocation open forever.
+        // one explicitly: an empty user must not bypass ownership checks.
         if req.user.is_empty() {
             return Err(Status::permission_denied(
                 "keepalive requires a user".to_string(),
@@ -1014,10 +1013,13 @@ impl SlurmController for ControllerService {
             .cluster
             .get_job(req.job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", req.job_id)))?;
-        spur_core::auth::check_job_owner(
+        spur_core::auth::check_job_caller(
             &req.user,
+            None,
             self.caller_is_admin(__identity.as_ref()),
             &job.spec.user,
+            job.spec.uid,
+            __identity.as_ref(),
             "send keepalive for",
         )
         .map_err(|e| Status::permission_denied(e.to_string()))?;
@@ -2035,10 +2037,13 @@ impl SlurmController for ControllerService {
             .get_job(job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))?;
 
-        spur_core::auth::check_job_owner(
+        spur_core::auth::check_job_caller(
             &req.user,
+            Some(req.uid),
             self.caller_is_admin(__identity.as_ref()),
             &job.spec.user,
+            job.spec.uid,
+            __identity.as_ref(),
             "attach to",
         )
         .map_err(|e| Status::permission_denied(e.to_string()))?;
@@ -2572,10 +2577,13 @@ impl SlurmController for ControllerService {
             .get_job(job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))?;
 
-        spur_core::auth::check_job_owner(
+        spur_core::auth::check_job_caller(
             &req.user,
+            None,
             self.caller_is_admin(__identity.as_ref()),
             &job.spec.user,
+            job.spec.uid,
+            __identity.as_ref(),
             "exec into",
         )
         .map_err(|e| Status::permission_denied(e.to_string()))?;
@@ -2645,10 +2653,13 @@ impl SlurmController for ControllerService {
 
         // A step executes arbitrary commands on the job's allocated nodes, so the
         // caller must own the target job — same gate as create_job_step / exec_in_job.
-        spur_core::auth::check_job_owner(
+        spur_core::auth::check_job_caller(
             &req.user,
+            Some(req.uid),
             self.caller_is_admin(__identity.as_ref()),
             &job.spec.user,
+            job.spec.uid,
+            __identity.as_ref(),
             "run a step in",
         )
         .map_err(|e| Status::permission_denied(e.to_string()))?;
@@ -5497,6 +5508,7 @@ mod tests {
                     winsize: None,
                     node: "ghost".into(),
                     user: "u".into(),
+                    ..Default::default()
                 }))
                 .await
                 .expect_err("unregistered target must fail");
@@ -5571,6 +5583,7 @@ mod tests {
                 pty: false,
                 winsize: None,
                 node: String::new(),
+                ..Default::default()
             }))
             .await
             .expect_err("a still-Pending job must not accept a new step");
@@ -5797,6 +5810,7 @@ mod tests {
                 winsize: None,
                 node: String::new(),
                 user: "rsikande".into(),
+                ..Default::default()
             }))
             .await
             .expect_err("a non-owner must not attach to another user's job");
@@ -5826,11 +5840,95 @@ mod tests {
                 winsize: None,
                 node: String::new(),
                 user: "ubuntu".into(),
+                ..Default::default()
             }))
             .await
             .expect("the owner must be allowed to attach");
 
         assert_eq!(resp.into_inner().node_addr, "127.0.0.1:6818");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_job_step_allows_uid_match_without_username() {
+        use spur_core::job::JobState;
+        use spur_core::resource::{ResourceAllocations, ResourceSet};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+
+        svc.cluster
+            .register_node(
+                "n1".into(),
+                "n1".into(),
+                ResourceSet {
+                    cpus: 8,
+                    memory_mb: 16000,
+                    ..Default::default()
+                },
+                "127.0.0.1".into(),
+                6818,
+                String::new(),
+                String::new(),
+                spur_core::node::NodeSource::NativeHost,
+                std::collections::HashMap::new(),
+                true,
+            )
+            .unwrap();
+        for _ in 0..200 {
+            if svc.cluster.get_node("n1").is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        let owner_uid = 1000;
+        let spec = spur_core::job::JobSpec {
+            name: "uid-owned".into(),
+            user: "jwt-subject".into(),
+            uid: owner_uid,
+            num_nodes: 1,
+            num_tasks: 1,
+            cpus_per_task: 1,
+            work_dir: "/tmp".into(),
+            ..Default::default()
+        };
+        let job_id = svc.cluster.submit_job(spec).unwrap().job_id;
+        let res = ResourceAllocations::with_scalar(1, 1000);
+        let per_node: std::collections::HashMap<_, _> =
+            [("n1".to_string(), res.clone())].into_iter().collect();
+        svc.cluster
+            .start_job(job_id, vec!["n1".into()], res, per_node)
+            .unwrap();
+        for _ in 0..200 {
+            if svc.cluster.get_job(job_id).map(|j| j.state) == Some(JobState::Running) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        let result = svc
+            .create_job_step(Request::new(CreateJobStepRequest {
+                job_id,
+                command: vec!["bash".into()],
+                num_tasks: 1,
+                cpus_per_task: 1,
+                overlap: true,
+                pty: false,
+                winsize: None,
+                node: String::new(),
+                user: "local-wire-name".into(),
+                uid: owner_uid,
+            }))
+            .await;
+
+        if let Err(e) = result {
+            assert_ne!(
+                e.code(),
+                Code::PermissionDenied,
+                "uid match must not be rejected as non-owner: {}",
+                e.message()
+            );
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -5965,6 +6063,85 @@ mod tests {
             .expect_err("a non-owner must not run a step in another user's allocation");
 
         assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_step_allows_uid_match_without_username() {
+        use spur_core::job::JobState;
+        use spur_core::resource::{ResourceAllocations, ResourceSet};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+
+        svc.cluster
+            .register_node(
+                "n1".into(),
+                "n1".into(),
+                ResourceSet {
+                    cpus: 8,
+                    memory_mb: 16000,
+                    ..Default::default()
+                },
+                "127.0.0.1".into(),
+                6818,
+                String::new(),
+                String::new(),
+                spur_core::node::NodeSource::NativeHost,
+                std::collections::HashMap::new(),
+                true,
+            )
+            .unwrap();
+        for _ in 0..200 {
+            if svc.cluster.get_node("n1").is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        let owner_uid = 1000;
+        let spec = spur_core::job::JobSpec {
+            name: "uid-owned".into(),
+            user: "jwt-subject".into(),
+            uid: owner_uid,
+            num_nodes: 1,
+            num_tasks: 1,
+            cpus_per_task: 1,
+            work_dir: "/tmp".into(),
+            ..Default::default()
+        };
+        let job_id = svc.cluster.submit_job(spec).unwrap().job_id;
+        let res = ResourceAllocations::with_scalar(1, 1000);
+        let per_node: std::collections::HashMap<_, _> =
+            [("n1".to_string(), res.clone())].into_iter().collect();
+        svc.cluster
+            .start_job(job_id, vec!["n1".into()], res, per_node)
+            .unwrap();
+        for _ in 0..200 {
+            if svc.cluster.get_job(job_id).map(|j| j.state) == Some(JobState::Running) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        let result = svc
+            .run_step(Request::new(RunStepRequest {
+                job_id,
+                command: vec!["id".into()],
+                uid: owner_uid,
+                step_id: 0,
+                user: "local-wire-name".into(),
+                ..Default::default()
+            }))
+            .await;
+
+        if let Err(e) = result {
+            assert_ne!(
+                e.code(),
+                Code::PermissionDenied,
+                "uid match must not be rejected as non-owner: {}",
+                e.message()
+            );
+        }
     }
 
     async fn assign_ha_control_plane(svc: &ControllerService) {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -5849,7 +5849,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn create_job_step_allows_uid_match_without_username() {
+    async fn create_job_step_allows_uid_match_despite_username_mismatch() {
         use spur_core::job::JobState;
         use spur_core::resource::{ResourceAllocations, ResourceSet};
 
@@ -5906,7 +5906,7 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(5)).await;
         }
 
-        let result = svc
+        let resp = svc
             .create_job_step(Request::new(CreateJobStepRequest {
                 job_id,
                 command: vec!["bash".into()],
@@ -5919,16 +5919,10 @@ mod tests {
                 user: "local-wire-name".into(),
                 uid: owner_uid,
             }))
-            .await;
+            .await
+            .expect("uid match must authorize step creation despite username mismatch");
 
-        if let Err(e) = result {
-            assert_ne!(
-                e.code(),
-                Code::PermissionDenied,
-                "uid match must not be rejected as non-owner: {}",
-                e.message()
-            );
-        }
+        assert_eq!(resp.into_inner().node_addr, "127.0.0.1:6818");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -6066,9 +6060,10 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn run_step_allows_uid_match_without_username() {
+    async fn run_step_allows_uid_match_despite_username_mismatch() {
         use spur_core::job::JobState;
         use spur_core::resource::{ResourceAllocations, ResourceSet};
+        use spur_core::step::{JobStep, StepState, TaskDistribution};
 
         let dir = tempfile::TempDir::new().unwrap();
         let svc = test_service(&dir).await;
@@ -6123,25 +6118,34 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(5)).await;
         }
 
-        let result = svc
-            .run_step(Request::new(RunStepRequest {
+        let allocated_nodes = svc.cluster.get_job(job_id).unwrap().allocated_nodes.clone();
+        svc.cluster
+            .create_step(JobStep {
                 job_id,
-                command: vec!["id".into()],
-                uid: owner_uid,
                 step_id: 0,
-                user: "local-wire-name".into(),
-                ..Default::default()
-            }))
-            .await;
+                name: "id".into(),
+                state: StepState::Running,
+                num_tasks: 1,
+                cpus_per_task: 1,
+                resources: ResourceAllocations::default(),
+                nodes: allocated_nodes,
+                distribution: TaskDistribution::Block,
+                start_time: Some(chrono::Utc::now()),
+                end_time: None,
+                exit_code: None,
+            })
+            .expect("test setup: seed step for run_step");
 
-        if let Err(e) = result {
-            assert_ne!(
-                e.code(),
-                Code::PermissionDenied,
-                "uid match must not be rejected as non-owner: {}",
-                e.message()
-            );
-        }
+        svc.run_step(Request::new(RunStepRequest {
+            job_id,
+            command: vec!["id".into()],
+            uid: owner_uid,
+            step_id: 0,
+            user: "local-wire-name".into(),
+            ..Default::default()
+        }))
+        .await
+        .expect("uid match must authorize step dispatch despite username mismatch");
     }
 
     async fn assign_ha_control_plane(svc: &ControllerService) {

--- a/docs/user-guide/interactive.rst
+++ b/docs/user-guide/interactive.rst
@@ -15,7 +15,10 @@ live. It operates in two modes:
 
 - **Standalone** — when run outside an allocation, it submits a new job, waits
   for the allocation, streams output from the node agent, and exits with the
-  job's exit code. Pressing Ctrl-C cancels the job.
+  job's exit code. Pressing Ctrl-C cancels the job. After the allocation is
+  granted, standalone ``srun`` (including ``--pty``) resolves the job owner from
+  the controller for step, keepalive, and cancel RPCs, the same way ``srun`` does
+  inside an ``salloc`` shell via ``SPUR_JOB_USER``.
 - **Step mode** — when run inside an existing allocation (``SPUR_JOB_ID`` is set,
   as under ``salloc`` or in a batch script), it creates a *job step* against the
   parent allocation instead of submitting a new job.
@@ -97,10 +100,16 @@ Interactive Allocation — ``salloc``
 
 ``spur alloc`` (Slurm ``salloc``) requests an interactive allocation, waits for
 it to start (up to 300 seconds), then spawns your ``$SHELL`` with the allocation
-environment exported (``SPUR_JOB_ID``, ``SPUR_NODELIST``, ``SPUR_NNODES``,
-``SPUR_NTASKS``, ``SPUR_CPUS_PER_TASK``, the partition/account/QOS variables, and
-their ``SLURM_*`` twins). When you exit the shell, the allocation is released.
-Ctrl-C cancels it.
+environment exported (``SPUR_JOB_ID``, ``SPUR_JOB_USER``, ``SPUR_NODELIST``,
+``SPUR_NNODES``, ``SPUR_NTASKS``, ``SPUR_CPUS_PER_TASK``, the
+partition/account/QOS variables, and their ``SLURM_*`` twins). When you exit the
+shell, the allocation is released. Ctrl-C cancels it.
+
+When authentication is enabled, ``salloc`` also passes ``$SPUR_AUTH_TOKEN`` (or
+``~/.spur/token``) into the allocation shell so step commands can authenticate
+to the controller. ``SPUR_JOB_USER`` records the job owner bound at submit time
+(for example the JWT subject); ``srun`` inside the shell uses it when step RPCs
+run without a token.
 
 Inside that shell, ``srun`` runs as a job step sized to the allocation.
 
@@ -123,7 +132,9 @@ Attach to a Running Job — ``sattach``
 ``spur attach`` (Slurm ``sattach``) connects to a running job's I/O. The
 positional argument is ``JOB_ID`` or ``JOB_ID.STEP_ID``; the step-id component is
 accepted, but only the job id is used to route the attach. By default it opens a
-full interactive raw-mode terminal attached through the node agent.
+full interactive raw-mode terminal attached through the node agent. Attach RPCs
+use the job owner from ``SPUR_JOB_USER`` (when set), the controller job record, or
+the local login name, matching step-mode ``srun`` under JWT auth.
 
 .. list-table::
    :header-rows: 1

--- a/docs/user-guide/interactive.rst
+++ b/docs/user-guide/interactive.rst
@@ -17,7 +17,8 @@ live. It operates in two modes:
   for the allocation, streams output from the node agent, and exits with the
   job's exit code. Pressing Ctrl-C cancels the job. After the allocation is
   granted, standalone ``srun`` (including ``--pty``) resolves the job owner from
-  the controller for step, keepalive, and cancel RPCs, the same way ``srun`` does
+  the controller for step, keepalive, and cancel RPCs, the same way
+  ``srun`` does
   inside an ``salloc`` shell via ``SPUR_JOB_USER``.
 - **Step mode** — when run inside an existing allocation (``SPUR_JOB_ID`` is set,
   as under ``salloc`` or in a batch script), it creates a *job step* against the
@@ -134,7 +135,7 @@ positional argument is ``JOB_ID`` or ``JOB_ID.STEP_ID``; the step-id component i
 accepted, but only the job id is used to route the attach. By default it opens a
 full interactive raw-mode terminal attached through the node agent. Attach RPCs
 use the job owner from ``SPUR_JOB_USER`` (when set), the controller job record, or
-the local login name, matching step-mode ``srun`` under JWT auth.
+the local login name, matching step-mode ``srun`` under JWT authentication.
 
 .. list-table::
    :header-rows: 1

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1518,6 +1518,7 @@ message CreateJobStepRequest {
   WindowSize winsize = 7;     // Initial terminal dimensions
   string node = 8;            // Target node (-w); empty = first allocated node
   string user = 9;            // Requesting user; verified identity must own the job; the controller/admin credential overrides
+  uint32 uid = 10;            // Caller Unix uid for Munge-like ownership when unauthenticated; 0 = absent
 }
 
 message CreateJobStepResponse {

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -423,15 +423,65 @@ class SpurCluster:
         code = stdout.channel.recv_exit_status()
         return code, stdout.read().decode() + stderr.read().decode()
 
-    def srun_in_allocation(self, job_id: int, args: list[str]) -> tuple[int, str]:
-        """Run srun inside an existing allocation (step mode, as after salloc)."""
+    def srun_in_allocation(
+        self,
+        job_id: int,
+        args: list[str],
+        extra_env: dict[str, str] | None = None,
+        unset_env: list[str] | None = None,
+    ) -> tuple[int, str]:
+        """Run srun inside an existing allocation (step mode, as after salloc).
+
+        *extra_env* can set ``SPUR_JOB_USER`` / ``SPUR_AUTH_TOKEN`` to exercise
+        step-mode identity separately from the invoking account.  *unset_env*
+        removes variables (via ``env -u``) so an empty value does not fall through
+        to ``~/.spur/token``.
+        """
         cmd_parts = [
             f"SPUR_JOB_ID={job_id}",
             f"SPUR_CONTROLLER_ADDR={shlex.quote(self.controller_addr)}",
             f"PATH={shlex.quote(self.bin_dir)}:$PATH",
-            shlex.quote(f"{self.bin_dir}/srun"),
         ]
+        for key, value in (extra_env or {}).items():
+            cmd_parts.append(f"{key}={shlex.quote(str(value))}")
+        cmd_parts.append(shlex.quote(f"{self.bin_dir}/srun"))
         cmd_parts.extend(shlex.quote(a) for a in args)
+        cmd = " ".join(cmd_parts)
+        if unset_env:
+            unset = " ".join(f"-u {shlex.quote(name)}" for name in unset_env)
+            cmd = f"env {unset} {cmd}"
+        _, stdout, stderr = self.nodes[0].client.exec_command(cmd)
+        code = stdout.channel.recv_exit_status()
+        return code, stdout.read().decode() + stderr.read().decode()
+
+    def salloc_run(
+        self,
+        shell_body: str,
+        *,
+        salloc_args: list[str] | None = None,
+        extra_env: dict[str, str] | None = None,
+    ) -> tuple[int, str]:
+        """Run salloc with *shell_body* as the allocation shell (via ``SHELL``).
+
+        salloc exports allocation env vars into the shell, then cancels the job
+        when the shell exits.  Returns ``(exit_code, combined_output)``.
+        """
+        script_path = self.write_file(
+            f"salloc-shell-{time.time_ns()}.sh",
+            f"#!/bin/bash\nset -euo pipefail\n{shell_body}\n",
+        )
+
+        cmd_parts = [
+            f"SPUR_CONTROLLER_ADDR={shlex.quote(self.controller_addr)}",
+            f"PATH={shlex.quote(self.bin_dir)}:$PATH",
+            f"SHELL={shlex.quote(script_path)}",
+        ]
+        for key, value in (extra_env or {}).items():
+            cmd_parts.append(f"{key}={shlex.quote(str(value))}")
+        cmd_parts.append(shlex.quote(f"{self.bin_dir}/spur"))
+        cmd_parts.append("salloc")
+        cmd_parts.extend(shlex.quote(a) for a in (salloc_args or ["-N", "1", "-t", "0:05"]))
+
         _, stdout, stderr = self.nodes[0].client.exec_command(" ".join(cmd_parts))
         code = stdout.channel.recv_exit_status()
         return code, stdout.read().decode() + stderr.read().decode()

--- a/tests/native_host/e2e/test_salloc_step_auth.py
+++ b/tests/native_host/e2e/test_salloc_step_auth.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for salloc allocation → srun step identity (SPUR-220).
+
+When JWT auth binds a job to the token subject at submit time, step RPCs must
+still succeed inside the allocation shell even after ``SPUR_AUTH_TOKEN`` is
+unset — via ``SPUR_JOB_USER`` from salloc and/or a ``GetJob`` owner lookup.
+"""
+
+import os
+
+import pytest
+
+from cluster import parse_job_id, wait_job_state
+
+# Must exist in NSS on the test nodes and differ from the typical SSH login.
+JWT_OWNER = "root"
+
+JWT_AUTH_CONFIG = {
+    "auth": {"plugin": "jwt", "jwt_key": "e2e-salloc-step-auth-key"},
+}
+
+
+def _ssh_user() -> str:
+    user = os.environ.get("SPUR_TEST_SSH_USER", "")
+    assert user, "SPUR_TEST_SSH_USER must be set"
+    return user
+
+
+def _token_for(cluster, user: str) -> str:
+    out = cluster.cli(
+        [
+            "spur",
+            "token",
+            "user",
+            f"--user={user}",
+            f"--config={cluster.etc_dir}/spur.conf",
+        ]
+    )
+    token = out.strip().split("\n")[0]
+    assert token.count(".") == 2, f"unexpected token format: {out}"
+    return token
+
+
+def _denied(combined: str) -> bool:
+    lower = combined.lower()
+    return (
+        "cannot run a step" in lower
+        or "cannot attach" in lower
+        or "permission denied" in lower
+        or "not job owner" in lower
+    )
+
+
+class TestSallocStepAuthJwt:
+    """JWT permissive: submit identity can differ from the local login name."""
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return JWT_AUTH_CONFIG
+
+    def test_salloc_exports_job_user(self, cluster):
+        token = _token_for(cluster, JWT_OWNER)
+        out_path = f"{cluster.remote_dir}/salloc-env.txt"
+        body = f"""
+unset SPUR_AUTH_TOKEN
+echo "$SPUR_JOB_USER" > '{out_path}'
+echo "$SLURM_JOB_USER" >> '{out_path}'
+"""
+        code, out = cluster.salloc_run(
+            body,
+            extra_env={"SPUR_AUTH_TOKEN": token},
+        )
+        assert code == 0, f"salloc failed (exit {code}):\n{out}"
+
+        lines = cluster.nodes[0].read_file(out_path).strip().splitlines()
+        assert len(lines) >= 2, f"expected SPUR/SLURM job user lines, got: {lines!r}"
+        assert lines[0] == JWT_OWNER, f"SPUR_JOB_USER must be the JWT owner, got {lines[0]!r}"
+        assert lines[1] == JWT_OWNER, f"SLURM_JOB_USER must mirror owner, got {lines[1]!r}"
+
+    def test_srun_step_after_salloc_without_token(self, cluster):
+        token = _token_for(cluster, JWT_OWNER)
+        out_path = f"{cluster.remote_dir}/salloc-step.out"
+        body = f"""
+unset SPUR_AUTH_TOKEN
+'{cluster.bin_dir}/srun' hostname > '{out_path}' 2>&1
+"""
+        code, out = cluster.salloc_run(
+            body,
+            extra_env={"SPUR_AUTH_TOKEN": token},
+        )
+        assert code == 0, f"salloc failed (exit {code}):\n{out}"
+
+        step_out = cluster.nodes[0].read_file(out_path)
+        assert not _denied(step_out), f"srun step must succeed inside salloc shell:\n{step_out}"
+        assert step_out.strip(), f"expected hostname output, got:\n{step_out}"
+
+    def test_srun_step_resolves_owner_via_get_job(self, cluster):
+        """Step mode with only SPUR_JOB_ID still finds the owner on the controller."""
+        ssh_user = _ssh_user()
+        token = _token_for(cluster, JWT_OWNER)
+        hold = cluster.write_file("auth-hold.sh", "#!/bin/bash\nsleep 120\n")
+        sb = cluster.cli_as_user(
+            ssh_user,
+            ["sbatch", "-J", "auth-hold", "-t", "5", hold],
+            extra_env={"SPUR_AUTH_TOKEN": token},
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch failed: {sb}"
+
+        wait_job_state(cluster, job_id, "R", timeout=60)
+        try:
+            code, out = cluster.srun_in_allocation(
+                job_id,
+                ["hostname"],
+                unset_env=["SPUR_AUTH_TOKEN"],
+            )
+            assert code == 0, f"srun step failed (exit {code}):\n{out}"
+            assert not _denied(out), out
+            assert out.strip(), f"expected hostname output, got:\n{out}"
+        finally:
+            cluster.scancel(str(job_id))
+
+    def test_srun_step_wrong_job_user_denied(self, cluster):
+        ssh_user = _ssh_user()
+        token = _token_for(cluster, JWT_OWNER)
+        hold = cluster.write_file("auth-hold-deny.sh", "#!/bin/bash\nsleep 120\n")
+        sb = cluster.cli_as_user(
+            ssh_user,
+            ["sbatch", "-J", "auth-hold-deny", "-t", "5", hold],
+            extra_env={"SPUR_AUTH_TOKEN": token},
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch failed: {sb}"
+
+        wait_job_state(cluster, job_id, "R", timeout=60)
+        try:
+            code, out = cluster.srun_in_allocation(
+                job_id,
+                ["hostname"],
+                extra_env={"SPUR_JOB_USER": "not-the-job-owner"},
+                unset_env=["SPUR_AUTH_TOKEN"],
+            )
+            assert code != 0, f"step with a spoofed job user must fail:\n{out}"
+            assert _denied(out), f"expected ownership denial, got:\n{out}"
+        finally:
+            cluster.scancel(str(job_id))
+
+    def test_srun_step_jwt_non_owner_denied(self, cluster):
+        """A JWT for a different subject cannot run a step in another user's job."""
+        ssh_user = _ssh_user()
+        if ssh_user == JWT_OWNER:
+            pytest.skip("SSH user is root; need a distinct non-owner account")
+
+        owner_token = _token_for(cluster, JWT_OWNER)
+        caller_token = _token_for(cluster, ssh_user)
+        hold = cluster.write_file("auth-hold-jwt.sh", "#!/bin/bash\nsleep 120\n")
+        sb = cluster.cli_as_user(
+            ssh_user,
+            ["sbatch", "-J", "auth-hold-jwt", "-t", "5", hold],
+            extra_env={"SPUR_AUTH_TOKEN": owner_token},
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch failed: {sb}"
+
+        wait_job_state(cluster, job_id, "R", timeout=60)
+        try:
+            code, out = cluster.srun_in_allocation(
+                job_id,
+                ["hostname"],
+                extra_env={"SPUR_AUTH_TOKEN": caller_token},
+            )
+            assert code != 0, f"non-owner JWT must not run a step:\n{out}"
+            assert _denied(out), f"expected ownership denial, got:\n{out}"
+        finally:
+            cluster.scancel(str(job_id))
+
+
+class TestSallocStepAuthUidFallback:
+    """Unauthenticated step RPCs may match the job via submit-time uid."""
+
+    def test_srun_step_uid_fallback_with_wrong_username(self, cluster):
+        hold = cluster.write_file("uid-hold.sh", "#!/bin/bash\nsleep 120\n")
+        sb = cluster.sbatch(["-J", "uid-hold", "-t", "5", hold])
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch failed: {sb}"
+
+        wait_job_state(cluster, job_id, "R", timeout=60)
+        try:
+            code, out = cluster.srun_in_allocation(
+                job_id,
+                ["hostname"],
+                extra_env={"SPUR_JOB_USER": "definitely-not-the-owner"},
+            )
+            assert code == 0, (
+                f"uid fallback must allow a step when caller uid matches submit uid "
+                f"(exit {code}):\n{out}"
+            )
+            assert not _denied(out), out
+            assert out.strip(), f"expected hostname output, got:\n{out}"
+        finally:
+            cluster.scancel(str(job_id))


### PR DESCRIPTION
## Summary

- Fix SPUR-220: after JWT submit via `salloc`, `srun` inside the allocation shell failed with "cannot run a step in job owned by …" because step RPCs used the local login name while the job was bound to the JWT subject at submit time.
- Add `check_job_caller` on the controller for keepalive, `create_job_step`, `exec_in_job`, and `run_step`: JWT subject when authenticated; username or submit-time uid match when unauthenticated (Munge-like).
- Teach the CLI to resolve the caller via matching `SPUR_JOB_ID` + `SPUR_JOB_USER`, `GetJob`, or a known owner from an earlier fetch; export `SPUR_JOB_USER` from `salloc`, inherit `SPUR_AUTH_TOKEN` into the allocation shell, and append `uid` to `CreateJobStepRequest` for uid fallback on step create.

## Approach

- Server: new `check_job_caller()` in `spur-core`; wire it into the step/keepalive/exec RPC handlers. `check_job_owner` unchanged for cancel/update paths.
- CLI: shared `job_caller_user()` helper used by `srun`, `sattach`, and `exec`. Allocation env vars are honored only when the exported job id matches the target job. Standalone `srun` and `srun --jobid --overlap` reuse the controller owner from `GetJob` / the running-allocation poll.
- Proto: append `CreateJobStepRequest.uid` (field 10); wire-compatible default 0 = absent.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`
- [x] `cargo test --locked`