### PR TITLE
feat(spurctld): add jobs_preempted event counter to scheduler stats

### DIFF
--- a/crates/spur-cli/src/sdiag.rs
+++ b/crates/spur-cli/src/sdiag.rs
@@ -151,6 +151,9 @@ fn print_job_statistics(metrics: &JobMetrics) {
     println!("  Total Jobs        : {}", metrics.total);
 
     for &state in &CoreJobState::ALL {
+        if matches!(state, CoreJobState::Preempted | CoreJobState::Requeued) {
+            continue;
+        }
         let count = job_count(metrics, state);
         println!("  {:18}: {}", state.display(), count);
     }
@@ -232,6 +235,7 @@ fn scheduler_statistics_lines(stats: &SchedStats) -> Vec<String> {
         format!("  Jobs submitted      : {}", stats.jobs_submitted),
         format!("  Jobs started        : {}", stats.jobs_started),
         format!("  Jobs finalized      : {}", stats.jobs_finalized),
+        format!("  Jobs preempted      : {}", stats.jobs_preempted),
         format!("  Jobs started (last) : {}", stats.jobs_started_last_cycle),
         format!("  Exit end of queue   : {}", stats.exit_end),
         format!("  Exit max depth      : {}", stats.exit_max_depth),
@@ -372,6 +376,7 @@ mod tests {
             jobs_submitted: 10,
             jobs_started: 8,
             jobs_finalized: 7,
+            jobs_preempted: 3,
             jobs_started_last_cycle: 2,
             exit_end: 4,
             exit_max_depth: 1,
@@ -381,6 +386,7 @@ mod tests {
         assert!(lines.iter().any(|l| l.contains("Cycles")));
         assert!(lines.iter().any(|l| l.contains("Cycle total (us)")));
         assert!(lines.iter().any(|l| l.contains("Schedule total (us)")));
+        assert!(lines.iter().any(|l| l.contains("Jobs preempted      : 3")));
         assert!(lines.iter().any(|l| l.contains("Jobs started (last) : 2")));
         assert!(lines.iter().any(|l| l.contains("Exit end of queue   : 4")));
         assert!(lines.iter().any(|l| l.contains("Exit max depth      : 1")));

--- a/crates/spur-metrics/src/export/scheduler.rs
+++ b/crates/spur-metrics/src/export/scheduler.rs
@@ -92,6 +92,12 @@ pub fn register_scheduler(registry: &mut Registry, snap: &SchedStatsSnapshot) {
     );
     register_counter(
         registry,
+        "spur_scheduler_jobs_preempted",
+        "Jobs preempted since reset",
+        snap.jobs_preempted,
+    );
+    register_counter(
+        registry,
         "spur_scheduler_exit_end",
         "Cycles that considered every pending job",
         snap.exit_end,
@@ -124,6 +130,7 @@ mod tests {
             jobs_submitted: 42,
             jobs_started: 30,
             jobs_finalized: 28,
+            jobs_preempted: 5,
             jobs_started_last_cycle: 3,
             exit_end: 8,
             exit_max_depth: 2,
@@ -151,6 +158,11 @@ mod tests {
         assert!(body.contains("spur_scheduler_jobs_started_last_cycle 3"));
         assert!(body.contains("spur_scheduler_exit_end_total 8"));
         assert!(body.contains("spur_scheduler_exit_max_depth_total 2"));
+        assert!(body.contains("spur_scheduler_jobs_preempted_total 5"));
+        assert_eq!(
+            metric_type(&body, "spur_scheduler_jobs_preempted"),
+            "counter"
+        );
         assert_eq!(metric_type(&body, "spur_scheduler_cycles"), "counter");
         assert_eq!(
             metric_type(&body, "spur_scheduler_jobs_submitted"),

--- a/crates/spur-metrics/src/scheduler.rs
+++ b/crates/spur-metrics/src/scheduler.rs
@@ -13,6 +13,7 @@ pub struct SchedStatsSnapshot {
     pub jobs_submitted: u64,
     pub jobs_started: u64,
     pub jobs_finalized: u64,
+    pub jobs_preempted: u64,
     pub jobs_started_last_cycle: u64,
     /// Cycles that considered every pending job (not depth-limited).
     pub exit_end: u64,

--- a/crates/spur-metrics/tests/fixtures/scheduler.prom
+++ b/crates/spur-metrics/tests/fixtures/scheduler.prom
@@ -28,6 +28,9 @@ spur_scheduler_jobs_started_total 30
 # HELP spur_scheduler_jobs_finalized Jobs reaching a terminal state since reset.
 # TYPE spur_scheduler_jobs_finalized counter
 spur_scheduler_jobs_finalized_total 28
+# HELP spur_scheduler_jobs_preempted Jobs preempted since reset.
+# TYPE spur_scheduler_jobs_preempted counter
+spur_scheduler_jobs_preempted_total 5
 # HELP spur_scheduler_exit_end Cycles that considered every pending job.
 # TYPE spur_scheduler_exit_end counter
 spur_scheduler_exit_end_total 8

--- a/crates/spur-metrics/tests/scheduler_export_golden.rs
+++ b/crates/spur-metrics/tests/scheduler_export_golden.rs
@@ -68,6 +68,7 @@ fn sample_snapshot() -> SchedStatsSnapshot {
         jobs_submitted: 42,
         jobs_started: 30,
         jobs_finalized: 28,
+        jobs_preempted: 5,
         jobs_started_last_cycle: 3,
         exit_end: 8,
         exit_max_depth: 2,

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1831,6 +1831,9 @@ impl ClusterManager {
     fn run_job_finalized_side_effects(&self, finalized: JobFinalized) {
         if let Some(stats) = self.sched_stats.get() {
             stats.record_finalized();
+            if finalized.state == JobState::Preempted {
+                stats.record_preempted();
+            }
         }
         self.run_epilog_slurmctld(finalized.job_id);
         self.notify_job_finished(finalized.job_id, finalized.state, finalized.exit_code);
@@ -9818,6 +9821,45 @@ mod tests {
         cm.complete_job(job_id, 0, JobState::Completed).unwrap();
         settle(&cm, job_id, JobState::Completed);
         assert_eq!(stats.snapshot().jobs_finalized, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sched_stats_track_preempted_jobs() {
+        use std::sync::Arc;
+
+        use crate::sched_stats::SchedStatsCollector;
+
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let stats = Arc::new(SchedStatsCollector::new("backfill"));
+        cm.set_sched_stats(stats.clone());
+
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job1 = run_job_on(&cm, "victim-1", "worker1");
+        cm.preempt_job(job1, PreemptMode::Requeue, 99, None)
+            .unwrap();
+        settle(&cm, job1, JobState::Pending);
+        assert_eq!(
+            stats.snapshot().jobs_preempted,
+            1,
+            "requeue preemption counted"
+        );
+
+        let job2 = run_job_on(&cm, "victim-2", "worker1");
+        cm.preempt_job(job2, PreemptMode::Cancel, 99, None).unwrap();
+        settle(&cm, job2, JobState::Cancelled);
+        assert_eq!(
+            stats.snapshot().jobs_preempted,
+            2,
+            "cancel preemption counted"
+        );
+
+        assert_eq!(
+            stats.snapshot().jobs_finalized,
+            2,
+            "both preemptions counted as finalized"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/metrics_proto.rs
+++ b/crates/spurctld/src/metrics_proto.rs
@@ -42,6 +42,7 @@ pub fn sched_stats_to_proto(snap: &SchedStatsSnapshot) -> SchedStats {
         jobs_submitted: snap.jobs_submitted,
         jobs_started: snap.jobs_started,
         jobs_finalized: snap.jobs_finalized,
+        jobs_preempted: snap.jobs_preempted,
         jobs_started_last_cycle: snap.jobs_started_last_cycle,
         exit_end: snap.exit_end,
         exit_max_depth: snap.exit_max_depth,
@@ -308,6 +309,7 @@ mod tests {
             jobs_submitted: 42,
             jobs_started: 30,
             jobs_finalized: 28,
+            jobs_preempted: 5,
             jobs_started_last_cycle: 3,
             exit_end: 8,
             exit_max_depth: 2,
@@ -330,6 +332,10 @@ mod tests {
         assert_eq!(
             proto.jobs_finalized,
             gauge_value(&body, "spur_scheduler_jobs_finalized_total")
+        );
+        assert_eq!(
+            proto.jobs_preempted,
+            gauge_value(&body, "spur_scheduler_jobs_preempted_total")
         );
         assert_eq!(
             proto.jobs_started_last_cycle,

--- a/crates/spurctld/src/sched_stats.rs
+++ b/crates/spurctld/src/sched_stats.rs
@@ -26,6 +26,7 @@ pub struct SchedStatsCollector {
     jobs_submitted: AtomicU64,
     jobs_started: AtomicU64,
     jobs_finalized: AtomicU64,
+    jobs_preempted: AtomicU64,
     exit_end: AtomicU64,
     exit_max_depth: AtomicU64,
 }
@@ -38,6 +39,7 @@ impl SchedStatsCollector {
             jobs_submitted: AtomicU64::new(0),
             jobs_started: AtomicU64::new(0),
             jobs_finalized: AtomicU64::new(0),
+            jobs_preempted: AtomicU64::new(0),
             exit_end: AtomicU64::new(0),
             exit_max_depth: AtomicU64::new(0),
         }
@@ -82,6 +84,10 @@ impl SchedStatsCollector {
         self.jobs_finalized.fetch_add(1, Ordering::Relaxed);
     }
 
+    pub fn record_preempted(&self) {
+        self.jobs_preempted.fetch_add(1, Ordering::Relaxed);
+    }
+
     pub fn snapshot(&self) -> SchedStatsSnapshot {
         let accum = self.cycle.lock();
         SchedStatsSnapshot {
@@ -94,6 +100,7 @@ impl SchedStatsCollector {
             jobs_submitted: self.jobs_submitted.load(Ordering::Relaxed),
             jobs_started: self.jobs_started.load(Ordering::Relaxed),
             jobs_finalized: self.jobs_finalized.load(Ordering::Relaxed),
+            jobs_preempted: self.jobs_preempted.load(Ordering::Relaxed),
             jobs_started_last_cycle: accum.jobs_started_last_cycle,
             exit_end: self.exit_end.load(Ordering::Relaxed),
             exit_max_depth: self.exit_max_depth.load(Ordering::Relaxed),
@@ -105,6 +112,7 @@ impl SchedStatsCollector {
         self.jobs_submitted.store(0, Ordering::Relaxed);
         self.jobs_started.store(0, Ordering::Relaxed);
         self.jobs_finalized.store(0, Ordering::Relaxed);
+        self.jobs_preempted.store(0, Ordering::Relaxed);
         self.exit_end.store(0, Ordering::Relaxed);
         self.exit_max_depth.store(0, Ordering::Relaxed);
     }
@@ -144,6 +152,32 @@ mod tests {
         assert_eq!(snap.jobs_submitted, 3);
         assert_eq!(snap.jobs_started, 2);
         assert_eq!(snap.jobs_finalized, 1);
+    }
+
+    #[test]
+    fn preempted_counter_increments_independently() {
+        let stats = SchedStatsCollector::new("backfill");
+        stats.record_finalized();
+        stats.record_finalized();
+        stats.record_preempted();
+        stats.record_finalized();
+        stats.record_preempted();
+        stats.record_preempted();
+
+        let snap = stats.snapshot();
+        assert_eq!(snap.jobs_finalized, 3);
+        assert_eq!(snap.jobs_preempted, 3);
+    }
+
+    #[test]
+    fn reset_clears_preempted_counter() {
+        let stats = SchedStatsCollector::new("backfill");
+        stats.record_preempted();
+        stats.record_preempted();
+        assert_eq!(stats.snapshot().jobs_preempted, 2);
+        stats.reset();
+        assert_eq!(stats.snapshot().jobs_preempted, 0);
+        assert_eq!(stats.snapshot().plugin, "backfill");
     }
 
     #[test]

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -707,6 +707,7 @@ message SchedStats {
   uint64 jobs_started_last_cycle = 12;
   uint64 exit_end = 13;
   uint64 exit_max_depth = 14;
+  uint64 jobs_preempted = 15;
 }
 
 message RegisterAgentRequest {

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -500,6 +500,20 @@ class SpurCluster:
     def scontrol(self, *args: str) -> str:
         return self.cli(["scontrol"] + list(args))
 
+    def sdiag(self) -> str:
+        return self.cli(["spur", "diag"])
+
+    def sdiag_jobs_preempted(self) -> int:
+        """Return the jobs_preempted counter from spur diag scheduler stats."""
+        import re
+        output = self.sdiag()
+        match = re.search(r"Jobs preempted\s+:\s+(\d+)", output)
+        if match is None:
+            raise AssertionError(
+                f"'Jobs preempted' not found in spur diag output:\n{output}"
+            )
+        return int(match.group(1))
+
     # --- Native k0s cluster (spur k8s) wrappers ---
 
     def k8s_up(self, args: list[str] | None = None) -> str:

--- a/tests/native_host/e2e/test_preemption.py
+++ b/tests/native_host/e2e/test_preemption.py
@@ -100,6 +100,12 @@ class TestChronicPreemption:
                 f"low-priority job held after {cycles} preemption cycles "
                 f"(max_batch_requeue={self.MAX_BATCH_REQUEUE}):\n{show}"
             )
+
+            preempted = cluster.sdiag_jobs_preempted()
+            assert preempted == cycles, (
+                f"sdiag jobs_preempted expected {cycles} after {cycles} preemption "
+                f"cycles, got {preempted}"
+            )
         finally:
             if low_id is not None:
                 cluster.cli_allow_fail(["scancel", str(low_id)])

--- a/tests/native_host/e2e/test_preemption_modes.py
+++ b/tests/native_host/e2e/test_preemption_modes.py
@@ -112,6 +112,10 @@ class TestCancelMode:
                 f"cancelled job must not re-enter the queue; got {recheck!r}"
             )
 
+            assert cluster.sdiag_jobs_preempted() == 1, (
+                "sdiag jobs_preempted counter must be 1 after one cancel-mode preemption"
+            )
+
             final = wait_job(cluster, aggressor_id, timeout=30)
             assert final == "CD", f"aggressor must complete successfully; got {final!r}"
         finally:
@@ -160,6 +164,10 @@ class TestRequeueMode:
                 "requeued victim must remain pending while aggressor holds the node"
             )
             _assert_scontrol_state(cluster, victim_id, "PENDING", "victim while aggressor runs")
+
+            assert cluster.sdiag_jobs_preempted() == 1, (
+                "sdiag jobs_preempted counter must be 1 after one requeue-mode preemption"
+            )
 
             final = wait_job(cluster, aggressor_id, timeout=30)
             assert final == "CD", f"aggressor must complete successfully; got {final!r}"


### PR DESCRIPTION
## Summary

- `PREEMPTED` is a transient pass-through state in Spur — jobs move through it instantly back to `Pending` or `Cancelled`, so it always shows `0` as a gauge in `spur diag`. This PR replaces it with a proper event counter.
- Removes `PREEMPTED` and `Requeued` from the Job Statistics section of `spur diag` (both are transient states that never accumulate meaningfully as gauges).
- Adds `jobs_preempted` as a monotonic counter alongside `jobs_submitted`, `jobs_started`, and `jobs_finalized` in the Scheduler Statistics section of `spur diag` and the `/metrics/scheduler` OpenMetrics endpoint.

## Approach

The counter lives in `SchedStatsCollector` as an `AtomicU64`, incremented in `run_job_finalized_side_effects` when `finalized.state == JobState::Preempted`. This catches both `PreemptMode::Requeue` (job lands in `Pending`) and `PreemptMode::Cancel` (job lands in `Cancelled`) — both transition through `Preempted` in the WAL apply. `PreemptMode::Suspend` does not set `Preempted` so it is correctly excluded.

The new field is exposed via:
- gRPC `SchedStats` proto (field 15, append-only — no wire compat break)
- `/metrics/scheduler` as `spur_scheduler_jobs_preempted_total` (counter type)
- `spur diag` Scheduler Statistics section as `Jobs preempted : N`

## Testing

- Unit tests in `sched_stats.rs`: counter increments independently from `jobs_finalized`, resets correctly.
- Integration test in `cluster.rs` (`sched_stats_track_preempted_jobs`): fires one requeue and one cancel preemption, asserts counter reaches 2.
- E2e `TestCancelMode` and `TestRequeueMode` in `test_preemption_modes.py`: each assert `sdiag_jobs_preempted() == 1` after a single preemption.
- E2e `TestChronicPreemption` in `test_preemption.py`: asserts `sdiag_jobs_preempted() == cycles` (5) after the multi-cycle loop, verifying the counter increments correctly across repeated preemptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)