### PR TITLE
fix(spurctld): stop logging replayed WAL operations as new events

### DIFF
--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -65,6 +65,36 @@ struct Args {
     allow_partial_wal_recovery: bool,
 }
 
+/// Install the log subscriber, and drop INFO and below inside the WAL replay
+/// span. A restart re-applies the whole log, thus without this filter one node
+/// removal or one partition change is printed again on every start, and a
+/// reader who greps the journal chases a fault that did not happen. WARN and
+/// ERROR pass, because a bad transition during a replay is a real defect.
+fn init_tracing(log_level: &str) {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::Layer;
+
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| log_level.parse().unwrap());
+
+    let quiet_replay = tracing_subscriber::filter::DynFilterFn::new(|meta, cx| {
+        if *meta.level() > tracing::Level::WARN {
+            if let Some(span) = cx.lookup_current() {
+                if span.scope().any(|s| s.name() == raft::WAL_REPLAY_SPAN) {
+                    return false;
+                }
+            }
+        }
+        true
+    });
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_subscriber::fmt::layer().with_filter(quiet_replay))
+        .init();
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     if std::env::args_os()
@@ -77,12 +107,7 @@ async fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| args.log_level.parse().unwrap()),
-        )
-        .init();
+    init_tracing(&args.log_level);
 
     info!(version = %spur_core::version::version_string(), "spurctld starting");
 

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -113,7 +113,19 @@ struct StoreInner {
     last_applied: Option<LogId<NodeId>>,
     last_membership: StoredMembership<NodeId, BasicNode>,
     applied_count: u64,
+    /// Highest log index present on disk at startup. Everything up to it is
+    /// replayed, not new, thus its side effects must not be reported as
+    /// events that happen now. See [`WAL_REPLAY_SPAN`].
+    #[serde(skip)]
+    replay_upto: Option<u64>,
 }
+
+/// Name of the span that wraps every replayed WAL operation. `spurctld` filters
+/// INFO and below inside it, because a restart re-applies the whole log: without
+/// this, one node removal is reported once per controller process, and a reader
+/// who greps the journal chases a fault that did not happen. WARN and ERROR stay,
+/// because a bad transition during a replay is a real defect.
+pub const WAL_REPLAY_SPAN: &str = "wal_replay";
 
 #[derive(Debug, Serialize, Deserialize)]
 struct PersistedSnapshot {
@@ -254,9 +266,12 @@ impl SpurStore {
             );
         }
 
+        inner.replay_upto = inner.log.keys().next_back().copied();
+
         info!(
             log_entries = inner.log.len(),
             vote = ?inner.vote,
+            replay_upto = ?inner.replay_upto,
             "raft store recovered from disk"
         );
         if skipped_records > 0 {
@@ -485,7 +500,18 @@ impl openraft::RaftStorage<SpurTypeConfig> for Arc<SpurStore> {
                 EntryPayload::Normal(op) => {
                     debug!(index = entry.log_id.index, "raft: applying WalOperation");
                     inner.applied_count += 1;
-                    results.push(self.applier.apply_operation(op));
+                    // An entry that was already on disk when this process started is
+                    // a replay of history, not something happening now.
+                    let replaying = inner
+                        .replay_upto
+                        .is_some_and(|upto| entry.log_id.index <= upto);
+                    if replaying {
+                        let span = tracing::info_span!(WAL_REPLAY_SPAN, index = entry.log_id.index);
+                        let _enter = span.enter();
+                        results.push(self.applier.apply_operation(op));
+                    } else {
+                        results.push(self.applier.apply_operation(op));
+                    }
                 }
                 EntryPayload::Membership(mem) => {
                     inner.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
@@ -1397,6 +1423,34 @@ mod tests {
         let mut store2 = Arc::new(SpurStore::new(dir.path(), noop_applier()).unwrap());
         let state = store2.get_log_state().await.unwrap();
         assert_eq!(state.last_purged_log_id, Some(log_id));
+    }
+
+    /// Everything on disk at startup is history, thus its log events must be
+    /// marked as a replay. A fresh store replays nothing.
+    #[test]
+    fn replay_upto_is_the_highest_index_on_disk() {
+        let dir = TempDir::new().unwrap();
+        {
+            let store = SpurStore::new(dir.path(), noop_applier()).unwrap();
+            assert_eq!(store.inner.read().replay_upto, None, "fresh store");
+            for index in [3u64, 17, 9] {
+                store
+                    .persist_log_entry(&Entry {
+                        log_id: LogId {
+                            leader_id: openraft::LeaderId {
+                                term: 1,
+                                node_id: 1,
+                            },
+                            index,
+                        },
+                        payload: EntryPayload::Blank,
+                    })
+                    .unwrap();
+            }
+        }
+
+        let restarted = SpurStore::new(dir.path(), noop_applier()).unwrap();
+        assert_eq!(restarted.inner.read().replay_upto, Some(17));
     }
 
     #[test]


### PR DESCRIPTION
## Symptom

Every start of `spurctld` re-applies the whole Raft log, and each apply logged again at `INFO`. One node removal is therefore printed once per controller process, on every node, carrying the timestamp of the **restart** rather than of the event:

```
Aug 31 10:49:15 host spurctld[6618]: INFO spurctld::cluster: node removed from cluster node=worker-3 reason="agent shutdown"
Aug 31 11:39:47 host spurctld[12125]: INFO spurctld::cluster: node removed from cluster node=worker-3 reason="agent shutdown"
Aug 31 11:43:40 host spurctld[12919]: INFO spurctld::cluster: node removed from cluster node=worker-3 reason="agent shutdown"
Aug 31 12:00:02 host spurctld[1241]: INFO spurctld::cluster: node removed from cluster node=worker-3 reason="agent shutdown"
```

One removal happened. The node was in `sinfo` the whole time. A reader who greps the journal after a restart finds a removal that did not happen and looks for a fault in the wrong place. This cost real time while diagnosing an unrelated defect, because the replayed line looked like a live event.

The same applies to every other `INFO` in `apply_operation`: partitions created, reservations updated, and so on.

## Change

`SpurStore` records the highest log index that was on disk when the process started (`replay_upto`). Every entry up to it is history, and `apply_to_state_machine` applies it inside a `wal_replay` span. The subscriber drops `INFO` and below inside that span.

`WARN` and `ERROR` still pass, because an invalid transition during a replay is a real defect and must stay visible.

Only the log output changes. The state is applied exactly as before.

## Test

`replay_upto_is_the_highest_index_on_disk` fails if the boundary between history and a live event is lost. 963 unit tests pass.

Verified on a three-node cluster:

| | before | after |
|---|---|---|
| `node removed from cluster` in the journal | 4, 4 and 7 lines, one per controller start | none |
| the replay itself | unchanged | `raft store recovered from disk log_entries=48 replay_upto=Some(47)` |
| `sinfo` after the restart | 3 nodes | 3 nodes, so the state is still applied |
| a real removal, live | logged | still logged |

The last row is the one that matters: with this change alone on the cluster, an actual node removal still prints its `INFO` line. The filter hides replayed history, not events.