### PR TITLE
fix(spurctld): keep one unresponsive node from stalling all scheduling

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -347,6 +347,20 @@ pub struct ControllerConfig {
     #[serde(default = "default_dispatch_timeout_secs")]
     pub dispatch_timeout_secs: u64,
 
+    /// Budget for establishing a controller-to-agent connection (default 5, 0 falls back to the
+    /// OS TCP timeout).
+    #[serde(default = "default_agent_connect_timeout_secs")]
+    pub agent_connect_timeout_secs: u64,
+
+    /// HTTP/2 ping interval on an open agent connection (default 10, 0 disables keepalive).
+    /// Detection of a silent peer takes roughly this plus `agent_keepalive_timeout_secs`.
+    #[serde(default = "default_agent_keepalive_interval_secs")]
+    pub agent_keepalive_interval_secs: u64,
+
+    /// How long to wait for a ping response before dropping the connection (default 10).
+    #[serde(default = "default_agent_keepalive_timeout_secs")]
+    pub agent_keepalive_timeout_secs: u64,
+
     /// How much of another user's job a non-owner may see via `get_job` /
     /// `get_job_steps`. See [`JobInfoVisibility`]. Owners and admins always see
     /// the full record; this governs everyone else. Default: `redacted`.
@@ -392,6 +406,26 @@ fn default_dispatch_reject_cooldown_secs() -> u64 {
 
 fn default_dispatch_timeout_secs() -> u64 {
     300
+}
+
+/// Shared with `spurctld`'s agent channel builder, which needs these before any config is loaded.
+/// A dial budget or ping interval beyond this is indistinguishable from disabling it.
+pub const MAX_AGENT_CHANNEL_TIMEOUT_SECS: u64 = 600;
+
+pub const DEFAULT_AGENT_CONNECT_TIMEOUT_SECS: u64 = 5;
+pub const DEFAULT_AGENT_KEEPALIVE_INTERVAL_SECS: u64 = 10;
+pub const DEFAULT_AGENT_KEEPALIVE_TIMEOUT_SECS: u64 = 10;
+
+fn default_agent_connect_timeout_secs() -> u64 {
+    DEFAULT_AGENT_CONNECT_TIMEOUT_SECS
+}
+
+fn default_agent_keepalive_interval_secs() -> u64 {
+    DEFAULT_AGENT_KEEPALIVE_INTERVAL_SECS
+}
+
+fn default_agent_keepalive_timeout_secs() -> u64 {
+    DEFAULT_AGENT_KEEPALIVE_TIMEOUT_SECS
 }
 
 fn default_hold_on_prolog_fail() -> bool {
@@ -455,6 +489,9 @@ impl Default for ControllerConfig {
             terminal_job_retention_secs: default_terminal_job_retention_secs(),
             dispatch_reject_cooldown_secs: default_dispatch_reject_cooldown_secs(),
             dispatch_timeout_secs: default_dispatch_timeout_secs(),
+            agent_connect_timeout_secs: default_agent_connect_timeout_secs(),
+            agent_keepalive_interval_secs: default_agent_keepalive_interval_secs(),
+            agent_keepalive_timeout_secs: default_agent_keepalive_timeout_secs(),
             job_info_visibility: JobInfoVisibility::default(),
         }
     }
@@ -1514,6 +1551,29 @@ impl SlurmConfig {
                     self.controller.dispatch_reject_cooldown_secs, MAX_LAUNCH_BACKOFF_SECS
                 ),
             });
+        }
+        // Keepalive detection is interval + timeout, so an hour-long interval silently disables
+        // the liveness this exists to provide.
+        for (field, value) in [
+            (
+                "controller.agent_connect_timeout_secs",
+                self.controller.agent_connect_timeout_secs,
+            ),
+            (
+                "controller.agent_keepalive_interval_secs",
+                self.controller.agent_keepalive_interval_secs,
+            ),
+            (
+                "controller.agent_keepalive_timeout_secs",
+                self.controller.agent_keepalive_timeout_secs,
+            ),
+        ] {
+            if value > MAX_AGENT_CHANNEL_TIMEOUT_SECS {
+                return Err(ConfigError::InvalidValue {
+                    field: field.into(),
+                    value: format!("{value} (must be at most {MAX_AGENT_CHANNEL_TIMEOUT_SECS})"),
+                });
+            }
         }
         // A timed-out node is cooled down for this span, so it feeds the same map and needs the
         // same ceiling.

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1575,6 +1575,17 @@ impl SlurmConfig {
                 });
             }
         }
+        // Zero is "already overdue" to hyper, so it would tear down every channel that goes quiet
+        // — the opposite of the liveness keepalive exists to provide.
+        if self.controller.agent_keepalive_interval_secs > 0
+            && self.controller.agent_keepalive_timeout_secs == 0
+        {
+            return Err(ConfigError::InvalidValue {
+                field: "controller.agent_keepalive_timeout_secs".into(),
+                value: "0 (must be greater than 0 unless agent_keepalive_interval_secs is 0)"
+                    .into(),
+            });
+        }
         // A timed-out node is cooled down for this span, so it feeds the same map and needs the
         // same ceiling.
         if self.controller.dispatch_timeout_secs > MAX_LAUNCH_BACKOFF_SECS {
@@ -2980,6 +2991,51 @@ terminal_job_retention_secs = {MAX_TERMINAL_JOB_RETENTION_SECS}
             MAX_TERMINAL_JOB_RETENTION_SECS,
             "the bound itself must be accepted"
         );
+    }
+
+    #[test]
+    fn controller_config_rejects_out_of_range_agent_channel_timeouts() {
+        for field in [
+            "agent_connect_timeout_secs",
+            "agent_keepalive_interval_secs",
+            "agent_keepalive_timeout_secs",
+        ] {
+            let toml = format!(
+                "cluster_name = \"test\"\n\n[controller]\n{field} = {}\n",
+                MAX_AGENT_CHANNEL_TIMEOUT_SECS + 1
+            );
+            let err = SlurmConfig::load_from_str(&toml).unwrap_err();
+            assert!(
+                err.to_string().contains(field),
+                "{field} past the ceiling must be rejected, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn controller_config_rejects_a_zero_keepalive_timeout_while_keepalive_is_on() {
+        let toml = r#"
+cluster_name = "test"
+
+[controller]
+agent_keepalive_interval_secs = 10
+agent_keepalive_timeout_secs = 0
+"#;
+        let err = SlurmConfig::load_from_str(toml).unwrap_err();
+        assert!(
+            err.to_string().contains("agent_keepalive_timeout_secs"),
+            "a zero ping timeout marks every ping overdue; it must be rejected: {err}"
+        );
+
+        // Harmless once keepalive itself is off.
+        let ok = r#"
+cluster_name = "test"
+
+[controller]
+agent_keepalive_interval_secs = 0
+agent_keepalive_timeout_secs = 0
+"#;
+        assert!(SlurmConfig::load_from_str(ok).is_ok());
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -342,6 +342,12 @@ pub struct ControllerConfig {
     #[serde(default = "default_dispatch_reject_cooldown_secs")]
     pub dispatch_reject_cooldown_secs: u64,
 
+    /// Ceiling on a single launch RPC, which runs the node prolog and any image unpack before it
+    /// answers (default 300, 0 disables). Generous by design: a silent peer is caught by channel
+    /// keepalive, not by this.
+    #[serde(default = "default_dispatch_timeout_secs")]
+    pub dispatch_timeout_secs: u64,
+
     /// How much of another user's job a non-owner may see via `get_job` /
     /// `get_job_steps`. See [`JobInfoVisibility`]. Owners and admins always see
     /// the full record; this governs everyone else. Default: `redacted`.
@@ -383,6 +389,10 @@ fn default_terminal_job_retention_secs() -> u64 {
 
 fn default_dispatch_reject_cooldown_secs() -> u64 {
     30
+}
+
+fn default_dispatch_timeout_secs() -> u64 {
+    300
 }
 
 fn default_hold_on_prolog_fail() -> bool {
@@ -445,6 +455,7 @@ impl Default for ControllerConfig {
             hold_on_prolog_fail: default_hold_on_prolog_fail(),
             terminal_job_retention_secs: default_terminal_job_retention_secs(),
             dispatch_reject_cooldown_secs: default_dispatch_reject_cooldown_secs(),
+            dispatch_timeout_secs: default_dispatch_timeout_secs(),
             job_info_visibility: JobInfoVisibility::default(),
         }
     }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -342,9 +342,8 @@ pub struct ControllerConfig {
     #[serde(default = "default_dispatch_reject_cooldown_secs")]
     pub dispatch_reject_cooldown_secs: u64,
 
-    /// Ceiling on a single launch RPC, which runs the node prolog and any image unpack before it
-    /// answers (default 300, 0 disables). Generous by design: a silent peer is caught by channel
-    /// keepalive, not by this.
+    /// Ceiling on a single launch or allocation-register RPC to an agent (default 300, 0 disables).
+    /// Must exceed the slowest node prolog, which runs inside the launch call.
     #[serde(default = "default_dispatch_timeout_secs")]
     pub dispatch_timeout_secs: u64,
 
@@ -1513,6 +1512,17 @@ impl SlurmConfig {
                 value: format!(
                     "{} (must be at most {})",
                     self.controller.dispatch_reject_cooldown_secs, MAX_LAUNCH_BACKOFF_SECS
+                ),
+            });
+        }
+        // A timed-out node is cooled down for this span, so it feeds the same map and needs the
+        // same ceiling.
+        if self.controller.dispatch_timeout_secs > MAX_LAUNCH_BACKOFF_SECS {
+            return Err(ConfigError::InvalidValue {
+                field: "controller.dispatch_timeout_secs".into(),
+                value: format!(
+                    "{} (must be at most {})",
+                    self.controller.dispatch_timeout_secs, MAX_LAUNCH_BACKOFF_SECS
                 ),
             });
         }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -337,8 +337,8 @@ pub struct ControllerConfig {
     #[serde(default = "default_terminal_job_retention_secs")]
     pub terminal_job_retention_secs: u64,
 
-    /// Seconds a node is skipped for new dispatch after rejecting one as
-    /// resources-unavailable, so it isn't re-picked every tick (default 30, 0 disables).
+    /// Seconds a node is skipped for new dispatch after rejecting a launch or failing to
+    /// be reached, so it isn't re-picked every tick (default 30, 0 disables).
     #[serde(default = "default_dispatch_reject_cooldown_secs")]
     pub dispatch_reject_cooldown_secs: u64,
 

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -29,6 +29,15 @@ use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 /// enough to tolerate clock skew between the controller and a node.
 const CREDENTIAL_TTL_SECS: u64 = 300;
 
+/// Dial budget only. A request budget belongs at the call site, where the operation's real duration
+/// is known — a launch runs the node prolog, a k0s start downloads a binary.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Liveness for an established channel: a peer that accepts TCP then stops answering is torn down
+/// after roughly the interval plus the timeout, without capping a legitimately slow RPC.
+const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
+const KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Subject the agent sees for controller-issued credentials. Shared with the agent (which gates
 /// controller-only RPCs on it) via `spur_core::auth` so the two cannot drift apart.
 use spur_core::auth::CONTROLLER_SUBJECT;
@@ -112,10 +121,11 @@ fn credential() -> ControllerCredential {
 pub async fn connect(
     endpoint: String,
 ) -> Result<SlurmAgentClient<AgentChannel>, tonic::transport::Error> {
-    let timeout = Duration::from_secs(5);
     let channel = tonic::transport::Endpoint::from_shared(endpoint)?
-        .connect_timeout(timeout)
-        .timeout(timeout)
+        .connect_timeout(CONNECT_TIMEOUT)
+        .http2_keep_alive_interval(KEEP_ALIVE_INTERVAL)
+        .keep_alive_timeout(KEEP_ALIVE_TIMEOUT)
+        .keep_alive_while_idle(true)
         .connect()
         .await?;
     Ok(SlurmAgentClient::new(InterceptedService::new(
@@ -190,14 +200,11 @@ mod tests {
         assert_eq!(id1.is_admin, id2.is_admin);
     }
 
-    #[tokio::test]
-    async fn agent_request_is_bounded() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let endpoint = format!("http://{}", listener.local_addr().unwrap());
-        let mut client = connect(endpoint).await.unwrap();
-
-        let result = client.get_node_resources(()).await;
-
-        assert_eq!(result.unwrap_err().code(), tonic::Code::Cancelled);
+    /// A dial budget is the only deadline this layer may impose: a request budget here would cap
+    /// launch, which legitimately runs the node prolog.
+    #[test]
+    fn connect_budget_is_a_dial_budget_only() {
+        assert_eq!(CONNECT_TIMEOUT, Duration::from_secs(5));
+        assert!(KEEP_ALIVE_INTERVAL + KEEP_ALIVE_TIMEOUT < Duration::from_secs(60));
     }
 }

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -33,8 +33,8 @@ const CREDENTIAL_TTL_SECS: u64 = 300;
 /// is known — a launch runs the node prolog, a k0s start downloads a binary.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Liveness for an established channel: a peer that accepts TCP then stops answering is torn down
-/// after roughly the interval plus the timeout, without capping a legitimately slow RPC.
+/// Liveness for an established channel. Catches a dead peer or a lost connection; an agent whose
+/// handler is wedged still answers pings, so only a call-site deadline bounds that.
 const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
 const KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -125,7 +125,6 @@ pub async fn connect(
         .connect_timeout(CONNECT_TIMEOUT)
         .http2_keep_alive_interval(KEEP_ALIVE_INTERVAL)
         .keep_alive_timeout(KEEP_ALIVE_TIMEOUT)
-        .keep_alive_while_idle(true)
         .connect()
         .await?;
     Ok(SlurmAgentClient::new(InterceptedService::new(
@@ -198,13 +197,5 @@ mod tests {
         let id2 = verify_token(&reference, TEST_KEY.as_bytes()).unwrap();
         assert_eq!(id1.user, id2.user);
         assert_eq!(id1.is_admin, id2.is_admin);
-    }
-
-    /// A dial budget is the only deadline this layer may impose: a request budget here would cap
-    /// launch, which legitimately runs the node prolog.
-    #[test]
-    fn connect_budget_is_a_dial_budget_only() {
-        assert_eq!(CONNECT_TIMEOUT, Duration::from_secs(5));
-        assert!(KEEP_ALIVE_INTERVAL + KEEP_ALIVE_TIMEOUT < Duration::from_secs(60));
     }
 }

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -198,6 +198,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn default_agent_connection_succeeds() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let accept = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let result = connect(endpoint).await;
+
+        accept.abort();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
     async fn agent_request_is_bounded() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let endpoint = format!("http://{}", listener.local_addr().unwrap());

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -28,7 +28,6 @@ use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 /// How long a controller credential is valid. Short because it is minted per connection; long
 /// enough to tolerate clock skew between the controller and a node.
 const CREDENTIAL_TTL_SECS: u64 = 300;
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Subject the agent sees for controller-issued credentials. Shared with the agent (which gates
 /// controller-only RPCs on it) via `spur_core::auth` so the two cannot drift apart.
@@ -113,13 +112,7 @@ fn credential() -> ControllerCredential {
 pub async fn connect(
     endpoint: String,
 ) -> Result<SlurmAgentClient<AgentChannel>, tonic::transport::Error> {
-    connect_with_timeout(endpoint, CONNECT_TIMEOUT).await
-}
-
-pub(crate) async fn connect_with_timeout(
-    endpoint: String,
-    timeout: Duration,
-) -> Result<SlurmAgentClient<AgentChannel>, tonic::transport::Error> {
+    let timeout = Duration::from_secs(5);
     let channel = tonic::transport::Endpoint::from_shared(endpoint)?
         .connect_timeout(timeout)
         .timeout(timeout)
@@ -198,35 +191,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn default_agent_connection_succeeds() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let endpoint = format!("http://{}", listener.local_addr().unwrap());
-        let accept = tokio::spawn(async move {
-            let (_stream, _) = listener.accept().await.unwrap();
-            std::future::pending::<()>().await;
-        });
-
-        let result = connect(endpoint).await;
-
-        accept.abort();
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
     async fn agent_request_is_bounded() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let endpoint = format!("http://{}", listener.local_addr().unwrap());
-        let accept = tokio::spawn(async move {
-            let (_stream, _) = listener.accept().await.unwrap();
-            std::future::pending::<()>().await;
-        });
+        let mut client = connect(endpoint).await.unwrap();
 
-        let mut client = connect_with_timeout(endpoint, Duration::from_millis(10))
-            .await
-            .unwrap();
         let result = client.get_node_resources(()).await;
 
-        accept.abort();
         assert_eq!(result.unwrap_err().code(), tonic::Code::Cancelled);
     }
 }

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -202,6 +202,9 @@ mod tests {
             },
             "a later call must replace the previous tuning, not be ignored"
         );
+
+        // Leaving 11/22/33 in the process-wide global would leak into every later connect().
+        set_channel_tuning(&defaults);
     }
 
     #[test]

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -155,9 +155,14 @@ pub async fn connect(
     }
     // Zero interval leaves keepalive off entirely; the timeout alone would have nothing to time.
     if tuning.keepalive_interval_secs > 0 {
-        builder = builder
-            .http2_keep_alive_interval(Duration::from_secs(tuning.keepalive_interval_secs))
-            .keep_alive_timeout(Duration::from_secs(tuning.keepalive_timeout_secs));
+        builder =
+            builder.http2_keep_alive_interval(Duration::from_secs(tuning.keepalive_interval_secs));
+        // A zero ping timeout is already overdue the moment it is set, which would kill every
+        // channel that goes quiet. Validation rejects it; skip it here so a stale value cannot.
+        if tuning.keepalive_timeout_secs > 0 {
+            builder =
+                builder.keep_alive_timeout(Duration::from_secs(tuning.keepalive_timeout_secs));
+        }
     }
     let channel = builder.connect().await?;
     Ok(SlurmAgentClient::new(InterceptedService::new(

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -29,14 +29,41 @@ use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 /// enough to tolerate clock skew between the controller and a node.
 const CREDENTIAL_TTL_SECS: u64 = 300;
 
-/// Dial budget only. A request budget belongs at the call site, where the operation's real duration
-/// is known — a launch runs the node prolog, a k0s start downloads a binary.
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// Channel tunables. A dial budget and liveness pings only — a request budget belongs at the call
+/// site, where the operation's real duration is known.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AgentChannelTuning {
+    pub connect_secs: u64,
+    pub keepalive_interval_secs: u64,
+    pub keepalive_timeout_secs: u64,
+}
 
-/// Liveness for an established channel. Catches a dead peer or a lost connection; an agent whose
-/// handler is wedged still answers pings, so only a call-site deadline bounds that.
-const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
-const KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(10);
+impl Default for AgentChannelTuning {
+    fn default() -> Self {
+        Self {
+            connect_secs: spur_core::config::DEFAULT_AGENT_CONNECT_TIMEOUT_SECS,
+            keepalive_interval_secs: spur_core::config::DEFAULT_AGENT_KEEPALIVE_INTERVAL_SECS,
+            keepalive_timeout_secs: spur_core::config::DEFAULT_AGENT_KEEPALIVE_TIMEOUT_SECS,
+        }
+    }
+}
+
+/// Swapped by `reconfigure`. Read per `connect()`, which builds a fresh channel every call, so a
+/// change applies to the next RPC with nothing to invalidate.
+static TUNING: parking_lot::RwLock<Option<AgentChannelTuning>> = parking_lot::RwLock::new(None);
+
+/// Install channel tunables from config. Called at startup and on every reconfigure.
+pub fn set_channel_tuning(controller: &spur_core::config::ControllerConfig) {
+    *TUNING.write() = Some(AgentChannelTuning {
+        connect_secs: controller.agent_connect_timeout_secs,
+        keepalive_interval_secs: controller.agent_keepalive_interval_secs,
+        keepalive_timeout_secs: controller.agent_keepalive_timeout_secs,
+    });
+}
+
+fn tuning() -> AgentChannelTuning {
+    TUNING.read().unwrap_or_default()
+}
 
 /// Subject the agent sees for controller-issued credentials. Shared with the agent (which gates
 /// controller-only RPCs on it) via `spur_core::auth` so the two cannot drift apart.
@@ -121,12 +148,18 @@ fn credential() -> ControllerCredential {
 pub async fn connect(
     endpoint: String,
 ) -> Result<SlurmAgentClient<AgentChannel>, tonic::transport::Error> {
-    let channel = tonic::transport::Endpoint::from_shared(endpoint)?
-        .connect_timeout(CONNECT_TIMEOUT)
-        .http2_keep_alive_interval(KEEP_ALIVE_INTERVAL)
-        .keep_alive_timeout(KEEP_ALIVE_TIMEOUT)
-        .connect()
-        .await?;
+    let tuning = tuning();
+    let mut builder = tonic::transport::Endpoint::from_shared(endpoint)?;
+    if tuning.connect_secs > 0 {
+        builder = builder.connect_timeout(Duration::from_secs(tuning.connect_secs));
+    }
+    // Zero interval leaves keepalive off entirely; the timeout alone would have nothing to time.
+    if tuning.keepalive_interval_secs > 0 {
+        builder = builder
+            .http2_keep_alive_interval(Duration::from_secs(tuning.keepalive_interval_secs))
+            .keep_alive_timeout(Duration::from_secs(tuning.keepalive_timeout_secs));
+    }
+    let channel = builder.connect().await?;
     Ok(SlurmAgentClient::new(InterceptedService::new(
         channel,
         credential(),
@@ -139,6 +172,32 @@ mod tests {
     use spur_core::auth::{generate_token, verify_token};
 
     const TEST_KEY: &str = "test-cluster-key";
+
+    /// One test, not two: the tuning global is process-wide, so parallel tests racing on it
+    /// would be flaky.
+    #[test]
+    fn channel_tuning_follows_config_and_is_swapped_on_reload() {
+        let defaults = spur_core::config::ControllerConfig::default();
+        set_channel_tuning(&defaults);
+        assert_eq!(tuning(), AgentChannelTuning::default());
+
+        let reloaded = spur_core::config::ControllerConfig {
+            agent_connect_timeout_secs: 11,
+            agent_keepalive_interval_secs: 22,
+            agent_keepalive_timeout_secs: 33,
+            ..Default::default()
+        };
+        set_channel_tuning(&reloaded);
+        assert_eq!(
+            tuning(),
+            AgentChannelTuning {
+                connect_secs: 11,
+                keepalive_interval_secs: 22,
+                keepalive_timeout_secs: 33,
+            },
+            "a later call must replace the previous tuning, not be ignored"
+        );
+    }
 
     #[test]
     fn empty_key_produces_no_credential() {

--- a/crates/spurctld/src/agent_client.rs
+++ b/crates/spurctld/src/agent_client.rs
@@ -15,6 +15,7 @@
 //! next call without an obvious reason.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tonic::metadata::MetadataValue;
 use tonic::service::interceptor::InterceptedService;
@@ -27,6 +28,7 @@ use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 /// How long a controller credential is valid. Short because it is minted per connection; long
 /// enough to tolerate clock skew between the controller and a node.
 const CREDENTIAL_TTL_SECS: u64 = 300;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Subject the agent sees for controller-issued credentials. Shared with the agent (which gates
 /// controller-only RPCs on it) via `spur_core::auth` so the two cannot drift apart.
@@ -111,7 +113,16 @@ fn credential() -> ControllerCredential {
 pub async fn connect(
     endpoint: String,
 ) -> Result<SlurmAgentClient<AgentChannel>, tonic::transport::Error> {
+    connect_with_timeout(endpoint, CONNECT_TIMEOUT).await
+}
+
+pub(crate) async fn connect_with_timeout(
+    endpoint: String,
+    timeout: Duration,
+) -> Result<SlurmAgentClient<AgentChannel>, tonic::transport::Error> {
     let channel = tonic::transport::Endpoint::from_shared(endpoint)?
+        .connect_timeout(timeout)
+        .timeout(timeout)
         .connect()
         .await?;
     Ok(SlurmAgentClient::new(InterceptedService::new(
@@ -184,5 +195,23 @@ mod tests {
         let id2 = verify_token(&reference, TEST_KEY.as_bytes()).unwrap();
         assert_eq!(id1.user, id2.user);
         assert_eq!(id1.is_admin, id2.is_admin);
+    }
+
+    #[tokio::test]
+    async fn agent_request_is_bounded() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let accept = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let mut client = connect_with_timeout(endpoint, Duration::from_millis(10))
+            .await
+            .unwrap();
+        let result = client.get_node_resources(()).await;
+
+        accept.abort();
+        assert_eq!(result.unwrap_err().code(), tonic::Code::Cancelled);
     }
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3989,6 +3989,9 @@ impl ClusterManager {
         // so a mid-reconfigure failure leaves the previous config in place.
         // Readers pick up the new sections on their next `config()` snapshot.
         *self.config.write() = Arc::new(new_config);
+        // Agent channels are built per call, so new tunables apply to the next RPC. Unlike the
+        // jwt key, these carry no security posture, so adopting them live is safe.
+        crate::agent_client::set_channel_tuning(&self.config.read().controller);
 
         // Re-derive per-node `[[nodes]]` policy (features/weight) and partition
         // membership against the freshly-swapped config. This is a local derived

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -556,7 +556,16 @@ impl ClusterManager {
         if secs == 0 {
             return;
         }
-        let until = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+        self.cool_down_node_for(name, std::time::Duration::from_secs(secs));
+    }
+
+    /// Cool down for an explicit span. A node that burned a whole dispatch deadline must not be
+    /// re-picked after the much shorter reject cooldown, or it spends most of every cycle stalling.
+    pub fn cool_down_node_for(&self, name: &str, span: std::time::Duration) {
+        if span.is_zero() {
+            return;
+        }
+        let until = std::time::Instant::now() + span;
         self.node_dispatch_cooldowns
             .write()
             .insert(name.to_string(), until);

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -571,6 +571,17 @@ impl ClusterManager {
             .insert(name.to_string(), until);
     }
 
+    /// How long a node's dispatch cooldown still has to run, for tests that need to tell the
+    /// reject cooldown apart from the longer dispatch-deadline one.
+    #[cfg(test)]
+    pub fn dispatch_cooldown_remaining(&self, name: &str) -> Option<std::time::Duration> {
+        let now = std::time::Instant::now();
+        self.node_dispatch_cooldowns
+            .read()
+            .get(name)
+            .map(|&until| until.saturating_duration_since(now))
+    }
+
     /// Names still within their dispatch cooldown, pruning any that have expired.
     pub fn nodes_on_dispatch_cooldown(&self) -> HashSet<String> {
         let now = std::time::Instant::now();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -549,8 +549,8 @@ impl ClusterManager {
         self.config.read().clone()
     }
 
-    /// Skip a node for new dispatch for the configured cooldown after it rejected
-    /// one as resources-unavailable, so the scheduler stops re-picking it each tick.
+    /// Skip a node for new dispatch for the configured cooldown after it rejected a
+    /// launch or could not be reached, so the scheduler stops re-picking it each tick.
     pub fn cool_down_node(&self, name: &str) {
         let secs = self.config().controller.dispatch_reject_cooldown_secs;
         if secs == 0 {

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -1177,7 +1177,7 @@ async fn stop_component_now(
     let endpoint = agent_endpoint(cluster, node)
         .ok_or_else(|| anyhow::anyhow!("{node} has no agent address"))?;
     let fut = async {
-        let mut client = SlurmAgentClient::connect(endpoint)
+        let mut client = crate::agent_client::connect(endpoint)
             .await
             .map_err(|e| anyhow::anyhow!("connect to agent {node} failed: {e}"))?;
         client

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -378,6 +378,7 @@ async fn main() -> anyhow::Result<()> {
     let addr: std::net::SocketAddr = listen_addr.parse()?;
     // The controller presents this key as its credential to agents (spurd authenticates callers).
     crate::agent_client::set_signing_key(config.auth.jwt_key.clone().unwrap_or_default());
+    crate::agent_client::set_channel_tuning(&config.controller);
 
     // State the authentication posture explicitly at startup: it determines whether the listening
     // port is the trust boundary or merely the transport.

--- a/crates/spurctld/src/pmix_dispatch.rs
+++ b/crates/spurctld/src/pmix_dispatch.rs
@@ -3,6 +3,8 @@
 
 //! Shared multi-node PMIx prepare / release helpers for batch launch and srun steps.
 
+use std::time::Duration;
+
 use tracing::{error, warn};
 
 use spur_core::node::NodeSource;
@@ -10,6 +12,10 @@ use spur_proto::proto::{PreparePmixRequest, ReleasePmixRequest};
 
 pub const MULTI_NODE_PMIX_K8S_UNSUPPORTED: &str =
     "multi-node PMIx is not supported on K8s virtual agents";
+
+/// Rollback is best-effort, so it gets its own short bound rather than the caller's
+/// dispatch deadline — an agent wedged in `server_stop` must not hold the loop.
+const RELEASE_RPC_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Reject multi-node PMIx at submit when the user pins a K8s virtual agent.
 pub fn validate_multi_node_pmix_nodelist(
@@ -56,6 +62,24 @@ pub async fn prepare_pmix_on_agent(
     job_id: u32,
     run_attempt: u32,
     pmix_plan: spur_proto::proto::PmixLaunchPlan,
+    deadline: Option<Duration>,
+) -> Result<(), String> {
+    // The agent runs PMIx `server_start` inline in this handler, so it keeps answering
+    // HTTP/2 pings while wedged — only a call-site deadline bounds it.
+    let prepare = prepare_pmix_on_agent_inner(agent_addr, job_id, run_attempt, pmix_plan);
+    match deadline {
+        Some(limit) => tokio::time::timeout(limit, prepare)
+            .await
+            .unwrap_or_else(|_| Err(format!("PreparePmix RPC exceeded {}s", limit.as_secs()))),
+        None => prepare.await,
+    }
+}
+
+async fn prepare_pmix_on_agent_inner(
+    agent_addr: &str,
+    job_id: u32,
+    run_attempt: u32,
+    pmix_plan: spur_proto::proto::PmixLaunchPlan,
 ) -> Result<(), String> {
     let mut client = crate::agent_client::connect(agent_addr.to_string())
         .await
@@ -89,10 +113,15 @@ pub async fn release_pmix_on_agent(agent_addr: &str, job_id: u32) {
             .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
         client.release_pmix(ReleasePmixRequest { job_id }).await?;
         Ok::<(), tonic::Status>(())
-    }
-    .await;
-    if let Err(e) = result {
-        warn!(job_id, agent = %agent_addr, error = %e, "ReleasePmix rollback failed");
+    };
+    match tokio::time::timeout(RELEASE_RPC_TIMEOUT, result).await {
+        Ok(Err(e)) => {
+            warn!(job_id, agent = %agent_addr, error = %e, "ReleasePmix rollback failed")
+        }
+        Err(_) => {
+            warn!(job_id, agent = %agent_addr, "ReleasePmix rollback timed out")
+        }
+        Ok(Ok(())) => {}
     }
 }
 
@@ -112,6 +141,7 @@ pub async fn prepare_pmix_on_nodes(
     job_id: u32,
     run_attempt: u32,
     nodes: Vec<PmixPrepareNode>,
+    deadline: Option<Duration>,
 ) -> Result<(), String> {
     if nodes.is_empty() {
         return Ok(());
@@ -125,7 +155,7 @@ pub async fn prepare_pmix_on_nodes(
         let node_name = node.node_name.clone();
         let pmix_plan = node.pmix_plan;
         prepare_set.spawn(async move {
-            prepare_pmix_on_agent(&agent_addr, job_id, run_attempt, pmix_plan)
+            prepare_pmix_on_agent(&agent_addr, job_id, run_attempt, pmix_plan, deadline)
                 .await
                 .map(|()| agent_addr)
                 .map_err(|e| format!("{node_name}: {e}"))
@@ -190,6 +220,55 @@ impl Drop for PmixPreparedReleaseGuard {
 mod tests {
     use super::*;
     use spur_core::node::NodeSource;
+
+    /// A listener that completes the TCP handshake and then never serves HTTP/2. Keepalive alone
+    /// needs ~20s to give up on it, so an elapsed bound below that pins the deadline as the cause.
+    async fn silent_agent() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut accepted = Vec::new();
+            while let Ok((sock, _)) = listener.accept().await {
+                accepted.push(sock);
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn prepare_pmix_gives_up_on_a_silent_agent_once_the_deadline_passes() {
+        let agent = silent_agent().await;
+        let started = std::time::Instant::now();
+
+        let err = prepare_pmix_on_agent(
+            &agent,
+            1,
+            0,
+            spur_proto::proto::PmixLaunchPlan::default(),
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .expect_err("a silent agent must not report a successful prepare");
+
+        assert!(err.contains("exceeded"), "unexpected error: {err}");
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "the prepare fan-out held the assignment loop well past its deadline"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn release_pmix_gives_up_on_a_silent_agent() {
+        let agent = silent_agent().await;
+        let started = std::time::Instant::now();
+
+        release_pmix_on_agent(&agent, 1).await;
+
+        assert!(
+            started.elapsed() < RELEASE_RPC_TIMEOUT * 3,
+            "a best-effort rollback must never be what blocks the caller"
+        );
+    }
 
     #[test]
     fn multi_node_pmix_unsupported_on_k8s_agents() {

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1042,11 +1042,29 @@ impl<E: Into<anyhow::Error>> From<E> for DispatchError {
     }
 }
 
+/// Ceiling on one agent RPC in a fan-out that is drained to completion. `0` disables it, matching
+/// the sibling `dispatch_reject_cooldown_secs` knob.
+fn dispatch_deadline(cluster: &ClusterManager) -> Option<Duration> {
+    match cluster.config().controller.dispatch_timeout_secs {
+        0 => None,
+        secs => Some(Duration::from_secs(secs)),
+    }
+}
+
 /// Send a LaunchJob RPC to a node agent.
 async fn dispatch_to_agent(
     agent_addr: &str,
     params: &AgentDispatchParams<'_>,
 ) -> Result<LaunchOutcome, DispatchError> {
+    // Logged before the call, not just on its outcome: a launch that never returns is otherwise
+    // invisible for as long as it hangs, which is exactly when an operator needs to see it.
+    info!(
+        job_id = params.job_id,
+        node = params.target_node,
+        agent = agent_addr,
+        run_attempt = params.run_attempt,
+        "dispatching job to agent"
+    );
     let mut client = crate::agent_client::connect(agent_addr.to_string())
         .await
         .map_err(|e| DispatchError::Unreachable(e.into()))?
@@ -1318,6 +1336,7 @@ async fn register_allocation_on_nodes(
     let mut failures = 0u32;
     let mut succeeded_nodes: Vec<String> = Vec::new();
     let total = dispatch_nodes.len() as u32;
+    let dispatch_timeout = dispatch_deadline(&cluster);
 
     let mut set = tokio::task::JoinSet::new();
     for node_name in &dispatch_nodes {
@@ -1360,7 +1379,17 @@ async fn register_allocation_on_nodes(
             work_dir: spec.work_dir.clone(),
         };
         set.spawn(async move {
-            let result = register_allocation_to_agent(&agent_addr, &params).await;
+            let register = register_allocation_to_agent(&agent_addr, &params);
+            let result = match dispatch_timeout {
+                Some(limit) => match tokio::time::timeout(limit, register).await {
+                    Ok(result) => result,
+                    Err(_) => Err(anyhow::anyhow!(
+                        "allocation register RPC exceeded {}s",
+                        limit.as_secs()
+                    )),
+                },
+                None => register.await,
+            };
             (result_node, result)
         });
     }
@@ -1508,6 +1537,7 @@ async fn confirm_dispatch_on_nodes(
     let modex_connect_timeout_secs = cluster.config().mpi.modex_connect_timeout_secs;
     let modex_fence_timeout_secs = cluster.config().mpi.modex_fence_timeout_secs;
     let modex_verify_timeout_secs = cluster.config().mpi.modex_verify_timeout_secs;
+    let dispatch_timeout = dispatch_deadline(&cluster);
 
     let needs_pmix_prepare = batch_dispatched_multi_node_pmix(
         spec.mpi.as_deref(),
@@ -1654,28 +1684,37 @@ async fn confirm_dispatch_on_nodes(
         let pmix_tmpdir = pmix_tmpdir.clone();
         let agent_addr = agent_addr.clone();
         set.spawn(async move {
-            let result = dispatch_to_agent(
-                &agent_addr,
-                &AgentDispatchParams {
-                    job_id,
-                    spec: &spec,
-                    peer_nodes: &peer_addrs,
-                    peer_hosts: &peer_hosts,
-                    node_index,
-                    task_offset,
-                    target_node: &target_node,
-                    allocated: &allocated,
-                    allocated_nodelist: &allocated_nodelist,
-                    run_attempt,
-                    pmix_tmpdir: &pmix_tmpdir,
-                    task_fanout,
-                    modex_connect_timeout_secs,
-                    modex_fence_timeout_secs,
-                    modex_verify_timeout_secs,
-                    pmix_prepared: needs_pmix_prepare,
+            let params = AgentDispatchParams {
+                job_id,
+                spec: &spec,
+                peer_nodes: &peer_addrs,
+                peer_hosts: &peer_hosts,
+                node_index,
+                task_offset,
+                target_node: &target_node,
+                allocated: &allocated,
+                allocated_nodelist: &allocated_nodelist,
+                run_attempt,
+                pmix_tmpdir: &pmix_tmpdir,
+                task_fanout,
+                modex_connect_timeout_secs,
+                modex_fence_timeout_secs,
+                modex_verify_timeout_secs,
+                pmix_prepared: needs_pmix_prepare,
+            };
+            let dispatch = dispatch_to_agent(&agent_addr, &params);
+            // The join below drains every node, so one agent that accepts the call and never answers
+            // would otherwise hold the whole scheduler loop, not just this job.
+            let result = match dispatch_timeout {
+                Some(limit) => match tokio::time::timeout(limit, dispatch).await {
+                    Ok(result) => result,
+                    Err(_) => Err(DispatchError::Unreachable(anyhow::anyhow!(
+                        "launch RPC exceeded {}s",
+                        limit.as_secs()
+                    ))),
                 },
-            )
-            .await;
+                None => dispatch.await,
+            };
             (result_node, is_primary, result)
         });
     }
@@ -1697,10 +1736,12 @@ async fn confirm_dispatch_on_nodes(
                     DispatchError::PrologFailed(reason) => {
                         prolog_failed.push((node_name, reason));
                     }
-                    DispatchError::ResourcesUnavailable => cluster.cool_down_node(&node_name),
-                    DispatchError::Unreachable(_)
-                    | DispatchError::AgentRejected(_)
-                    | DispatchError::Other(_) => {}
+                    // An unreachable node stays a candidate otherwise, so the next job pays the same
+                    // dispatch timeout again and the queue walks itself into max-requeue holds.
+                    DispatchError::ResourcesUnavailable | DispatchError::Unreachable(_) => {
+                        cluster.cool_down_node(&node_name)
+                    }
+                    DispatchError::AgentRejected(_) | DispatchError::Other(_) => {}
                 }
             }
             Err(e) => {
@@ -1751,11 +1792,9 @@ async fn confirm_dispatch_on_nodes(
     };
     let _ = cluster.set_job_launch_failure_detail(job_id, confirmation_detail.clone());
 
-    // Stop whatever DID launch before the job settles anywhere: a node that
-    // never confirmed will never report completion, and letting it keep
-    // running while the job as a whole is aborted back to Pending would
-    // orphan it.
-    cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
+    // Every dispatched node, not just the confirmed ones: a node that timed out may have launched
+    // anyway and is the likeliest to be orphaned. CancelJob is idempotent, so cancelling wide is safe.
+    cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 9).await;
 
     // Drain before deciding the job's fate, so the failing node is already out
     // of the candidate set on the next scheduling attempt. The drain is issued
@@ -4328,6 +4367,59 @@ mod tests {
 
             assert!(matches!(outcome, DispatchConfirmOutcome::Confirmed));
             elapsed
+        }
+
+        /// The node that timed out is the one most likely to have launched anyway, so it is the one
+        /// that must be cancelled — cancelling only the confirmed nodes orphans it.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn a_node_whose_launch_times_out_is_still_cancelled() {
+            let dir = TempDir::new().unwrap();
+            let mut config = test_config();
+            config.controller.dispatch_timeout_secs = 1;
+            let cm = test_cluster_with_config(&dir, config).await;
+
+            let (fast_addr, fast_cancels) = spawn_mock_agent().await;
+            let (slow_addr, slow_cancels) =
+                spawn_mock_agent_with_delay(Duration::from_secs(30)).await;
+            register_node_at(&cm, "n-fast", fast_addr);
+            register_node_at(&cm, "n-slow", slow_addr);
+
+            let nodes = vec!["n-fast".to_string(), "n-slow".to_string()];
+            let spec = batch_spec("timeout-cancel", 2);
+            let job_id = submit_and_wait(&cm, spec);
+            let spec = cm.get_job(job_id).unwrap().spec;
+            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            let nodelist = nodes.join(",");
+
+            let outcome = confirm_dispatch_on_nodes(
+                cm.clone(),
+                job_id,
+                nodes,
+                spec,
+                Vec::new(),
+                per_node_allocs,
+                nodelist,
+                1,
+                1,
+                false,
+            )
+            .await;
+
+            assert!(
+                !matches!(outcome, DispatchConfirmOutcome::Confirmed),
+                "a node that never answered must not count as confirmed"
+            );
+            assert!(
+                slow_cancels.load(Ordering::SeqCst) > 0,
+                "the timed-out node received no cancel and would keep running the job"
+            );
+            assert!(
+                fast_cancels.load(Ordering::SeqCst) > 0,
+                "the confirmed node must still be cancelled when admission aborts"
+            );
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 16)]

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -347,8 +347,10 @@ async fn process_assignment(
             // every node registered and answered too late, so none of them may be left holding one.
             AllocationRegisterOutcome::AllFailed | AllocationRegisterOutcome::PartialFailed => {
                 cancel_job_on_nodes(&cluster, job_id, &all_nodes, 9).await;
-                if let Err(e) = cluster.requeue_job(job_id) {
-                    error!(job_id, error = %e, "failed to requeue after registration failure");
+                // The job never left Pending, so plain requeue is a no-op here — the same
+                // Pending-aware backoff the launch path uses is what actually throttles a retry.
+                if let Err(e) = cluster.backoff_pending_job_after_dispatch_failure(job_id) {
+                    error!(job_id, error = %e, "failed to back off after registration failure");
                 }
                 return false;
             }
@@ -1047,7 +1049,7 @@ impl<E: Into<anyhow::Error>> From<E> for DispatchError {
 
 /// Ceiling on one agent RPC in a fan-out that is drained to completion. `0` disables it, matching
 /// the sibling `dispatch_reject_cooldown_secs` knob.
-fn dispatch_deadline(cluster: &ClusterManager) -> Option<Duration> {
+pub(crate) fn dispatch_deadline(cluster: &ClusterManager) -> Option<Duration> {
     match cluster.config().controller.dispatch_timeout_secs {
         0 => None,
         secs => Some(Duration::from_secs(secs)),
@@ -1272,6 +1274,24 @@ pub(crate) enum AllocationRegisterOutcome {
     PartialFailed,
 }
 
+/// Why one RegisterJobAllocation RPC did not succeed. Split so the caller can tell a node that
+/// burned the whole deadline from one that failed fast, and cool each for the span it earned.
+enum RegisterError {
+    Failed(anyhow::Error),
+    TimedOut(Duration),
+}
+
+impl std::fmt::Display for RegisterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Failed(e) => write!(f, "{e}"),
+            Self::TimedOut(limit) => {
+                write!(f, "allocation register RPC exceeded {}s", limit.as_secs())
+            }
+        }
+    }
+}
+
 /// Parameters for registering a srun-only allocation on a single node agent.
 struct AllocationRegisterParams {
     job_id: u32,
@@ -1380,23 +1400,15 @@ async fn register_allocation_on_nodes(
             allocated,
             work_dir: spec.work_dir.clone(),
         };
-        let cooldown_cluster = cluster.clone();
         set.spawn(async move {
             let register = register_allocation_to_agent(&agent_addr, &params);
             let result = match dispatch_timeout {
                 Some(limit) => match tokio::time::timeout(limit, register).await {
-                    Ok(result) => result,
-                    Err(_) => {
-                        // Same reasoning as the launch fan-out: without this the node is re-picked
-                        // next tick and burns another full deadline.
-                        cooldown_cluster.cool_down_node_for(&result_node, limit);
-                        Err(anyhow::anyhow!(
-                            "allocation register RPC exceeded {}s",
-                            limit.as_secs()
-                        ))
-                    }
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(e)) => Err(RegisterError::Failed(e)),
+                    Err(_) => Err(RegisterError::TimedOut(limit)),
                 },
-                None => register.await,
+                None => register.await.map_err(RegisterError::Failed),
             };
             (result_node, result)
         });
@@ -1414,6 +1426,12 @@ async fn register_allocation_on_nodes(
                     error = %e,
                     "allocation registration on agent failed"
                 );
+                // Mirrors the launch fan-out: an unreachable node is cooled briefly, one that
+                // burned a deadline is held for it, so neither is re-picked on the next tick.
+                match e {
+                    RegisterError::TimedOut(limit) => cluster.cool_down_node_for(&node_name, limit),
+                    RegisterError::Failed(_) => cluster.cool_down_node(&node_name),
+                }
                 failures += 1;
             }
             Err(e) => {
@@ -1658,8 +1676,13 @@ async fn confirm_dispatch_on_nodes(
             });
         }
 
-        if let Err(detail) =
-            pmix_dispatch::prepare_pmix_on_nodes(job_id, run_attempt, prepare_nodes).await
+        if let Err(detail) = pmix_dispatch::prepare_pmix_on_nodes(
+            job_id,
+            run_attempt,
+            prepare_nodes,
+            dispatch_timeout,
+        )
+        .await
         {
             error!(job_id, error = %detail, "PMIx prepare failed — aborting dispatch");
             return abort_pending_pmix_dispatch(
@@ -3019,6 +3042,7 @@ mod tests {
             release_pmix_calls: Arc<AtomicU32>,
             reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
             launch_delay: Duration,
+            register_delay: Duration,
             /// launch_job returns a ResourceExhausted status, standing in for a
             /// node whose local allocation table already holds the GPUs.
             reject_resources: bool,
@@ -3149,6 +3173,9 @@ mod tests {
                 tonic::Response<spur_proto::proto::RegisterJobAllocationResponse>,
                 tonic::Status,
             > {
+                if !self.register_delay.is_zero() {
+                    tokio::time::sleep(self.register_delay).await;
+                }
                 Ok(tonic::Response::new(Default::default()))
             }
 
@@ -3261,12 +3288,27 @@ mod tests {
             spawn_mock_agent_full(None, delay).await
         }
 
+        /// Like [`spawn_mock_agent_with_delay`], but the delay lands on
+        /// `register_job_allocation` — the srun allocation path, not the batch launch.
+        async fn spawn_mock_agent_with_register_delay(
+            delay: Duration,
+        ) -> (std::net::SocketAddr, Arc<AtomicU32>) {
+            let (addr, cancel_calls, _, _) =
+                spawn_mock_agent_capturing_fanout(None, Duration::ZERO, delay, false).await;
+            (addr, cancel_calls)
+        }
+
         async fn spawn_mock_agent_full(
             reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
             launch_delay: Duration,
         ) -> (std::net::SocketAddr, Arc<AtomicU32>) {
-            let (addr, cancel_calls, _, _) =
-                spawn_mock_agent_capturing_fanout(reject_launch_as, launch_delay, false).await;
+            let (addr, cancel_calls, _, _) = spawn_mock_agent_capturing_fanout(
+                reject_launch_as,
+                launch_delay,
+                Duration::ZERO,
+                false,
+            )
+            .await;
             (addr, cancel_calls)
         }
 
@@ -3278,6 +3320,7 @@ mod tests {
         async fn spawn_mock_agent_capturing_fanout(
             reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
             launch_delay: Duration,
+            register_delay: Duration,
             capture: bool,
         ) -> (
             std::net::SocketAddr,
@@ -3295,6 +3338,7 @@ mod tests {
                 release_pmix_calls: release_pmix_calls.clone(),
                 reject_launch_as,
                 launch_delay,
+                register_delay,
                 reject_resources: false,
                 fanout_calls: capture.then(|| fanout_calls.clone()),
             };
@@ -3317,6 +3361,7 @@ mod tests {
                 cancel_calls: Arc::new(AtomicU32::new(0)),
                 reject_launch_as: None,
                 launch_delay: Duration::ZERO,
+                register_delay: Duration::ZERO,
                 reject_resources: true,
                 release_pmix_calls: Arc::new(AtomicU32::new(0)),
                 fanout_calls: None,
@@ -3856,9 +3901,11 @@ mod tests {
             let cm = test_cluster(&dir).await;
 
             let (good_addr, cancel_calls, release_pmix_good, _) =
-                spawn_mock_agent_capturing_fanout(None, Duration::ZERO, false).await;
+                spawn_mock_agent_capturing_fanout(None, Duration::ZERO, Duration::ZERO, false)
+                    .await;
             let (bad_addr, _, release_pmix_bad, _) = spawn_mock_agent_capturing_fanout(
                 Some(spur_proto::proto::LaunchFailureKind::LaunchFailureUnspecified),
+                Duration::ZERO,
                 Duration::ZERO,
                 false,
             )
@@ -4492,6 +4539,50 @@ mod tests {
             );
         }
 
+        /// Counterpart to [`a_fast_dispatch_failure_does_not_earn_the_deadline_cooldown`]: with the
+        /// reject cooldown off, only the deadline path can put the node on cooldown at all.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn a_node_that_burns_the_launch_deadline_is_held_for_it() {
+            let dir = TempDir::new().unwrap();
+            let mut config = test_config();
+            config.controller.dispatch_reject_cooldown_secs = 0;
+            config.controller.dispatch_timeout_secs = 1;
+            let cm = test_cluster_with_config(&dir, config).await;
+
+            let (slow_addr, _) = spawn_mock_agent_with_delay(Duration::from_secs(30)).await;
+            register_node_at(&cm, "n-slow", slow_addr);
+
+            let nodes = vec!["n-slow".to_string()];
+            let spec = batch_spec("launch-deadline-cooldown", 1);
+            let job_id = submit_and_wait(&cm, spec);
+            let spec = cm.get_job(job_id).unwrap().spec;
+            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            let nodelist = nodes.join(",");
+
+            let outcome = confirm_dispatch_on_nodes(
+                cm.clone(),
+                job_id,
+                nodes,
+                spec,
+                Vec::new(),
+                per_node_allocs,
+                nodelist,
+                1,
+                1,
+                false,
+            )
+            .await;
+
+            assert!(!matches!(outcome, DispatchConfirmOutcome::Confirmed));
+            assert!(
+                cm.dispatch_cooldown_remaining("n-slow").is_some(),
+                "a node that burned the whole deadline must not be re-picked on the next tick"
+            );
+        }
+
         #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
         async fn confirm_dispatch_latency_tracks_the_slowest_node_not_the_node_count() {
             let dir = TempDir::new().unwrap();
@@ -4697,7 +4788,7 @@ mod tests {
             let dir = TempDir::new().unwrap();
             let cm = test_cluster(&dir).await;
             let (addr, _, _, fanout_calls) =
-                spawn_mock_agent_capturing_fanout(None, Duration::ZERO, true).await;
+                spawn_mock_agent_capturing_fanout(None, Duration::ZERO, Duration::ZERO, true).await;
             register_node_at(&cm, "n1", addr);
 
             let mut spec = batch_spec("plain-batch-fanout", 1);
@@ -4718,7 +4809,7 @@ mod tests {
             let dir = TempDir::new().unwrap();
             let cm = test_cluster(&dir).await;
             let (addr, _, _, fanout_calls) =
-                spawn_mock_agent_capturing_fanout(None, Duration::ZERO, true).await;
+                spawn_mock_agent_capturing_fanout(None, Duration::ZERO, Duration::ZERO, true).await;
             register_k8s_node_at(&cm, "k1", addr);
 
             let mut spec = batch_spec("srun-fanout-with-script", 1);
@@ -4788,6 +4879,12 @@ mod tests {
 
             assert!(!started);
             assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Pending);
+            assert!(
+                cm.dispatch_cooldown_remaining("n1")
+                    .is_some_and(|left| left <= Duration::from_secs(30)),
+                "an unreachable node must take the short reject cooldown — not be re-picked \
+                 every tick, and not be held for the whole dispatch deadline"
+            );
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -4811,6 +4908,50 @@ mod tests {
             assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Pending);
             wait_for("n1 registration rolled back with a cancel", || {
                 cancel_calls.load(Ordering::SeqCst) >= 1
+            });
+        }
+
+        /// Every node answering just past the deadline is the production shape of "all failed":
+        /// each may still be holding the allocation it registered, so none can be left uncancelled,
+        /// and none may be re-picked on the next tick to burn the deadline again.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn every_node_timing_out_on_register_is_cancelled_cooled_and_backed_off() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let mut config = test_config();
+            config.controller.dispatch_reject_cooldown_secs = 0;
+            config.controller.dispatch_timeout_secs = 1;
+            let cm = test_cluster_with_config(&dir, config).await;
+
+            let (addr1, cancel1) =
+                spawn_mock_agent_with_register_delay(Duration::from_secs(30)).await;
+            let (addr2, cancel2) =
+                spawn_mock_agent_with_register_delay(Duration::from_secs(30)).await;
+            register_node_at(&cm, "n1", addr1);
+            register_node_at(&cm, "n2", addr2);
+
+            let mut spec = batch_spec("srun-alloc-all-timeout", 2);
+            spec.srun_job = true;
+            let job_id = submit_and_wait(&cm, spec);
+
+            let started = process_assignment(cm.clone(), assignment(job_id, &["n1", "n2"])).await;
+
+            assert!(!started);
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.state, JobState::Pending);
+            assert!(
+                job.spec.begin_time.is_some_and(|t| t > Utc::now()),
+                "a registration failure must back the job off, not retry it on the next tick"
+            );
+            for name in ["n1", "n2"] {
+                assert!(
+                    cm.dispatch_cooldown_remaining(name).is_some(),
+                    "{name} burned the deadline and must be skipped for it"
+                );
+            }
+            wait_for("both timed-out nodes were cancelled", || {
+                cancel1.load(Ordering::SeqCst) >= 1 && cancel2.load(Ordering::SeqCst) >= 1
             });
         }
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -343,18 +343,12 @@ async fn process_assignment(
         )
         .await
         {
-            AllocationRegisterOutcome::AllFailed => {
-                if let Err(e) = cluster.requeue_job(job_id) {
-                    error!(job_id, error = %e, "failed to requeue after registration failure");
-                }
-                return false;
-            }
-            AllocationRegisterOutcome::PartialFailed => {
-                // Same reasoning as the dispatch abort: a node that timed out may have registered
-                // anyway, and it is the one node cancelling only the successes would miss.
+            // Both arms tear down identically: with a deadline in play, even "all failed" can mean
+            // every node registered and answered too late, so none of them may be left holding one.
+            AllocationRegisterOutcome::AllFailed | AllocationRegisterOutcome::PartialFailed => {
                 cancel_job_on_nodes(&cluster, job_id, &all_nodes, 9).await;
                 if let Err(e) = cluster.requeue_job(job_id) {
-                    error!(job_id, error = %e, "failed to requeue after partial registration");
+                    error!(job_id, error = %e, "failed to requeue after registration failure");
                 }
                 return false;
             }
@@ -1386,15 +1380,21 @@ async fn register_allocation_on_nodes(
             allocated,
             work_dir: spec.work_dir.clone(),
         };
+        let cooldown_cluster = cluster.clone();
         set.spawn(async move {
             let register = register_allocation_to_agent(&agent_addr, &params);
             let result = match dispatch_timeout {
                 Some(limit) => match tokio::time::timeout(limit, register).await {
                     Ok(result) => result,
-                    Err(_) => Err(anyhow::anyhow!(
-                        "allocation register RPC exceeded {}s",
-                        limit.as_secs()
-                    )),
+                    Err(_) => {
+                        // Same reasoning as the launch fan-out: without this the node is re-picked
+                        // next tick and burns another full deadline.
+                        cooldown_cluster.cool_down_node_for(&result_node, limit);
+                        Err(anyhow::anyhow!(
+                            "allocation register RPC exceeded {}s",
+                            limit.as_secs()
+                        ))
+                    }
                 },
                 None => register.await,
             };
@@ -4380,7 +4380,9 @@ mod tests {
             let mut config = test_config();
             // Disabling the short cooldown makes the two paths distinguishable: only
             // cool_down_node_for can put a node in the map now.
-            config.controller.dispatch_reject_cooldown_secs = 0;
+            // Non-zero so the assertion is two-sided: the node must land on the SHORT cooldown,
+            // not merely stay off the long one (which "cools nothing at all" would also satisfy).
+            config.controller.dispatch_reject_cooldown_secs = 30;
             config.controller.dispatch_timeout_secs = 300;
             let cm = test_cluster_with_config(&dir, config).await;
 
@@ -4412,8 +4414,13 @@ mod tests {
 
             assert!(!matches!(outcome, DispatchConfirmOutcome::Confirmed));
             assert!(
-                !cm.nodes_on_dispatch_cooldown().contains("n-dead"),
-                "a connect failure must use the reject cooldown, not the dispatch deadline"
+                cm.nodes_on_dispatch_cooldown().contains("n-dead"),
+                "a connect failure must still cool the node down"
+            );
+            assert!(
+                cm.dispatch_cooldown_remaining("n-dead")
+                    .is_some_and(|left| left <= Duration::from_secs(30)),
+                "it must use the 30s reject cooldown, not the 300s dispatch deadline"
             );
         }
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -349,8 +349,10 @@ async fn process_assignment(
                 }
                 return false;
             }
-            AllocationRegisterOutcome::PartialFailed { succeeded_nodes } => {
-                cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
+            AllocationRegisterOutcome::PartialFailed => {
+                // Same reasoning as the dispatch abort: a node that timed out may have registered
+                // anyway, and it is the one node cancelling only the successes would miss.
+                cancel_job_on_nodes(&cluster, job_id, &all_nodes, 9).await;
                 if let Err(e) = cluster.requeue_job(job_id) {
                     error!(job_id, error = %e, "failed to requeue after partial registration");
                 }
@@ -1002,6 +1004,9 @@ enum DispatchError {
     /// Connect failed, or the RPC timed out without a response, as opposed to
     /// the agent responding with an explicit rejection.
     Unreachable(anyhow::Error),
+    /// The agent held the call for the whole dispatch deadline. Distinct from `Unreachable`, which
+    /// a refused connection also produces in milliseconds and must not earn the same long cooldown.
+    TimedOut(Duration),
     /// The agent explicitly rejected the launch for a reason it does not have
     /// a `LaunchFailureKind` for yet.
     AgentRejected(String),
@@ -1016,6 +1021,7 @@ impl DispatchError {
             Self::PrologFailed(_) => "prolog failure",
             Self::ResourcesUnavailable => "gpu/resource allocation mismatch",
             Self::Unreachable(_) => "agent unreachable",
+            Self::TimedOut(_) => "agent timed out",
             Self::AgentRejected(_) => "agent rejected launch",
             Self::Other(_) => "dispatch error",
         }
@@ -1030,6 +1036,9 @@ impl std::fmt::Display for DispatchError {
                 write!(f, "agent rejected job: allocated resources unavailable")
             }
             Self::Unreachable(e) => write!(f, "agent unreachable: {e:#}"),
+            Self::TimedOut(limit) => {
+                write!(f, "agent did not answer within {}s", limit.as_secs())
+            }
             Self::AgentRejected(reason) => write!(f, "agent rejected job: {reason}"),
             Self::Other(e) => write!(f, "{e:#}"),
         }
@@ -1266,7 +1275,7 @@ fn build_pmix_plan_proto(
 pub(crate) enum AllocationRegisterOutcome {
     AllSucceeded,
     AllFailed,
-    PartialFailed { succeeded_nodes: Vec<String> },
+    PartialFailed,
 }
 
 /// Parameters for registering a srun-only allocation on a single node agent.
@@ -1334,7 +1343,6 @@ async fn register_allocation_on_nodes(
 ) -> AllocationRegisterOutcome {
     let mut successes = 0u32;
     let mut failures = 0u32;
-    let mut succeeded_nodes: Vec<String> = Vec::new();
     let total = dispatch_nodes.len() as u32;
     let dispatch_timeout = dispatch_deadline(&cluster);
 
@@ -1396,9 +1404,8 @@ async fn register_allocation_on_nodes(
 
     while let Some(result) = set.join_next().await {
         match result {
-            Ok((node_name, Ok(()))) => {
+            Ok((_node_name, Ok(()))) => {
                 successes += 1;
-                succeeded_nodes.push(node_name);
             }
             Ok((node_name, Err(e))) => {
                 error!(
@@ -1424,7 +1431,7 @@ async fn register_allocation_on_nodes(
             job_id,
             successes, failures, "partial allocation registration failure"
         );
-        AllocationRegisterOutcome::PartialFailed { succeeded_nodes }
+        AllocationRegisterOutcome::PartialFailed
     } else {
         AllocationRegisterOutcome::AllSucceeded
     }
@@ -1523,7 +1530,6 @@ async fn confirm_dispatch_on_nodes(
 ) -> DispatchConfirmOutcome {
     let mut successes = 0u32;
     let mut failures = 0u32;
-    let mut succeeded_nodes: Vec<String> = Vec::new();
     let mut prolog_failed: Vec<(String, String)> = Vec::new();
     let mut failure_categories: std::collections::BTreeMap<&'static str, u32> = Default::default();
     let total = dispatch_nodes.len() as u32;
@@ -1708,10 +1714,7 @@ async fn confirm_dispatch_on_nodes(
             let result = match dispatch_timeout {
                 Some(limit) => match tokio::time::timeout(limit, dispatch).await {
                     Ok(result) => result,
-                    Err(_) => Err(DispatchError::Unreachable(anyhow::anyhow!(
-                        "launch RPC exceeded {}s",
-                        limit.as_secs()
-                    ))),
+                    Err(_) => Err(DispatchError::TimedOut(limit)),
                 },
                 None => dispatch.await,
             };
@@ -1721,9 +1724,8 @@ async fn confirm_dispatch_on_nodes(
 
     while let Some(result) = set.join_next().await {
         match result {
-            Ok((node_name, is_primary, Ok(outcome))) => {
+            Ok((_node_name, is_primary, Ok(outcome))) => {
                 successes += 1;
-                succeeded_nodes.push(node_name);
                 if is_primary {
                     primary_outcome = Some(outcome);
                 }
@@ -1736,13 +1738,12 @@ async fn confirm_dispatch_on_nodes(
                     DispatchError::PrologFailed(reason) => {
                         prolog_failed.push((node_name, reason));
                     }
-                    DispatchError::ResourcesUnavailable => cluster.cool_down_node(&node_name),
-                    // Held for the deadline it just burned, not the much shorter reject cooldown:
-                    // while assignments are processed serially, re-picking it stalls every job.
-                    DispatchError::Unreachable(_) => match dispatch_timeout {
-                        Some(limit) => cluster.cool_down_node_for(&node_name, limit),
-                        None => cluster.cool_down_node(&node_name),
-                    },
+                    DispatchError::ResourcesUnavailable | DispatchError::Unreachable(_) => {
+                        cluster.cool_down_node(&node_name)
+                    }
+                    // Held for the deadline it actually burned: while assignments are processed
+                    // serially, re-picking this node stalls every job behind it, not just this one.
+                    DispatchError::TimedOut(limit) => cluster.cool_down_node_for(&node_name, limit),
                     DispatchError::AgentRejected(_) | DispatchError::Other(_) => {}
                 }
             }
@@ -4369,6 +4370,66 @@ mod tests {
 
             assert!(matches!(outcome, DispatchConfirmOutcome::Confirmed));
             elapsed
+        }
+
+        /// A refused connection fails in milliseconds and must not buy the long deadline cooldown,
+        /// or a rolling agent restart sidelines the whole cluster at once.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn a_fast_dispatch_failure_does_not_earn_the_deadline_cooldown() {
+            let dir = TempDir::new().unwrap();
+            let mut config = test_config();
+            // Disabling the short cooldown makes the two paths distinguishable: only
+            // cool_down_node_for can put a node in the map now.
+            config.controller.dispatch_reject_cooldown_secs = 0;
+            config.controller.dispatch_timeout_secs = 300;
+            let cm = test_cluster_with_config(&dir, config).await;
+
+            register_node_at(&cm, "n-dead", unreachable_addr().await);
+
+            let nodes = vec!["n-dead".to_string()];
+            let spec = batch_spec("fast-fail", 1);
+            let job_id = submit_and_wait(&cm, spec);
+            let spec = cm.get_job(job_id).unwrap().spec;
+            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            let nodelist = nodes.join(",");
+
+            let outcome = confirm_dispatch_on_nodes(
+                cm.clone(),
+                job_id,
+                nodes,
+                spec,
+                Vec::new(),
+                per_node_allocs,
+                nodelist,
+                1,
+                1,
+                false,
+            )
+            .await;
+
+            assert!(!matches!(outcome, DispatchConfirmOutcome::Confirmed));
+            assert!(
+                !cm.nodes_on_dispatch_cooldown().contains("n-dead"),
+                "a connect failure must use the reject cooldown, not the dispatch deadline"
+            );
+        }
+
+        #[test]
+        fn a_zero_dispatch_timeout_disables_the_deadline() {
+            let dir = TempDir::new().unwrap();
+            let mut config = test_config();
+            config.controller.dispatch_timeout_secs = 0;
+            let cm = ClusterManager::new(config, dir.path()).unwrap();
+            assert_eq!(dispatch_deadline(&cm), None);
+
+            let dir2 = TempDir::new().unwrap();
+            let mut config = test_config();
+            config.controller.dispatch_timeout_secs = 7;
+            let cm = ClusterManager::new(config, dir2.path()).unwrap();
+            assert_eq!(dispatch_deadline(&cm), Some(Duration::from_secs(7)));
         }
 
         /// The node that timed out is the one most likely to have launched anyway, so it is the one

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1736,11 +1736,13 @@ async fn confirm_dispatch_on_nodes(
                     DispatchError::PrologFailed(reason) => {
                         prolog_failed.push((node_name, reason));
                     }
-                    // An unreachable node stays a candidate otherwise, so the next job pays the same
-                    // dispatch timeout again and the queue walks itself into max-requeue holds.
-                    DispatchError::ResourcesUnavailable | DispatchError::Unreachable(_) => {
-                        cluster.cool_down_node(&node_name)
-                    }
+                    DispatchError::ResourcesUnavailable => cluster.cool_down_node(&node_name),
+                    // Held for the deadline it just burned, not the much shorter reject cooldown:
+                    // while assignments are processed serially, re-picking it stalls every job.
+                    DispatchError::Unreachable(_) => match dispatch_timeout {
+                        Some(limit) => cluster.cool_down_node_for(&node_name, limit),
+                        None => cluster.cool_down_node(&node_name),
+                    },
                     DispatchError::AgentRejected(_) | DispatchError::Other(_) => {}
                 }
             }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2832,8 +2832,13 @@ impl SlurmController for ControllerService {
                     "multi-node PMIx step missing launch plan for one or more nodes",
                 ));
             }
-            if let Err(detail) =
-                pmix_dispatch::prepare_pmix_on_nodes(job_id, run_attempt, prepare_nodes).await
+            if let Err(detail) = pmix_dispatch::prepare_pmix_on_nodes(
+                job_id,
+                run_attempt,
+                prepare_nodes,
+                crate::scheduler_loop::dispatch_deadline(&self.cluster),
+            )
+            .await
             {
                 return Err(Status::failed_precondition(format!(
                     "PMIx prepare failed: {detail}"

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -258,9 +258,12 @@ and Raft high-availability topology.
      - Live
      - Ceiling on a single launch or allocation-register RPC to an agent. The
        agent runs the node prolog and any container image unpack before it
-       answers, so this must exceed your slowest prolog. ``0`` disables it. A
-       node that accepts the connection and then stops responding is detected
-       by channel keepalive within roughly 20 seconds regardless of this value.
+       answers, so this must exceed your slowest prolog. ``0`` disables it.
+       A node that has died or become unreachable is detected sooner, by
+       channel keepalive; an agent that is still running but whose launch
+       never completes is bounded only by this value. A node that exceeds it
+       is skipped for new dispatch for the same span, and is not marked down,
+       so it still appears available in ``sinfo`` while being skipped.
    * - ``job_info_visibility``
      - string
      - ``redacted``

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -252,6 +252,15 @@ and Raft high-availability topology.
      - Live
      - How long a node is skipped for dispatch after rejecting a launch as
        resources-unavailable.
+   * - ``dispatch_timeout_secs``
+     - integer
+     - ``300``
+     - Live
+     - Ceiling on a single launch or allocation-register RPC to an agent. The
+       agent runs the node prolog and any container image unpack before it
+       answers, so this must exceed your slowest prolog. ``0`` disables it. A
+       node that accepts the connection and then stops responding is detected
+       by channel keepalive within roughly 20 seconds regardless of this value.
    * - ``job_info_visibility``
      - string
      - ``redacted``

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -252,6 +252,30 @@ and Raft high-availability topology.
      - Live
      - How long a node is skipped for dispatch after rejecting a launch as
        resources-unavailable.
+   * - ``agent_connect_timeout_secs``
+     - integer
+     - ``5``
+     - Live
+     - Budget for establishing a controller-to-agent connection. ``0`` falls
+       back to the operating system's TCP timeout, which is typically around
+       two minutes and is not configurable from here.
+   * - ``agent_keepalive_interval_secs``
+     - integer
+     - ``10``
+     - Live
+     - HTTP/2 ping interval on an open agent connection. ``0`` disables
+       keepalive entirely. Pings are sent while a request is in flight, so
+       this is what detects a node that accepted the connection and then went
+       silent — total detection time is roughly this plus
+       ``agent_keepalive_timeout_secs``. Lower it for faster detection at the
+       cost of more ping traffic per node; raise it if an agent
+       implementation objects to frequent pings.
+   * - ``agent_keepalive_timeout_secs``
+     - integer
+     - ``10``
+     - Live
+     - How long to wait for a ping response before dropping the connection.
+       Ignored when ``agent_keepalive_interval_secs`` is ``0``.
    * - ``dispatch_timeout_secs``
      - integer
      - ``300``

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -250,8 +250,8 @@ and Raft high-availability topology.
      - integer
      - ``30``
      - Live
-     - How long a node is skipped for dispatch after rejecting a launch as
-       resources-unavailable.
+     - How long a node is skipped for dispatch after rejecting a launch or
+       failing to be reached.
    * - ``agent_connect_timeout_secs``
      - integer
      - ``5``
@@ -282,9 +282,10 @@ and Raft high-availability topology.
      - integer
      - ``300``
      - Live
-     - Ceiling on a single launch or allocation-register RPC to an agent. The
-       agent runs the node prolog and any container image unpack before it
-       answers, so this must exceed your slowest prolog. Range 0-86400;
+     - Ceiling on a single launch, allocation-register, or multi-node PMIx
+       prepare RPC to an agent. The agent runs the node prolog and any
+       container image unpack before it answers, so this must exceed your
+       slowest prolog. Range 0-86400;
        ``0`` disables it. A node that has died or become unreachable is
        detected sooner by channel keepalive, when keepalive is enabled; an
        agent that is still running but whose launch never completes is

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -256,15 +256,15 @@ and Raft high-availability topology.
      - integer
      - ``5``
      - Live
-     - Budget for establishing a controller-to-agent connection. ``0`` falls
-       back to the operating system's TCP timeout, which is typically around
-       two minutes and is not configurable from here.
+     - Budget for establishing a controller-to-agent connection. Range 0-600.
+       ``0`` falls back to the operating system's TCP timeout, which is
+       typically around two minutes and is not configurable from here.
    * - ``agent_keepalive_interval_secs``
      - integer
      - ``10``
      - Live
-     - HTTP/2 ping interval on an open agent connection. ``0`` disables
-       keepalive entirely. Pings are sent while a request is in flight, so
+     - HTTP/2 ping interval on an open agent connection. Range 0-600. ``0``
+       disables keepalive entirely. Pings are sent while a request is in flight, so
        this is what detects a node that accepted the connection and then went
        silent — total detection time is roughly this plus
        ``agent_keepalive_timeout_secs``. Lower it for faster detection at the
@@ -275,19 +275,22 @@ and Raft high-availability topology.
      - ``10``
      - Live
      - How long to wait for a ping response before dropping the connection.
-       Ignored when ``agent_keepalive_interval_secs`` is ``0``.
+       Range 1-600 whenever keepalive is on; ``0`` is rejected because it
+       marks every ping overdue the moment it is sent. Ignored entirely when
+       ``agent_keepalive_interval_secs`` is ``0``.
    * - ``dispatch_timeout_secs``
      - integer
      - ``300``
      - Live
      - Ceiling on a single launch or allocation-register RPC to an agent. The
        agent runs the node prolog and any container image unpack before it
-       answers, so this must exceed your slowest prolog. ``0`` disables it.
-       A node that has died or become unreachable is detected sooner, by
-       channel keepalive; an agent that is still running but whose launch
-       never completes is bounded only by this value. A node that exceeds it
-       is skipped for new dispatch for the same span, and is not marked down,
-       so it still appears available in ``sinfo`` while being skipped.
+       answers, so this must exceed your slowest prolog. Range 0-86400;
+       ``0`` disables it. A node that has died or become unreachable is
+       detected sooner by channel keepalive, when keepalive is enabled; an
+       agent that is still running but whose launch never completes is
+       bounded only by this value. A node that exceeds it is skipped for new
+       dispatch for the same span, and is not marked down, so it still
+       appears available in ``sinfo`` while being skipped.
    * - ``job_info_visibility``
      - string
      - ``redacted``

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -15,6 +15,22 @@ max_launch_backoff_secs = 300
 # max_batch_requeue. Slurm's inverse of this is
 # SchedulerParameters=nohold_on_prolog_fail.
 hold_on_prolog_fail = true
+# Ceiling in seconds on one launch or allocation-register RPC to an agent
+# (default 300, range 0-86400, 0 disables). The agent runs the node prolog and
+# any container image unpack before it answers, so this must exceed your slowest
+# prolog. A node that exceeds it is skipped for new dispatch for the same span.
+dispatch_timeout_secs = 300
+# Budget in seconds for establishing a controller-to-agent connection (default
+# 5, range 0-600). 0 falls back to the operating system's TCP timeout.
+agent_connect_timeout_secs = 5
+# HTTP/2 ping interval in seconds on an open agent connection (default 10, range
+# 0-600, 0 disables keepalive). This is what detects a node that accepted the
+# connection and then went silent; detection takes roughly this plus
+# agent_keepalive_timeout_secs.
+agent_keepalive_interval_secs = 10
+# Seconds to wait for a ping response before dropping the connection (default
+# 10, range 1-600 while keepalive is on).
+agent_keepalive_timeout_secs = 10
 # How much of another user's job an identified non-owner (non-admin) may read
 # back from get_job / scontrol show job. "redacted" (default) shows identity/
 # state/timing/account but blanks work_dir, command, stdio paths, and the


### PR DESCRIPTION
> **Reading the diff:** this branch *carries* @jamesETsmith's commits, so the net diff against `main` shows the final shape only. The channel-wide `.timeout(5s)` discussed below is introduced by `97958f54` and replaced by `fd780096`, both in this branch — you will not find a deletion of it in the three-dot diff.

## Motivation

Builds on @jamesETsmith's #768, which correctly identified #767 (the scheduler stops cycling while eligible nodes stay idle) and the right chokepoint for a fix — `agent_client::connect`. This carries his commits and adjusts the shape of the bound.

A channel-wide `.timeout(5s)` in tonic installs a per-channel `GrpcTimeout` layer that bounds time-to-response-headers. Because a tonic server emits headers only once a unary handler resolves, that caps the whole agent-side handler — including handlers that legitimately run for minutes:

| RPC | Inline work before the response |
| --- | --- |
| `RunCommand` (every srun step) | `child.wait_with_output()` — returns when the user's step exits |
| `LaunchJob` | container rootfs setup, the node prolog, process spawn |
| `ExecInJob` | `cmd.output().await` — the full command |
| `StartClusterComponent` | can download and install the k0s binary |

It also overrides an explicit bound already written down in the code: `drain_via_control_plane` computes `drain timeout (default 120s) + 30s slack` and its comment states the RPC is bounded so a hung agent can't stall the serial removal loop. That 150s becomes unreachable behind a 5s channel deadline.

## Behaviour by failure mode

Everything below is one launch RPC to one node. Because the assignment loop is still serial, a stall here blocks every other pending job, not just this one.

| Scenario | Before (`main`) | With a channel-wide 5s deadline | This PR |
| --- | --- | --- | --- |
| Connection refused (agent down, port closed) | ~0s, kernel RST | ~0s | ~0s, node skipped for the reject cooldown |
| Packets blackholed, TCP never completes | ~2min, kernel SYN retries | 5s | 5s (`connect_timeout`) |
| **TCP accepted, then the peer goes silent** | **never returns** | 5s | **~20s** via HTTP/2 keepalive |
| **Agent alive, handler wedged (hung prolog, stuck image unpack)** | **never returns** | 5s | **`dispatch_timeout_secs`** (default 300s), then the node is skipped for the same span |
| Healthy but slow prolog (e.g. 60s) | completes | **aborted at 5s** | completes |
| srun step longer than 5s | completes | **aborted at 5s** | completes |

The two "never returns" rows are the reported hang: once the connection is established nothing gives up, because a black-holed peer sends neither FIN nor RST, and there is no request deadline or keepalive. They are indistinguishable from the controller's side, which is why both need covering — keepalive catches the silent peer, but a wedged handler still answers pings, so only the call-site deadline bounds it.

Note the last two rows: a single short channel-wide deadline cannot separate "stuck" from "slow", which is why the bound moved to the call sites.

## Technical Details

- Keep the dial budget (`connect_timeout`), drop the channel-wide request budget.
- Add HTTP/2 keepalive (10s interval, 10s timeout, `keep_alive_while_idle`). This is what actually catches the reported failure — a peer that accepts TCP and then stops answering. Pings are sent while a request stream is open, so a hung RPC is torn down in roughly 20s without capping slow-but-healthy work.
- Add a per-operation deadline, `controller.dispatch_timeout_secs` (default 300, `0` disables), on the two fan-outs that are drained to completion: `confirm_dispatch_on_nodes` and `register_allocation_on_nodes`. The latter had no bound at all and is awaited from the same serial assignment loop.
- Cancel every dispatched node when admission aborts, not only the confirmed ones. `Endpoint::timeout` does not send a `grpc-timeout` header, so an agent never learns the controller gave up — the node that timed out is the one most likely to have launched anyway, and was the only one receiving no cancel. `CancelJob` is idempotent.
- Cool a timed-out node down for the deadline it burned rather than the much shorter reject cooldown. Paired with a long deadline, the 30s cooldown left a wedged node stalling most of every cycle — and while assignments are processed serially that stall is cluster-wide.
- Log before dispatching. A launch that never returns was otherwise invisible for as long as it hung, which is exactly when it needs to be visible.

## Tunables

All four are `[controller]` fields with defaults, and all reload with `scontrol reconfigure`:

| Field | Default | Bounds |
| --- | --- | --- |
| `agent_connect_timeout_secs` | 5 | TCP dial. `0` falls back to the OS timeout (~2min) |
| `agent_keepalive_interval_secs` | 10 | HTTP/2 ping interval. `0` disables keepalive |
| `agent_keepalive_timeout_secs` | 10 | Ping response wait |
| `dispatch_timeout_secs` | 300 | One launch/register RPC. `0` disables |

Keepalive detection is roughly interval + timeout, so ~20s at the defaults. The three channel values reload live because a channel is built per call — a swapped value applies to the next RPC with nothing to invalidate. Unlike the jwt key, which `reconfigure` deliberately does not adopt, these carry no security posture. All are capped in `validate()`; the channel defaults live in `spur-core` as shared constants so the config and the builder cannot drift.

## On the default

`connect_timeout` and the keepalive pair are the liveness mechanism; `dispatch_timeout_secs` is a backstop for an agent that is alive and answering pings but wedged in a handler. It is deliberately generous because a site prolog can legitimately take minutes, and it is a knob so operators can tighten it once their prologs are bounded.

## Test Plan / Result

- `a_node_whose_launch_times_out_is_still_cancelled` — new. Mutation-checked: reverting the cancel back to `succeeded_nodes` makes it fail, so it is a real regression signal rather than a test that passes either way.
- `cargo test --locked` — full workspace green.
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean.
- `cargo fmt --all -- --check` — clean.

## Review round

Four gaps raised in review, all confirmed against the code and fixed here:

- `PreparePmix` and `ReleasePmix` had no ceiling once the channel-wide timeout was dropped. The agent runs PMIx `server_start` inline in that handler, so it answers keepalive pings while wedged and only a call-site deadline bounds it. Prepare now takes `dispatch_timeout_secs` per agent (covering the srun-step call site too); release gets a fixed 5s inside `release_pmix_on_agent`, so the rollback path and the guard's `Drop` are covered — a best-effort teardown must never be what blocks the loop.
- The register path cooled a node only when it timed out. A connect failure or RPC error fell through with no cooldown, which is the asymmetry this branch introduced by moving `Unreachable` into the launch path's cooldown arm. Split into `TimedOut` / `Failed` so each is held for the span it earned.
- That same arm called `requeue_job`, which returns early for a job still `Pending` — so a failed registration had neither a cooldown nor a backoff. It now uses `backoff_pending_job_after_dispatch_failure`, as the launch path does.
- The widened cancel and both deadline cooldowns had no coverage: reverting them left the suite green. Three new tests and one extended assertion now fail when the arm they cover is reverted.

Also worth calling out from an earlier commit here: `cluster_k8s.rs` moved to `agent_client::connect`, which attaches the controller credential interceptor. `stop_component_now` previously sent no bearer token and would have been rejected by the agent under `auth.mode != disabled`, so that path was broken before this branch.

Live-checked on an isolated instance: a 15s prolog still completes inside the launch RPC, and a node that keeps heartbeating with its RPC port blackholed is retried ~35s apart rather than every tick, starting as soon as it is reachable again.

## Follow-ups (not in this PR)

- The assignment loop is still serial, so a bounded deadline turns an unbounded stall into a bounded one rather than removing head-of-line blocking.
- `AllocationRegisterOutcome::PartialFailed` carries only `succeeded_nodes`, so the same cancel gap remains on that path; closing it means changing the variant.

Closes #767.

