### PR TITLE
feat(cgroup): add [cgroup] config and derive limits from the node allocation

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -290,3 +290,9 @@ Scaffolded
 ClusterIP
 DNATs
 kube
+cgroups
+cpuset
+CFS
+MiB
+OOM
+pluggable

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1579,6 +1579,52 @@ pub struct CgroupLimits {
 }
 
 impl CgroupConfig {
+    /// `(memory.max, memory.high, memory.swap.max)` for a job whose per-node
+    /// budget is `memory_mb`, resolved as Slurm's cgroup/v2 plugin resolves
+    /// them across all four `Constrain{RAMSpace,SwapSpace}` combinations.
+    ///
+    /// The subtle case is swap-without-RAM: Slurm forces `AllowedRAMSpace` to
+    /// 100% and sets the RAM ceiling to the combined RAM+swap total, so the
+    /// *sum* stays bounded. Leaving memory unlimited there would let a job
+    /// bypass the very ceiling the swap bound is derived from.
+    fn memory_limits(&self, memory_mb: u64) -> (Option<u64>, Option<u64>, Option<u64>) {
+        // A job with no memory budget gets no ceiling at all. Bounding swap on
+        // its own here would forbid swap while RAM stayed unlimited.
+        if memory_mb == 0 || !(self.constrain_ram_space || self.constrain_swap) {
+            return (None, None, None);
+        }
+        let memory_bytes = memory_mb.saturating_mul(1024 * 1024);
+        let min_ram_bytes = self.min_ram_mb.saturating_mul(1024 * 1024);
+
+        // The percentage only exists to build the ceilings from, so it reverts
+        // to 100% when RAM itself is unconstrained.
+        let ram_percent = if self.constrain_ram_space {
+            self.allowed_ram_percent as u64
+        } else {
+            100
+        };
+
+        // Hard ceiling is AllowedRAMSpace% of the budget, soft is 100% of it,
+        // both floored at MinRAMSpace. A soft limit above the hard one is moot,
+        // so it collapses onto it.
+        let hard = (memory_bytes.saturating_mul(ram_percent) / 100).max(min_ram_bytes);
+        let soft = memory_bytes.max(min_ram_bytes).min(hard);
+        let combined = hard
+            .saturating_add(memory_bytes.saturating_mul(self.allowed_swap_percent as u64) / 100);
+
+        let memory_max = if self.constrain_ram_space {
+            hard
+        } else {
+            combined
+        };
+        let swap_max = if self.constrain_swap {
+            Some(combined.saturating_sub(memory_max))
+        } else {
+            None
+        };
+        (Some(memory_max), Some(soft), swap_max)
+    }
+
     /// Resolve the limits for a job whose per-node budget is `cpus`/`memory_mb`
     /// on cores `cpu_ids`. `None` when enforcement is off — the single place
     /// `enabled` is consulted, so no caller can half-apply the master switch.
@@ -1587,32 +1633,7 @@ impl CgroupConfig {
             return None;
         }
         let cpus = cpus.max(1);
-        // memory_mb == 0 means the job has no memory budget, so neither ceiling
-        // applies. Writing swap = 0 there would forbid swap while RAM stays
-        // unlimited — a pair Slurm never emits.
-        let bounded_memory = memory_mb > 0;
-        let memory_bytes = memory_mb.saturating_mul(1024 * 1024);
-        let min_ram_bytes = self.min_ram_mb.saturating_mul(1024 * 1024);
-
-        // Slurm's `_memcg_initialize`: the hard ceiling is AllowedRAMSpace% of
-        // the budget and the soft one is 100% of it, both floored at
-        // MinRAMSpace. A soft limit above the hard one is moot — the kernel
-        // would never reach it — so it collapses onto the hard limit.
-        let (memory_max_bytes, memory_high_bytes) = if self.constrain_ram_space && bounded_memory {
-            let hard = (memory_bytes.saturating_mul(self.allowed_ram_percent as u64) / 100)
-                .max(min_ram_bytes);
-            let soft = memory_bytes.max(min_ram_bytes).min(hard);
-            (Some(hard), Some(soft))
-        } else {
-            (None, None)
-        };
-        // Percent of the *allocated* memory. Slurm's `memsw - mem` cancels the
-        // AllowedRAMSpace term, so this does not depend on the hard ceiling.
-        let swap_max_bytes = if self.constrain_swap && bounded_memory {
-            Some(memory_bytes.saturating_mul(self.allowed_swap_percent as u64) / 100)
-        } else {
-            None
-        };
+        let (memory_max_bytes, memory_high_bytes, swap_max_bytes) = self.memory_limits(memory_mb);
         let cpu_quota_us = if self.cpu_quota {
             Some(cpus as u64 * CPU_PERIOD_US)
         } else {
@@ -2306,6 +2327,55 @@ mod tests {
             c.limits_for(4, 1024, &[]).unwrap().swap_max_bytes,
             Some(256 * 1024 * 1024)
         );
+    }
+
+    #[test]
+    fn memory_ceilings_cover_the_constrain_matrix() {
+        // 1 GiB budget with AllowedSwapSpace=25%, checked against what Slurm's
+        // cgroup/v2 plugin writes for each Constrain{RAMSpace,SwapSpace} pair.
+        const GIB: u64 = 1024 * 1024 * 1024;
+        let cases = [
+            // Neither constrained: the memory cgroup is left alone entirely.
+            (false, false, None, None, None),
+            // RAM only: ceiling at the budget, swap left to the kernel.
+            (true, false, Some(GIB), Some(GIB), None),
+            // Swap only: the RAM ceiling becomes the RAM+swap total so the sum
+            // stays bounded, and swap itself is then pinned to zero.
+            (false, true, Some(GIB + GIB / 4), Some(GIB), Some(0)),
+            // Both: swap gets its own allowance on top of the RAM ceiling.
+            (true, true, Some(GIB), Some(GIB), Some(GIB / 4)),
+        ];
+
+        for (constrain_ram, constrain_swap, want_max, want_high, want_swap) in cases {
+            let c = CgroupConfig {
+                constrain_ram_space: constrain_ram,
+                constrain_swap,
+                allowed_swap_percent: 25,
+                ..CgroupConfig::default()
+            };
+            let l = c.limits_for(1, 1024, &[]).expect("enabled");
+            assert_eq!(
+                (l.memory_max_bytes, l.memory_high_bytes, l.swap_max_bytes),
+                (want_max, want_high, want_swap),
+                "constrain_ram_space={constrain_ram}, constrain_swap={constrain_swap}"
+            );
+        }
+    }
+
+    #[test]
+    fn ram_percent_is_ignored_when_ram_is_not_constrained() {
+        // AllowedRAMSpace only shapes the ceiling Spur derives the swap bound
+        // from, so with RAM unconstrained Slurm reverts it to 100%.
+        let c = CgroupConfig {
+            constrain_ram_space: false,
+            allowed_ram_percent: 150,
+            allowed_swap_percent: 50,
+            ..CgroupConfig::default()
+        };
+        let l = c.limits_for(1, 1024, &[]).expect("enabled");
+        assert_eq!(l.memory_max_bytes, Some(1536 * 1024 * 1024));
+        assert_eq!(l.memory_high_bytes, Some(1024 * 1024 * 1024));
+        assert_eq!(l.swap_max_bytes, Some(0));
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -112,7 +112,7 @@ pub struct SlurmConfig {
     #[serde(default)]
     pub rlimits: RlimitsConfig,
 
-    /// cgroup enforcement policy for job processes.
+    /// cgroup-v2 job resource enforcement (spurd, native-host jobs).
     #[serde(default)]
     pub cgroup: CgroupConfig,
 
@@ -1491,6 +1491,151 @@ impl RlimitsConfig {
     }
 }
 
+/// CFS period that cgroup-v2 CPU quotas are expressed against.
+const CPU_PERIOD_US: u64 = 100_000;
+
+/// cgroup-v2 enforcement settings for native-host jobs (spurd).
+///
+/// A focused equivalent of Slurm's `cgroup.conf`: the same user-facing knobs
+/// without the plugin selectors. Where Slurm defaults to permissive, Spur
+/// defaults to enforcing — see `docs/admin-guide/configuration.rst`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CgroupConfig {
+    /// Master switch. When false, spurd creates no cgroup and applies no limits.
+    #[serde(default = "default_true_fn")]
+    pub enabled: bool,
+    /// Pin the job to its allocated cores via `cpuset.cpus` (`ConstrainCores`).
+    #[serde(default = "default_true_fn")]
+    pub constrain_cores: bool,
+    /// Additionally cap CPU time with a CFS quota (`cpu.max`). Off by default:
+    /// Slurm bounds whole-core allocations with the cpuset alone, and a quota
+    /// layered on top only adds throttling risk when it is mis-derived.
+    #[serde(default)]
+    pub cpu_quota: bool,
+    /// Cap resident memory via `memory.max` + `memory.high`
+    /// (`ConstrainRAMSpace`).
+    #[serde(default = "default_true_fn")]
+    pub constrain_ram_space: bool,
+    /// Hard memory ceiling as a percentage of the job's budget
+    /// (`AllowedRAMSpace`). `memory.high` stays at 100% of the budget, so a
+    /// value above 100 buys reclaim pressure at the allocation and an OOM kill
+    /// only at the headroom — at the cost of letting the node over-commit.
+    #[serde(default = "default_allowed_ram_percent")]
+    pub allowed_ram_percent: u32,
+    /// Bound swap via `memory.swap.max` (`ConstrainSwapSpace`).
+    #[serde(default = "default_true_fn")]
+    pub constrain_swap: bool,
+    /// Swap allowance as a percentage of the job's memory budget
+    /// (`AllowedSwapSpace`). Default 0 = no swap.
+    #[serde(default)]
+    pub allowed_swap_percent: u32,
+    /// Floor for `memory.max`, in MiB (`MinRAMSpace`). Below this a job is
+    /// killed during its own startup, before anything can clean up after it.
+    #[serde(default = "default_min_ram_mb")]
+    pub min_ram_mb: u64,
+    /// Kill every process in the job on OOM (`memory.oom.group`) rather than
+    /// letting the kernel pick one. Slurm's `OOMKillStep` defaults off; Spur
+    /// defaults on because a partially-killed job fails in murkier ways.
+    #[serde(default = "default_true_fn")]
+    pub oom_kill_job: bool,
+}
+
+fn default_min_ram_mb() -> u64 {
+    30
+}
+
+fn default_allowed_ram_percent() -> u32 {
+    100
+}
+
+impl Default for CgroupConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            constrain_cores: true,
+            cpu_quota: false,
+            constrain_ram_space: true,
+            allowed_ram_percent: default_allowed_ram_percent(),
+            constrain_swap: true,
+            allowed_swap_percent: 0,
+            min_ram_mb: default_min_ram_mb(),
+            oom_kill_job: true,
+        }
+    }
+}
+
+/// Resolved cgroup-v2 control-file values for one job. `None`/empty means
+/// "leave the kernel default", which is not the same as a limit of zero.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CgroupLimits {
+    pub cpu_quota_us: Option<u64>,
+    pub cpu_period_us: u64,
+    pub memory_max_bytes: Option<u64>,
+    pub memory_high_bytes: Option<u64>,
+    pub swap_max_bytes: Option<u64>,
+    pub oom_kill_job: bool,
+    pub pids_max: u64,
+    pub cpuset_cpus: Vec<u32>,
+}
+
+impl CgroupConfig {
+    /// Resolve the limits for a job whose per-node budget is `cpus`/`memory_mb`
+    /// on cores `cpu_ids`. `None` when enforcement is off — the single place
+    /// `enabled` is consulted, so no caller can half-apply the master switch.
+    pub fn limits_for(&self, cpus: u32, memory_mb: u64, cpu_ids: &[u32]) -> Option<CgroupLimits> {
+        if !self.enabled {
+            return None;
+        }
+        let cpus = cpus.max(1);
+        // memory_mb == 0 means the job has no memory budget, so neither ceiling
+        // applies. Writing swap = 0 there would forbid swap while RAM stays
+        // unlimited — a pair Slurm never emits.
+        let bounded_memory = memory_mb > 0;
+        let memory_bytes = memory_mb.saturating_mul(1024 * 1024);
+        let min_ram_bytes = self.min_ram_mb.saturating_mul(1024 * 1024);
+
+        // Slurm's `_memcg_initialize`: the hard ceiling is AllowedRAMSpace% of
+        // the budget and the soft one is 100% of it, both floored at
+        // MinRAMSpace. A soft limit above the hard one is moot — the kernel
+        // would never reach it — so it collapses onto the hard limit.
+        let (memory_max_bytes, memory_high_bytes) = if self.constrain_ram_space && bounded_memory {
+            let hard = (memory_bytes.saturating_mul(self.allowed_ram_percent as u64) / 100)
+                .max(min_ram_bytes);
+            let soft = memory_bytes.max(min_ram_bytes).min(hard);
+            (Some(hard), Some(soft))
+        } else {
+            (None, None)
+        };
+        // Percent of the *allocated* memory. Slurm's `memsw - mem` cancels the
+        // AllowedRAMSpace term, so this does not depend on the hard ceiling.
+        let swap_max_bytes = if self.constrain_swap && bounded_memory {
+            Some(memory_bytes.saturating_mul(self.allowed_swap_percent as u64) / 100)
+        } else {
+            None
+        };
+        let cpu_quota_us = if self.cpu_quota {
+            Some(cpus as u64 * CPU_PERIOD_US)
+        } else {
+            None
+        };
+
+        Some(CgroupLimits {
+            cpu_quota_us,
+            cpu_period_us: CPU_PERIOD_US,
+            memory_max_bytes,
+            memory_high_bytes,
+            swap_max_bytes,
+            oom_kill_job: self.oom_kill_job,
+            pids_max: (cpus as u64 * 256).max(1024),
+            cpuset_cpus: if self.constrain_cores {
+                cpu_ids.to_vec()
+            } else {
+                Vec::new()
+            },
+        })
+    }
+}
+
 impl SlurmConfig {
     /// Load from a TOML file.
     pub fn load_from_file(path: &Path) -> Result<Self, ConfigError> {
@@ -1610,6 +1755,26 @@ impl SlurmConfig {
                     "{} (must be between 1 and {})",
                     self.accounting.grp_wall_window_days, MAX_GRP_WALL_WINDOW_DAYS
                 ),
+            });
+        }
+        // Above 100% the swap ceiling exceeds the memory the job was granted,
+        // which defeats the bound rather than tuning it.
+        if self.cgroup.allowed_swap_percent > 100 {
+            return Err(ConfigError::InvalidValue {
+                field: "cgroup.allowed_swap_percent".into(),
+                value: format!(
+                    "{} (must be between 0 and 100)",
+                    self.cgroup.allowed_swap_percent
+                ),
+            });
+        }
+        // Zero collapses every job's memory ceiling onto `min_ram_mb`, which is
+        // a typo and never an intent. No upper bound: over-committing the node
+        // is a documented (if hazardous) choice, as it is in Slurm.
+        if self.cgroup.allowed_ram_percent == 0 {
+            return Err(ConfigError::InvalidValue {
+                field: "cgroup.allowed_ram_percent".into(),
+                value: "0 (must be at least 1)".into(),
             });
         }
         // A limit below the client's ping interval would reap a live client
@@ -2056,6 +2221,188 @@ pub fn format_time_seconds(total_seconds: Option<i64>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cgroup_config_defaults_match_intended_posture() {
+        let c = CgroupConfig::default();
+        assert!(c.enabled);
+        assert!(c.constrain_cores && c.constrain_ram_space && c.constrain_swap);
+        assert!(c.oom_kill_job);
+        // Slurm bounds whole-core allocations with the cpuset alone (D4).
+        assert!(!c.cpu_quota);
+        assert_eq!(c.allowed_swap_percent, 0);
+        assert_eq!(c.allowed_ram_percent, 100);
+        assert_eq!(c.min_ram_mb, 30);
+    }
+
+    #[test]
+    fn memory_high_tracks_memory_max_at_the_default_percent() {
+        // AllowedRAMSpace=100: Slurm clamps the soft limit to the hard one, so
+        // both land on the allocation.
+        let l = CgroupConfig::default()
+            .limits_for(4, 1024, &[])
+            .expect("enabled");
+        assert_eq!(l.memory_max_bytes, Some(1024 * 1024 * 1024));
+        assert_eq!(l.memory_high_bytes, l.memory_max_bytes);
+    }
+
+    #[test]
+    fn headroom_splits_the_soft_and_hard_ceilings() {
+        // AllowedRAMSpace=150: reclaim at the allocation, OOM kill at 1.5x.
+        let c = CgroupConfig {
+            allowed_ram_percent: 150,
+            ..CgroupConfig::default()
+        };
+        let l = c.limits_for(4, 1024, &[]).expect("enabled");
+        assert_eq!(l.memory_high_bytes, Some(1024 * 1024 * 1024));
+        assert_eq!(l.memory_max_bytes, Some(1536 * 1024 * 1024));
+    }
+
+    #[test]
+    fn shrinking_the_hard_ceiling_pulls_the_soft_one_down_with_it() {
+        // AllowedRAMSpace=50: a soft limit above the hard one is moot, so Slurm
+        // collapses them.
+        let c = CgroupConfig {
+            allowed_ram_percent: 50,
+            ..CgroupConfig::default()
+        };
+        let l = c.limits_for(4, 1024, &[]).expect("enabled");
+        assert_eq!(l.memory_max_bytes, Some(512 * 1024 * 1024));
+        assert_eq!(l.memory_high_bytes, l.memory_max_bytes);
+    }
+
+    #[test]
+    fn swap_ceiling_is_a_percent_of_allocated_memory() {
+        // Default 0% => memory.swap.max = 0, i.e. Slurm's `memsw - mem` with
+        // AllowedSwapSpace=0 and AllowedRAMSpace=100.
+        let c = CgroupConfig::default();
+        assert_eq!(c.limits_for(4, 1024, &[]).unwrap().swap_max_bytes, Some(0));
+
+        let c50 = CgroupConfig {
+            allowed_swap_percent: 50,
+            ..CgroupConfig::default()
+        };
+        assert_eq!(
+            c50.limits_for(4, 1024, &[]).unwrap().swap_max_bytes,
+            Some(512 * 1024 * 1024)
+        );
+
+        let off = CgroupConfig {
+            constrain_swap: false,
+            ..CgroupConfig::default()
+        };
+        assert_eq!(off.limits_for(4, 1024, &[]).unwrap().swap_max_bytes, None);
+    }
+
+    #[test]
+    fn swap_ceiling_is_independent_of_the_ram_percent() {
+        // Slurm's `memsw - mem` cancels the AllowedRAMSpace term.
+        let c = CgroupConfig {
+            allowed_ram_percent: 150,
+            allowed_swap_percent: 25,
+            ..CgroupConfig::default()
+        };
+        assert_eq!(
+            c.limits_for(4, 1024, &[]).unwrap().swap_max_bytes,
+            Some(256 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn unbounded_memory_leaves_swap_unbounded() {
+        // Writing memory.swap.max = 0 for a job with no memory limit would
+        // forbid swap while RAM stays unlimited — a pair Slurm never emits.
+        let l = CgroupConfig::default()
+            .limits_for(4, 0, &[])
+            .expect("enabled");
+        assert_eq!(l.memory_max_bytes, None);
+        assert_eq!(l.memory_high_bytes, None);
+        assert_eq!(l.swap_max_bytes, None);
+    }
+
+    #[test]
+    fn memory_limits_floor_at_min_ram_mb() {
+        let l = CgroupConfig::default()
+            .limits_for(1, 8, &[])
+            .expect("enabled");
+        assert_eq!(l.memory_max_bytes, Some(30 * 1024 * 1024));
+        assert_eq!(l.memory_high_bytes, Some(30 * 1024 * 1024));
+    }
+
+    #[test]
+    fn cpu_quota_is_opt_in() {
+        assert_eq!(
+            CgroupConfig::default()
+                .limits_for(4, 0, &[])
+                .unwrap()
+                .cpu_quota_us,
+            None
+        );
+        let q = CgroupConfig {
+            cpu_quota: true,
+            ..CgroupConfig::default()
+        };
+        assert_eq!(q.limits_for(4, 0, &[]).unwrap().cpu_quota_us, Some(400_000));
+    }
+
+    #[test]
+    fn core_pinning_can_be_turned_off() {
+        let on = CgroupConfig::default()
+            .limits_for(2, 0, &[0, 1])
+            .expect("enabled");
+        assert_eq!(on.cpuset_cpus, vec![0, 1]);
+
+        let off = CgroupConfig {
+            constrain_cores: false,
+            ..CgroupConfig::default()
+        };
+        assert!(off
+            .limits_for(2, 0, &[0, 1])
+            .unwrap()
+            .cpuset_cpus
+            .is_empty());
+    }
+
+    #[test]
+    fn disabled_yields_no_limits_at_all() {
+        let off = CgroupConfig {
+            enabled: false,
+            ..CgroupConfig::default()
+        };
+        assert!(off.limits_for(4, 1024, &[0, 1]).is_none());
+    }
+
+    #[test]
+    fn missing_cgroup_section_uses_defaults() {
+        let cfg = SlurmConfig::load_from_str("cluster_name = \"test\"").expect("parses");
+        assert!(cfg.cgroup.enabled);
+        assert_eq!(cfg.cgroup.allowed_swap_percent, 0);
+    }
+
+    #[test]
+    fn swap_percent_above_100_is_rejected() {
+        let err = SlurmConfig::load_from_str(
+            "cluster_name = \"test\"\n[cgroup]\nallowed_swap_percent = 150\n",
+        )
+        .expect_err("must not validate");
+        assert!(matches!(err, ConfigError::InvalidValue { .. }));
+    }
+
+    #[test]
+    fn zero_ram_percent_is_rejected_but_over_100_is_allowed() {
+        let err = SlurmConfig::load_from_str(
+            "cluster_name = \"test\"\n[cgroup]\nallowed_ram_percent = 0\n",
+        )
+        .expect_err("must not validate");
+        assert!(matches!(err, ConfigError::InvalidValue { .. }));
+
+        // Over-committing the node is a legitimate (documented) choice, as in Slurm.
+        let cfg = SlurmConfig::load_from_str(
+            "cluster_name = \"test\"\n[cgroup]\nallowed_ram_percent = 150\n",
+        )
+        .expect("parses");
+        assert_eq!(cfg.cgroup.allowed_ram_percent, 150);
+    }
 
     #[test]
     fn test_controller_endpoints_single_host() {

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1463,8 +1463,9 @@ pub struct CgroupConfig {
     /// `memory.high` stays at 100%, so above 100 reclaims first and kills later.
     #[serde(default = "default_allowed_ram_percent")]
     pub allowed_ram_percent: u32,
-    /// Bound swap via `memory.swap.max` (`ConstrainSwapSpace`).
-    #[serde(default = "default_true_fn")]
+    /// Bound swap via `memory.swap.max` (`ConstrainSwapSpace`). Off by default,
+    /// as in Slurm: turning it on kills jobs that used to survive by swapping.
+    #[serde(default)]
     pub constrain_swap: bool,
     /// Swap allowance as a percent of the memory budget (`AllowedSwapSpace`), 0 =
     /// none. Uncapped above 100, as in Slurm: swap may legitimately exceed RAM.
@@ -1497,7 +1498,7 @@ impl Default for CgroupConfig {
             cpu_quota: false,
             constrain_ram_space: true,
             allowed_ram_percent: default_allowed_ram_percent(),
-            constrain_swap: true,
+            constrain_swap: false,
             allowed_swap_percent: 0,
             min_ram_mb: default_min_ram_mb(),
             oom_kill_job: true,
@@ -2168,12 +2169,14 @@ mod tests {
     fn cgroup_config_defaults_match_intended_posture() {
         let c = CgroupConfig::default();
         assert!(c.enabled);
-        assert!(c.constrain_cores && c.constrain_ram_space && c.constrain_swap);
+        assert!(c.constrain_cores && c.constrain_ram_space);
         assert!(c.oom_kill_job);
         // Degrade rather than stop accepting work on a misconfigured host.
         assert!(!c.required);
         // Slurm bounds whole-core allocations with the cpuset alone (D4).
         assert!(!c.cpu_quota);
+        // Off as in Slurm: bounding swap kills jobs that used to ride it out.
+        assert!(!c.constrain_swap);
         assert_eq!(c.allowed_swap_percent, 0);
         assert_eq!(c.allowed_ram_percent, 100);
         assert_eq!(c.min_ram_mb, 30);
@@ -2217,12 +2220,16 @@ mod tests {
 
     #[test]
     fn swap_ceiling_is_a_percent_of_allocated_memory() {
-        // Default 0% => memory.swap.max = 0, i.e. Slurm's `memsw - mem` with
+        // 0% => memory.swap.max = 0, i.e. Slurm's `memsw - mem` with
         // AllowedSwapSpace=0 and AllowedRAMSpace=100.
-        let c = CgroupConfig::default();
+        let c = CgroupConfig {
+            constrain_swap: true,
+            ..CgroupConfig::default()
+        };
         assert_eq!(c.limits_for(4, 1024, &[]).unwrap().swap_max_bytes, Some(0));
 
         let c50 = CgroupConfig {
+            constrain_swap: true,
             allowed_swap_percent: 50,
             ..CgroupConfig::default()
         };
@@ -2242,6 +2249,7 @@ mod tests {
     fn swap_ceiling_is_independent_of_the_ram_percent() {
         // Slurm's `memsw - mem` cancels the AllowedRAMSpace term.
         let c = CgroupConfig {
+            constrain_swap: true,
             allowed_ram_percent: 150,
             allowed_swap_percent: 25,
             ..CgroupConfig::default()
@@ -2291,6 +2299,7 @@ mod tests {
         // from, so with RAM unconstrained Slurm reverts it to 100%.
         let c = CgroupConfig {
             constrain_ram_space: false,
+            constrain_swap: true,
             allowed_ram_percent: 150,
             allowed_swap_percent: 50,
             ..CgroupConfig::default()
@@ -2377,7 +2386,7 @@ mod tests {
         // Slurm applies no upper bound to AllowedSwapSpace, so a `cgroup.conf`
         // carrying one must not stop the controller from starting.
         let cfg = SlurmConfig::load_from_str(
-            "cluster_name = \"test\"\n[cgroup]\nallowed_swap_percent = 200\n",
+            "cluster_name = \"test\"\n[cgroup]\nconstrain_swap = true\nallowed_swap_percent = 200\n",
         )
         .expect("parses");
         assert_eq!(cfg.cgroup.allowed_swap_percent, 200);

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1494,48 +1494,45 @@ impl RlimitsConfig {
 /// CFS period that cgroup-v2 CPU quotas are expressed against.
 const CPU_PERIOD_US: u64 = 100_000;
 
-/// cgroup-v2 enforcement settings for native-host jobs (spurd).
-///
-/// A focused equivalent of Slurm's `cgroup.conf`: the same user-facing knobs
-/// without the plugin selectors. Where Slurm defaults to permissive, Spur
-/// defaults to enforcing — see `docs/admin-guide/configuration.rst`.
+/// cgroup-v2 enforcement for native-host jobs — a focused `cgroup.conf` without
+/// the plugin selectors. Slurm defaults permissive here, Spur enforcing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CgroupConfig {
     /// Master switch. When false, spurd creates no cgroup and applies no limits.
     #[serde(default = "default_true_fn")]
     pub enabled: bool,
+    /// Refuse to launch when a constraint cannot be applied, rather than warning and
+    /// running unconstrained. Off by default so a bad host degrades, not stalls.
+    #[serde(default)]
+    pub required: bool,
     /// Pin the job to its allocated cores via `cpuset.cpus` (`ConstrainCores`).
     #[serde(default = "default_true_fn")]
     pub constrain_cores: bool,
-    /// Additionally cap CPU time with a CFS quota (`cpu.max`). Off by default:
-    /// Slurm bounds whole-core allocations with the cpuset alone, and a quota
-    /// layered on top only adds throttling risk when it is mis-derived.
+    /// Also cap CPU time with a CFS quota (`cpu.max`). Off by default: Slurm bounds
+    /// whole cores with the cpuset alone, and a quota on top only risks throttling.
     #[serde(default)]
     pub cpu_quota: bool,
     /// Cap resident memory via `memory.max` + `memory.high`
     /// (`ConstrainRAMSpace`).
     #[serde(default = "default_true_fn")]
     pub constrain_ram_space: bool,
-    /// Hard memory ceiling as a percentage of the job's budget
-    /// (`AllowedRAMSpace`). `memory.high` stays at 100% of the budget, so a
-    /// value above 100 buys reclaim pressure at the allocation and an OOM kill
-    /// only at the headroom — at the cost of letting the node over-commit.
+    /// Hard ceiling as a percent of the job's budget (`AllowedRAMSpace`).
+    /// `memory.high` stays at 100%, so above 100 reclaims first and kills later.
     #[serde(default = "default_allowed_ram_percent")]
     pub allowed_ram_percent: u32,
     /// Bound swap via `memory.swap.max` (`ConstrainSwapSpace`).
     #[serde(default = "default_true_fn")]
     pub constrain_swap: bool,
-    /// Swap allowance as a percentage of the job's memory budget
-    /// (`AllowedSwapSpace`). Default 0 = no swap.
+    /// Swap allowance as a percent of the memory budget (`AllowedSwapSpace`), 0 =
+    /// none. Uncapped above 100, as in Slurm: swap may legitimately exceed RAM.
     #[serde(default)]
     pub allowed_swap_percent: u32,
     /// Floor for `memory.max`, in MiB (`MinRAMSpace`). Below this a job is
     /// killed during its own startup, before anything can clean up after it.
     #[serde(default = "default_min_ram_mb")]
     pub min_ram_mb: u64,
-    /// Kill every process in the job on OOM (`memory.oom.group`) rather than
-    /// letting the kernel pick one. Slurm's `OOMKillStep` defaults off; Spur
-    /// defaults on because a partially-killed job fails in murkier ways.
+    /// Kill the whole job on OOM (`memory.oom.group`), not one process. Slurm's
+    /// `OOMKillStep` defaults off; on here, since partial kills fail murkily.
     #[serde(default = "default_true_fn")]
     pub oom_kill_job: bool,
 }
@@ -1552,6 +1549,7 @@ impl Default for CgroupConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            required: false,
             constrain_cores: true,
             cpu_quota: false,
             constrain_ram_space: true,
@@ -1579,14 +1577,8 @@ pub struct CgroupLimits {
 }
 
 impl CgroupConfig {
-    /// `(memory.max, memory.high, memory.swap.max)` for a job whose per-node
-    /// budget is `memory_mb`, resolved as Slurm's cgroup/v2 plugin resolves
-    /// them across all four `Constrain{RAMSpace,SwapSpace}` combinations.
-    ///
-    /// The subtle case is swap-without-RAM: Slurm forces `AllowedRAMSpace` to
-    /// 100% and sets the RAM ceiling to the combined RAM+swap total, so the
-    /// *sum* stays bounded. Leaving memory unlimited there would let a job
-    /// bypass the very ceiling the swap bound is derived from.
+    /// `(memory.max, memory.high, memory.swap.max)` as Slurm's cgroup/v2 plugin
+    /// computes them. Swap-without-RAM: the RAM ceiling becomes the RAM+swap total.
     fn memory_limits(&self, memory_mb: u64) -> (Option<u64>, Option<u64>, Option<u64>) {
         // A job with no memory budget gets no ceiling at all. Bounding swap on
         // its own here would forbid swap while RAM stayed unlimited.
@@ -1604,9 +1596,8 @@ impl CgroupConfig {
             100
         };
 
-        // Hard ceiling is AllowedRAMSpace% of the budget, soft is 100% of it,
-        // both floored at MinRAMSpace. A soft limit above the hard one is moot,
-        // so it collapses onto it.
+        // Hard is AllowedRAMSpace% of the budget, soft 100%, both floored at
+        // MinRAMSpace. A soft limit above the hard one is moot, so it collapses.
         let hard = (memory_bytes.saturating_mul(ram_percent) / 100).max(min_ram_bytes);
         let soft = memory_bytes.max(min_ram_bytes).min(hard);
         let combined = hard
@@ -1625,9 +1616,8 @@ impl CgroupConfig {
         (Some(memory_max), Some(soft), swap_max)
     }
 
-    /// Resolve the limits for a job whose per-node budget is `cpus`/`memory_mb`
-    /// on cores `cpu_ids`. `None` when enforcement is off — the single place
-    /// `enabled` is consulted, so no caller can half-apply the master switch.
+    /// Limits for a job budgeted `cpus`/`memory_mb` on `cpu_ids`. `None` when
+    /// disabled — the only place `enabled` is read, so it cannot be half-applied.
     pub fn limits_for(&self, cpus: u32, memory_mb: u64, cpu_ids: &[u32]) -> Option<CgroupLimits> {
         if !self.enabled {
             return None;
@@ -1778,20 +1768,8 @@ impl SlurmConfig {
                 ),
             });
         }
-        // Above 100% the swap ceiling exceeds the memory the job was granted,
-        // which defeats the bound rather than tuning it.
-        if self.cgroup.allowed_swap_percent > 100 {
-            return Err(ConfigError::InvalidValue {
-                field: "cgroup.allowed_swap_percent".into(),
-                value: format!(
-                    "{} (must be between 0 and 100)",
-                    self.cgroup.allowed_swap_percent
-                ),
-            });
-        }
-        // Zero collapses every job's memory ceiling onto `min_ram_mb`, which is
-        // a typo and never an intent. No upper bound: over-committing the node
-        // is a documented (if hazardous) choice, as it is in Slurm.
+        // Zero collapses every ceiling onto `min_ram_mb` — a typo, never an intent.
+        // Above 100 is legal (as in Slurm), so only zero is rejected.
         if self.cgroup.allowed_ram_percent == 0 {
             return Err(ConfigError::InvalidValue {
                 field: "cgroup.allowed_ram_percent".into(),
@@ -2249,6 +2227,8 @@ mod tests {
         assert!(c.enabled);
         assert!(c.constrain_cores && c.constrain_ram_space && c.constrain_swap);
         assert!(c.oom_kill_job);
+        // Degrade rather than stop accepting work on a misconfigured host.
+        assert!(!c.required);
         // Slurm bounds whole-core allocations with the cpuset alone (D4).
         assert!(!c.cpu_quota);
         assert_eq!(c.allowed_swap_percent, 0);
@@ -2450,12 +2430,19 @@ mod tests {
     }
 
     #[test]
-    fn swap_percent_above_100_is_rejected() {
-        let err = SlurmConfig::load_from_str(
-            "cluster_name = \"test\"\n[cgroup]\nallowed_swap_percent = 150\n",
+    fn swap_percent_above_100_is_accepted() {
+        // Slurm applies no upper bound to AllowedSwapSpace, so a `cgroup.conf`
+        // carrying one must not stop the controller from starting.
+        let cfg = SlurmConfig::load_from_str(
+            "cluster_name = \"test\"\n[cgroup]\nallowed_swap_percent = 200\n",
         )
-        .expect_err("must not validate");
-        assert!(matches!(err, ConfigError::InvalidValue { .. }));
+        .expect("parses");
+        assert_eq!(cfg.cgroup.allowed_swap_percent, 200);
+
+        // 200% of a 1 GiB grant is 2 GiB of swap on top of the RAM ceiling.
+        let l = cfg.cgroup.limits_for(1, 1024, &[]).expect("enabled");
+        assert_eq!(l.memory_max_bytes, Some(1024 * 1024 * 1024));
+        assert_eq!(l.swap_max_bytes, Some(2048 * 1024 * 1024));
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1362,75 +1362,18 @@ impl MpiConfig {
     }
 }
 
-/// cgroup enforcement settings for a job's processes (Slurm's `cgroup.conf`).
-/// See `docs/admin-guide/configuration.rst` for the semantics.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct CgroupConfig {
-    /// Cap a job's swap alongside its memory (Slurm's `ConstrainSwapSpace`).
-    ///
-    /// Off by default, as in Slurm: while off, `memory.max` bounds resident
-    /// memory only and a job that outgrows `--mem` swaps instead of being killed.
-    #[serde(default)]
-    pub constrain_swap_space: bool,
-
-    /// Swap a job may use, as a percentage of its memory allocation (Slurm's
-    /// `AllowedSwapSpace`). Only consulted when `constrain_swap_space` is set.
-    #[serde(default)]
-    pub allowed_swap_space: u32,
-}
-
-/// Swap budget for a job's cgroup.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SwapLimit {
-    /// Leave `memory.swap.max` alone; the job may swap without bound.
-    Unconstrained,
-    /// Cap swap at this percentage of the job's memory allocation.
-    Percent(u32),
-}
-
-impl SwapLimit {
-    /// Swap budget in bytes for a job capped at `memory_bytes`, or `None` when
-    /// swap is unconstrained.
-    pub fn bytes_for(&self, memory_bytes: u64) -> Option<u64> {
-        match self {
-            Self::Unconstrained => None,
-            Self::Percent(percent) => Some(memory_bytes.saturating_mul(u64::from(*percent)) / 100),
-        }
-    }
-}
-
-impl CgroupConfig {
-    pub fn swap_limit(&self) -> Result<SwapLimit, ConfigError> {
-        if !self.constrain_swap_space {
-            return Ok(SwapLimit::Unconstrained);
-        }
-        if self.allowed_swap_space > 100 {
-            return Err(ConfigError::InvalidValue {
-                field: "cgroup.allowed_swap_space".into(),
-                value: format!(
-                    "{} (expected a percentage of the memory allocation, 0 to 100)",
-                    self.allowed_swap_space
-                ),
-            });
-        }
-        Ok(SwapLimit::Percent(self.allowed_swap_space))
-    }
-}
-
 /// Resolved limits an agent applies to every job it launches, as opposed to
 /// the per-job sizes that come from the allocation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct JobLimits {
     /// Applied before exec, while still privileged.
     pub memlock: MemlockLimit,
-    pub swap: SwapLimit,
 }
 
 impl Default for JobLimits {
     fn default() -> Self {
         Self {
             memlock: MemlockLimit::Unlimited,
-            swap: SwapLimit::Unconstrained,
         }
     }
 }
@@ -3556,76 +3499,6 @@ cluster_name = "test"
         assert_eq!(
             config.rlimits.memlock_limit().unwrap(),
             MemlockLimit::Unlimited
-        );
-    }
-
-    #[test]
-    fn cgroup_swap_is_unconstrained_by_default() {
-        let cfg = CgroupConfig::default();
-        assert_eq!(cfg.swap_limit().unwrap(), SwapLimit::Unconstrained);
-        assert_eq!(SwapLimit::Unconstrained.bytes_for(64 * 1024 * 1024), None);
-    }
-
-    #[test]
-    fn cgroup_constrained_swap_defaults_to_denying_swap() {
-        let cfg = CgroupConfig {
-            constrain_swap_space: true,
-            allowed_swap_space: 0,
-        };
-        let limit = cfg.swap_limit().unwrap();
-        assert_eq!(limit, SwapLimit::Percent(0));
-        assert_eq!(limit.bytes_for(64 * 1024 * 1024), Some(0));
-    }
-
-    #[test]
-    fn cgroup_allowed_swap_is_a_percentage_of_the_allocation() {
-        let cfg = CgroupConfig {
-            constrain_swap_space: true,
-            allowed_swap_space: 50,
-        };
-        assert_eq!(
-            cfg.swap_limit().unwrap().bytes_for(64 * 1024 * 1024),
-            Some(32 * 1024 * 1024)
-        );
-    }
-
-    #[test]
-    fn cgroup_allowed_swap_percentage_above_100_errors() {
-        let cfg = CgroupConfig {
-            constrain_swap_space: true,
-            allowed_swap_space: 101,
-        };
-        assert!(cfg.swap_limit().is_err());
-    }
-
-    #[test]
-    fn cgroup_allowed_swap_is_ignored_while_unconstrained() {
-        let cfg = CgroupConfig {
-            constrain_swap_space: false,
-            allowed_swap_space: 999,
-        };
-        assert_eq!(cfg.swap_limit().unwrap(), SwapLimit::Unconstrained);
-    }
-
-    #[test]
-    fn cgroup_from_toml_explicit() {
-        let toml = r#"
-cluster_name = "test"
-
-[cgroup]
-constrain_swap_space = true
-allowed_swap_space = 25
-"#;
-        let config = SlurmConfig::load_from_str(toml).unwrap();
-        assert_eq!(config.cgroup.swap_limit().unwrap(), SwapLimit::Percent(25));
-    }
-
-    #[test]
-    fn cgroup_from_toml_default() {
-        let config = SlurmConfig::load_from_str("cluster_name = \"test\"\n").unwrap();
-        assert_eq!(
-            config.cgroup.swap_limit().unwrap(),
-            SwapLimit::Unconstrained
         );
     }
 

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -2382,6 +2382,18 @@ mod tests {
     }
 
     #[test]
+    fn shipped_example_config_parses() {
+        // Releases ship this as etc/spur.conf.example, so a stale field here
+        // reaches operators as a config that will not load.
+        let example = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/spur.conf"
+        ));
+        let cfg = SlurmConfig::load_from_str(example).expect("examples/spur.conf parses");
+        assert!(cfg.cgroup.constrain_swap, "example should bound swap");
+    }
+
+    #[test]
     fn swap_percent_above_100_is_accepted() {
         // Slurm applies no upper bound to AllowedSwapSpace, so a `cgroup.conf`
         // carrying one must not stop the controller from starting.

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -116,10 +116,8 @@ async fn cleanup_completed_job_mpi(job_id: u32, mpi: &str, mpi_host: &MpiPluginH
     }
 }
 
-/// Enforced per-node budget. The controller's allocation is authoritative; the
-/// spec is the fallback for fields the allocation did not carry, resolved the
-/// way the controller would have (every task on this node, and `--mem-per-cpu`
-/// when `--mem` is absent).
+/// Enforced per-node budget: the controller's allocation wins, the spec is the
+/// fallback (every task on this node, and `--mem-per-cpu` when `--mem` is unset).
 fn resolve_cgroup_budget(
     alloc: Option<&ResourceAllocations>,
     spec: &JobSpec,
@@ -2747,9 +2745,8 @@ impl AgentService {
         }
     }
 
-    /// Record controller-allocated GPUs and reserve the job's local CPU/memory
-    /// budget. `cpus`/`memory_mb` are the resolved per-node budget, so the core
-    /// IDs this picks (and thus `cpuset.cpus`) match what the controller granted.
+    /// Record controller-allocated GPUs and reserve the local CPU/memory budget.
+    /// `cpus`/`memory_mb` are the resolved grant, so the core IDs match it.
     async fn allocate_local_resources(
         &self,
         job_id: u32,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -334,10 +334,7 @@ impl AgentService {
             hooks,
             device_registry,
             &spur_core::config::ClusterConfig::default(),
-            spur_core::config::JobLimits {
-                memlock,
-                ..Default::default()
-            },
+            spur_core::config::JobLimits { memlock },
             CgroupConfig::default(),
             MpiConfig::default(),
             new_running_jobs(),
@@ -1569,7 +1566,6 @@ impl SlurmAgent for AgentService {
             host_device_plan: Some(host_device_plan),
             memlock: self.limits.memlock,
             cgroup: self.cgroup.clone(),
-            swap_limit: self.limits.swap,
             io_mode: if spec.pty {
                 executor::LaunchIo::Pty
             } else {

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -124,17 +124,21 @@ fn resolve_cgroup_budget(
     tasks_per_node: u32,
 ) -> (u32, u64) {
     let (alloc_cpus, alloc_mem_mb) = alloc.map(|a| (a.cpus, a.memory_mb)).unwrap_or((0, 0));
+    // Saturating: the spec is caller-supplied, and a wrapped product would set
+    // limits from a budget bearing no relation to what the job asked for.
     let cpus = if alloc_cpus > 0 {
         alloc_cpus
     } else {
-        tasks_per_node.max(1) * spec.cpus_per_task.max(1)
+        tasks_per_node
+            .max(1)
+            .saturating_mul(spec.cpus_per_task.max(1))
     };
     let memory_mb = if alloc_mem_mb > 0 {
         alloc_mem_mb
     } else if spec.memory_per_node_mb > 0 {
         spec.memory_per_node_mb
     } else {
-        spec.memory_per_cpu_mb * cpus as u64
+        spec.memory_per_cpu_mb.saturating_mul(cpus as u64)
     };
     (cpus, memory_mb)
 }
@@ -276,6 +280,19 @@ mod budget_tests {
     fn spec_fallback_honors_mem_per_cpu() {
         // --mem-per-cpu=512 with 8 cores on this node.
         assert_eq!(resolve_cgroup_budget(None, &spec(2, 0, 512), 4), (8, 4096));
+    }
+
+    #[test]
+    fn an_absurd_spec_saturates_instead_of_wrapping() {
+        // A spec reaches the agent unvalidated, and a wrapped product would
+        // hand limits_for a budget unrelated to the request.
+        let (cpus, memory_mb) = resolve_cgroup_budget(None, &spec(100_000, 0, 0), 100_000);
+        assert_eq!(cpus, u32::MAX);
+        assert_eq!(memory_mb, 0, "no memory request stays unbounded");
+
+        let (cpus, memory_mb) = resolve_cgroup_budget(None, &spec(u32::MAX, 0, u64::MAX), 2);
+        assert_eq!(cpus, u32::MAX);
+        assert_eq!(memory_mb, u64::MAX);
     }
 
     #[test]
@@ -1228,7 +1245,7 @@ impl SlurmAgent for AgentService {
         senv.set_with_slurm_twin("SPURD_NODENAME", &hostname);
         senv.set_with_slurm_twin(
             "SPUR_CPUS_ON_NODE",
-            tasks_per_node * spec.cpus_per_task.max(1),
+            tasks_per_node.saturating_mul(spec.cpus_per_task.max(1)),
         );
 
         if array_job_id != 0 {

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -20,7 +20,7 @@ use spur_sched::cons_tres::{AllocError, AllocationResult, NodeAllocation};
 
 use spur_spank::{SpankContext, SpankHandle, SpankHook, SpankHost};
 
-use spur_core::config::{HooksConfig, MpiConfig};
+use spur_core::config::{CgroupConfig, HooksConfig, MpiConfig};
 use spur_core::mpi::{resolve_step_mpi, PmixLaunchPlan, MPI_NONE, MPI_PMIX};
 use spur_core::spur_env::SpurEnv;
 use spur_core::task_launch::{
@@ -114,6 +114,31 @@ async fn cleanup_completed_job_mpi(job_id: u32, mpi: &str, mpi_host: &MpiPluginH
             warn!(job_id, error = %e, "PMIx batch ref release failed");
         }
     }
+}
+
+/// Enforced per-node budget. The controller's allocation is authoritative; the
+/// spec is the fallback for fields the allocation did not carry, resolved the
+/// way the controller would have (every task on this node, and `--mem-per-cpu`
+/// when `--mem` is absent).
+fn resolve_cgroup_budget(
+    alloc: Option<&ResourceAllocations>,
+    spec: &JobSpec,
+    tasks_per_node: u32,
+) -> (u32, u64) {
+    let (alloc_cpus, alloc_mem_mb) = alloc.map(|a| (a.cpus, a.memory_mb)).unwrap_or((0, 0));
+    let cpus = if alloc_cpus > 0 {
+        alloc_cpus
+    } else {
+        tasks_per_node.max(1) * spec.cpus_per_task.max(1)
+    };
+    let memory_mb = if alloc_mem_mb > 0 {
+        alloc_mem_mb
+    } else if spec.memory_per_node_mb > 0 {
+        spec.memory_per_node_mb
+    } else {
+        spec.memory_per_cpu_mb * cpus as u64
+    };
+    (cpus, memory_mb)
 }
 
 /// Job ids this node holds, shared with the reporter so heartbeats carry them.
@@ -213,6 +238,54 @@ fn signal_step_process_group(pid: u32, signal: i32) {
     }
 }
 
+#[cfg(test)]
+mod budget_tests {
+    use super::resolve_cgroup_budget;
+    // Explicit path: `spur_core::resource::ResourceAllocations` is a different
+    // type with the same name, and the module glob-imports the proto one.
+    use spur_proto::proto::{JobSpec, ResourceAllocations};
+
+    fn spec(cpus_per_task: u32, mem_node: u64, mem_per_cpu: u64) -> JobSpec {
+        JobSpec {
+            cpus_per_task,
+            memory_per_node_mb: mem_node,
+            memory_per_cpu_mb: mem_per_cpu,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn allocation_wins_when_present() {
+        // Spec asks 2 cpus / 1024 MB per task; the node allocation grants 8/32G.
+        let alloc = ResourceAllocations {
+            cpus: 8,
+            memory_mb: 32_768,
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_cgroup_budget(Some(&alloc), &spec(2, 1024, 0), 4),
+            (8, 32_768)
+        );
+    }
+
+    #[test]
+    fn spec_fallback_counts_every_task_on_the_node() {
+        // The G1 undercount: 4 tasks x 2 cpus is 8 cores, not 2.
+        assert_eq!(resolve_cgroup_budget(None, &spec(2, 1024, 0), 4), (8, 1024));
+    }
+
+    #[test]
+    fn spec_fallback_honors_mem_per_cpu() {
+        // --mem-per-cpu=512 with 8 cores on this node.
+        assert_eq!(resolve_cgroup_budget(None, &spec(2, 0, 512), 4), (8, 4096));
+    }
+
+    #[test]
+    fn floors_cpus_at_one() {
+        assert_eq!(resolve_cgroup_budget(None, &spec(0, 0, 0), 0), (1, 0));
+    }
+}
+
 async fn step_cancel_requested(
     steps: &Arc<Mutex<HashMap<(u32, u32), ActiveStep>>>,
     key: (u32, u32),
@@ -234,6 +307,7 @@ pub struct AgentService {
     mpi_host: Arc<MpiPluginHost>,
     hooks: Arc<HooksConfig>,
     limits: spur_core::config::JobLimits,
+    cgroup: CgroupConfig,
     #[allow(dead_code)]
     device_registry: Arc<Mutex<DeviceRegistry>>,
     /// RPC-driven owner of this node's k0s systemd unit.
@@ -266,6 +340,7 @@ impl AgentService {
                 memlock,
                 ..Default::default()
             },
+            CgroupConfig::default(),
             MpiConfig::default(),
             new_running_jobs(),
             spur_core::config::AuthConfig::default().allow_root_jobs,
@@ -284,6 +359,7 @@ impl AgentService {
         device_registry: Arc<Mutex<DeviceRegistry>>,
         cluster: &spur_core::config::ClusterConfig,
         limits: spur_core::config::JobLimits,
+        cgroup: CgroupConfig,
         mpi: MpiConfig,
         running: RunningJobs,
         allow_root_jobs: bool,
@@ -347,6 +423,7 @@ impl AgentService {
             mpi_host: Arc::new(MpiPluginHost::new(mpi)),
             hooks: Arc::new(hooks),
             limits,
+            cgroup,
             device_registry,
             k0s: Arc::new(crate::cluster::K0sAgent::from_config(cluster)),
             active_steps: Arc::new(Mutex::new(HashMap::new())),
@@ -1366,8 +1443,11 @@ impl SlurmAgent for AgentService {
                 launch_script
             };
 
+        let (cpus, memory_mb) =
+            resolve_cgroup_budget(req.allocated.as_ref(), &spec, tasks_per_node);
+
         let (alloc_result, allocated_device_ids) = self
-            .allocate_local_resources(job_id, &spec, req.allocated.as_ref())
+            .allocate_local_resources(job_id, &spec, req.allocated.as_ref(), cpus, memory_mb)
             .await?;
 
         // Release the reservation on any exit before commit, including a
@@ -1405,8 +1485,8 @@ impl SlurmAgent for AgentService {
                 nodelist: spec.nodelist.clone(),
                 script_context: "prolog_slurmd".into(),
                 gpu_devices: allocated_device_ids.clone(),
-                cpus: spec.cpus_per_task.max(1),
-                memory_mb: spec.memory_per_node_mb,
+                cpus,
+                memory_mb,
             };
             if let Err(e) = spur_core::hooks::run_hook(prolog, &ctx).await {
                 // No completion report and no self-drain: the controller owns
@@ -1473,8 +1553,8 @@ impl SlurmAgent for AgentService {
             stdout_path: spec.stdout_path.clone(),
             stderr_path: spec.stderr_path.clone(),
             stdin_path: spec.stdin_path.clone(),
-            cpus: spec.cpus_per_task.max(1),
-            memory_mb: spec.memory_per_node_mb,
+            cpus,
+            memory_mb,
             gpu_devices: allocated_device_ids,
             cpu_ids,
             open_mode: if spec.open_mode.is_empty() {
@@ -1490,6 +1570,7 @@ impl SlurmAgent for AgentService {
             nodelist: spec.nodelist.clone(),
             host_device_plan: Some(host_device_plan),
             memlock: self.limits.memlock,
+            cgroup: self.cgroup.clone(),
             swap_limit: self.limits.swap,
             io_mode: if spec.pty {
                 executor::LaunchIo::Pty
@@ -2666,12 +2747,16 @@ impl AgentService {
         }
     }
 
-    /// Record controller-allocated GPUs and allocate local CPU/memory resources.
+    /// Record controller-allocated GPUs and reserve the job's local CPU/memory
+    /// budget. `cpus`/`memory_mb` are the resolved per-node budget, so the core
+    /// IDs this picks (and thus `cpuset.cpus`) match what the controller granted.
     async fn allocate_local_resources(
         &self,
         job_id: u32,
         spec: &JobSpec,
         allocated: Option<&ResourceAllocations>,
+        cpus: u32,
+        memory_mb: u64,
     ) -> Result<(AllocationResult, Vec<u32>), Status> {
         let controller_gpu_ids: Vec<u32> = allocated
             .and_then(|a| a.devices.get("gpu"))
@@ -2695,17 +2780,7 @@ impl AgentService {
 
         let mut alloc = self.allocation.lock().await;
 
-        let cpus = if spec.cpus_per_task > 0 {
-            spec.cpus_per_task
-        } else {
-            0
-        };
-        let result = match alloc.allocate_for_job(
-            job_id,
-            cpus,
-            spec.memory_per_node_mb,
-            &controller_gpu_ids,
-        ) {
+        let result = match alloc.allocate_for_job(job_id, cpus, memory_mb, &controller_gpu_ids) {
             Ok(result) => result,
             Err(AllocError::GpusUnavailable) => {
                 // A conflicting owner absent from the live set is stale (the
@@ -2726,12 +2801,7 @@ impl AgentService {
                         alloc.release_job(*owner);
                     }
                 }
-                match alloc.allocate_for_job(
-                    job_id,
-                    cpus,
-                    spec.memory_per_node_mb,
-                    &controller_gpu_ids,
-                ) {
+                match alloc.allocate_for_job(job_id, cpus, memory_mb, &controller_gpu_ids) {
                     Ok(result) => result,
                     Err(_) => {
                         warn!(
@@ -2765,6 +2835,20 @@ impl AgentService {
 
         let gpu_ids = controller_gpu_ids;
         Ok((result, gpu_ids))
+    }
+
+    /// Resolve the per-node budget the way `launch_job` does, then reserve, so
+    /// GPU-path tests exercise the real resolution instead of fixed numbers.
+    #[cfg(test)]
+    async fn allocate_local_for_test(
+        &self,
+        job_id: u32,
+        spec: &JobSpec,
+        allocated: Option<&ResourceAllocations>,
+    ) -> Result<(AllocationResult, Vec<u32>), Status> {
+        let (cpus, memory_mb) = resolve_cgroup_budget(allocated, spec, 1);
+        self.allocate_local_resources(job_id, spec, allocated, cpus, memory_mb)
+            .await
     }
 
     fn parse_gpu_gres(gres: &[String]) -> (u32, Option<String>) {
@@ -4387,6 +4471,63 @@ mod tests {
         assert!(!status.success());
     }
 
+    // G1: the enforced budget — and therefore the cpuset — must cover every task
+    // the controller placed here, not just one task's `--cpus-per-task`.
+    #[tokio::test]
+    async fn cpuset_covers_every_task_on_the_node() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        // 2 tasks x 2 cpus each, on the 4-cpu test node.
+        let spec = JobSpec {
+            cpus_per_task: 2,
+            tasks_per_node: 2,
+            ..Default::default()
+        };
+        let (cpus, memory_mb) = resolve_cgroup_budget(None, &spec, 2);
+        assert_eq!(cpus, 4, "budget must count both tasks");
+
+        let (result, _) = svc
+            .allocate_local_resources(7, &spec, None, cpus, memory_mb)
+            .await
+            .expect("allocation succeeds");
+        assert_eq!(result.cpu_ids, vec![0, 1, 2, 3]);
+    }
+
+    // The allocation is authoritative even when it disagrees with the spec.
+    #[tokio::test]
+    async fn cpuset_follows_the_controller_allocation_over_the_spec() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let spec = JobSpec {
+            cpus_per_task: 1,
+            ..Default::default()
+        };
+        let allocated = ResourceAllocations {
+            cpus: 3,
+            memory_mb: 2048,
+            ..Default::default()
+        };
+        let (cpus, memory_mb) = resolve_cgroup_budget(Some(&allocated), &spec, 1);
+        assert_eq!((cpus, memory_mb), (3, 2048));
+
+        let (result, _) = svc
+            .allocate_local_resources(7, &spec, Some(&allocated), cpus, memory_mb)
+            .await
+            .expect("allocation succeeds");
+        assert_eq!(result.cpu_ids, vec![0, 1, 2]);
+        assert_eq!(result.memory_mb, 2048);
+    }
+
     fn test_reporter_with_gpus(device_ids: &[u32]) -> Arc<NodeReporter> {
         use spur_core::resource::{GpuLinkType, GpuResource};
         let gpus = device_ids
@@ -4865,7 +5006,7 @@ mod tests {
         };
 
         let res = svc
-            .allocate_local_resources(100, &spec, Some(&allocated))
+            .allocate_local_for_test(100, &spec, Some(&allocated))
             .await;
         assert!(
             res.is_ok(),
@@ -4914,7 +5055,7 @@ mod tests {
         };
 
         let res = svc
-            .allocate_local_resources(100, &spec, Some(&allocated))
+            .allocate_local_for_test(100, &spec, Some(&allocated))
             .await;
         let err = res.expect_err("must reject: the conflicting GPU owner is still running");
         assert_eq!(err.code(), tonic::Code::ResourceExhausted);
@@ -4959,7 +5100,7 @@ mod tests {
         };
 
         let res = svc
-            .allocate_local_resources(100, &spec, Some(&allocated))
+            .allocate_local_for_test(100, &spec, Some(&allocated))
             .await;
         let err = res.expect_err("must reject: the conflicting GPU owner is still launching");
         assert_eq!(err.code(), tonic::Code::ResourceExhausted);
@@ -5015,7 +5156,7 @@ mod tests {
             ..Default::default()
         };
         let res = svc
-            .allocate_local_resources(100, &spec, Some(&gpu_alloc_request(&[0, 1])))
+            .allocate_local_for_test(100, &spec, Some(&gpu_alloc_request(&[0, 1])))
             .await;
         assert!(
             res.is_ok(),
@@ -5050,7 +5191,7 @@ mod tests {
             ..Default::default()
         };
         let res = svc
-            .allocate_local_resources(100, &spec, Some(&gpu_alloc_request(&[0, 1])))
+            .allocate_local_for_test(100, &spec, Some(&gpu_alloc_request(&[0, 1])))
             .await;
         let err = res.expect_err("must reject: GPU 1's owner is still running");
         assert_eq!(err.code(), tonic::Code::ResourceExhausted);
@@ -5140,6 +5281,7 @@ mod tests {
             Arc::new(Mutex::new(DeviceRegistry::new())),
             &spur_core::config::ClusterConfig::default(),
             spur_core::config::JobLimits::default(),
+            CgroupConfig::default(),
             MpiConfig::default(),
             running,
             false, // allow_root_jobs

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -162,6 +162,8 @@ pub struct JobLaunchConfig {
     pub host_device_plan: Option<spur_devices::inject::HostInjectionPlan>,
     /// RLIMIT_MEMLOCK to apply before exec (while still privileged).
     pub memlock: MemlockLimit,
+    /// cgroup-v2 enforcement settings from `[cgroup]`.
+    pub cgroup: CgroupConfig,
     /// Swap budget for the job's cgroup.
     pub swap_limit: SwapLimit,
     /// I/O mode for the job.
@@ -505,7 +507,7 @@ async fn spawn_job_process(
     info!(job_id, work_dir, "launching job");
 
     // Set up cgroup for isolation
-    let cgroup_path = setup_cgroup(job_id, &CgroupConfig::default(), cpus, memory_mb, cpu_ids, cfg.swap_limit)?;
+    let cgroup_path = setup_cgroup(job_id, &cfg.cgroup, cpus, memory_mb, cpu_ids, cfg.swap_limit)?;
 
     // Ensure work_dir exists on this node (the submitted path may only exist on the submitting
     // node). If creation fails (e.g. path is under another user's home), fall back to /tmp so
@@ -2361,6 +2363,7 @@ mod tests {
             nodelist: String::new(),
             host_device_plan: None,
             memlock: MemlockLimit::Unlimited,
+            cgroup: CgroupConfig::default(),
             swap_limit: SwapLimit::Unconstrained,
             io_mode: LaunchIo::File,
             pmix_multi_task: false,

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -505,7 +505,7 @@ async fn spawn_job_process(
     info!(job_id, work_dir, "launching job");
 
     // Set up cgroup for isolation
-    let cgroup_path = setup_cgroup(job_id, &cfg.cgroup, cpus, memory_mb, cpu_ids)?;
+    let cgroup_path = CgroupGuard(setup_cgroup(job_id, &cfg.cgroup, cpus, memory_mb, cpu_ids)?);
 
     // Ensure work_dir exists on this node (the submitted path may only exist on the submitting
     // node). If creation fails (e.g. path is under another user's home), fall back to /tmp so
@@ -663,7 +663,7 @@ async fn spawn_job_process(
                 "stdin redirection is not supported for container jobs, ignoring"
             );
         }
-        let (job, pty_master) = launch_container_job(cfg, ctn, &env, job_io).await?;
+        let (job, pty_master) = launch_container_job(cfg, ctn, &env, job_io, cgroup_path).await?;
         return Ok(LaunchResult {
             job,
             stdout_path: stdout_resolved,
@@ -758,7 +758,7 @@ async fn spawn_job_process(
     // Join pre-exec, not parent-side after spawn: under `unshare --fork` a
     // parent-side move races the fork and misses the workload's cgroup.
     let cgroup_procs = cgroup_path
-        .as_ref()
+        .path()
         .and_then(|p| CString::new(p.join("cgroup.procs").as_os_str().as_bytes()).ok());
     // fd 2 is redirected to the job's stdio before pre_exec runs, so hand the
     // child a dup of spurd's stderr (CLOEXEC) to report a join failure.
@@ -876,8 +876,9 @@ async fn spawn_job_process(
     // The child joined its own cgroup pre-exec; confirm it landed so `required`
     // can refuse a job that would otherwise run outside every limit.
     if cfg.cgroup.required {
-        if let (Some(cgroup), Some(pid)) = (cgroup_path.as_ref(), child.id()) {
+        if let (Some(cgroup), Some(pid)) = (cgroup_path.path(), child.id()) {
             if !cgroup_has_pid(cgroup, pid) {
+                // Reaps as well as kills, so the guard finds the cgroup empty.
                 let _ = child.kill().await;
                 return Err(anyhow::anyhow!(
                     "[cgroup] required but the job did not join its cgroup"
@@ -895,7 +896,10 @@ async fn spawn_job_process(
     );
 
     Ok(LaunchResult {
-        job: RunningJob::Managed { child, cgroup_path },
+        job: RunningJob::Managed {
+            child,
+            cgroup_path: cgroup_path.into_inner(),
+        },
         stdout_path: stdout_resolved,
         stderr_path: stderr_resolved,
         pty_master,
@@ -1162,6 +1166,29 @@ pub fn cgroup_oom_killed(cgroup_path: &Path) -> bool {
         let mut it = line.split_whitespace();
         matches!((it.next(), it.next()), (Some("oom_kill"), Some(n)) if n != "0")
     })
+}
+
+/// Owns a job's cgroup between creation and the point the running job takes it
+/// over. Every error return in between would otherwise strand the directory.
+struct CgroupGuard(Option<PathBuf>);
+
+impl CgroupGuard {
+    fn path(&self) -> Option<&Path> {
+        self.0.as_deref()
+    }
+
+    /// Hand the cgroup to the caller; dropping the guard no longer removes it.
+    fn into_inner(mut self) -> Option<PathBuf> {
+        self.0.take()
+    }
+}
+
+impl Drop for CgroupGuard {
+    fn drop(&mut self) {
+        if let Some(path) = self.0.take() {
+            cleanup_cgroup(&path);
+        }
+    }
 }
 
 /// Kill any leftover processes in the job's cgroup and remove the directory.
@@ -1585,9 +1612,9 @@ async fn launch_container_job(
     ctn: &ContainerLaunchConfig,
     env: &HashMap<String, String>,
     job_io: JobIo,
+    cgroup_path: CgroupGuard,
 ) -> anyhow::Result<(RunningJob, Option<OwnedFd>)> {
     let job_id = cfg.job_id;
-    let cgroup_path = setup_cgroup(job_id, &cfg.cgroup, cfg.cpus, cfg.memory_mb, &cfg.cpu_ids)?;
 
     // Sync pipe: child writes status, parent reads.
     let (pipe_r, pipe_w) = nix::unistd::pipe().context("create sync pipe")?;
@@ -1614,7 +1641,7 @@ async fn launch_container_job(
 
     // Precomputed before fork; the forked child joins the cgroup itself (below).
     let cgroup_procs = cgroup_path
-        .as_ref()
+        .path()
         .and_then(|p| CString::new(p.join("cgroup.procs").as_os_str().as_bytes()).ok());
     // Dup spurd's stderr (CLOEXEC) so the child can report a join failure; its
     // own stderr is wired to the job before the join runs.
@@ -1749,10 +1776,13 @@ async fn launch_container_job(
             // rather than write (DC2): the container tree inherits this membership.
             if cfg.cgroup.required {
                 let joined = cgroup_path
-                    .as_ref()
+                    .path()
                     .is_none_or(|cgroup| cgroup_has_pid(cgroup, child_pid as u32));
                 if !joined {
-                    let _ = signal::kill(Pid::from_raw(child_pid), Signal::SIGKILL);
+                    signal::kill(Pid::from_raw(child_pid), Signal::SIGKILL).ok();
+                    // Reap before returning: the guard's rmdir races an exit
+                    // that has been signalled but not yet completed.
+                    let _ = nix::sys::wait::waitpid(child, None);
                     anyhow::bail!("[cgroup] required but the container did not join its cgroup");
                 }
             }
@@ -1768,7 +1798,7 @@ async fn launch_container_job(
                 RunningJob::Forked {
                     pid: child_pid,
                     _pidfd: pidfd,
-                    cgroup_path,
+                    cgroup_path: cgroup_path.into_inner(),
                     reaped: false,
                 },
                 pty_master,
@@ -1917,6 +1947,42 @@ mod cpuset_tests {
     fn keeps_the_full_set_when_the_parent_permits_it() {
         assert_eq!(permitted_cores(&[0, 1, 2, 3], "0-3"), vec![0, 1, 2, 3]);
         assert_eq!(permitted_cores(&[2, 3], "0-1,2-3"), vec![2, 3]);
+    }
+}
+
+#[cfg(test)]
+mod cgroup_guard_tests {
+    use super::CgroupGuard;
+
+    #[test]
+    fn dropping_the_guard_removes_the_cgroup() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("job_1");
+        std::fs::create_dir(&cgroup).unwrap();
+
+        drop(CgroupGuard(Some(cgroup.clone())));
+        assert!(
+            !cgroup.exists(),
+            "a failed launch must not strand its cgroup"
+        );
+    }
+
+    #[test]
+    fn releasing_the_guard_keeps_the_cgroup() {
+        // The running job owns the cgroup once a launch succeeds; removing it
+        // here would unbound the job it was created for.
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("job_2");
+        std::fs::create_dir(&cgroup).unwrap();
+
+        let released = CgroupGuard(Some(cgroup.clone())).into_inner();
+        assert_eq!(released.as_deref(), Some(cgroup.as_path()));
+        assert!(cgroup.exists());
+    }
+
+    #[test]
+    fn a_disabled_cgroup_is_a_no_op() {
+        drop(CgroupGuard(None));
     }
 }
 

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -15,7 +15,7 @@ use nix::unistd::Pid;
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
-use spur_core::config::{CgroupConfig, CgroupLimits, MemlockLimit, SwapLimit};
+use spur_core::config::{CgroupConfig, CgroupLimits, MemlockLimit};
 use spur_core::job::JobId;
 use spur_spank::{SpankContext, SpankHandle, SpankHost};
 
@@ -164,8 +164,6 @@ pub struct JobLaunchConfig {
     pub memlock: MemlockLimit,
     /// cgroup-v2 enforcement settings from `[cgroup]`.
     pub cgroup: CgroupConfig,
-    /// Swap budget for the job's cgroup.
-    pub swap_limit: SwapLimit,
     /// I/O mode for the job.
     pub io_mode: LaunchIo,
     /// Direct multi-rank PMIx launch via a wrapper script (batch `--mpi=pmix`).
@@ -507,7 +505,7 @@ async fn spawn_job_process(
     info!(job_id, work_dir, "launching job");
 
     // Set up cgroup for isolation
-    let cgroup_path = setup_cgroup(job_id, &cfg.cgroup, cpus, memory_mb, cpu_ids, cfg.swap_limit)?;
+    let cgroup_path = setup_cgroup(job_id, &cfg.cgroup, cpus, memory_mb, cpu_ids)?;
 
     // Ensure work_dir exists on this node (the submitted path may only exist on the submitting
     // node). If creation fails (e.g. path is under another user's home), fall back to /tmp so
@@ -875,14 +873,14 @@ async fn spawn_job_process(
     // Drop the slave fd immediately so the master gets EOF when the child exits.
     let pty_master = job_io.into_master();
 
-    // Attaches after `exec`, so an immediate fork strands descendants. A `pre_exec`
-    // barrier cannot fix it: `Command::spawn` returns only once the child execs.
-    if let Some(ref cgroup) = cgroup_path {
-        if let Some(pid) = child.id() {
-            if !move_to_cgroup(cgroup, pid) && cfg.cgroup.required {
+    // The child joined its own cgroup pre-exec; confirm it landed so `required`
+    // can refuse a job that would otherwise run outside every limit.
+    if cfg.cgroup.required {
+        if let (Some(cgroup), Some(pid)) = (cgroup_path.as_ref(), child.id()) {
+            if !cgroup_has_pid(cgroup, pid) {
                 let _ = child.kill().await;
                 return Err(anyhow::anyhow!(
-                    "[cgroup] required but the job could not join its cgroup"
+                    "[cgroup] required but the job did not join its cgroup"
                 )
                 .into());
             }
@@ -943,7 +941,6 @@ fn setup_cgroup(
     cpus: u32,
     memory_mb: u64,
     cpu_ids: &[u32],
-    swap_limit: SwapLimit,
 ) -> anyhow::Result<Option<PathBuf>> {
     let Some(mut limits) = cgroup.limits_for(cpus, memory_mb, cpu_ids) else {
         debug!(job_id, "cgroup enforcement disabled by config");
@@ -1025,35 +1022,6 @@ fn setup_cgroup(
             warn!(job_id, file = name, error = %e, "failed to write cgroup control file");
             degrade(&format!("{name} not applied"));
         }
-    // Set CPU limit (cpu.max: quota period)
-    // e.g., 4 CPUs → "400000 100000" (400ms out of 100ms period)
-    let quota = cpus as u64 * 100_000;
-    let cpu_max = format!("{} 100000", quota);
-    if let Err(e) = std::fs::write(cgroup_path.join("cpu.max"), &cpu_max) {
-        warn!(job_id, error = %e, "failed to set cpu.max");
-    }
-
-    // Set memory limit
-    if memory_mb > 0 {
-        let memory_bytes = memory_mb * 1024 * 1024;
-        if let Err(e) = std::fs::write(cgroup_path.join("memory.max"), memory_bytes.to_string()) {
-            warn!(job_id, error = %e, "failed to set memory.max");
-        }
-        // memory.max bounds resident memory only: with swap available the
-        // kernel pages the overflow out instead of OOM-killing. Opt-in, since
-        // capping swap starts killing jobs that used to survive.
-        if let Some(swap_bytes) = swap_limit.bytes_for(memory_bytes) {
-            if let Err(e) =
-                std::fs::write(cgroup_path.join("memory.swap.max"), swap_bytes.to_string())
-            {
-                warn!(job_id, error = %e, "failed to set memory.swap.max");
-            }
-        }
-    }
-
-    // OOM isolation: kill entire cgroup on OOM, not a random process
-    if let Err(e) = std::fs::write(cgroup_path.join("memory.oom.group"), "1") {
-        warn!(job_id, error = %e, "failed to set memory.oom.group");
     }
 
     // The cpuset is the only CPU bound once the quota is off, and a rejected write
@@ -1125,36 +1093,63 @@ fn permitted_cores(requested: &[u32], parent_effective: &str) -> Vec<u32> {
         .collect()
 }
 
-/// Hold the forked child until the parent attaches it: cgroup-v2 moves only the
-/// written pid, so forking first strands descendants. Post-`fork`; fails open.
-unsafe fn await_cgroup_attach(read_fd: RawFd, write_fd: RawFd) {
-    // The child inherits the write end across fork, so EOF never arrives unless
-    // it drops its own copy first.
-    libc::close(write_fd);
-    let mut byte = 0u8;
+/// Join the calling process to a cgroup (its pid → `cgroup.procs`). Runs post-fork
+/// pre-exec so it's async-signal-safe (raw syscalls only); best-effort, warns to `log_fd`.
+fn join_cgroup_self(procs_path: &std::ffi::CStr, log_fd: RawFd) {
+    let pid = unsafe { libc::getpid() };
+
+    let mut buf = [0u8; 24];
+    let mut i = buf.len();
+    let mut n = pid.max(0) as u64;
     loop {
-        let n = libc::read(read_fd, &mut byte as *mut u8 as *mut libc::c_void, 1);
-        if n < 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
-            continue;
+        i -= 1;
+        buf[i] = b'0' + (n % 10) as u8;
+        n /= 10;
+        if n == 0 {
+            break;
         }
-        break;
     }
-    libc::close(read_fd);
+    let digits = &buf[i..];
+
+    unsafe {
+        let fd = libc::open(procs_path.as_ptr(), libc::O_WRONLY);
+        if fd < 0 {
+            warn_cgroup_join_failed(log_fd);
+            return;
+        }
+        let written = libc::write(fd, digits.as_ptr() as *const libc::c_void, digits.len());
+        libc::close(fd);
+        if written < 0 {
+            warn_cgroup_join_failed(log_fd);
+        }
+    }
 }
 
-/// Move a process into a cgroup. Returns true if successful.
-fn move_to_cgroup(cgroup_path: &Path, pid: u32) -> bool {
-    let procs_file = cgroup_path.join("cgroup.procs");
-    if let Err(e) = std::fs::write(&procs_file, pid.to_string()) {
-        warn!(
-            pid,
-            error = %e,
-            "failed to move process to cgroup — job runs without isolation"
-        );
-        false
-    } else {
-        true
+/// Async-signal-safe warning for a failed cgroup join: a fixed message to
+/// `log_fd`, or a no-op when it is negative.
+fn warn_cgroup_join_failed(log_fd: RawFd) {
+    if log_fd < 0 {
+        return;
     }
+    const MSG: &[u8] = b"spur: failed to join cgroup; job runs without resource limits\n";
+    unsafe {
+        libc::write(log_fd, MSG.as_ptr() as *const libc::c_void, MSG.len());
+    }
+}
+
+/// Duplicate `fd` with CLOEXEC set, returning the new fd or -1. The copy is
+/// usable in the pre-exec child but closes automatically at exec.
+fn dup_cloexec(fd: RawFd) -> RawFd {
+    unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 3) }
+}
+
+/// Whether `pid` is in the job's cgroup. The child joins itself pre-exec, so
+/// this verifies the join rather than performing it.
+fn cgroup_has_pid(cgroup_path: &Path, pid: u32) -> bool {
+    let Ok(procs) = std::fs::read_to_string(cgroup_path.join("cgroup.procs")) else {
+        return false;
+    };
+    procs.lines().any(|line| line.trim() == pid.to_string())
 }
 
 /// Whether the job's cgroup recorded an OOM kill (cgroup-v2 `memory.events`).
@@ -1592,19 +1587,7 @@ async fn launch_container_job(
     job_io: JobIo,
 ) -> anyhow::Result<(RunningJob, Option<OwnedFd>)> {
     let job_id = cfg.job_id;
-    let cgroup_path = setup_cgroup(
-        
-        job_id,
-        &CgroupConfig::default(),
-       
-        cfg.cpus,
-       
-        cfg.memory_mb,
-       
-        &cfg.cpu_ids,
-    ,
-        cfg.swap_limit,
-    )?;
+    let cgroup_path = setup_cgroup(job_id, &cfg.cgroup, cfg.cpus, cfg.memory_mb, &cfg.cpu_ids)?;
 
     // Sync pipe: child writes status, parent reads.
     let (pipe_r, pipe_w) = nix::unistd::pipe().context("create sync pipe")?;
@@ -1616,12 +1599,6 @@ async fn launch_container_job(
     .ok();
     let ready_r = pipe_r.as_raw_fd();
     let ready_w = pipe_w.as_raw_fd();
-
-    // Must clear before `container_init`, which forks the pid-namespace PID 1:
-    // forking before the attach would strand the whole container tree.
-    let (barrier_r, barrier_w) = nix::unistd::pipe().context("create cgroup attach barrier")?;
-    let barrier_r_raw = barrier_r.as_raw_fd();
-    let barrier_w_raw = barrier_w.as_raw_fd();
 
     // Snapshot raw I/O fds before fork — the Copy JobIoRaw can be used
     // in the child without owning the fds (parent's OwnedFds keep them alive
@@ -1657,11 +1634,6 @@ async fn launch_container_job(
             unsafe {
                 libc::signal(libc::SIGCHLD, libc::SIG_DFL);
                 libc::signal(libc::SIGPIPE, libc::SIG_DFL);
-            }
-
-            // Before anything that forks.
-            unsafe {
-                await_cgroup_attach(barrier_r_raw, barrier_w_raw);
             }
 
             unsafe {
@@ -1757,22 +1729,6 @@ async fn launch_container_job(
 
             let child_pid = child.as_raw();
 
-            // Verify rather than trust (DC2): the container tree inherits this
-            // membership, so losing it silently unbounds the whole tree.
-            let joined = match cgroup_path {
-                Some(ref cgroup) => move_to_cgroup(cgroup, child_pid as u32),
-                None => true,
-            };
-            // Releases the child to run container_init; see await_cgroup_attach.
-            drop(barrier_w);
-
-            if !joined && cfg.cgroup.required {
-                let _ = signal::kill(Pid::from_raw(child_pid), Signal::SIGKILL);
-                anyhow::bail!("[cgroup] required but the container could not join its cgroup");
-            }
-            // Cgroup placement already happened in the child before exec; a
-            // parent-side write here would race the container's execve.
-
             // pidfd prevents PID recycling; falls back gracefully on kernels < 5.3
             let pidfd = pidfd_open(child_pid).ok();
             if pidfd.is_none() {
@@ -1787,6 +1743,18 @@ async fn launch_container_job(
             if n < 2 || &buf[..2] != b"OK" {
                 let msg = String::from_utf8_lossy(&buf[..n]);
                 bail!("container init failed for job {}: {}", job_id, msg);
+            }
+
+            // Only now is the child's self-join guaranteed to have run. Verify
+            // rather than write (DC2): the container tree inherits this membership.
+            if cfg.cgroup.required {
+                let joined = cgroup_path
+                    .as_ref()
+                    .is_none_or(|cgroup| cgroup_has_pid(cgroup, child_pid as u32));
+                if !joined {
+                    let _ = signal::kill(Pid::from_raw(child_pid), Signal::SIGKILL);
+                    anyhow::bail!("[cgroup] required but the container did not join its cgroup");
+                }
             }
 
             info!(
@@ -2506,7 +2474,6 @@ mod tests {
             host_device_plan: None,
             memlock: MemlockLimit::Unlimited,
             cgroup: CgroupConfig::default(),
-            swap_limit: SwapLimit::Unconstrained,
             io_mode: LaunchIo::File,
             pmix_multi_task: false,
         }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -875,8 +875,19 @@ async fn spawn_job_process(
     // Drop the slave fd immediately so the master gets EOF when the child exits.
     let pty_master = job_io.into_master();
 
-    // Cgroup placement already happened pre-exec (join_cgroup_self); a move here
-    // would race the wrapper's fork.
+    // Attaches after `exec`, so an immediate fork strands descendants. A `pre_exec`
+    // barrier cannot fix it: `Command::spawn` returns only once the child execs.
+    if let Some(ref cgroup) = cgroup_path {
+        if let Some(pid) = child.id() {
+            if !move_to_cgroup(cgroup, pid) && cfg.cgroup.required {
+                let _ = child.kill().await;
+                return Err(anyhow::anyhow!(
+                    "[cgroup] required but the job could not join its cgroup"
+                )
+                .into());
+            }
+        }
+    }
 
     debug!(
         job_id,
@@ -893,10 +904,8 @@ async fn spawn_job_process(
     })
 }
 
-/// Render a job's cgroup-v2 control files as (filename, content) pairs.
-///
-/// Pure so the file layout is testable without a real cgroupfs; the values
-/// themselves are resolved by `CgroupConfig::limits_for`.
+/// Render a job's cgroup-v2 control files as (filename, content) pairs. Pure so
+/// the layout is testable without a cgroupfs; values come from `limits_for`.
 fn cgroup_limit_files(limits: &CgroupLimits) -> Vec<(&'static str, String)> {
     let mut files: Vec<(&'static str, String)> = Vec::new();
     if let Some(quota) = limits.cpu_quota_us {
@@ -936,7 +945,7 @@ fn setup_cgroup(
     cpu_ids: &[u32],
     swap_limit: SwapLimit,
 ) -> anyhow::Result<Option<PathBuf>> {
-    let Some(limits) = cgroup.limits_for(cpus, memory_mb, cpu_ids) else {
+    let Some(mut limits) = cgroup.limits_for(cpus, memory_mb, cpu_ids) else {
         debug!(job_id, "cgroup enforcement disabled by config");
         return Ok(None);
     };
@@ -947,9 +956,21 @@ fn setup_cgroup(
     // Delegate controllers to children: in cgroup-v2 a child only gets
     // memory.*/cpu.*/pids.* files if the parent lists them in subtree_control;
     // without this the per-job memory limit is never enforced. Root failure fatal.
+    // Steps below degrade to a warning by default; `required` turns the first
+    // degrade into a refusal so a node that cannot enforce stops pretending.
+    let mut degraded: Option<String> = None;
+    let mut degrade = |what: &str| {
+        if degraded.is_none() {
+            degraded = Some(what.to_string());
+        }
+    };
+
     if let Err(e) = std::fs::create_dir_all(&cgroup_root) {
         if nix::unistd::geteuid().is_root() {
             anyhow::bail!("cgroup root creation failed as root: {}", e);
+        }
+        if cgroup.required {
+            anyhow::bail!("[cgroup] required but the cgroup root is unavailable: {e}");
         }
         warn!(job_id, error = %e, "cgroup creation failed (not root), running without isolation");
         return Ok(None);
@@ -958,11 +979,15 @@ fn setup_cgroup(
     for ctrl in ["+memory", "+cpu", "+pids", "+cpuset"] {
         if let Err(e) = std::fs::write(&subtree, ctrl) {
             warn!(job_id, controller = ctrl, error = %e, "failed to delegate cgroup controller");
+            degrade(&format!("controller {ctrl} not delegated"));
         }
     }
     if let Err(e) = std::fs::create_dir_all(&cgroup_path) {
         if nix::unistd::geteuid().is_root() {
             anyhow::bail!("cgroup creation failed as root: {}", e);
+        }
+        if cgroup.required {
+            anyhow::bail!("[cgroup] required but the job cgroup could not be created: {e}");
         }
         warn!(
             job_id,
@@ -972,6 +997,34 @@ fn setup_cgroup(
         return Ok(None);
     }
 
+    // Core ids come from a synthesized 0..n range, which can name cores this
+    // cgroup may not hold. Drop those rather than let the whole write fail.
+    if !limits.cpuset_cpus.is_empty() {
+        match std::fs::read_to_string(cgroup_root.join("cpuset.cpus.effective")) {
+            Ok(effective) => {
+                let permitted = permitted_cores(&limits.cpuset_cpus, effective.trim());
+                if permitted.len() != limits.cpuset_cpus.len() {
+                    warn!(
+                        job_id,
+                        allocated = ?limits.cpuset_cpus,
+                        permitted = ?permitted,
+                        effective = effective.trim(),
+                        "some allocated cores lie outside the cgroup's permitted set"
+                    );
+                }
+                limits.cpuset_cpus = permitted;
+            }
+            Err(e) => {
+                warn!(job_id, error = %e, "cannot read cpuset.cpus.effective; writing the allocated set unchecked");
+            }
+        }
+    }
+
+    for (name, content) in cgroup_limit_files(&limits) {
+        if let Err(e) = std::fs::write(cgroup_path.join(name), &content) {
+            warn!(job_id, file = name, error = %e, "failed to write cgroup control file");
+            degrade(&format!("{name} not applied"));
+        }
     // Set CPU limit (cpu.max: quota period)
     // e.g., 4 CPUs → "400000 100000" (400ms out of 100ms period)
     let quota = cpus as u64 * 100_000;
@@ -1003,10 +1056,27 @@ fn setup_cgroup(
         warn!(job_id, error = %e, "failed to set memory.oom.group");
     }
 
-    // With the CFS quota off by default the cpuset is the only CPU bound, so an
-    // empty one means the job is not CPU-constrained at all.
-    if cgroup.constrain_cores && limits.cpuset_cpus.is_empty() {
+    // The cpuset is the only CPU bound once the quota is off, and a rejected write
+    // reads back empty — i.e. inherit everything. Verify rather than trust.
+    if cgroup.constrain_cores && !limits.cpuset_cpus.is_empty() {
+        let applied = std::fs::read_to_string(cgroup_path.join("cpuset.cpus")).unwrap_or_default();
+        let applied = parse_cpu_list(applied.trim());
+        if applied.is_empty() {
+            warn!(job_id, allocated = ?limits.cpuset_cpus, "cpuset not applied; job runs without a CPU bound");
+            degrade("cpuset not applied");
+        } else if applied != limits.cpuset_cpus.iter().copied().collect() {
+            warn!(job_id, expected = ?limits.cpuset_cpus, applied = ?applied, "cpuset differs from the allocated cores");
+            degrade("cpuset differs from the allocated cores");
+        }
+    } else if cgroup.constrain_cores {
         warn!(job_id, "no cores to pin; job runs without a CPU bound");
+    }
+
+    if let Some(reason) = degraded {
+        if cgroup.required {
+            let _ = std::fs::remove_dir(&cgroup_path);
+            anyhow::bail!("[cgroup] required but enforcement is incomplete: {reason}");
+        }
     }
 
     debug!(
@@ -1020,54 +1090,71 @@ fn setup_cgroup(
     Ok(Some(cgroup_path))
 }
 
-/// Join the calling process to a cgroup (its pid → `cgroup.procs`). Runs post-fork
-/// pre-exec so it's async-signal-safe (raw syscalls only); best-effort, warns to `log_fd`.
-fn join_cgroup_self(procs_path: &std::ffi::CStr, log_fd: RawFd) {
-    let pid = unsafe { libc::getpid() };
+/// Parse a cgroup cpu list (`"0-3"`, `"0-1,4"`, `""`) into core ids.
+fn parse_cpu_list(spec: &str) -> std::collections::BTreeSet<u32> {
+    let mut ids = std::collections::BTreeSet::new();
+    for part in spec.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        match part.split_once('-') {
+            Some((lo, hi)) => {
+                if let (Ok(lo), Ok(hi)) = (lo.parse::<u32>(), hi.parse::<u32>()) {
+                    ids.extend(lo..=hi);
+                }
+            }
+            None => {
+                if let Ok(id) = part.parse::<u32>() {
+                    ids.insert(id);
+                }
+            }
+        }
+    }
+    ids
+}
 
-    let mut buf = [0u8; 24];
-    let mut i = buf.len();
-    let mut n = pid.max(0) as u64;
+/// Cores from `requested` the parent cgroup permits. A child cpuset must be a
+/// subset: an id the parent lacks fails ERANGE and leaves the job unpinned.
+fn permitted_cores(requested: &[u32], parent_effective: &str) -> Vec<u32> {
+    let allowed = parse_cpu_list(parent_effective);
+    requested
+        .iter()
+        .copied()
+        .filter(|id| allowed.contains(id))
+        .collect()
+}
+
+/// Hold the forked child until the parent attaches it: cgroup-v2 moves only the
+/// written pid, so forking first strands descendants. Post-`fork`; fails open.
+unsafe fn await_cgroup_attach(read_fd: RawFd, write_fd: RawFd) {
+    // The child inherits the write end across fork, so EOF never arrives unless
+    // it drops its own copy first.
+    libc::close(write_fd);
+    let mut byte = 0u8;
     loop {
-        i -= 1;
-        buf[i] = b'0' + (n % 10) as u8;
-        n /= 10;
-        if n == 0 {
-            break;
+        let n = libc::read(read_fd, &mut byte as *mut u8 as *mut libc::c_void, 1);
+        if n < 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+            continue;
         }
+        break;
     }
-    let digits = &buf[i..];
-
-    unsafe {
-        let fd = libc::open(procs_path.as_ptr(), libc::O_WRONLY);
-        if fd < 0 {
-            warn_cgroup_join_failed(log_fd);
-            return;
-        }
-        let written = libc::write(fd, digits.as_ptr() as *const libc::c_void, digits.len());
-        libc::close(fd);
-        if written < 0 {
-            warn_cgroup_join_failed(log_fd);
-        }
-    }
+    libc::close(read_fd);
 }
 
-/// Async-signal-safe warning for a failed cgroup join: a fixed message to
-/// `log_fd`, or a no-op when it is negative.
-fn warn_cgroup_join_failed(log_fd: RawFd) {
-    if log_fd < 0 {
-        return;
+/// Move a process into a cgroup. Returns true if successful.
+fn move_to_cgroup(cgroup_path: &Path, pid: u32) -> bool {
+    let procs_file = cgroup_path.join("cgroup.procs");
+    if let Err(e) = std::fs::write(&procs_file, pid.to_string()) {
+        warn!(
+            pid,
+            error = %e,
+            "failed to move process to cgroup — job runs without isolation"
+        );
+        false
+    } else {
+        true
     }
-    const MSG: &[u8] = b"spur: failed to join cgroup; job runs without resource limits\n";
-    unsafe {
-        libc::write(log_fd, MSG.as_ptr() as *const libc::c_void, MSG.len());
-    }
-}
-
-/// Duplicate `fd` with CLOEXEC set, returning the new fd or -1. The copy is
-/// usable in the pre-exec child but closes automatically at exec.
-fn dup_cloexec(fd: RawFd) -> RawFd {
-    unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 3) }
 }
 
 /// Whether the job's cgroup recorded an OOM kill (cgroup-v2 `memory.events`).
@@ -1530,6 +1617,12 @@ async fn launch_container_job(
     let ready_r = pipe_r.as_raw_fd();
     let ready_w = pipe_w.as_raw_fd();
 
+    // Must clear before `container_init`, which forks the pid-namespace PID 1:
+    // forking before the attach would strand the whole container tree.
+    let (barrier_r, barrier_w) = nix::unistd::pipe().context("create cgroup attach barrier")?;
+    let barrier_r_raw = barrier_r.as_raw_fd();
+    let barrier_w_raw = barrier_w.as_raw_fd();
+
     // Snapshot raw I/O fds before fork — the Copy JobIoRaw can be used
     // in the child without owning the fds (parent's OwnedFds keep them alive
     // across the fork boundary).
@@ -1564,6 +1657,11 @@ async fn launch_container_job(
             unsafe {
                 libc::signal(libc::SIGCHLD, libc::SIG_DFL);
                 libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+            }
+
+            // Before anything that forks.
+            unsafe {
+                await_cgroup_attach(barrier_r_raw, barrier_w_raw);
             }
 
             unsafe {
@@ -1659,6 +1757,19 @@ async fn launch_container_job(
 
             let child_pid = child.as_raw();
 
+            // Verify rather than trust (DC2): the container tree inherits this
+            // membership, so losing it silently unbounds the whole tree.
+            let joined = match cgroup_path {
+                Some(ref cgroup) => move_to_cgroup(cgroup, child_pid as u32),
+                None => true,
+            };
+            // Releases the child to run container_init; see await_cgroup_attach.
+            drop(barrier_w);
+
+            if !joined && cfg.cgroup.required {
+                let _ = signal::kill(Pid::from_raw(child_pid), Signal::SIGKILL);
+                anyhow::bail!("[cgroup] required but the container could not join its cgroup");
+            }
             // Cgroup placement already happened in the child before exec; a
             // parent-side write here would race the container's execve.
 
@@ -1808,6 +1919,37 @@ fn wrap_with_burst_buffer(script: &str, bb: &str) -> String {
 
     wrapper.push_str("exit $SPUR_BB_EXIT\n");
     wrapper
+}
+
+#[cfg(test)]
+mod cpuset_tests {
+    use super::{parse_cpu_list, permitted_cores};
+
+    #[test]
+    fn parses_ranges_lists_and_empty() {
+        assert_eq!(parse_cpu_list("0-3"), [0, 1, 2, 3].into_iter().collect());
+        assert_eq!(parse_cpu_list("0,2,4"), [0, 2, 4].into_iter().collect());
+        assert_eq!(
+            parse_cpu_list("0-1,4-5"),
+            [0, 1, 4, 5].into_iter().collect()
+        );
+        assert!(parse_cpu_list("").is_empty());
+        assert!(parse_cpu_list("\n").is_empty());
+    }
+
+    #[test]
+    fn drops_cores_the_parent_cgroup_does_not_hold() {
+        // Core ids are synthesized from a count, so a sparse online mask can name
+        // cores that do not exist. Writing one fails ERANGE, leaving it unbounded.
+        assert_eq!(permitted_cores(&[0, 1, 99], "0-3"), vec![0, 1]);
+        assert_eq!(permitted_cores(&[64, 65], "0-63"), Vec::<u32>::new());
+    }
+
+    #[test]
+    fn keeps_the_full_set_when_the_parent_permits_it() {
+        assert_eq!(permitted_cores(&[0, 1, 2, 3], "0-3"), vec![0, 1, 2, 3]);
+        assert_eq!(permitted_cores(&[2, 3], "0-1,2-3"), vec![2, 3]);
+    }
 }
 
 #[cfg(test)]

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1041,7 +1041,10 @@ fn setup_cgroup(
             degrade("cpuset differs from the allocated cores");
         }
     } else if cgroup.constrain_cores {
+        // No cpuset is written at all in this case, so the job is free to run on
+        // every core on the node — the clamp above can empty a non-empty set.
         warn!(job_id, "no cores to pin; job runs without a CPU bound");
+        degrade("no cores to pin");
     }
 
     if let Some(reason) = degraded {

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -15,7 +15,7 @@ use nix::unistd::Pid;
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
-use spur_core::config::{MemlockLimit, SwapLimit};
+use spur_core::config::{CgroupConfig, CgroupLimits, MemlockLimit, SwapLimit};
 use spur_core::job::JobId;
 use spur_spank::{SpankContext, SpankHandle, SpankHost};
 
@@ -505,7 +505,7 @@ async fn spawn_job_process(
     info!(job_id, work_dir, "launching job");
 
     // Set up cgroup for isolation
-    let cgroup_path = setup_cgroup(job_id, cpus, memory_mb, cpu_ids, cfg.swap_limit)?;
+    let cgroup_path = setup_cgroup(job_id, &CgroupConfig::default(), cpus, memory_mb, cpu_ids, cfg.swap_limit)?;
 
     // Ensure work_dir exists on this node (the submitted path may only exist on the submitting
     // node). If creation fails (e.g. path is under another user's home), fall back to /tmp so
@@ -891,14 +891,54 @@ async fn spawn_job_process(
     })
 }
 
+/// Render a job's cgroup-v2 control files as (filename, content) pairs.
+///
+/// Pure so the file layout is testable without a real cgroupfs; the values
+/// themselves are resolved by `CgroupConfig::limits_for`.
+fn cgroup_limit_files(limits: &CgroupLimits) -> Vec<(&'static str, String)> {
+    let mut files: Vec<(&'static str, String)> = Vec::new();
+    if let Some(quota) = limits.cpu_quota_us {
+        files.push(("cpu.max", format!("{} {}", quota, limits.cpu_period_us)));
+    }
+    if let Some(bytes) = limits.memory_max_bytes {
+        files.push(("memory.max", bytes.to_string()));
+    }
+    if let Some(bytes) = limits.memory_high_bytes {
+        files.push(("memory.high", bytes.to_string()));
+    }
+    if let Some(bytes) = limits.swap_max_bytes {
+        files.push(("memory.swap.max", bytes.to_string()));
+    }
+    if limits.oom_kill_job {
+        files.push(("memory.oom.group", "1".to_string()));
+    }
+    files.push(("pids.max", limits.pids_max.to_string()));
+    if !limits.cpuset_cpus.is_empty() {
+        let cpuset = limits
+            .cpuset_cpus
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        files.push(("cpuset.cpus", cpuset));
+    }
+    files
+}
+
 /// Set up a cgroups v2 hierarchy for a job.
 fn setup_cgroup(
     job_id: JobId,
+    cgroup: &CgroupConfig,
     cpus: u32,
     memory_mb: u64,
     cpu_ids: &[u32],
     swap_limit: SwapLimit,
 ) -> anyhow::Result<Option<PathBuf>> {
+    let Some(limits) = cgroup.limits_for(cpus, memory_mb, cpu_ids) else {
+        debug!(job_id, "cgroup enforcement disabled by config");
+        return Ok(None);
+    };
+
     let cgroup_root = PathBuf::from(CGROUP_ROOT);
     let cgroup_path = cgroup_root.join(format!("job_{}", job_id));
 
@@ -961,24 +1001,10 @@ fn setup_cgroup(
         warn!(job_id, error = %e, "failed to set memory.oom.group");
     }
 
-    // Fork bomb protection: limit total processes per job
-    let max_pids = (cpus as u64 * 256).max(1024);
-    if let Err(e) = std::fs::write(cgroup_path.join("pids.max"), max_pids.to_string()) {
-        warn!(job_id, error = %e, "failed to set pids.max");
-    }
-
-    // Pin to specific CPU cores via cpuset
-    if !cpu_ids.is_empty() {
-        let cpuset_str: String = cpu_ids
-            .iter()
-            .map(|id| id.to_string())
-            .collect::<Vec<_>>()
-            .join(",");
-        if let Err(e) = std::fs::write(cgroup_path.join("cpuset.cpus"), &cpuset_str) {
-            warn!(job_id, error = %e, "failed to set cpuset.cpus");
-        } else {
-            debug!(job_id, cpuset = %cpuset_str, "cpuset pinning configured");
-        }
+    // With the CFS quota off by default the cpuset is the only CPU bound, so an
+    // empty one means the job is not CPU-constrained at all.
+    if cgroup.constrain_cores && limits.cpuset_cpus.is_empty() {
+        warn!(job_id, "no cores to pin; job runs without a CPU bound");
     }
 
     debug!(
@@ -1478,10 +1504,16 @@ async fn launch_container_job(
 ) -> anyhow::Result<(RunningJob, Option<OwnedFd>)> {
     let job_id = cfg.job_id;
     let cgroup_path = setup_cgroup(
+        
         job_id,
+        &CgroupConfig::default(),
+       
         cfg.cpus,
+       
         cfg.memory_mb,
+       
         &cfg.cpu_ids,
+    ,
         cfg.swap_limit,
     )?;
 
@@ -1774,6 +1806,87 @@ fn wrap_with_burst_buffer(script: &str, bb: &str) -> String {
 
     wrapper.push_str("exit $SPUR_BB_EXIT\n");
     wrapper
+}
+
+#[cfg(test)]
+mod cgroup_files_tests {
+    use super::cgroup_limit_files;
+    use spur_core::config::CgroupConfig;
+
+    fn files_for(
+        cfg: &CgroupConfig,
+        cpus: u32,
+        memory_mb: u64,
+        cpu_ids: &[u32],
+    ) -> Vec<(&'static str, String)> {
+        cgroup_limit_files(&cfg.limits_for(cpus, memory_mb, cpu_ids).expect("enabled"))
+    }
+
+    #[test]
+    fn writes_defaults_without_a_cfs_quota() {
+        let files = files_for(&CgroupConfig::default(), 4, 2048, &[0, 1, 2, 3]);
+        let get = |k: &str| files.iter().find(|(n, _)| *n == k).map(|(_, v)| v.as_str());
+        let expect_mem = (2048u64 * 1024 * 1024).to_string();
+        assert_eq!(get("cpu.max"), None);
+        assert_eq!(get("memory.max"), Some(expect_mem.as_str()));
+        // AllowedRAMSpace=100 collapses the soft limit onto the hard one.
+        assert_eq!(get("memory.high"), Some(expect_mem.as_str()));
+        assert_eq!(get("memory.swap.max"), Some("0"));
+        assert_eq!(get("memory.oom.group"), Some("1"));
+        assert_eq!(get("pids.max"), Some("1024")); // max(4*256, 1024)
+        assert_eq!(get("cpuset.cpus"), Some("0,1,2,3"));
+    }
+
+    #[test]
+    fn cpu_quota_knob_emits_cpu_max() {
+        let cfg = CgroupConfig {
+            cpu_quota: true,
+            ..CgroupConfig::default()
+        };
+        let files = files_for(&cfg, 4, 0, &[]);
+        assert_eq!(
+            files
+                .iter()
+                .find(|(n, _)| *n == "cpu.max")
+                .map(|(_, v)| v.as_str()),
+            Some("400000 100000")
+        );
+    }
+
+    #[test]
+    fn headroom_emits_a_lower_memory_high_than_memory_max() {
+        let cfg = CgroupConfig {
+            allowed_ram_percent: 150,
+            ..CgroupConfig::default()
+        };
+        let files = files_for(&cfg, 1, 1024, &[]);
+        let get = |k: &str| files.iter().find(|(n, _)| *n == k).map(|(_, v)| v.as_str());
+        let high = (1024u64 * 1024 * 1024).to_string();
+        let max = (1536u64 * 1024 * 1024).to_string();
+        assert_eq!(get("memory.high"), Some(high.as_str()));
+        assert_eq!(get("memory.max"), Some(max.as_str()));
+    }
+
+    #[test]
+    fn omits_memory_and_swap_for_an_unbounded_job() {
+        let files = files_for(&CgroupConfig::default(), 1, 0, &[]);
+        let has = |k: &str| files.iter().any(|(n, _)| *n == k);
+        assert!(!has("memory.max"));
+        assert!(!has("memory.high"));
+        assert!(!has("memory.swap.max"));
+        assert!(!has("cpuset.cpus"));
+        assert!(has("pids.max"));
+    }
+
+    #[test]
+    fn oom_kill_job_can_be_turned_off() {
+        let cfg = CgroupConfig {
+            oom_kill_job: false,
+            ..CgroupConfig::default()
+        };
+        let files = files_for(&cfg, 1, 1024, &[]);
+        assert!(!files.iter().any(|(n, _)| *n == "memory.oom.group"));
+    }
 }
 
 #[cfg(test)]

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1943,7 +1943,8 @@ mod cgroup_files_tests {
         assert_eq!(get("memory.max"), Some(expect_mem.as_str()));
         // AllowedRAMSpace=100 collapses the soft limit onto the hard one.
         assert_eq!(get("memory.high"), Some(expect_mem.as_str()));
-        assert_eq!(get("memory.swap.max"), Some("0"));
+        // Swap is unconstrained by default, as in Slurm.
+        assert_eq!(get("memory.swap.max"), None);
         assert_eq!(get("memory.oom.group"), Some("1"));
         assert_eq!(get("pids.max"), Some("1024")); // max(4*256, 1024)
         assert_eq!(get("cpuset.cpus"), Some("0,1,2,3"));

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -344,6 +344,10 @@ async fn main() -> anyhow::Result<()> {
         None => spur_core::config::JobLimits::default(),
     };
     log_memlock_status(limits.memlock);
+    let cgroup_config = config
+        .as_ref()
+        .map(|c| c.cgroup.clone())
+        .unwrap_or_default();
     log_swap_status(limits.swap);
     let cluster_config = config
         .as_ref()
@@ -377,6 +381,7 @@ async fn main() -> anyhow::Result<()> {
         registry.clone(),
         &cluster_config,
         limits,
+        cgroup_config,
         mpi_config,
         running_jobs,
         allow_root_jobs,

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -56,6 +56,38 @@ fn log_memlock_status(memlock: spur_core::config::MemlockLimit) {
     }
 }
 
+/// Record the enforcement posture at startup: `[cgroup]` decides whether a job is
+/// bounded at all, and the agent log is the only place that shows what it booted with.
+fn log_cgroup_status(cgroup: &spur_core::config::CgroupConfig) {
+    if !cgroup.enabled {
+        warn!("[cgroup] enforcement disabled; jobs run with no cpu or memory bound");
+        return;
+    }
+    info!(
+        required = cgroup.required,
+        constrain_cores = cgroup.constrain_cores,
+        cpu_quota = cgroup.cpu_quota,
+        constrain_ram_space = cgroup.constrain_ram_space,
+        allowed_ram_percent = cgroup.allowed_ram_percent,
+        constrain_swap = cgroup.constrain_swap,
+        allowed_swap_percent = cgroup.allowed_swap_percent,
+        min_ram_mb = cgroup.min_ram_mb,
+        oom_kill_job = cgroup.oom_kill_job,
+        "cgroup enforcement"
+    );
+    // An unprivileged agent cannot create the cgroup root, so `required` turns every
+    // launch into a refusal. Say so now rather than once per rejected job.
+    if cgroup.required && unsafe { libc::geteuid() } != 0 {
+        warn!("[cgroup] required = true but spurd is not root; every job launch will be refused");
+    }
+    if cgroup.constrain_swap && cgroup.allowed_swap_percent == 0 {
+        info!(
+            "[cgroup] swap denied outright (allowed_swap_percent = 0); a job that outgrows \
+             its allocation is OOM-killed rather than paging out"
+        );
+    }
+}
+
 /// Whether a best-effort config load failed only because no file exists at the default
 /// path, which is the expected shape for an agent configured entirely by flags.
 ///
@@ -334,6 +366,7 @@ async fn main() -> anyhow::Result<()> {
         .as_ref()
         .map(|c| c.cgroup.clone())
         .unwrap_or_default();
+    log_cgroup_status(&cgroup_config);
     let cluster_config = config
         .as_ref()
         .map(|c| c.cluster.clone())

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -121,19 +121,6 @@ struct Args {
     log_level: String,
 }
 
-fn log_swap_status(swap: spur_core::config::SwapLimit) {
-    use spur_core::config::SwapLimit;
-    match swap {
-        SwapLimit::Unconstrained => info!(
-            "job swap unconstrained; --mem bounds resident memory only \
-             (see cgroup.constrain_swap_space)"
-        ),
-        SwapLimit::Percent(percent) => {
-            info!(allowed_swap_space = percent, "job swap constrained")
-        }
-    }
-}
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     if std::env::args_os()
@@ -339,7 +326,6 @@ async fn main() -> anyhow::Result<()> {
     let limits = match config.as_ref() {
         Some(c) => spur_core::config::JobLimits {
             memlock: c.rlimits.memlock_limit()?,
-            swap: c.cgroup.swap_limit()?,
         },
         None => spur_core::config::JobLimits::default(),
     };
@@ -348,7 +334,6 @@ async fn main() -> anyhow::Result<()> {
         .as_ref()
         .map(|c| c.cgroup.clone())
         .unwrap_or_default();
-    log_swap_status(limits.swap);
     let cluster_config = config
         .as_ref()
         .map(|c| c.cluster.clone())

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -1239,8 +1239,10 @@ unaffected: there the kubelet owns the cgroups.
        reverts to 100%.
    * - ``constrain_swap``
      - bool
-     - ``true``
-     - Bound swap via ``memory.swap.max``. Turning this on with
+     - ``false``
+     - Bound swap via ``memory.swap.max``. Off by default, as in Slurm: while
+       off, ``memory.max`` bounds resident memory only and a job that outgrows
+       ``--mem`` swaps instead of being killed. Turning it on with
        ``constrain_ram_space`` off still bounds memory — see below.
    * - ``allowed_swap_percent``
      - int
@@ -1377,9 +1379,11 @@ them, so a site's existing percentages carry over directly.
 
 Deliberate differences from Slurm:
 
-- **Spur enforces by default.** Every Slurm ``Constrain*`` defaults to ``no``. A
-  job that overran ``--mem`` or leaned on host swap under a stock Slurm
-  configuration will be reclaimed against, or killed, on Spur.
+- **Spur constrains cores and RAM by default.** Every Slurm ``Constrain*``
+  defaults to ``no``, so a job that overran ``--mem`` under a stock Slurm
+  configuration will be reclaimed against, or killed, on Spur. Swap is the
+  exception and stays off, matching Slurm: bounding it turns a job that
+  completed slowly into one that is killed outright.
 - **``allowed_ram_percent = 0`` is rejected**, where Slurm would accept it and
   floor every job at ``MinRAMSpace``. That silently caps a whole cluster at
   30 MiB per job, so Spur treats it as the typo it almost certainly is. Every

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -14,7 +14,8 @@ and meaning.
 
    ``spurctld`` reads every section of ``spur.conf``. ``spurd`` reads the same file
    but only for local agent settings (``[hooks]``, ``[devices]``, ``rlimits.memlock``,
-   ``[cluster]``, and ``[mpi]``); its identity and networking come from CLI flags.
+   ``[cgroup]``, ``[cluster]``, and ``[mpi]``); its identity and networking come from
+   CLI flags.
    Node CPU, memory, and GRES are reported by each agent when it registers, not
    declared here — ``[[nodes]]`` only overlays scheduling policy onto nodes that
    have already registered.
@@ -1204,6 +1205,151 @@ Job isolation layers.
      - Landlock filesystem access control. Actually opt-in via the
        ``SPUR_LANDLOCK=1`` environment variable on ``spurd`` and **off** unless
        that is set.
+
+``[cgroup]``
+------------
+
+cgroup-v2 resource enforcement that ``spurd`` applies to native-host jobs. Each
+job gets its own cgroup at ``/sys/fs/cgroup/spur/job_<id>``, and the limits are
+derived from the **per-node budget the controller allocated** — not from the
+``--cpus-per-task`` / ``--mem`` the user requested. Kubernetes jobs are unaffected:
+there the kubelet owns the cgroups.
+
+.. note::
+
+   **Reload: Not implemented.** ``spurd`` reads this section once at startup, so
+   ``scontrol reconfigure`` does not apply changes here. Restart the agent.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 8 10 60
+
+   * - Field
+     - Type
+     - Default
+     - Description
+   * - ``enabled``
+     - bool
+     - ``true``
+     - Master switch. When ``false``, no cgroup is created and no limit is
+       applied.
+   * - ``constrain_cores``
+     - bool
+     - ``true``
+     - Pin the job to its allocated cores via ``cpuset.cpus``. With
+       ``cpu_quota`` off this is the only CPU bound, so a job whose allocation
+       yields no cores runs CPU-unconstrained and ``spurd`` logs a warning.
+   * - ``cpu_quota``
+     - bool
+     - ``false``
+     - Additionally cap CPU time with a CFS quota (``cpu.max``). Off because the
+       cpuset already bounds whole-core allocations; enabling it adds a hard
+       throttle on top.
+   * - ``constrain_ram_space``
+     - bool
+     - ``true``
+     - Cap memory via ``memory.max`` and ``memory.high``. Costs some per-node job
+       throughput — see the note below.
+   * - ``allowed_ram_percent``
+     - int
+     - ``100``
+     - Hard ceiling (``memory.max``) as a percentage of the allocated memory.
+       ``memory.high`` stays at 100% of the allocation, so the default makes the
+       two equal and a value above 100 opens a soft-throttle band. Must be at
+       least 1.
+   * - ``constrain_swap``
+     - bool
+     - ``true``
+     - Bound swap via ``memory.swap.max``.
+   * - ``allowed_swap_percent``
+     - int
+     - ``0``
+     - Swap allowance as a percentage of the allocated memory. ``0`` means no
+       swap. Must be between 0 and 100.
+   * - ``min_ram_mb``
+     - int
+     - ``30``
+     - Floor for the memory ceilings, in MiB. Guards against a tiny ``--mem``
+       creating a cgroup so small the job dies during its own startup.
+   * - ``oom_kill_job``
+     - bool
+     - ``true``
+     - On OOM, kill every process in the job (``memory.oom.group``) instead of
+       letting the kernel pick one.
+
+A job submitted without ``--mem`` has no memory budget, so ``memory.max``,
+``memory.high``, and ``memory.swap.max`` are all left at the kernel default.
+Constraining swap to zero while memory stayed unlimited would be incoherent.
+
+.. note::
+
+   **Memory constraints cost throughput.** ``memory.high`` makes the kernel
+   reclaim against a job approaching its ceiling rather than failing the
+   allocation outright. At the default ``allowed_ram_percent = 100`` that
+   pressure starts at the same point the OOM kill would, so a job that overruns
+   its budget slows down before it dies. Sites that would rather have headroom
+   than reclaim stalls should raise ``allowed_ram_percent`` (e.g. ``125``) rather
+   than turn ``constrain_ram_space`` off.
+
+Verify what a running job actually got:
+
+.. code-block:: bash
+
+   cat /sys/fs/cgroup/spur/job_1234/cpuset.cpus       # allocated cores
+   cat /sys/fs/cgroup/spur/job_1234/memory.max        # hard ceiling, bytes
+   cat /sys/fs/cgroup/spur/job_1234/memory.high       # reclaim threshold
+   cat /sys/fs/cgroup/spur/job_1234/memory.swap.max   # swap ceiling
+
+Migrating from ``cgroup.conf``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The memory ceilings are computed exactly as Slurm's ``cgroup/v2`` plugin computes
+them, so a site's existing percentages carry over directly.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 34 32
+
+   * - Slurm ``cgroup.conf``
+     - Spur ``[cgroup]``
+     - Notes
+   * - ``ConstrainCores``
+     - ``constrain_cores``
+     -
+   * - ``ConstrainRAMSpace``
+     - ``constrain_ram_space``
+     -
+   * - ``AllowedRAMSpace``
+     - ``allowed_ram_percent``
+     - Integer only; Slurm accepts ``101.5``.
+   * - ``ConstrainSwapSpace``
+     - ``constrain_swap``
+     -
+   * - ``AllowedSwapSpace``
+     - ``allowed_swap_percent``
+     - Integer only.
+   * - ``MinRAMSpace``
+     - ``min_ram_mb``
+     -
+   * - ``OOMKillStep``
+     - ``oom_kill_job``
+     - Applies to the whole job; Spur has no per-step cgroups yet.
+
+Deliberate differences from Slurm:
+
+- **Spur enforces by default.** Every Slurm ``Constrain*`` defaults to ``no``. A
+  job that overran ``--mem`` or leaned on host swap under a stock Slurm
+  configuration will be reclaimed against, or killed, on Spur.
+- **Whole-job OOM kill by default.** Slurm's default kills one process and lets
+  the step keep running; set ``oom_kill_job = false`` for that behaviour.
+- **No CFS quota.** Slurm never writes ``cpu.max``; neither does Spur by default.
+  ``cpu_quota`` exists for sites that want one.
+- **No ``--mem`` means unbounded.** Slurm substitutes the node's configured
+  ``RealMemory``; Spur has no such per-node figure and leaves the ceilings unset.
+- **No plugin selectors.** ``CgroupPlugin``, ``TaskPlugin``, and ``ProctrackType``
+  have no Spur equivalent — the mechanism is not pluggable.
+- **Raising ``allowed_ram_percent`` above 100 over-commits the node** and can
+  trigger a system-wide OOM, the same warning Slurm gives for ``AllowedRAMSpace``.
 
 ``[metrics]``
 -------------

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -955,43 +955,6 @@ POSIX ``RLIMIT_*`` values ``spurd`` applies to job steps at launch.
    ``memlock = "unlimited"`` lets RDMA and NCCL workloads pin memory out of the box.
    Lower it only when a hard cap is required.
 
-``[cgroup]``
-------------
-
-How ``spurd`` enforces a job's cgroup limits. The limits themselves come from the
-allocation (``--mem``, ``--cpus-per-task``); this section only sets policy. The
-fields mirror ``ConstrainSwapSpace`` and ``AllowedSwapSpace`` in Slurm's
-``cgroup.conf``, including their defaults.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 24 10 12 54
-
-   * - Field
-     - Type
-     - Default
-     - Description
-   * - ``constrain_swap_space``
-     - bool
-     - ``false``
-     - Cap a job's swap along with its memory. While ``false``, ``memory.max``
-       bounds resident memory only: on a node with swap, a job that outgrows
-       ``--mem`` keeps running on swap instead of being killed.
-   * - ``allowed_swap_space``
-     - integer
-     - ``0``
-     - Swap a job may use, as a percentage (0-100) of its memory allocation.
-       Only consulted when ``constrain_swap_space`` is set; ``0`` denies swap
-       outright. A value above 100 is rejected when spurd starts.
-
-.. note::
-
-   Enabling ``constrain_swap_space`` is what makes ``--mem`` a hard cap and lets a
-   runaway job be reported as ``OUT_OF_MEMORY`` rather than completing slowly on
-   swap. It is off by default because turning it on starts killing jobs that
-   previously survived by swapping. Both fields are read at ``spurd`` startup, so
-   changing them needs an agent restart.
-
 ``[mpi]``
 ---------
 

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -1256,11 +1256,13 @@ there the kubelet owns the cgroups.
      - Hard ceiling (``memory.max``) as a percentage of the allocated memory.
        ``memory.high`` stays at 100% of the allocation, so the default makes the
        two equal and a value above 100 opens a soft-throttle band. Must be at
-       least 1.
+       least 1. Ignored when ``constrain_ram_space`` is ``false``, where it
+       reverts to 100%.
    * - ``constrain_swap``
      - bool
      - ``true``
-     - Bound swap via ``memory.swap.max``.
+     - Bound swap via ``memory.swap.max``. Turning this on with
+       ``constrain_ram_space`` off still bounds memory — see below.
    * - ``allowed_swap_percent``
      - int
      - ``0``
@@ -1280,6 +1282,43 @@ there the kubelet owns the cgroups.
 A job submitted without ``--mem`` has no memory budget, so ``memory.max``,
 ``memory.high``, and ``memory.swap.max`` are all left at the kernel default.
 Constraining swap to zero while memory stayed unlimited would be incoherent.
+
+The two ``constrain_*`` memory switches interact, matching Slurm. Constraining
+swap on its own does **not** leave RAM unlimited: the RAM ceiling becomes the
+combined RAM+swap total, so the sum a job can reach stays bounded.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 16 22 22 22
+
+   * - ``constrain_ram_space``
+     - ``constrain_swap``
+     - ``memory.max``
+     - ``memory.high``
+     - ``memory.swap.max``
+   * - ``false``
+     - ``false``
+     - unset
+     - unset
+     - unset
+   * - ``true``
+     - ``false``
+     - ``allowed_ram_percent``\ % of the allocation
+     - the allocation
+     - unset
+   * - ``false``
+     - ``true``
+     - allocation + ``allowed_swap_percent``\ %
+     - the allocation
+     - ``0``
+   * - ``true``
+     - ``true``
+     - ``allowed_ram_percent``\ % of the allocation
+     - the allocation
+     - ``allowed_swap_percent``\ % of the allocation
+
+Every ceiling is floored at ``min_ram_mb``, and ``memory.high`` never exceeds
+``memory.max``.
 
 .. note::
 

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -1305,9 +1305,10 @@ Every ceiling is floored at ``min_ram_mb``, and ``memory.high`` never exceeds
 When enforcement fails
 ~~~~~~~~~~~~~~~~~~~~~~
 
-By default every step degrades to a warning: an undelegated controller, a
-rejected control-file write, a cpuset that did not apply, or a process that
-could not join the cgroup all leave the job **running unconstrained**. Grep the
+By default every step degrades to a warning: a controller that could not be
+delegated, a rejected control-file write, a cpuset that did not apply, or a
+process that could not join the cgroup all leave the job **running
+unconstrained**. Grep the
 agent log for these to find silently-unenforced nodes:
 
 .. code-block:: text

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -1209,16 +1209,27 @@ Job isolation layers.
 ``[cgroup]``
 ------------
 
-cgroup-v2 resource enforcement that ``spurd`` applies to native-host jobs. Each
-job gets its own cgroup at ``/sys/fs/cgroup/spur/job_<id>``, and the limits are
-derived from the **per-node budget the controller allocated** — not from the
-``--cpus-per-task`` / ``--mem`` the user requested. Kubernetes jobs are unaffected:
-there the kubelet owns the cgroups.
+cgroup-v2 resource enforcement that ``spurd`` applies to native-host jobs. The
+job's batch payload runs in a cgroup at ``/sys/fs/cgroup/spur/job_<id>``, and the
+limits are derived from the **per-node budget the controller allocated** — not
+from the ``--cpus-per-task`` / ``--mem`` the user requested. Kubernetes jobs are
+unaffected: there the kubelet owns the cgroups.
+
+.. warning::
+
+   These limits bound the batch payload only. ``srun`` steps, ``spur exec``, and
+   interactive attaches into a running job currently run outside the job cgroup,
+   so they are not bounded by these settings and this section is not a security
+   boundary between users sharing a node. See
+   :ref:`cgroup-containment-gaps` for the full list.
 
 .. note::
 
    **Reload: Not implemented.** ``spurd`` reads this section once at startup, so
    ``scontrol reconfigure`` does not apply changes here. Restart the agent.
+
+   Upgrading a cluster whose ``spur.conf`` has no ``[cgroup]`` section changes
+   what gets enforced — see :ref:`cgroup-upgrade-notes`.
 
 .. list-table::
    :header-rows: 1
@@ -1233,6 +1244,11 @@ there the kubelet owns the cgroups.
      - ``true``
      - Master switch. When ``false``, no cgroup is created and no limit is
        applied.
+   * - ``required``
+     - bool
+     - ``false``
+     - Refuse to launch a job when a requested constraint cannot be applied,
+       instead of warning and running it unconstrained. See the note below.
    * - ``constrain_cores``
      - bool
      - ``true``
@@ -1267,7 +1283,8 @@ there the kubelet owns the cgroups.
      - int
      - ``0``
      - Swap allowance as a percentage of the allocated memory. ``0`` means no
-       swap. Must be between 0 and 100.
+       swap. Not capped at 100 — a swap-rich node may grant more swap than RAM,
+       and Slurm places no upper bound on ``AllowedSwapSpace`` either.
    * - ``min_ram_mb``
      - int
      - ``30``
@@ -1320,6 +1337,27 @@ combined RAM+swap total, so the sum a job can reach stays bounded.
 Every ceiling is floored at ``min_ram_mb``, and ``memory.high`` never exceeds
 ``memory.max``.
 
+When enforcement fails
+~~~~~~~~~~~~~~~~~~~~~~
+
+By default every step degrades to a warning: an undelegated controller, a
+rejected control-file write, a cpuset that did not apply, or a process that
+could not join the cgroup all leave the job **running unconstrained**. Grep the
+agent log for these to find silently-unenforced nodes:
+
+.. code-block:: text
+
+   failed to delegate cgroup controller
+   failed to write cgroup control file
+   cpuset not applied; job runs without a CPU bound
+   failed to move process to cgroup
+
+Set ``required = true`` to refuse the launch instead. The job fails rather than
+running outside its limits, which is the right trade on a shared node where the
+limits are the isolation boundary. It also means a host that cannot enforce
+stops accepting work, so roll it out only once the agent runs as root and the
+cgroup tree is confirmed writable.
+
 .. note::
 
    **Memory constraints cost throughput.** ``memory.high`` makes the kernel
@@ -1366,7 +1404,7 @@ them, so a site's existing percentages carry over directly.
      -
    * - ``AllowedSwapSpace``
      - ``allowed_swap_percent``
-     - Integer only.
+     - Integer only. Values above 100 carry over unchanged.
    * - ``MinRAMSpace``
      - ``min_ram_mb``
      -
@@ -1379,6 +1417,10 @@ Deliberate differences from Slurm:
 - **Spur enforces by default.** Every Slurm ``Constrain*`` defaults to ``no``. A
   job that overran ``--mem`` or leaned on host swap under a stock Slurm
   configuration will be reclaimed against, or killed, on Spur.
+- **``allowed_ram_percent = 0`` is rejected**, where Slurm would accept it and
+  floor every job at ``MinRAMSpace``. That silently caps a whole cluster at
+  30 MiB per job, so Spur treats it as the typo it almost certainly is. Every
+  other percentage carries over from ``cgroup.conf`` unchanged.
 - **Whole-job OOM kill by default.** Slurm's default kills one process and lets
   the step keep running; set ``oom_kill_job = false`` for that behaviour.
 - **No CFS quota.** Slurm never writes ``cpu.max``; neither does Spur by default.

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -394,8 +394,8 @@ CPU and Memory Limits (cgroups)
 
 ``spurd`` puts the payload it launches for a job into a cgroup-v2 group at
 ``/sys/fs/cgroup/spur/job_<id>`` and enforces the **per-node budget the controller
-allocated** — the cores, memory, and swap the scheduler actually granted this node,
-not what the job asked for.
+allocated** — the cores and memory the scheduler actually granted this node, not
+what the job asked for.
 
 This covers the batch payload: ``sbatch`` scripts, ``--pty`` jobs, and
 containerized jobs (a container's process tree inherits the job cgroup). It does
@@ -407,7 +407,9 @@ Out of the box the batch payload gets:
 - ``cpuset.cpus`` pinned to its allocated cores.
 - ``memory.max`` at its allocated memory, with ``memory.high`` at the same value so
   the kernel reclaims against the job before killing it.
-- ``memory.swap.max`` at ``0`` — jobs cannot fall back on host swap.
+- ``memory.swap.max`` left alone: swap is unconstrained by default, as in Slurm, so
+  ``memory.max`` bounds resident memory only. Set ``constrain_swap`` to make
+  ``--mem`` a hard cap.
 - ``memory.oom.group`` set, so an OOM kills the whole job rather than one process.
 - ``pids.max`` as a fork-bomb guard.
 

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -109,9 +109,10 @@ The two daemons are configured with command-line flags. The most common are belo
 
    Node identity and networking (controller address, hostname, listen address) come
    from CLI flags. ``spurd`` also reads ``spur.conf`` for local agent settings —
-   ``[hooks]``, ``[devices]`` (GRES and CDI), ``rlimits.memlock``, ``[cluster]``, and
-   ``[mpi]``. If the file is absent, the agent logs a warning and falls back to
-   defaults for those sections, which is fine when none of them are in use.
+   ``[hooks]``, ``[devices]`` (GRES and CDI), ``rlimits.memlock``, ``[cgroup]``,
+   ``[cluster]``, and ``[mpi]``. If the file is absent, the agent logs a warning and
+   falls back to defaults for those sections, which is fine when none of them are
+   in use.
 
 Quick Start: Two-Node Cluster
 -----------------------------
@@ -387,6 +388,42 @@ The default can be changed in ``spur.conf``:
    With the default ``"unlimited"`` setting, a ``LimitMEMLOCK=infinity`` line on
    the ``spurd`` systemd unit is no longer required. The agent raises the limit
    itself while still privileged.
+
+CPU and Memory Limits (cgroups)
+-------------------------------
+
+``spurd`` puts every native-host job in its own cgroup-v2 group at
+``/sys/fs/cgroup/spur/job_<id>`` and enforces the **per-node budget the controller
+allocated** — the cores, memory, and swap the scheduler actually granted this node,
+not what the job asked for. This is what makes it safe for two users' jobs to share
+a node.
+
+Out of the box each job gets:
+
+- ``cpuset.cpus`` pinned to its allocated cores.
+- ``memory.max`` at its allocated memory, with ``memory.high`` at the same value so
+  the kernel reclaims against the job before killing it.
+- ``memory.swap.max`` at ``0`` — jobs cannot fall back on host swap.
+- ``memory.oom.group`` set, so an OOM kills the whole job rather than one process.
+- ``pids.max`` as a fork-bomb guard.
+
+A job submitted without ``--mem`` has no memory budget, so the memory ceilings are
+left unset.
+
+Inspect what a running job actually got:
+
+.. code-block:: bash
+
+   ls /sys/fs/cgroup/spur/                            # one dir per running job
+   cat /sys/fs/cgroup/spur/job_1234/cpuset.cpus
+   cat /sys/fs/cgroup/spur/job_1234/memory.max
+   cat /sys/fs/cgroup/spur/job_1234/memory.swap.max
+
+Enforcement requires ``spurd`` to run as root. An unprivileged agent logs a warning
+and runs jobs unconstrained. Every knob — including turning enforcement off
+entirely — lives in the ``[cgroup]`` section; see
+:doc:`/admin-guide/configuration` for the full field list and the mapping from
+Slurm's ``cgroup.conf``.
 
 MPI (PMIx)
 ----------

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -392,13 +392,17 @@ The default can be changed in ``spur.conf``:
 CPU and Memory Limits (cgroups)
 -------------------------------
 
-``spurd`` puts every native-host job in its own cgroup-v2 group at
+``spurd`` puts the payload it launches for a job into a cgroup-v2 group at
 ``/sys/fs/cgroup/spur/job_<id>`` and enforces the **per-node budget the controller
 allocated** — the cores, memory, and swap the scheduler actually granted this node,
-not what the job asked for. This is what makes it safe for two users' jobs to share
-a node.
+not what the job asked for.
 
-Out of the box each job gets:
+This covers the batch payload: ``sbatch`` scripts, ``--pty`` jobs, and
+containerized jobs (a container's process tree inherits the job cgroup). It does
+**not** yet cover every process a job can start — see
+:ref:`cgroup-containment-gaps` below.
+
+Out of the box the batch payload gets:
 
 - ``cpuset.cpus`` pinned to its allocated cores.
 - ``memory.max`` at its allocated memory, with ``memory.high`` at the same value so
@@ -424,6 +428,40 @@ and runs jobs unconstrained. Every knob — including turning enforcement off
 entirely — lives in the ``[cgroup]`` section; see
 :doc:`/admin-guide/configuration` for the full field list and the mapping from
 Slurm's ``cgroup.conf``.
+
+.. _cgroup-containment-gaps:
+
+What is not contained yet
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Only the payload launched through the agent's ``LaunchJob`` path joins
+``job_<id>``. These paths start processes that stay outside it, in ``spurd``'s own
+cgroup, and are therefore **not** bounded by the job's limits:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Path
+     - Why it escapes
+   * - ``srun`` steps inside a job
+     - Steps are spawned directly by the agent rather than through the batch
+       launch path.
+   * - ``spur exec`` into a running job
+     - Enters the job's *namespaces* via ``nsenter``; namespaces are not cgroups,
+       so the process keeps ``spurd``'s cgroup.
+   * - Interactive attach to a running job
+     - Same namespace-entry path as ``spur exec``. Note this is distinct from a
+       ``--pty`` job, which *is* contained because it launches as a batch payload.
+   * - Standalone ``srun`` allocations
+     - The allocation is recorded for accounting, but its steps run through the
+       ``srun`` step path above.
+
+Practically: a job cannot exceed its memory or core budget through its batch
+script, but it can through ``srun`` steps or an interactive shell. Closing this
+needs per-step cgroups nested under the job, which is planned but not implemented.
+Until then, do not rely on these limits as a security boundary between users on a
+shared node.
 
 MPI (PMIx)
 ----------

--- a/docs/deployment/upgrading.rst
+++ b/docs/deployment/upgrading.rst
@@ -261,7 +261,7 @@ Job resource enforcement (``[cgroup]``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The release introducing the ``[cgroup]`` section changed what ``spurd`` writes for
-a config that has **no** ``[cgroup]`` section. One of these can affect jobs that
+a config that has **no** ``[cgroup]`` section. The first two can affect jobs that
 ran fine before the upgrade; the rest relax an existing bound.
 
 .. list-table::
@@ -272,6 +272,12 @@ ran fine before the upgrade; the rest relax an existing bound.
      - Before
      - After
      - Effect
+   * - ``memory.max``
+     - unset for ``--mem-per-cpu`` jobs
+     - the memory the scheduler allocated
+     - **A ``--mem-per-cpu`` job that ran unbounded is now capped, and is
+       OOM-killed if it overruns.** Only the per-node request was read before,
+       which those jobs do not set.
    * - ``memory.high``
      - unset
      - equal to ``memory.max``
@@ -300,11 +306,13 @@ restart — ``scontrol reconfigure`` will not apply it afterwards.
 
 .. note::
 
-   No knob disables ``memory.high`` on its own; it is written whenever
-   ``constrain_ram_space`` is on, matching Slurm's ``cgroup/v2`` plugin. If reclaim
-   stalls are the problem, raise ``allowed_ram_percent`` (for example ``125``) so
-   reclaim begins above the allocation instead of at it, rather than turning memory
-   constraints off entirely.
+   Neither memory change has a knob of its own: ``memory.max`` and ``memory.high``
+   are both written whenever ``constrain_ram_space`` is on, matching Slurm's
+   ``cgroup/v2`` plugin. Setting ``constrain_ram_space = false`` restores the old
+   behaviour but drops the memory ceiling for *every* job, not just the
+   ``--mem-per-cpu`` ones. Prefer raising ``allowed_ram_percent`` (for example
+   ``125``), which gives jobs headroom above their allocation and starts reclaim
+   there, over turning memory constraints off.
 
 Rolling back is safe with the section left in place: older binaries do not know
 ``[cgroup]`` and ignore it.

--- a/docs/deployment/upgrading.rst
+++ b/docs/deployment/upgrading.rst
@@ -249,6 +249,71 @@ Follow this order for any cluster upgrade:
    32-bit and its accounting queries fail against a migrated database. Take a database
    backup before upgrading if you need a recovery path.
 
+Behavior Changes Between Releases
+---------------------------------
+
+Some releases change how an existing ``spur.conf`` behaves without that file being
+edited. Review these before rolling binaries out.
+
+.. _cgroup-upgrade-notes:
+
+Job resource enforcement (``[cgroup]``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The release introducing the ``[cgroup]`` section changed what ``spurd`` writes for
+a config that has **no** ``[cgroup]`` section. Two of these can affect jobs that
+ran fine before the upgrade.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 26 26 26
+
+   * - Control file
+     - Before
+     - After
+     - Effect
+   * - ``memory.swap.max``
+     - unset — swap unbounded
+     - ``0`` — no swap
+     - **A job that was completing by swapping is now OOM-killed.**
+   * - ``memory.high``
+     - unset
+     - equal to ``memory.max``
+     - **Memory-heavy jobs stall in reclaim before the OOM kill**, costing
+       throughput.
+   * - ``cpu.max``
+     - CFS quota sized from ``--cpus-per-task``
+     - unset
+     - Relaxed: the cpuset is the CPU bound, as in Slurm.
+   * - ``cpuset.cpus``
+     - sized from ``--cpus-per-task``
+     - sized from the node allocation
+     - Relaxed: a multi-task job gets all the cores it was granted, not one
+       task's worth.
+
+To keep the previous behavior, put this in ``spur.conf`` on every compute node
+**before** restarting ``spurd``:
+
+.. code-block:: toml
+
+   [cgroup]
+   cpu_quota = true        # restore the CFS quota
+   constrain_swap = false  # restore unbounded swap
+
+``spurd`` reads ``[cgroup]`` only at startup, so this has to be in place before the
+restart — ``scontrol reconfigure`` will not apply it afterwards.
+
+.. note::
+
+   No knob disables ``memory.high`` on its own; it is written whenever
+   ``constrain_ram_space`` is on, matching Slurm's ``cgroup/v2`` plugin. If reclaim
+   stalls are the problem, raise ``allowed_ram_percent`` (for example ``125``) so
+   reclaim begins above the allocation instead of at it, rather than turning memory
+   constraints off entirely.
+
+Rolling back is safe with the section left in place: older binaries do not know
+``[cgroup]`` and ignore it.
+
 See Also
 --------
 

--- a/docs/deployment/upgrading.rst
+++ b/docs/deployment/upgrading.rst
@@ -261,8 +261,8 @@ Job resource enforcement (``[cgroup]``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The release introducing the ``[cgroup]`` section changed what ``spurd`` writes for
-a config that has **no** ``[cgroup]`` section. Two of these can affect jobs that
-ran fine before the upgrade.
+a config that has **no** ``[cgroup]`` section. One of these can affect jobs that
+ran fine before the upgrade; the rest relax an existing bound.
 
 .. list-table::
    :header-rows: 1
@@ -272,10 +272,6 @@ ran fine before the upgrade.
      - Before
      - After
      - Effect
-   * - ``memory.swap.max``
-     - unset — swap unbounded
-     - ``0`` — no swap
-     - **A job that was completing by swapping is now OOM-killed.**
    * - ``memory.high``
      - unset
      - equal to ``memory.max``
@@ -297,8 +293,7 @@ To keep the previous behavior, put this in ``spur.conf`` on every compute node
 .. code-block:: toml
 
    [cgroup]
-   cpu_quota = true        # restore the CFS quota
-   constrain_swap = false  # restore unbounded swap
+   cpu_quota = true  # restore the CFS quota
 
 ``spurd`` reads ``[cgroup]`` only at startup, so this has to be in place before the
 restart — ``scontrol reconfigure`` will not apply it afterwards.

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -148,6 +148,22 @@ format = "text"
 # it to that many bytes (e.g. "1073741824" for 1 GiB).
 memlock = "unlimited"
 
+# cgroup-v2 limits spurd applies to each batch and container job, derived from the
+# per-node allocation the scheduler granted. Cores and memory are bounded by
+# default; the settings below are the ones worth a decision.
+[cgroup]
+# Bound swap as well as RAM, which is what makes --mem a hard cap: without it
+# memory.max limits resident memory only, and a job that outgrows its allocation
+# pages out and finishes slowly instead of being killed. Recommended, but it does
+# start killing jobs that were quietly surviving on swap — leave it off while
+# migrating a workload you have not sized yet. No effect on a node without swap.
+constrain_swap = true
+# allowed_ram_percent = 125  # hard ceiling above the allocation; reclaim still
+                             # starts at 100%, so jobs get headroom before the kill
+# required = false           # refuse to launch when limits cannot be applied,
+                             # instead of warning and running the job unconstrained
+# cpu_quota = false          # add a CFS quota on top of the cpuset; off as in Slurm
+
 # Lifecycle hook scripts. All optional; a fully-qualified path enables the hook.
 # job_submit (shell) and job_submit_lua both run on the controller at submission
 # and can accept, reject (message shown to the user), or modify the job

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -217,6 +217,33 @@ def multi_node_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
 
 
 @pytest.fixture
+def cgroup_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
+    """
+    Per-test fixture for cgroup enforcement tests: a rootful, non-GPU cluster.
+
+    spurd must be root to create ``/sys/fs/cgroup/spur/job_<id>``; an
+    unprivileged agent degrades to "no isolation" and every limit assertion
+    would then pass vacuously, so the agent's user is checked up front.
+    """
+    if len(ssh_nodes) < 1:
+        pytest.skip("cgroup tests require at least one node in SPUR_TEST_NODES")
+    fstype = ssh_nodes[0].exec_allow_fail("stat -fc %T /sys/fs/cgroup").strip()
+    if "cgroup2fs" not in fstype:
+        pytest.skip(f"node 0 is not running cgroup v2 (/sys/fs/cgroup is {fstype!r})")
+
+    c = _deploy_cluster(ssh_nodes, remote_bin_dir, agent_as_root=True,
+                        config_overrides=cluster_config_overrides)
+    try:
+        agent_user = c.spurd_agent_user(0)
+        assert agent_user == "root", (
+            f"cgroup enforcement needs a rootful agent, got user {agent_user!r}"
+        )
+        yield c
+    finally:
+        c.teardown()
+
+
+@pytest.fixture
 def k8s_multicp_cluster(ssh_nodes, remote_bin_dir):
     """Native k0s enabled, spurd rootful. Skips unless >= 3 nodes (etcd quorum) + sudo."""
     if len(ssh_nodes) < 3:

--- a/tests/native_host/e2e/test_cgroup_limits.py
+++ b/tests/native_host/e2e/test_cgroup_limits.py
@@ -210,6 +210,28 @@ class TestCgroupRamHeadroom:
         assert probe.values["memory.max"] == str(1536 * MIB), probe.context()
 
 
+class TestCgroupSwapOnly:
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {
+            "cgroup": {
+                "constrain_ram_space": False,
+                "constrain_swap": True,
+                "allowed_swap_percent": 25,
+            }
+        }
+
+    def test_swap_only_still_bounds_the_ram_plus_swap_total(self, cgroup_cluster):
+        # Constraining swap alone must not leave RAM unlimited: the RAM ceiling
+        # becomes the combined total, and swap itself is then pinned to zero.
+        probe = _run_probe(
+            cgroup_cluster, ["--cpus-per-task=1", "--mem=1024"], "cg-swaponly"
+        )
+        assert probe.values["memory.max"] == str(1280 * MIB), probe.context()
+        assert probe.values["memory.high"] == str(1024 * MIB), probe.context()
+        assert probe.values["memory.swap.max"] == "0", probe.context()
+
+
 class TestCgroupDisabled:
     @pytest.fixture
     def cluster_config_overrides(self):

--- a/tests/native_host/e2e/test_cgroup_limits.py
+++ b/tests/native_host/e2e/test_cgroup_limits.py
@@ -10,6 +10,7 @@ instead of on the submitted request. Each job reads its own cgroup through
 which the ``cgroup_cluster`` fixture enforces.
 """
 
+import time
 from typing import NamedTuple
 
 import pytest
@@ -144,9 +145,8 @@ class TestCgroupDefaults:
         assert _core_count(probe.values["cpuset.cpus"]) == 4, probe.context()
 
     def test_job_without_a_memory_request_is_left_unbounded(self, cgroup_cluster):
-        # A job with no memory budget gets no memory ceiling — and therefore no
-        # swap ceiling either. Bounding swap to 0 while RAM stays unlimited is a
-        # combination Slurm never emits.
+        # No memory budget means no memory ceiling, and so no swap ceiling either:
+        # swap 0 with RAM unlimited is a pair Slurm never emits.
         probe = _run_probe(cgroup_cluster, ["--cpus-per-task=1"], "cg-nomem")
         vals = probe.values
 
@@ -164,10 +164,8 @@ class TestCgroupDefaults:
         assert probe.values["memory.high"] == str(30 * MIB), probe.context()
 
     def test_container_job_runs_inside_the_job_cgroup(self, cgroup_cluster, tmp_path):
-        # Containers share the batch cgroup, so the limits come for free; the
-        # container-specific risk is the pid-namespace tree escaping it. The
-        # container mounts a fresh sysfs with no cgroup2 under it, so membership
-        # is asserted via /proc/self/cgroup rather than by re-reading the files.
+        # Containers share the batch cgroup, so the risk is the pid-namespace tree
+        # escaping it. /sys/fs/cgroup is unmounted inside, so read /proc/self/cgroup.
         cluster = cgroup_cluster
         cluster.container_preflight()
         image = cluster.build_container_image(tmp_path)
@@ -251,16 +249,51 @@ class TestCgroupDisabled:
         )
 
 
+class TestCgroupRequired:
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {"cgroup": {"required": True}}
+
+    def test_required_refuses_to_launch_when_enforcement_is_unavailable(self, cluster):
+        # Unprivileged `cluster`, not cgroup_cluster, on purpose: an agent that cannot
+        # enforce must refuse the job rather than run it unconstrained.
+        script = cluster.write_file("cg-required.sh", "#!/bin/bash\necho RAN\n")
+        out_path = f"{cluster.remote_dir}/cg-required.out"
+        sb = cluster.sbatch(
+            ["-J", "cg-required", "-N", "1", "--cpus-per-task=1", "--mem=256",
+             "-o", out_path, script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch failed: {sb}"
+
+        # A refused launch is retried, so the job stays pending rather than failing.
+        # What matters is that the body never runs and the agent says why.
+        deadline = time.time() + 45
+        while time.time() < deadline:
+            if "required" in cluster.spurd_log(0):
+                break
+            time.sleep(2)
+
+        assert "RAN" not in cluster.read_output_on_any_node(out_path), (
+            f"job body executed despite [cgroup] required\n{cluster.debug_job(job_id)}"
+        )
+        assert "required but" in cluster.spurd_log(0), (
+            "agent must log why it refused the launch\n"
+            f"{cluster.spurd_log(0)[-2000:]}"
+        )
+        cluster.scancel(str(job_id))
+
+
 class TestCgroupConfigValidation:
-    def test_controller_refuses_an_out_of_range_swap_percent(self, unstarted_cluster):
-        # An ignored bad value would silently hand jobs a swap ceiling larger
-        # than the memory they were granted, so the daemon must refuse to start.
+    def test_controller_refuses_a_zero_ram_percent(self, unstarted_cluster):
+        # Zero silently floors every job's memory ceiling to min_ram_mb, so the
+        # daemon refuses to start rather than run a whole cluster that way.
         cluster = unstarted_cluster
         conf = cluster.write_file(
             "bad-cgroup.conf",
             'cluster_name = "cgroup-validation"\n'
             "[cgroup]\n"
-            "allowed_swap_percent = 150\n",
+            "allowed_ram_percent = 0\n",
             executable=False,
         )
         out = cluster.nodes[0].exec_allow_fail(
@@ -269,6 +302,6 @@ class TestCgroupConfigValidation:
             f"2>&1; echo EXIT=$?"
         )
         assert "EXIT=0" not in out, f"spurctld must not start with an invalid config:\n{out}"
-        assert "allowed_swap_percent" in out, (
+        assert "allowed_ram_percent" in out, (
             f"startup failure must name the offending field:\n{out}"
         )

--- a/tests/native_host/e2e/test_cgroup_limits.py
+++ b/tests/native_host/e2e/test_cgroup_limits.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for cgroup-v2 job resource enforcement.
+
+The limits spurd writes derive from the controller's per-node allocation rather
+than from what the user asked for, so these assert on the live control files
+instead of on the submitted request. Each job reads its own cgroup through
+``/proc/self/cgroup``, which needs no privilege — only the agent must be root,
+which the ``cgroup_cluster`` fixture enforces.
+"""
+
+from typing import NamedTuple
+
+import pytest
+
+from cluster import parse_job_id, wait_job
+
+MIB = 1024 * 1024
+
+# Pure bash on purpose: the minimal container image has no awk or cut, and the
+# same probe is reused there.
+_PROBE = """#!/bin/bash
+CG=""
+while IFS= read -r line; do
+  case "$line" in 0::*) CG="${line#0::}" ;; esac
+done < /proc/self/cgroup
+echo "CGROUP_PATH=$CG"
+B="/sys/fs/cgroup$CG"
+for f in cpu.max cpuset.cpus memory.max memory.high memory.swap.max \
+         memory.oom.group pids.max; do
+  if [ -r "$B/$f" ]; then echo "$f=$(cat "$B/$f")"; else echo "$f=UNREADABLE"; fi
+done
+echo CGROUP_PROBE_OK
+"""
+
+
+class _Probe(NamedTuple):
+    values: dict[str, str]
+    job_id: int
+    output: str
+
+    def context(self) -> str:
+        return f"job {self.job_id} probe output:\n{self.output}"
+
+
+def _parse(output: str) -> dict[str, str]:
+    values = {}
+    for line in output.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            values[key.strip()] = value.strip()
+    return values
+
+
+def _core_count(cpuset: str) -> int:
+    """Number of cores in a cgroup cpuset list.
+
+    The kernel normalises what spurd writes (``0,1,2,3``) into ranges
+    (``0-3``), so both spellings have to parse.
+    """
+    total = 0
+    for part in cpuset.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        low, _, high = part.partition("-")
+        total += int(high) - int(low) + 1 if high else 1
+    return total
+
+
+def _require_cores(cluster, needed: int) -> None:
+    cores = int(cluster.nodes[0].exec("nproc").strip())
+    if cores < needed:
+        pytest.skip(f"need a node with at least {needed} cores (node 0 has {cores})")
+
+
+def _run_probe(
+    cluster, sbatch_args: list[str], name: str, *, expect_enforced: bool = True
+) -> _Probe:
+    """Submit the probe pinned to node 0 and return its parsed cgroup values.
+
+    With *expect_enforced* the job is required to have landed in its own
+    ``/spur/job_<id>`` cgroup. Checking that here turns "every control file
+    reads UNREADABLE" into one legible failure naming the cgroup it did land
+    in, which is otherwise an easy symptom to misread.
+    """
+    script = cluster.write_file(f"{name}.sh", _PROBE)
+    out_path = f"{cluster.remote_dir}/{name}.out"
+    sb = cluster.sbatch(
+        ["-J", name, "-N", "1", "-w", cluster.node_names[0], "-o", out_path]
+        + sbatch_args
+        + [script]
+    )
+    job_id = parse_job_id(sb)
+    assert job_id is not None, f"sbatch failed: {sb}"
+
+    wait_job(cluster, job_id, timeout=120)
+    content = cluster.wait_output(out_path, "CGROUP_PROBE_OK", timeout=120)
+    assert "CGROUP_PROBE_OK" in content, (
+        f"probe did not run to completion\n{cluster.debug_job(job_id)}\n"
+        f"output:\n{content}"
+    )
+
+    probe = _Probe(_parse(content), job_id, content)
+    if expect_enforced:
+        assert probe.values.get("CGROUP_PATH") == f"/spur/job_{job_id}", (
+            f"job ran outside its own cgroup, so no limit was applied to it "
+            f"(agent user: {cluster.spurd_agent_user(0)!r})\n{probe.context()}\n"
+            f"spurd log:\n{cluster.spurd_log(0)[-2000:]}"
+        )
+    return probe
+
+
+class TestCgroupDefaults:
+    def test_limits_match_the_node_allocation(self, cgroup_cluster):
+        cluster = cgroup_cluster
+        _require_cores(cluster, 2)
+        probe = _run_probe(
+            cluster, ["--cpus-per-task=2", "--mem=1024"], "cg-alloc"
+        )
+        vals = probe.values
+
+        assert vals["memory.max"] == str(1024 * MIB), probe.context()
+        # allowed_ram_percent defaults to 100, which collapses the soft ceiling
+        # onto the hard one.
+        assert vals["memory.high"] == vals["memory.max"], probe.context()
+        assert vals["memory.swap.max"] == "0", probe.context()
+        assert vals["memory.oom.group"] == "1", probe.context()
+        assert _core_count(vals["cpuset.cpus"]) == 2, probe.context()
+        # Slurm bounds CPU with the cpuset alone; the CFS quota is opt-in.
+        assert vals["cpu.max"] == "max 100000", probe.context()
+
+    def test_cpuset_covers_every_task_on_the_node(self, cgroup_cluster):
+        # Sizing the budget from `cpus_per_task` alone would pin 2 cores here
+        # instead of 4, which is the under-provisioning this closes.
+        cluster = cgroup_cluster
+        _require_cores(cluster, 4)
+        probe = _run_probe(
+            cluster,
+            ["--ntasks-per-node=2", "--cpus-per-task=2", "--mem=512"],
+            "cg-multitask",
+        )
+        assert _core_count(probe.values["cpuset.cpus"]) == 4, probe.context()
+
+    def test_job_without_a_memory_request_is_left_unbounded(self, cgroup_cluster):
+        # A job with no memory budget gets no memory ceiling — and therefore no
+        # swap ceiling either. Bounding swap to 0 while RAM stays unlimited is a
+        # combination Slurm never emits.
+        probe = _run_probe(cgroup_cluster, ["--cpus-per-task=1"], "cg-nomem")
+        vals = probe.values
+
+        assert vals["memory.max"] == "max", probe.context()
+        assert vals["memory.high"] == "max", probe.context()
+        assert vals["memory.swap.max"] == "max", probe.context()
+
+    def test_memory_ceiling_floors_at_min_ram_mb(self, cgroup_cluster):
+        # Below the floor a job is OOM-killed during its own startup, before
+        # anything can clean up after it.
+        probe = _run_probe(
+            cgroup_cluster, ["--cpus-per-task=1", "--mem=8"], "cg-tinymem"
+        )
+        assert probe.values["memory.max"] == str(30 * MIB), probe.context()
+        assert probe.values["memory.high"] == str(30 * MIB), probe.context()
+
+    def test_container_job_runs_inside_the_job_cgroup(self, cgroup_cluster, tmp_path):
+        # Containers share the batch cgroup, so the limits come for free; the
+        # container-specific risk is the pid-namespace tree escaping it. The
+        # container mounts a fresh sysfs with no cgroup2 under it, so membership
+        # is asserted via /proc/self/cgroup rather than by re-reading the files.
+        cluster = cgroup_cluster
+        cluster.container_preflight()
+        image = cluster.build_container_image(tmp_path)
+        probe = _run_probe(
+            cluster,
+            ["--cpus-per-task=1", "--mem=256", f"--container-image={image}"],
+            "cg-container",
+        )
+        assert probe.values["CGROUP_PATH"] == f"/spur/job_{probe.job_id}", (
+            probe.context()
+        )
+
+
+class TestCgroupCpuQuota:
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {"cgroup": {"cpu_quota": True}}
+
+    def test_cpu_quota_opt_in_writes_cpu_max(self, cgroup_cluster):
+        cluster = cgroup_cluster
+        _require_cores(cluster, 2)
+        probe = _run_probe(
+            cluster, ["--cpus-per-task=2", "--mem=512"], "cg-quota"
+        )
+        assert probe.values["cpu.max"] == "200000 100000", probe.context()
+
+
+class TestCgroupRamHeadroom:
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {"cgroup": {"allowed_ram_percent": 150}}
+
+    def test_headroom_splits_the_soft_and_hard_ceilings(self, cgroup_cluster):
+        # memory.high stays at the allocation so reclaim starts there, while
+        # memory.max moves out to the configured headroom.
+        probe = _run_probe(
+            cgroup_cluster, ["--cpus-per-task=1", "--mem=1024"], "cg-headroom"
+        )
+        assert probe.values["memory.high"] == str(1024 * MIB), probe.context()
+        assert probe.values["memory.max"] == str(1536 * MIB), probe.context()
+
+
+class TestCgroupDisabled:
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {"cgroup": {"enabled": False}}
+
+    def test_master_switch_creates_no_cgroup(self, cgroup_cluster):
+        # The job still runs; it just inherits the agent's cgroup instead of
+        # getting one of its own.
+        probe = _run_probe(
+            cgroup_cluster,
+            ["--cpus-per-task=1", "--mem=512"],
+            "cg-off",
+            expect_enforced=False,
+        )
+        assert not probe.values["CGROUP_PATH"].startswith("/spur/job_"), (
+            probe.context()
+        )
+
+
+class TestCgroupConfigValidation:
+    def test_controller_refuses_an_out_of_range_swap_percent(self, unstarted_cluster):
+        # An ignored bad value would silently hand jobs a swap ceiling larger
+        # than the memory they were granted, so the daemon must refuse to start.
+        cluster = unstarted_cluster
+        conf = cluster.write_file(
+            "bad-cgroup.conf",
+            'cluster_name = "cgroup-validation"\n'
+            "[cgroup]\n"
+            "allowed_swap_percent = 150\n",
+            executable=False,
+        )
+        out = cluster.nodes[0].exec_allow_fail(
+            f"timeout 20 '{cluster.bin_dir}/spurctld' -f '{conf}' "
+            f"--listen '[::]:16899' --state-dir '{cluster.remote_dir}/bad-state' "
+            f"2>&1; echo EXIT=$?"
+        )
+        assert "EXIT=0" not in out, f"spurctld must not start with an invalid config:\n{out}"
+        assert "allowed_swap_percent" in out, (
+            f"startup failure must name the offending field:\n{out}"
+        )

--- a/tests/native_host/e2e/test_cgroup_limits.py
+++ b/tests/native_host/e2e/test_cgroup_limits.py
@@ -76,6 +76,12 @@ def _require_cores(cluster, needed: int) -> None:
         pytest.skip(f"need a node with at least {needed} cores (node 0 has {cores})")
 
 
+def _spurd_logs(cluster) -> str:
+    """Every agent log joined: an unpinned job lands on whichever node the
+    scheduler picked, so node 0 alone is not where the evidence has to be."""
+    return "\n".join(cluster.spurd_log(i) for i in range(len(cluster.nodes)))
+
+
 def _run_probe(
     cluster, sbatch_args: list[str], name: str, *, expect_enforced: bool = True
 ) -> _Probe:
@@ -267,20 +273,21 @@ class TestCgroupRequired:
         job_id = parse_job_id(sb)
         assert job_id is not None, f"sbatch failed: {sb}"
 
-        # A refused launch is retried, so the job stays pending rather than failing.
-        # What matters is that the body never runs and the agent says why.
+        # A refused launch is retried, so the job stays pending: poll the log, not state.
+        # Match the refusal itself — the startup banner also says `required`.
+        refusal = "required but"
         deadline = time.time() + 45
         while time.time() < deadline:
-            if "required" in cluster.spurd_log(0):
+            if refusal in _spurd_logs(cluster):
                 break
             time.sleep(2)
 
         assert "RAN" not in cluster.read_output_on_any_node(out_path), (
             f"job body executed despite [cgroup] required\n{cluster.debug_job(job_id)}"
         )
-        assert "required but" in cluster.spurd_log(0), (
+        assert refusal in _spurd_logs(cluster), (
             "agent must log why it refused the launch\n"
-            f"{cluster.spurd_log(0)[-2000:]}"
+            f"{_spurd_logs(cluster)[-2000:]}"
         )
         cluster.scancel(str(job_id))
 

--- a/tests/native_host/e2e/test_cgroup_limits.py
+++ b/tests/native_host/e2e/test_cgroup_limits.py
@@ -126,7 +126,8 @@ class TestCgroupDefaults:
         # allowed_ram_percent defaults to 100, which collapses the soft ceiling
         # onto the hard one.
         assert vals["memory.high"] == vals["memory.max"], probe.context()
-        assert vals["memory.swap.max"] == "0", probe.context()
+        # Swap is unconstrained by default, as in Slurm.
+        assert vals["memory.swap.max"] == "max", probe.context()
         assert vals["memory.oom.group"] == "1", probe.context()
         assert _core_count(vals["cpuset.cpus"]) == 2, probe.context()
         # Slurm bounds CPU with the cpuset alone; the CFS quota is opt-in.


### PR DESCRIPTION
## What this changes

Adds a `[cgroup]` section to `spur.conf` and fixes two enforcement bugs on the
native-host launch path.

Limits were sized from the job's request rather than the scheduler's allocation: a
4-task job got a cpuset and `cpu.max` sized for one task, and `--mem-per-cpu` jobs —
which never set `memory_per_node_mb` — skipped `memory.max` entirely and ran
unbounded. Limits now come from the per-node allocation. Swap can also be bounded,
which is what makes `--mem` a hard cap. Everything previously hardcoded in
`setup_cgroup` is now config-driven.

## Defaults

Defaults reproduce what `spurd` does today, so this makes existing behaviour
configurable rather than changing it: `constrain_cores`, `constrain_ram_space`, and
`oom_kill_job` on; `constrain_swap` off.

Swap follows Slurm's split. Slurm doesn't make `--mem` a hard cap by default either,
but ships a `cgroup.conf` example that enables the constraints. So `constrain_swap`
defaults off, meaning an in-place upgrade changes nothing, and `examples/spur.conf`
turns it on so new deployments get the hard cap. It's a no-op on nodes without swap.

## Upgrade impact

- **`--mem-per-cpu` jobs now get a memory ceiling** and are OOM-killed if they
  overrun, where they previously ran unbounded. This is the fix working as intended,
  but it's the one change that can kill a job that used to succeed, and no knob
  restores it selectively.
- `memory.high` is now written, so memory-heavy jobs may stall in reclaim before the
  OOM kill.
- `cpu.max` is no longer written by default — relaxes a bound, matching Slurm.

`constrain_swap_space` / `allowed_swap_space` are renamed, but only ever existed on
unreleased `main`. `docs/deployment/upgrading.rst` covers each with remediation.

## Worth a look in review

- **The cpuset is clamped to the parent's effective set, then verified.** A core id
  the parent doesn't hold fails `ERANGE` and leaves `cpuset.cpus` empty, which the
  kernel reads as "all cores" — the CPU bound would silently vanish.
- **Constraining swap alone still bounds memory**: the RAM ceiling becomes the
  RAM+swap total, matching Slurm, rather than unlimited RAM with zero swap.
- **Kept `join_cgroup_self` from `main`** rather than adding a parent-side attach.
  The child joining `cgroup.procs` pre-exec closes the fork-before-attach race on
  both launch paths; `required` verifies membership by reading `cgroup.procs`.
- **`required` fails closed but is off by default**, so a host that can't enforce
  degrades to a warning instead of stalling the queue.

## Not covered yet

Only batch and container payloads, plus whatever those jobs fork. `srun` steps,
`spur exec`, and interactive attach spawn as children of `spurd` and stay outside
the job cgroup, so these limits are not a security boundary between users on a
shared node. Tracked in #662, whose fix is to route `run_command` through the same
`setup_cgroup` — a small change now that it takes a config and resolves its budget
from the allocation.

## Testing

Unit tests cover the `constrain_ram_space` × `constrain_swap` matrix, percent
validation, budget resolution, and cpuset clamping against a sparse parent mask.
11 e2e tests in `test_cgroup_limits.py` on the bare-metal cluster, plus
`test_container.py` and `test_single_node.py` as a regression check on the fork
path. Also added a test that parses `examples/spur.conf`, which ships in release
tarballs but was never loaded by anything. Clippy clean, `cargo test --locked` green.