### PR TITLE
feat(spur-cli): read cluster name from controller in scontrol show config

### DIFF
--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -555,6 +555,15 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     }
 }
 
+/// Render `scontrol show config` from a controller ping. The cluster name and
+/// version follow the live controller, not the login node's local config.
+fn format_config(controller: &str, ping: &spur_proto::proto::PingResponse) -> String {
+    format!(
+        "ClusterName={}\nSlurmctldAddr={}\nVersion={}\n",
+        ping.cluster_name, controller, ping.version
+    )
+}
+
 async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> {
     let channel = crate::authclient::connect(controller)
         .await
@@ -848,9 +857,12 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
             }
         }
         "config" => {
-            println!("ClusterName=spur");
-            println!("SlurmctldAddr={}", controller);
-            println!("Version={}", env!("CARGO_PKG_VERSION"));
+            let inner = client
+                .ping(())
+                .await
+                .context("failed to ping controller")?
+                .into_inner();
+            print!("{}", format_config(controller, &inner));
         }
         "federation" => {
             let resp = client.ping(()).await.context("failed to ping controller")?;
@@ -1717,6 +1729,20 @@ fn gpu_tres_label(detail: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn config_reports_cluster_name_from_ping() {
+        let ping = spur_proto::proto::PingResponse {
+            cluster_name: "prod-west".into(),
+            version: "9.9.9".into(),
+            ..Default::default()
+        };
+        let out = format_config("http://ctld:6817", &ping);
+        assert!(out.contains("ClusterName=prod-west"), "{out}");
+        assert!(!out.contains("ClusterName=spur"), "{out}");
+        assert!(out.contains("SlurmctldAddr=http://ctld:6817"), "{out}");
+        assert!(out.contains("Version=9.9.9"), "{out}");
+    }
 
     #[test]
     fn gpu_tres_label_per_node() {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1508,6 +1508,7 @@ impl SlurmController for ControllerService {
             server_time: Some(prost_types::Timestamp::from(std::time::SystemTime::now())),
             version: env!("CARGO_PKG_VERSION").into(),
             federation_peers,
+            cluster_name: self.cluster.config().cluster_name.clone(),
         }))
     }
 
@@ -5269,6 +5270,16 @@ mod tests {
             control_plane_replicas: 1,
             jwt_key: String::new(),
         }
+    }
+
+    // Ping carries the configured cluster name so `scontrol show config` can
+    // report it without reading the login node's local config.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ping_reports_configured_cluster_name() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let resp = svc.ping(Request::new(())).await.unwrap().into_inner();
+        assert_eq!(resp.cluster_name, "test");
     }
 
     // Exercises the requeue RPC boundary: gRPC status mapping (auth vs. state

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -137,8 +137,9 @@ Top-level keys
      - **(required)**
      - Live
      - Cluster name. An empty value fails to load with ``missing required field:
-       cluster_name``. Changing it live re-labels metrics mid-series; prefer a
-       restart.
+       cluster_name``. Reported by ``scontrol show config``, which reads it from
+       the live controller rather than the login node's local config. Changing it
+       live re-labels metrics mid-series; prefer a restart.
    * - ``licenses``
      - table<string, integer>
      - ``{}``

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -636,6 +636,7 @@ message PingResponse {
   google.protobuf.Timestamp server_time = 2;
   string version = 3;
   repeated string federation_peers = 4;
+  string cluster_name = 5;
 }
 
 message JobStateCount {


### PR DESCRIPTION
## What

`scontrol show config` printed a hardcoded `ClusterName=spur`, ignoring the controller's configured `cluster_name`. It now reports the live value from the controller.

## Approach

- Add an additive `PingResponse.cluster_name = 5` (previously-unused tag, no `!` needed).
- Controller fills it from `config().cluster_name` in `ping`.
- `scontrol show config` pings the controller and prints `ClusterName` and `Version` from the response instead of the hardcoded string. A small `format_config` helper makes the rendering unit-testable.
- The login node no longer needs a local `/etc/spur/spur.conf` to report the cluster name; the controller is the source of truth.

## Notes

- `Version` in `scontrol show config` now reflects the controller's version (`ping.version`) rather than the CLI binary's `CARGO_PKG_VERSION`. This is more correct for a command that describes the controller, and the output format is unchanged. The config command already required a reachable controller (the client connects eagerly), so the ping adds no new failure path.
- Scoped intentionally to the CLI wiring. Propagating `cluster_name` into the job/hook runtime environment (`SPUR_CLUSTER_NAME` / `SLURM_CLUSTER_NAME`, salloc, prolog/epilog) is a separate, larger change and will land in a follow-up PR.

## Test plan

- [x] `cargo test -p spurctld ping_reports_configured_cluster_name`
- [x] `cargo test -p spur-cli config_reports_cluster_name_from_ping`
- [x] `cargo clippy -p spur-cli -p spurctld --all-targets` clean
- [x] Manual: deployed to the bare-metal testbed, `scontrol show config` reports `ClusterName=bare-metal-test` from the controller; confirmed it ignores a divergent local `spur.conf` on a different node