### PR TITLE
fix(spurctld): prevent unresponsive nodes from stalling scheduling

### DIFF
--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -198,6 +198,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn default_agent_connection_succeeds() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let accept = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let result = connect(endpoint).await;
+
+        accept.abort();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
     async fn agent_request_is_bounded() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let endpoint = format!("http://{}", listener.local_addr().unwrap());

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -28,7 +28,6 @@ use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 /// How long a controller credential is valid. Short because it is minted per connection; long
 /// enough to tolerate clock skew between the controller and a node.
 const CREDENTIAL_TTL_SECS: u64 = 300;
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Subject the agent sees for controller-issued credentials. Shared with the agent (which gates
 /// controller-only RPCs on it) via `spur_core::auth` so the two cannot drift apart.
@@ -113,13 +112,7 @@ fn credential() -> ControllerCredential {
 pub async fn connect(
     endpoint: String,
 ) -> Result<SlurmAgentClient<AgentChannel>, tonic::transport::Error> {
-    connect_with_timeout(endpoint, CONNECT_TIMEOUT).await
-}
-
-pub(crate) async fn connect_with_timeout(
-    endpoint: String,
-    timeout: Duration,
-) -> Result<SlurmAgentClient<AgentChannel>, tonic::transport::Error> {
+    let timeout = Duration::from_secs(5);
     let channel = tonic::transport::Endpoint::from_shared(endpoint)?
         .connect_timeout(timeout)
         .timeout(timeout)
@@ -198,35 +191,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn default_agent_connection_succeeds() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let endpoint = format!("http://{}", listener.local_addr().unwrap());
-        let accept = tokio::spawn(async move {
-            let (_stream, _) = listener.accept().await.unwrap();
-            std::future::pending::<()>().await;
-        });
-
-        let result = connect(endpoint).await;
-
-        accept.abort();
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
     async fn agent_request_is_bounded() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let endpoint = format!("http://{}", listener.local_addr().unwrap());
-        let accept = tokio::spawn(async move {
-            let (_stream, _) = listener.accept().await.unwrap();
-            std::future::pending::<()>().await;
-        });
+        let mut client = connect(endpoint).await.unwrap();
 
-        let mut client = connect_with_timeout(endpoint, Duration::from_millis(10))
-            .await
-            .unwrap();
         let result = client.get_node_resources(()).await;
 
-        accept.abort();
         assert_eq!(result.unwrap_err().code(), tonic::Code::Cancelled);
     }
 }

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -15,6 +15,7 @@
 //! next call without an obvious reason.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tonic::metadata::MetadataValue;
 use tonic::service::interceptor::InterceptedService;
@@ -27,6 +28,7 @@ use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 /// How long a controller credential is valid. Short because it is minted per connection; long
 /// enough to tolerate clock skew between the controller and a node.
 const CREDENTIAL_TTL_SECS: u64 = 300;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Subject the agent sees for controller-issued credentials. Shared with the agent (which gates
 /// controller-only RPCs on it) via `spur_core::auth` so the two cannot drift apart.
@@ -111,7 +113,16 @@ fn credential() -> ControllerCredential {
 pub async fn connect(
     endpoint: String,
 ) -> Result<SlurmAgentClient<AgentChannel>, tonic::transport::Error> {
+    connect_with_timeout(endpoint, CONNECT_TIMEOUT).await
+}
+
+pub(crate) async fn connect_with_timeout(
+    endpoint: String,
+    timeout: Duration,
+) -> Result<SlurmAgentClient<AgentChannel>, tonic::transport::Error> {
     let channel = tonic::transport::Endpoint::from_shared(endpoint)?
+        .connect_timeout(timeout)
+        .timeout(timeout)
         .connect()
         .await?;
     Ok(SlurmAgentClient::new(InterceptedService::new(
@@ -184,5 +195,23 @@ mod tests {
         let id2 = verify_token(&reference, TEST_KEY.as_bytes()).unwrap();
         assert_eq!(id1.user, id2.user);
         assert_eq!(id1.is_admin, id2.is_admin);
+    }
+
+    #[tokio::test]
+    async fn agent_request_is_bounded() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let accept = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let mut client = connect_with_timeout(endpoint, Duration::from_millis(10))
+            .await
+            .unwrap();
+        let result = client.get_node_resources(()).await;
+
+        accept.abort();
+        assert_eq!(result.unwrap_err().code(), tonic::Code::Cancelled);
     }
 }


### PR DESCRIPTION
## Motivation
Prevent an unresponsive node agent from indefinitely blocking the controlle scheduler loop. Without a request deadline, one node could stop all subsequent scheduling cycles and leave eligible jobs pending despite idle capacity.

Fixes #767.

## Technical Details
• Added a five-second timeout to controller-to-agent connections and requests.
• Applied the timeout centrally so launch, allocation, PMIx, cancellation, and other agent RPC callers are bounded.
• Added regression coverage for an agent that accepts a TCP connection but never serves the gRPC request.

## Test Plan
• Run the controller-to-agent timeout regression test.
• Run focused scheduler dispatch tests.
• Run the full workspace test suite and Clippy.
• Verify Rust formatting.

## Test Result
• cargo test -p spurctld agent_client::tests::agent_request_is_bounded --locked: 1 passed.
• cargo test -p spurctld scheduler_loop::tests::dispatch_trigger_tests --locked: 32 passed.
• TMPDIR="$PWD/target/test-tmp" cargo test --locked: passed.
• cargo clippy --workspace --exclude spur-ffi --all-targets --locked -- -D warnings: passed.
• cargo fmt --all -- --check: passed.

## Submission Checklist
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.