### PR TITLE
fix(spurctld): reject zero partition default time

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -20317,6 +20317,33 @@ mod tests {
     }
 
     #[test]
+    fn validate_default_time_limit_rejects_when_any_requested_partition_is_zero() {
+        let mut spec = basic_spec("j");
+        spec.partition = Some("gpu,cpu".into());
+        spec.time_limit = None;
+        let partitions = vec![
+            Partition {
+                name: "gpu".into(),
+                default_time_minutes: Some(30),
+                ..Default::default()
+            },
+            Partition {
+                name: "cpu".into(),
+                default_time_minutes: Some(0),
+                ..Default::default()
+            },
+        ];
+        let err = super::validate_default_time_limit(&spec, &partitions).unwrap_err();
+        assert_eq!(
+            err,
+            SubmitError::invalid(
+                "partition 'cpu' has a default time limit of zero; specify a time limit"
+            )
+        );
+        assert!(spec.time_limit.is_none());
+    }
+
+    #[test]
     fn apply_default_time_limit_falls_back_to_partition_max_time() {
         // No DefaultTime but a finite MaxTime: Slurm uses MaxTime as the default.
         let mut spec = basic_spec("j");

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -662,6 +662,7 @@ impl ClusterManager {
         // the hook may rewrite, so defaulting follows the hook and reads the scope
         // that actually governs the job. A limit the hook set is left alone.
         let wall_caps = self.wall_caps(&spec);
+        validate_default_time_limit(&spec, &partitions)?;
         apply_default_time_limit(
             &mut spec,
             &partitions,
@@ -7348,6 +7349,26 @@ impl WallCaps {
     }
 }
 
+fn validate_default_time_limit(
+    spec: &JobSpec,
+    partitions: &[Partition],
+) -> Result<(), SubmitError> {
+    if spec.time_limit.is_some() {
+        return Ok(());
+    }
+    let requested = partitions_for_defaulting(spec, partitions);
+    if let Some(partition) = requested
+        .iter()
+        .find(|part| part.default_time_minutes == Some(0))
+    {
+        return Err(SubmitError::invalid(format!(
+            "partition '{}' has a default time limit of zero; specify a time limit",
+            partition.name
+        )));
+    }
+    Ok(())
+}
+
 /// Fill in a job's wall-time when none was requested. Each requested partition
 /// resolves to `DefaultTime`, else (only when `cluster_default_minutes > 0`) its
 /// `MaxTime`, else the cluster fallback. The smallest resulting limit is chosen
@@ -9634,6 +9655,26 @@ mod tests {
         exact.num_tasks = 4;
         let outcome = cm.submit_job(exact).unwrap();
         assert!(outcome.warnings.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_rejects_zero_partition_default_time_when_time_is_unset() {
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.partitions[0].default_time = Some("0".into());
+        let cm = test_cluster_with_config(&dir, config).await;
+
+        let err = cm.submit_job(basic_spec("untimed")).unwrap_err();
+        assert_eq!(
+            err,
+            SubmitError::invalid(
+                "partition 'default' has a default time limit of zero; specify a time limit"
+            )
+        );
+
+        let mut timed = basic_spec("timed");
+        timed.time_limit = Some(chrono::Duration::minutes(5));
+        assert!(cm.submit_job(timed).is_ok());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -20252,6 +20293,26 @@ mod tests {
             ..Default::default()
         }];
         default_time_limit(&mut spec, &partitions, 0);
+        assert!(spec.time_limit.is_none());
+    }
+
+    #[test]
+    fn validate_default_time_limit_rejects_zero_partition_default() {
+        let mut spec = basic_spec("j");
+        spec.partition = Some("gpu".into());
+        spec.time_limit = None;
+        let partitions = vec![Partition {
+            name: "gpu".into(),
+            default_time_minutes: Some(0),
+            ..Default::default()
+        }];
+        let err = super::validate_default_time_limit(&spec, &partitions).unwrap_err();
+        assert_eq!(
+            err,
+            SubmitError::invalid(
+                "partition 'gpu' has a default time limit of zero; specify a time limit"
+            )
+        );
         assert!(spec.time_limit.is_none());
     }
 


### PR DESCRIPTION
## Motivation

Prevent jobs submitted without an explicit time limit from receiving a zero-length limit when their partition configures  DefaultTime=0 . This matches Slurm behavior by rejecting the submission instead of accepting a job that may be terminated immediately.

Fixes https://github.com/ROCm/spur/issues/759.

## Technical Details

• Changed partition time-limit defaulting to return a submission error when any selected partition explicitly defines  DefaultTime=0 .
• Preserved existing behavior for positive defaults, unset defaults, cluster fallbacks, multi-partition requests, and jobs with an explicit time limit.
• Added regression coverage for both the defaulting helper and the complete job submission path.

## Test Plan

• Run focused unit tests for partition time-limit defaulting.
• Run the submission-path regression test for  DefaultTime=0 .
• Verify Rust formatting.

## Test Result

•  cargo test -p spurctld apply_default_time_limit : 11 passed.
•  cargo test -p spurctld submit_rejects_zero_partition_default_time_when_time_is_unset : 1 passed.
•  cargo fmt --all -- --check : passed.

## Submission Checklist

[X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.
md#pull-requests.