### PR TITLE
docs(user-guide): document JobArrayTaskLimit pending reason

### DIFF
--- a/docs/user-guide/monitoring-jobs.rst
+++ b/docs/user-guide/monitoring-jobs.rst
@@ -171,8 +171,9 @@ For a pending job the ``NODELIST(REASON)`` column shows why it is waiting.
 Common reasons include ``Priority`` (waiting its turn), ``Resources`` (waiting
 for nodes to free up), ``Dependency`` (waiting on another job), ``Reservation``
 (waiting for a reservation window), ``Preempted`` (requeue-preempted and held
-until its eligibility window reopens), and various QOS or association limit
-reasons (``QOSMax*``, ``AssocMax*``, ``AssocGrp*``).
+until its eligibility window reopens), ``JobArrayTaskLimit`` (held back by the
+array's own ``%N`` concurrency cap, see :ref:`submit-arrays`), and various QOS
+or association limit reasons (``QOSMax*``, ``AssocMax*``, ``AssocGrp*``).
 
 View Nodes & Partitions — ``sinfo``
 -----------------------------------

--- a/docs/user-guide/submitting-jobs.rst
+++ b/docs/user-guide/submitting-jobs.rst
@@ -264,6 +264,10 @@ A job array submits many near-identical tasks from one script. Use ``--array``
    sbatch --array=0-99%10 train.sh
 
 This submits 100 tasks (indices ``0``–``99``) with at most 10 running at a time.
+Tasks held back by the ``%10`` cap show ``Reason=JobArrayTaskLimit`` in
+``squeue``/``scontrol show job`` until a running task completes and frees a
+slot.
+
 Each task sees its array identity through these variables (each with a
 ``SLURM_*`` twin):
 

--- a/docs/user-guide/submitting-jobs.rst
+++ b/docs/user-guide/submitting-jobs.rst
@@ -264,9 +264,10 @@ A job array submits many near-identical tasks from one script. Use ``--array``
    sbatch --array=0-99%10 train.sh
 
 This submits 100 tasks (indices ``0``–``99``) with at most 10 running at a time.
-Tasks held back by the ``%10`` cap show ``Reason=JobArrayTaskLimit`` in
-``squeue``/``scontrol show job`` until a running task completes and frees a
-slot.
+Tasks held back by the ``%10`` cap show ``JobArrayTaskLimit`` as their pending
+reason — ``(JobArrayTaskLimit)`` in ``squeue``'s ``NODELIST(REASON)`` column,
+``Reason=JobArrayTaskLimit`` in ``scontrol show job`` — until a running task
+completes and frees a slot.
 
 Each task sees its array identity through these variables (each with a
 ``SLURM_*`` twin):


### PR DESCRIPTION
## Summary

Amends the user guide for the `JobArrayTaskLimit` pending reason added in #720 (`--array=...%N`-throttled tasks previously showed `Reason=None`; that PR gives them a Slurm-compatible reason string). Per repo convention, user-facing reason strings need to be documented, and this was flagged as an outstanding ask on #720's review.

## Changes

- `docs/user-guide/monitoring-jobs.rst`: add `JobArrayTaskLimit` to the list of common pending reasons, cross-referenced to the array docs.
- `docs/user-guide/submitting-jobs.rst`: note that tasks held back by the `%N` cap show `JobArrayTaskLimit` — `(JobArrayTaskLimit)` in `squeue`'s `NODELIST(REASON)` column, `Reason=JobArrayTaskLimit` in `scontrol show job` — until a slot frees up.

#720 has already merged to main.