### PR TITLE
fix(spurctld): type the EXPLAIN fixture's job id as JobId

### DIFF
--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -1587,7 +1587,7 @@ mod job_history_tests {
     /// leaves the job running with a NULL end_time.
     async fn seed_job(
         conn: &mut PgConnection,
-        job_id: i32,
+        job_id: JobId,
         qos: &str,
         start_time: DateTime<Utc>,
         end: Option<DateTime<Utc>>,
@@ -1595,7 +1595,7 @@ mod job_history_tests {
         record_job_start(
             conn,
             &JobStartRecord {
-                job_id: job_id as JobId,
+                job_id,
                 name: "fixture".to_string(),
                 user: "root".to_string(),
                 account: String::new(),
@@ -2234,7 +2234,7 @@ mod job_history_tests {
         // one out-of-window, one still running (NULL end_time, the branch the
         // predicate deliberately omits), one with no QOS. ANALYZE makes it visible
         // to the planner; everything rolls back.
-        let base = 9_100_000 + (std::process::id() as i32 % 10_000) * 10;
+        let base = 9_100_000 + (std::process::id() % 10_000) * 10;
         seed_job(
             &mut tx,
             base,


### PR DESCRIPTION
main does not build. `cargo test` fails to compile `spurctld`:

```
error[E0308]: mismatched types
    --> crates/spurctld/src/accounting/db.rs:1615:34
1615 | record_job_end(conn, job_id, "COMPLETED", 0, end_time, 0, 0, None, "", "").await?;
     |                      ^^^^^^ expected `u32`, found `i32`
```

#753 changed `record_job_end` to take `JobId`; #752 added a `seed_job` fixture typed `i32`. Neither touched the others lines, so both merged clean and were green against a main that lacked the other.

Fixes the fixture rather than casting at the call site — after #753 the accounting path is `JobId` throughout, so the `i32` parameter (and its `as JobId` cast) was the odd one out. `std::process::id()` already returns `u32`, so the `base` computation just drops its cast.

Production binaries were unaffected; only the test target failed.

Verified: `cargo clippy --workspace --exclude spur-ffi --all-targets` clean, `cargo fmt --check` clean, `cargo test` passes.