### PR TITLE
fix(spurctld): address review comments on jobs_preempted counter

### DIFF
--- a/crates/spur-metrics/src/export/scheduler.rs
+++ b/crates/spur-metrics/src/export/scheduler.rs
@@ -93,7 +93,7 @@ pub fn register_scheduler(registry: &mut Registry, snap: &SchedStatsSnapshot) {
     register_counter(
         registry,
         "spur_scheduler_jobs_preempted",
-        "Jobs preempted since reset",
+        "Jobs preempted (cancel or requeue mode) since reset; suspend-mode preemptions are excluded",
         snap.jobs_preempted,
     );
     register_counter(

--- a/crates/spur-metrics/tests/fixtures/scheduler.prom
+++ b/crates/spur-metrics/tests/fixtures/scheduler.prom
@@ -28,7 +28,7 @@ spur_scheduler_jobs_started_total 30
 # HELP spur_scheduler_jobs_finalized Jobs reaching a terminal state since reset.
 # TYPE spur_scheduler_jobs_finalized counter
 spur_scheduler_jobs_finalized_total 28
-# HELP spur_scheduler_jobs_preempted Jobs preempted since reset.
+# HELP spur_scheduler_jobs_preempted Jobs preempted (cancel or requeue mode) since reset; suspend-mode preemptions are excluded.
 # TYPE spur_scheduler_jobs_preempted counter
 spur_scheduler_jobs_preempted_total 5
 # HELP spur_scheduler_exit_end Cycles that considered every pending job.

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1831,6 +1831,8 @@ impl ClusterManager {
     fn run_job_finalized_side_effects(&self, finalized: JobFinalized) {
         if let Some(stats) = self.sched_stats.get() {
             stats.record_finalized();
+            // JobPreemptCancel and JobPreemptRequeue are the only WAL
+            // operations that set state=Preempted; Suspend does not.
             if finalized.state == JobState::Preempted {
                 stats.record_preempted();
             }

--- a/crates/spurctld/src/sched_stats.rs
+++ b/crates/spurctld/src/sched_stats.rs
@@ -84,6 +84,9 @@ impl SchedStatsCollector {
         self.jobs_finalized.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Increment the preemption counter. Also call `record_finalized` for the
+    /// same job — `jobs_preempted` is a subset of `jobs_finalized`, not a
+    /// separate category.
     pub fn record_preempted(&self) {
         self.jobs_preempted.fetch_add(1, Ordering::Relaxed);
     }


### PR DESCRIPTION
## Summary

Follow-up to #765. Addresses three review comments:

- `cluster.rs`: add a comment on the `Preempted` state check explaining that only `JobPreemptCancel` and `JobPreemptRequeue` ever set `finalized.state == Preempted` — a future WAL variant transitioning through `Preempted` for another reason would need to update this guard
- `sched_stats.rs`: document that `jobs_preempted` is a subset of `jobs_finalized` (both are incremented for the same job), not a separate/exclusive category
- `export/scheduler.rs`: clarify the OpenMetrics HELP text that suspend-mode preemptions are excluded from the counter (only cancel and requeue modes finalize the job with state=Preempted)

## Test plan

- All existing unit and golden tests pass unchanged
- No behaviour change; comments and HELP text only

🤖 Generated with [Claude Code](https://claude.com/claude-code)