### PR TITLE
fix(spur-cli): let salloc wait for pending allocations

### DIFF
--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -34,6 +34,7 @@ pub(crate) struct StepCapture {
     get_job_calls: Arc<AtomicU32>,
     /// When set, `get_job` returns `JobInfo { user: ... }` or the configured error.
     get_job_response: Arc<Mutex<Option<Result<String, tonic::Code>>>>,
+    cancel_job_requests: Arc<Mutex<Vec<proto::CancelJobRequest>>>,
     create_step_num_tasks: Arc<AtomicU32>,
     run_step_step_id: Arc<AtomicU32>,
     run_step_calls: Arc<AtomicU32>,
@@ -57,6 +58,10 @@ impl StepCapture {
 
     pub(crate) fn set_get_job_error(&self, code: tonic::Code) {
         *self.get_job_response.lock().unwrap() = Some(Err(code));
+    }
+
+    pub(crate) fn cancel_job_requests(&self) -> Vec<proto::CancelJobRequest> {
+        self.cancel_job_requests.lock().unwrap().clone()
     }
 
     /// Task count carried by the most recent `CreateJobStep`.
@@ -158,6 +163,18 @@ mock_controller_impl! {
             }
         }
 
+        async fn cancel_job(
+            &self,
+            request: tonic::Request<proto::CancelJobRequest>,
+        ) -> Result<tonic::Response<()>, tonic::Status> {
+            self.capture
+                .cancel_job_requests
+                .lock()
+                .unwrap()
+                .push(request.into_inner());
+            Ok(tonic::Response::new(()))
+        }
+
         async fn run_step(
             &self,
             request: tonic::Request<proto::RunStepRequest>,
@@ -244,7 +261,6 @@ mock_controller_impl! {
     unimplemented {
         submit_job(proto::SubmitJobRequest) -> proto::SubmitJobResponse;
         get_jobs(proto::GetJobsRequest) -> proto::GetJobsResponse;
-        cancel_job(proto::CancelJobRequest) -> ();
         complete_job(proto::CompleteJobRequest) -> ();
         job_keepalive(proto::JobKeepaliveRequest) -> proto::JobKeepaliveResponse;
         suspend_job(proto::SuspendJobRequest) -> ();

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -169,58 +169,21 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         }
     });
 
-    let job_info;
-    let wait_started = std::time::Instant::now();
-    let mut last_reason = String::new();
-    loop {
-        match client.get_job(GetJobRequest { job_id }).await {
-            Ok(resp) => {
-                let job = resp.into_inner();
-                match job.state {
-                    1 => {
-                        // RUNNING
-                        job_info = job;
-                        break;
-                    }
-                    3..=7 => {
-                        // Terminal
-                        eprintln!("salloc: job {} ended before allocation was granted", job_id);
-                        std::process::exit(1);
-                    }
-                    _ => {
-                        let reason = job.state_reason.clone();
-                        if reason != last_reason && !reason.is_empty() && reason != "None" {
-                            eprintln!("salloc: job {} pending ({})", job_id, reason);
-                            last_reason = reason;
-                        }
-                    }
-                }
+    let job_info =
+        match wait_for_allocation(&mut client, job_id, &submit_user, args.immediate).await {
+            AllocationWait::Granted(job) => job,
+            AllocationWait::Ended => {
+                eprintln!("salloc: job {} ended before allocation was granted", job_id);
+                std::process::exit(1);
             }
-            Err(e) => {
-                eprintln!("salloc: warning: {}", e.message());
+            AllocationWait::TimedOut(last_reason) => {
+                eprintln!(
+                    "salloc: job {} has not started within the requested time (last reason: {})",
+                    job_id, last_reason
+                );
+                std::process::exit(1);
             }
-        }
-
-        if immediate_wait_expired(args.immediate, wait_started.elapsed()) {
-            eprintln!(
-                "salloc: job {} has not started within the requested time (last reason: {})",
-                job_id, last_reason
-            );
-            let cancel_user =
-                crate::interactive::resolve_job_owner_for_cancel(&mut client, job_id, &submit_user)
-                    .await;
-            let _ = client
-                .cancel_job(CancelJobRequest {
-                    job_id,
-                    signal: 0,
-                    user: cancel_user,
-                })
-                .await;
-            std::process::exit(1);
-        }
-
-        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-    }
+        };
 
     let nodelist = &job_info.nodelist;
     eprintln!("salloc: Nodes {} are ready for job {}", nodelist, job_id);
@@ -431,6 +394,58 @@ fn parse_memory_mb(s: &str) -> Result<u64> {
     }
 }
 
+enum AllocationWait {
+    Granted(Box<spur_proto::proto::JobInfo>),
+    Ended,
+    TimedOut(String),
+}
+
+async fn wait_for_allocation(
+    client: &mut spur_proto::proto::slurm_controller_client::SlurmControllerClient<
+        crate::authclient::AuthChannel,
+    >,
+    job_id: u32,
+    submit_user: &str,
+    immediate: Option<u64>,
+) -> AllocationWait {
+    let wait_started = std::time::Instant::now();
+    let mut last_reason = String::new();
+    loop {
+        match client.get_job(GetJobRequest { job_id }).await {
+            Ok(resp) => {
+                let job = resp.into_inner();
+                match job.state {
+                    1 => return AllocationWait::Granted(Box::new(job)),
+                    3..=7 => return AllocationWait::Ended,
+                    _ => {
+                        let reason = job.state_reason;
+                        if reason != last_reason && !reason.is_empty() && reason != "None" {
+                            eprintln!("salloc: job {} pending ({})", job_id, reason);
+                            last_reason = reason;
+                        }
+                    }
+                }
+            }
+            Err(error) => eprintln!("salloc: warning: {}", error.message()),
+        }
+
+        if immediate_wait_expired(immediate, wait_started.elapsed()) {
+            let cancel_user =
+                crate::interactive::resolve_job_owner_for_cancel(client, job_id, submit_user).await;
+            let _ = client
+                .cancel_job(CancelJobRequest {
+                    job_id,
+                    signal: 0,
+                    user: cancel_user,
+                })
+                .await;
+            return AllocationWait::TimedOut(last_reason);
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    }
+}
+
 fn immediate_wait_expired(immediate: Option<u64>, elapsed: std::time::Duration) -> bool {
     immediate.is_some_and(|seconds| elapsed >= std::time::Duration::from_secs(seconds))
 }
@@ -518,6 +533,22 @@ mod tests {
             Some(30),
             std::time::Duration::from_secs(30)
         ));
+    }
+
+    #[tokio::test]
+    async fn immediate_timeout_cancels_pending_allocation() {
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        capture.set_get_job_user("job-owner");
+        let mut client = crate::mock_controller::client(addr).await;
+
+        let outcome = wait_for_allocation(&mut client, 42, "submit-user", Some(0)).await;
+
+        assert!(matches!(outcome, AllocationWait::TimedOut(reason) if reason.is_empty()));
+        let requests = capture.cancel_job_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].job_id, 42);
+        assert_eq!(requests[0].signal, 0);
+        assert_eq!(requests[0].user, "job-owner");
     }
 
     #[test]

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -98,6 +98,10 @@ pub struct SallocArgs {
     #[arg(long)]
     pub exclusive: bool,
 
+    /// Exit if resources are not available within this many seconds
+    #[arg(short = 'I', long, num_args = 0..=1, default_missing_value = "1")]
+    pub immediate: Option<u64>,
+
     /// Controller address
     #[arg(
         long,
@@ -165,32 +169,10 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         }
     });
 
-    // Wait for the job to start running (with timeout and progress)
     let job_info;
-    let start = std::time::Instant::now();
-    let timeout = std::time::Duration::from_secs(300);
+    let wait_started = std::time::Instant::now();
     let mut last_reason = String::new();
     loop {
-        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-
-        if start.elapsed() > timeout {
-            eprintln!(
-                "salloc: timed out waiting for job {} to start (last reason: {})",
-                job_id, last_reason
-            );
-            let cancel_user =
-                crate::interactive::resolve_job_owner_for_cancel(&mut client, job_id, &submit_user)
-                    .await;
-            let _ = client
-                .cancel_job(CancelJobRequest {
-                    job_id,
-                    signal: 0,
-                    user: cancel_user,
-                })
-                .await;
-            std::process::exit(1);
-        }
-
         match client.get_job(GetJobRequest { job_id }).await {
             Ok(resp) => {
                 let job = resp.into_inner();
@@ -218,6 +200,26 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 eprintln!("salloc: warning: {}", e.message());
             }
         }
+
+        if immediate_wait_expired(args.immediate, wait_started.elapsed()) {
+            eprintln!(
+                "salloc: job {} has not started within the requested time (last reason: {})",
+                job_id, last_reason
+            );
+            let cancel_user =
+                crate::interactive::resolve_job_owner_for_cancel(&mut client, job_id, &submit_user)
+                    .await;
+            let _ = client
+                .cancel_job(CancelJobRequest {
+                    job_id,
+                    signal: 0,
+                    user: cancel_user,
+                })
+                .await;
+            std::process::exit(1);
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
     }
 
     let nodelist = &job_info.nodelist;
@@ -429,6 +431,10 @@ fn parse_memory_mb(s: &str) -> Result<u64> {
     }
 }
 
+fn immediate_wait_expired(immediate: Option<u64>, elapsed: std::time::Duration) -> bool {
+    immediate.is_some_and(|seconds| elapsed >= std::time::Duration::from_secs(seconds))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -464,6 +470,54 @@ mod tests {
 
         let long = SallocArgs::try_parse_from(["salloc", "--qos=normal"]).expect("parse long qos");
         assert_eq!(long.qos.as_deref(), Some("normal"));
+    }
+
+    #[test]
+    fn parses_immediate_with_slurm_compatible_defaults() {
+        assert_eq!(
+            SallocArgs::try_parse_from(["salloc"])
+                .expect("parse without immediate")
+                .immediate,
+            None
+        );
+        assert_eq!(
+            SallocArgs::try_parse_from(["salloc", "--immediate"])
+                .expect("parse bare immediate")
+                .immediate,
+            Some(1)
+        );
+        assert_eq!(
+            SallocArgs::try_parse_from(["salloc", "--immediate=30"])
+                .expect("parse long immediate")
+                .immediate,
+            Some(30)
+        );
+        assert_eq!(
+            SallocArgs::try_parse_from(["salloc", "-I15"])
+                .expect("parse short immediate")
+                .immediate,
+            Some(15)
+        );
+    }
+
+    #[test]
+    fn pending_allocation_has_no_default_deadline() {
+        assert!(!immediate_wait_expired(
+            None,
+            std::time::Duration::from_secs(301)
+        ));
+    }
+
+    #[test]
+    fn immediate_allocation_expires_at_requested_deadline() {
+        assert!(!immediate_wait_expired(
+            Some(30),
+            std::time::Duration::from_secs(29)
+        ));
+        assert!(immediate_wait_expired(
+            Some(30),
+            std::time::Duration::from_secs(30)
+        ));
     }
 
     #[test]

--- a/docs/user-guide/interactive.rst
+++ b/docs/user-guide/interactive.rst
@@ -99,12 +99,12 @@ Examples:
 Interactive Allocation — ``salloc``
 ------------------------------------
 
-``spur alloc`` (Slurm ``salloc``) requests an interactive allocation, waits for
-it to start (up to 300 seconds), then spawns your ``$SHELL`` with the allocation
-environment exported (``SPUR_JOB_ID``, ``SPUR_JOB_USER``, ``SPUR_NODELIST``,
-``SPUR_NNODES``, ``SPUR_NTASKS``, ``SPUR_CPUS_PER_TASK``, the
-partition/account/QOS variables, and their ``SLURM_*`` twins). When you exit the
-shell, the allocation is released. Ctrl-C cancels it.
+``spur alloc`` (Slurm ``salloc``) requests an interactive allocation and waits
+until it starts, then spawns your ``$SHELL`` with the allocation environment
+exported (``SPUR_JOB_ID``, ``SPUR_JOB_USER``, ``SPUR_NODELIST``, ``SPUR_NNODES``,
+``SPUR_NTASKS``, ``SPUR_CPUS_PER_TASK``, the partition/account/QOS variables, and
+their ``SLURM_*`` twins). Pending reason changes are displayed while waiting.
+When you exit the shell, the allocation is released. Ctrl-C cancels it.
 
 When authentication is enabled, ``salloc`` also passes ``$SPUR_AUTH_TOKEN`` (or
 ``~/.spur/token``) into the allocation shell so step commands can authenticate
@@ -118,7 +118,9 @@ Common options: ``--nodes``/``-N`` (default ``1``), ``--ntasks``/``-n`` (default
 ``1``), ``--cpus-per-task``/``-c`` (default ``1``), ``--mem``, ``--time``/``-t``
 (default ``1:00:00``), ``--gres``, ``--gpus``/``-G``, ``--partition``/``-p``,
 ``--constraint``/``-C``, ``--nodelist``/``-w``, ``--exclude``/``-x``,
-``--reservation``, and ``--exclusive``.
+``--reservation``, ``--exclusive``, and ``--immediate[=seconds]``/``-I[seconds]``.
+Use ``--immediate`` to cancel if the allocation does not start within one second,
+or provide a number of seconds for a longer bounded wait.
 
 Examples:
 


### PR DESCRIPTION
## Summary

`salloc` currently cancels jobs that stay pending for five minutes. Long waits are normal on busy clusters, so this loses the user's queue position.

This removes that timeout. By default, `salloc` now waits until resources are available, matching Slurm. Users who want a bounded wait can use Slurm's `-I` / `--immediate[=<seconds>]` option.

Closes #789.

## Testing

- `cargo test --locked`
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`
- `cargo fmt --all -- --check`

💘 Generated with Crush