### PR TITLE
fix(spurctld): keep the node record when its agent shuts down

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3113,6 +3113,44 @@ impl ClusterManager {
         })
     }
 
+    /// Mark a node Down because its agent is stopping (reboot, service restart).
+    /// Returns finalized jobs from eviction so callers can send cancel RPCs.
+    ///
+    /// An agent that stops is down, not gone: the node record — with its
+    /// `wg_pubkey` and mesh IP — is what holds the WireGuard membership
+    /// together (`cluster_k8s::mesh_from_nodes`), and removing it makes every
+    /// other node prune this node's peer, which leaves the node unable to
+    /// register again over the mesh it needs. The record therefore stays, and
+    /// `check_node_health` recovers the node when its heartbeat returns.
+    /// Removal stays an operator action (`spur node remove`, `spur k8s down`).
+    pub fn mark_node_down(
+        &self,
+        name: &str,
+        reason: Option<String>,
+    ) -> anyhow::Result<Vec<JobFinalized>> {
+        // An admin hold's reason and lock outrank the shutdown reason, so an
+        // operator's drain is not silently cleared when the agent restarts.
+        let (old_state, admin_locked, admin_reason) = {
+            let nodes = self.nodes.read();
+            let node = nodes
+                .get(name)
+                .ok_or_else(|| anyhow::anyhow!("node '{}' not found", name))?;
+            (node.state, node.admin_locked, node.state_reason.clone())
+        };
+        let resp = self.propose(WalOperation::NodeStateChange {
+            name: name.to_string(),
+            old_state,
+            new_state: NodeState::Down,
+            reason: if admin_locked { admin_reason } else { reason },
+            admin_locked,
+        })?;
+        self.k8s_metrics
+            .set_node_up(&self.config().cluster_name, name, false);
+        self.run_all_finalized_side_effects(&resp);
+        info!(node = %name, "node marked DOWN (agent shutdown), record kept");
+        Ok(resp.jobs_finalized)
+    }
+
     /// Remove a node from the cluster. If `force`, evict running jobs first.
     /// Returns finalized jobs from eviction so callers can send cancel RPCs.
     pub fn remove_node(
@@ -22502,6 +22540,33 @@ mod tests {
         cm.remove_node("n1", true, Some("bad node".into())).unwrap();
         wait_for("n1 removed", || cm.get_node("n1").is_none());
 
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::NodeFail);
+    }
+
+    /// A stopping agent must not delete its node: the record carries the
+    /// `wg_pubkey` that keeps the node in the WireGuard membership, and
+    /// without it every other node prunes the peer and the node cannot
+    /// register again after a reboot.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn agent_shutdown_marks_node_down_and_keeps_it() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+        cm.update_node_wg_pubkey("n1", "pubkey1");
+        let id = submit_and_wait(&cm, basic_spec("j"));
+        start_job_on(&cm, id, "n1");
+
+        cm.mark_node_down("n1", Some("agent shutdown".into()))
+            .unwrap();
+        wait_for("n1 down", || {
+            cm.get_node("n1")
+                .is_some_and(|n| n.state == NodeState::Down)
+        });
+
+        let node = cm.get_node("n1").expect("node must survive a shutdown");
+        assert_eq!(node.wg_pubkey.as_deref(), Some("pubkey1"));
+        assert!(!node.admin_locked, "must stay recoverable on heartbeat");
         assert_eq!(cm.get_job(id).unwrap().state, JobState::NodeFail);
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1453,11 +1453,14 @@ impl SlurmController for ControllerService {
         if self.cluster.get_node(&req.hostname).is_none() {
             return Ok(Response::new(()));
         }
+        // A stopping agent is Down, not gone. Deleting the record here would
+        // drop the node from the WireGuard membership, every other node would
+        // prune its peer, and the node could not register again over the mesh
+        // after a reboot. See `ClusterManager::mark_node_down`.
         let evicted = self
             .cluster
-            .remove_node(
+            .mark_node_down(
                 &req.hostname,
-                true,
                 Some(req.reason.clone()).filter(|r| !r.is_empty()),
             )
             .map_err(|e| Status::internal(e.to_string()))?;


### PR DESCRIPTION
## Symptom

On a cluster with the WireGuard mesh and k0s, rebooting a node takes it out of Kubernetes **and** out of the batch cluster, permanently. Nothing repairs itself, and no signal names the network:

| | |
|---|---|
| `sinfo` | 2 nodes of 3 |
| Kubernetes node | `NotReady`, still after 5 minutes |
| `spurd` on the rebooted node | restart loop, 44 restarts |
| WireGuard peers on the rebooted node | 2, correct |
| WireGuard peers on every node that stayed up | 1, the rebooted node pruned |

The error on the rebooted node points at Raft, while the fault is in the mesh:

```
Error: registration failed
Caused by: code: 'The service is currently unavailable', message: "not the Raft leader"
```

A reboot is a normal event, so a kernel update or a power cut loses a node for good.

## Cause

`spurd` deregisters on `SIGTERM` (`spurd/main.rs`), and `deregister_agent` answered with `remove_node(force = true)`, which **deletes** the node record. `mesh_from_nodes` builds the WireGuard membership from that record, so the membership loses the node, and `reconcile_mesh` then removes its peer on every node that stayed up. The rebooted node cannot register again, because the controllers are only reachable at their mesh addresses — the mesh it was just removed from. The local controller answers, is not the leader, and cannot forward to the leader over the broken mesh, which produces the message above.

The comment in `cluster_k8s.rs` says the prune exists so that node-local drift, "reboot, wg restart", can self-heal. A reboot is the case the prune makes unrecoverable.

The fault fires only when the rebooted node is **not** the Raft leader: the removal of the leader cannot commit while the leader goes down, so rebooting the leader is survivable by accident. On a cluster of N nodes, N-1 of them break the cluster when they reboot.

## Change

A stopping agent is Down, not gone. `DeregisterAgent` now marks the node Down and keeps the record, its `wg_pubkey` and its mesh IP:

- Jobs are evicted exactly as before, because the `Down` transition evicts them.
- An admin hold keeps its reason and its lock, so an operator drain is not cleared by a service restart.
- `check_node_health` recovers the node when its heartbeat returns.
- Removal stays an operator action: `spur node remove` and `spur k8s down`.

## Test

`agent_shutdown_marks_node_down_and_keeps_it` fails if the record, the `wg_pubkey` or the automatic recovery is lost. 963 unit tests pass.

Verified on a three-node cluster with k0s and the WireGuard mesh, the k0s control plane on node 2 and a worker on node 3:

| | before | after |
|---|---|---|
| `node removed from cluster` on the survivors | yes | none |
| node lifecycle | deleted | `marked DOWN`, then recovered about 30 s later |
| `sinfo` | 2 of 3 | 3 of 3 |
| WireGuard peers | 1 / 1 / 2 | 2 / 2 / 2 |
| Kubernetes node | `NotReady` | `Ready`, it never left |
| `spurd` restarts | 37 and rising | 0 |
| repair by hand | `wg syncconf` needed | none |

Two reboots in a row, plus a batch job afterwards. A reboot of all three nodes at the same time also comes back complete.

## Not in this PR

The agent still has no path to a controller that does not go through the mesh: `spur.conf` names only mesh addresses. This change removes the fault; an underlay fallback for registration would remove the whole class, and is a larger change worth its own discussion.