### PR TITLE
docs(accounting): say that a TRES dimension of 0 is ignored, not blocking

### DIFF
--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -66,6 +66,9 @@ page:
 
 ``show`` renders an unset limit as a blank cell and a literal ``0`` as ``0``.
 
+The ``0`` rule above covers job counts and wall time. A ``0`` inside a TRES
+value behaves differently — see :ref:`tres-zero-dimension`.
+
 Limit changes are not instant: the controller reads accounting and QOS limits
 from a cache that refreshes every ``fairshare_refresh_secs`` (default 300s,
 floored at 10s), so a ``sacctmgr modify`` can take up to one refresh interval
@@ -1097,6 +1100,22 @@ The three TRES caps differ by scope:
 - **MaxTRESPerJob** (``maxtresperjob``) caps a **single job**.
 - **MaxTRESPerUser** (``maxtresperuser``) caps a **single user's** total across
   their jobs.
+
+.. _tres-zero-dimension:
+
+A TRES dimension of 0 is ignored, not "block all"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unlike a ``0`` job-count or wall limit (:ref:`limit-values`), a TRES dimension
+set to ``0`` does not block: the gate compares only dimensions whose cap is
+above zero, so ``maxtresperjob=cpu=0`` leaves CPU uncapped rather than rejecting
+every job. This holds for all three TRES caps, on both QOS and account
+associations, and other dimensions in the same value are still enforced —
+``maxtresperjob=cpu=0,gres/gpu=4`` caps GPUs and ignores CPUs.
+
+A resource therefore cannot be denied by capping it at ``0``. To keep jobs off a
+resource, leave it out of what they request; to stop a scope from running
+anything, use ``maxsubmitjobs=0``.
 
 .. _grptres-node-packing:
 

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -1114,8 +1114,9 @@ associations, and other dimensions in the same value are still enforced —
 ``maxtresperjob=cpu=0,gres/gpu=4`` caps GPUs and ignores CPUs.
 
 A resource therefore cannot be denied by capping it at ``0``. To keep jobs off a
-resource, leave it out of what they request; to stop a scope from running
-anything, use ``maxsubmitjobs=0``.
+resource, leave it out of what they request; to stop a scope from having any job
+accepted, use ``maxsubmitjobs=0`` — it rejects every submission outright, so
+nothing is queued.
 
 .. _grptres-node-packing:
 


### PR DESCRIPTION
## Summary

The "Limit values" section of the accounting guide tells operators that a literal `0` means **block all** and explicitly does *not* mean "no limit". That is true for job counts and wall time, but not for TRES: `tres_cap_breach` and its account-side twin compare a dimension only when its cap is above zero, so `maxtresperjob=cpu=0` leaves CPU **uncapped** rather than rejecting every job.

An operator following the page would expect the exact opposite, and nothing errors to correct them — the cap is simply never applied.

## Approach

The detail is documented where the TRES semantics already live, as a new `A TRES dimension of 0 is ignored, not "block all"` subsection, with a short pointer from the `0` rule that currently overstates its reach. Both directions are cross-referenced so a reader arriving at either place learns the distinction.

The behaviour itself is left alone. It matches Slurm, and changing it would silently turn existing `0` dimensions in deployed configs into blocks.

## Scope

Docs only, no behaviour change. This was raised by an automated review comment on #746; the wording it commented on is pre-existing on `main` and unrelated to that PR, so it is fixed here on its own rather than folded in.

## Testing

Confirmed against the code that every TRES cap behaves as described: `max_tres_per_job`, `max_tres_per_user` and `grp_tres` all route through the zero-guarded comparison in `crates/spur-core/src/qos.rs`, and the account association path repeats the same guard in `crates/spur-core/src/account_limits.rs`. `crates/spur-core/src/accounting.rs` already carries a test named `exceeded_caps_treats_a_zero_tres_dimension_as_uncapped` asserting it.

Ran the repo's `pyspelling` config over `docs/`: the new prose adds no unknown words. The full sphinx build could not run locally — the pinned doc toolchain needs Python 3.11 and this host has 3.10 — so `sphinx-build -W` is left to CI.
