### PR TITLE
fix(spurd)!: stop injecting torch rendezvous env vars, match Slurm

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -296,3 +296,4 @@ CFS
 MiB
 OOM
 pluggable
+torchrun

--- a/crates/spur-core/src/spur_env.rs
+++ b/crates/spur-core/src/spur_env.rs
@@ -55,13 +55,12 @@ impl SpurEnv {
     /// Generate bash `export` lines for per-task variables (`PROCID`, `LOCALID`).
     ///
     /// These are interpolated inside the multi-task wrapper loop where
-    /// `$LOCAL_RANK` and `$SPUR_TASK_OFFSET` are shell variables, not Rust values.
+    /// `$SPUR_LOCALID` and `$SPUR_TASK_OFFSET` are shell variables, not Rust values.
     pub fn per_task_bash_exports() -> &'static str {
         concat!(
-            "  export SPUR_LOCALID=$LOCAL_RANK\n",
-            "  export SLURM_LOCALID=$LOCAL_RANK\n",
-            "  export SPUR_PROCID=$((SPUR_TASK_OFFSET + LOCAL_RANK))\n",
-            "  export SLURM_PROCID=$((SPUR_TASK_OFFSET + LOCAL_RANK))\n",
+            "  export SLURM_LOCALID=$SPUR_LOCALID\n",
+            "  export SPUR_PROCID=$((SPUR_TASK_OFFSET + SPUR_LOCALID))\n",
+            "  export SLURM_PROCID=$((SPUR_TASK_OFFSET + SPUR_LOCALID))\n",
         )
     }
 
@@ -87,17 +86,9 @@ impl SpurEnv {
     }
 
     /// Per-task rank variables for a single-process step or batch launch.
-    pub fn apply_task_rank(
-        senv: &mut SpurEnv,
-        task_offset: u32,
-        local_rank: u32,
-        tasks_on_node: u32,
-    ) {
+    pub fn apply_task_rank(senv: &mut SpurEnv, task_offset: u32, local_rank: u32) {
         let procid = task_offset + local_rank;
         senv.set("SPUR_TASK_OFFSET", task_offset);
-        senv.set("LOCAL_RANK", local_rank);
-        senv.set("LOCAL_WORLD_SIZE", tasks_on_node);
-        senv.set("NPROC_PER_NODE", tasks_on_node);
         senv.set_with_slurm_twin("SPUR_LOCALID", local_rank);
         senv.set_with_slurm_twin("SPUR_PROCID", procid);
     }
@@ -201,12 +192,32 @@ mod tests {
     #[test]
     fn apply_task_rank_sets_procid_twins() {
         let mut env = SpurEnv::new();
-        SpurEnv::apply_task_rank(&mut env, 1, 0, 1);
+        SpurEnv::apply_task_rank(&mut env, 1, 0);
         let map = env.into_map();
         assert_eq!(map["SPUR_PROCID"], "1");
         assert_eq!(map["SLURM_PROCID"], "1");
         assert_eq!(map["SPUR_LOCALID"], "0");
         assert_eq!(map["SLURM_LOCALID"], "0");
+    }
+
+    #[test]
+    fn apply_task_rank_omits_torchrun_names() {
+        let mut env = SpurEnv::new();
+        SpurEnv::apply_task_rank(&mut env, 8, 2);
+        let map = env.into_map();
+        for key in [
+            "LOCAL_RANK",
+            "LOCAL_WORLD_SIZE",
+            "NPROC_PER_NODE",
+            "NODE_RANK",
+            "RANK",
+            "WORLD_SIZE",
+            "MASTER_ADDR",
+            "MASTER_PORT",
+        ] {
+            assert!(!map.contains_key(key), "should not set {key}");
+        }
+        assert_eq!(map["SPUR_PROCID"], "10");
     }
 
     #[test]

--- a/crates/spur-core/src/spur_env.rs
+++ b/crates/spur-core/src/spur_env.rs
@@ -52,10 +52,12 @@ impl SpurEnv {
         self.vars
     }
 
-    /// Generate bash `export` lines for per-task variables (`PROCID`, `LOCALID`).
+    /// Generate bash `export` lines for the `PROCID` twins and `SLURM_LOCALID`.
     ///
-    /// These are interpolated inside the multi-task wrapper loop where
-    /// `$SPUR_LOCALID` and `$SPUR_TASK_OFFSET` are shell variables, not Rust values.
+    /// `SPUR_LOCALID` itself is exported by the wrapper loop; this derives the
+    /// `SLURM_LOCALID` twin and both `PROCID` variables from it. These lines are
+    /// interpolated inside the loop where `$SPUR_LOCALID` and `$SPUR_TASK_OFFSET`
+    /// are shell variables, not Rust values.
     pub fn per_task_bash_exports() -> &'static str {
         concat!(
             "  export SLURM_LOCALID=$SPUR_LOCALID\n",

--- a/crates/spur-core/src/task_launch.rs
+++ b/crates/spur-core/src/task_launch.rs
@@ -324,7 +324,7 @@ fn mask_cpu_bind_bash_prefix(masks: &[&str]) -> String {
         let entries = masks.join(" ");
         format!(
             "_CPU_MASK=({entries})\n  \
-             _CPU_IDX=$((SPUR_TASK_OFFSET + LOCAL_RANK))\n  \
+             _CPU_IDX=$((SPUR_TASK_OFFSET + SPUR_LOCALID))\n  \
              if [ \"$_CPU_IDX\" -ge ${{#_CPU_MASK[@]}} ]; then\n    \
                echo \"mask_cpu: rank $_CPU_IDX exceeds CPU mask list (len ${{#_CPU_MASK[@]}})\" >&2\n    \
                exit 1\n  \
@@ -388,12 +388,12 @@ pub fn mask_cpu_bind_error(source: &HashMap<String, String>, num_tasks: u32) -> 
 /// Bash prefix that pins a task to CPUs per `map_cpu`, `mask_cpu`, or `rank`.
 fn cpu_bind_bash_prefix(bind: &CpuBind, map_cpus: &[&str]) -> String {
     match bind {
-        CpuBind::Rank => "taskset -c $((SPUR_TASK_OFFSET + LOCAL_RANK)) ".to_string(),
+        CpuBind::Rank => "taskset -c $((SPUR_TASK_OFFSET + SPUR_LOCALID)) ".to_string(),
         CpuBind::Map(_) if !map_cpus.is_empty() => {
             let entries = map_cpus.join(" ");
             format!(
                 "_CPU_MAP=({entries})\n  \
-                 _CPU_IDX=$((SPUR_TASK_OFFSET + LOCAL_RANK))\n  \
+                 _CPU_IDX=$((SPUR_TASK_OFFSET + SPUR_LOCALID))\n  \
                  if [ \"$_CPU_IDX\" -ge ${{#_CPU_MAP[@]}} ]; then\n    \
                    echo \"map_cpu: rank $_CPU_IDX exceeds CPU map (len ${{#_CPU_MAP[@]}})\" >&2\n    \
                    exit 1\n  \
@@ -575,10 +575,10 @@ pub fn build_multi_task_pmix_wrapper(
     wrapper.push_str(&format!(
         "_TASKS_ON_NODE={tasks_on_node}\nSPUR_TASK_OFFSET=${{SPUR_TASK_OFFSET:-0}}\n"
     ));
-    wrapper.push_str("for LOCAL_RANK in $(seq 0 $((_TASKS_ON_NODE - 1))); do\n");
-    wrapper.push_str("  export LOCAL_RANK\n");
+    wrapper.push_str("for SPUR_LOCALID in $(seq 0 $((_TASKS_ON_NODE - 1))); do\n");
+    wrapper.push_str("  export SPUR_LOCALID\n");
     wrapper.push_str(SpurEnv::per_task_bash_exports());
-    wrapper.push_str("  case $LOCAL_RANK in\n");
+    wrapper.push_str("  case $SPUR_LOCALID in\n");
     for (local_rank, rank_env) in per_local_rank_env.iter().enumerate() {
         wrapper.push_str(&format!("  {local_rank})\n"));
         wrapper.push_str(&mpi_direct_task_preamble("    "));
@@ -591,7 +591,7 @@ pub fn build_multi_task_pmix_wrapper(
     wrapper.push_str("    IFS=',' read -ra _ALL_GPUS <<< \"$SPUR_JOB_GPUS\"\n");
     wrapper.push_str("    _GPUS_PER_TASK=$(( ${#_ALL_GPUS[@]} / _TASKS_ON_NODE ))\n");
     wrapper.push_str("    if [ $_GPUS_PER_TASK -gt 0 ]; then\n");
-    wrapper.push_str("      _START=$((LOCAL_RANK * _GPUS_PER_TASK))\n");
+    wrapper.push_str("      _START=$((SPUR_LOCALID * _GPUS_PER_TASK))\n");
     wrapper.push_str(
         "      _TASK_GPUS=$(echo \"${_ALL_GPUS[@]:$_START:$_GPUS_PER_TASK}\" | tr ' ' ',')\n",
     );
@@ -613,7 +613,7 @@ pub fn build_multi_task_pmix_wrapper(
 }
 
 /// Build a bash wrapper that forks `tasks_on_node` copies of `user_script_path`,
-/// assigning distinct `LOCAL_RANK` / `SLURM_PROCID` values in each fork.
+/// assigning distinct `SPUR_LOCALID` / `SLURM_PROCID` values in each fork.
 ///
 /// Output labeling is controlled at runtime via the `SPUR_LABEL=1` environment
 /// variable (matching batch `launch_job` and srun `-l`).
@@ -642,15 +642,15 @@ pub fn build_multi_task_wrapper(
     wrapper.push_str(&format!(
         "_TASKS_ON_NODE={tasks_on_node}\nSPUR_TASK_OFFSET=${{SPUR_TASK_OFFSET:-0}}\n"
     ));
-    wrapper.push_str("for LOCAL_RANK in $(seq 0 $((_TASKS_ON_NODE - 1))); do\n");
-    wrapper.push_str("  export LOCAL_RANK\n");
+    wrapper.push_str("for SPUR_LOCALID in $(seq 0 $((_TASKS_ON_NODE - 1))); do\n");
+    wrapper.push_str("  export SPUR_LOCALID\n");
     wrapper.push_str(SpurEnv::per_task_bash_exports());
 
     wrapper.push_str("  if [ -n \"$SPUR_JOB_GPUS\" ]; then\n");
     wrapper.push_str("    IFS=',' read -ra _ALL_GPUS <<< \"$SPUR_JOB_GPUS\"\n");
     wrapper.push_str("    _GPUS_PER_TASK=$(( ${#_ALL_GPUS[@]} / _TASKS_ON_NODE ))\n");
     wrapper.push_str("    if [ $_GPUS_PER_TASK -gt 0 ]; then\n");
-    wrapper.push_str("      _START=$((LOCAL_RANK * _GPUS_PER_TASK))\n");
+    wrapper.push_str("      _START=$((SPUR_LOCALID * _GPUS_PER_TASK))\n");
     wrapper.push_str(
         "      _TASK_GPUS=$(echo \"${_ALL_GPUS[@]:$_START:$_GPUS_PER_TASK}\" | tr ' ' ',')\n",
     );
@@ -901,7 +901,7 @@ mod tests {
         assert!(script.contains("_TASKS_ON_NODE=4"));
         assert!(script.contains("PMIX_SERVER_URI4"));
         assert!(script.contains("'/tmp/hello_mpi'"));
-        assert!(!script.contains("for LOCAL_RANK in"));
+        assert!(!script.contains("for SPUR_LOCALID in"));
     }
 
     #[test]
@@ -930,11 +930,11 @@ mod tests {
         rank1.insert("PMIX_SIZE".into(), "4".into());
         let script =
             build_multi_task_pmix_wrapper("/tmp/hello_mpi", 2, &[rank0, rank1], None).unwrap();
-        assert!(script.contains("case $LOCAL_RANK in"));
+        assert!(script.contains("case $SPUR_LOCALID in"));
         assert!(script.contains("0)\n"));
         assert!(script.contains("export PMIX_RANK='0'"));
         assert!(script.contains("export PMIX_RANK='1'"));
-        assert!(script.contains("for LOCAL_RANK in"));
+        assert!(script.contains("for SPUR_LOCALID in"));
         assert!(!script.contains("mpirun"));
         assert!(script.contains("export SLURM_STEP_ID=${SLURM_STEP_ID:-0}"));
         assert!(script.contains("OMPI_MCA_ess='^singleton,^slurm,^srun'"));

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -256,19 +256,6 @@ impl SlurmAgent for VirtualAgent {
             senv.set("SPUR_TARGET_NODE", &target_node);
         }
 
-        senv.set("LOCAL_RANK", "0");
-        senv.set("LOCAL_WORLD_SIZE", tasks_per_node);
-        senv.set("NPROC_PER_NODE", tasks_per_node);
-        senv.set("NODE_RANK", node_rank);
-
-        if num_peers > 1 {
-            let master_addr = format!("spur-job-{}.{}.svc.cluster.local", job_id, ns);
-            senv.set("MASTER_ADDR", master_addr);
-            senv.set("MASTER_PORT", "29500");
-            senv.set("WORLD_SIZE", num_peers);
-            senv.set("RANK", node_rank);
-        }
-
         let mut env_vars: Vec<EnvVar> = senv
             .into_map()
             .into_iter()

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1266,12 +1266,9 @@ impl SlurmAgent for AgentService {
             senv.set_with_slurm_twin("SPUR_MPI_TYPE", MPI_PMIX);
             senv.set("SPUR_TASK_OFFSET", task_offset);
         } else if tasks_per_node == 1 {
-            SpurEnv::apply_task_rank(&mut senv, task_offset, 0, 1);
+            SpurEnv::apply_task_rank(&mut senv, task_offset, 0);
         } else {
             senv.set("SPUR_TASK_OFFSET", task_offset);
-            senv.set("LOCAL_RANK", "0");
-            senv.set("LOCAL_WORLD_SIZE", tasks_per_node);
-            senv.set("NPROC_PER_NODE", tasks_per_node);
         }
         if !peer_nodes.is_empty() {
             senv.set("SPUR_PEER_NODES", peer_nodes.join(","));
@@ -1281,30 +1278,6 @@ impl SlurmAgent for AgentService {
         }
         if !spec.burst_buffer.is_empty() {
             senv.set("SPUR_BURST_BUFFER", &spec.burst_buffer);
-        }
-
-        if !pmix_multi_task {
-            // Third-party distributed training / MPI env vars
-            if tasks_per_node > 1 {
-                senv.set("LOCAL_RANK", "0");
-                senv.set("LOCAL_WORLD_SIZE", tasks_per_node);
-                senv.set("NPROC_PER_NODE", tasks_per_node);
-            }
-            senv.set("NODE_RANK", node_rank);
-
-            if peer_nodes.len() > 1 {
-                if let Some(first_peer) = peer_nodes.first() {
-                    let master_addr = first_peer
-                        .rsplit(':')
-                        .nth(1)
-                        .or_else(|| first_peer.split(':').next())
-                        .unwrap_or(first_peer);
-                    senv.set("MASTER_ADDR", master_addr);
-                }
-                senv.set("MASTER_PORT", "29500");
-                senv.set("WORLD_SIZE", peer_nodes.len());
-                senv.set("RANK", node_rank);
-            }
         }
 
         let mut env = senv.into_map();
@@ -2231,12 +2204,12 @@ impl SlurmAgent for AgentService {
             if num_tasks > 1 {
                 senv.set("SPUR_TASK_OFFSET", req.task_offset);
             } else {
-                SpurEnv::apply_task_rank(&mut senv, req.task_offset, 0, 1);
+                SpurEnv::apply_task_rank(&mut senv, req.task_offset, 0);
             }
             let wrapper_path_string = wrapper_path.to_string_lossy().into_owned();
             ("bash".to_string(), vec![wrapper_path_string], Some(guard))
         } else {
-            SpurEnv::apply_task_rank(&mut senv, req.task_offset, 0, 1);
+            SpurEnv::apply_task_rank(&mut senv, req.task_offset, 0);
             let (program, args) = spur_core::task_launch::wrap_command_with_cpu_bind(
                 &req.command[0],
                 &req.command[1..],

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -765,10 +765,10 @@ Submitting Jobs
 
    torchrun \
        --nnodes=$SPUR_NNODES \
-       --node_rank=$SPUR_TASK_OFFSET \
+       --node_rank=$SPUR_NODE_RANK \
        --master_addr=$(echo $SPUR_PEER_NODES | cut -d: -f1) \
        --master_port=29500 \
-       --nproc_per_node=8 \
+       --nproc_per_node=$SPUR_TASKS_PER_NODE \
        train.py
    EOF
 

--- a/docs/user-guide/submitting-jobs.rst
+++ b/docs/user-guide/submitting-jobs.rst
@@ -338,11 +338,44 @@ works unchanged. The most useful are below.
    * - ``SPUR_ARRAY_TASK_ID``
      - Array task index (array jobs only).
 
-For MPI and distributed-training frameworks, the agent also sets the variables
-those runtimes expect — ``LOCAL_RANK``, ``LOCAL_WORLD_SIZE``, ``NODE_RANK``, the
-``PMI_*``/``PMIX_*`` ranks (the latter with ``--mpi=pmix``), the
-``OMPI_COMM_WORLD_*`` ranks, and ``SPUR_PEER_NODES`` — so ``torchrun``, MPI, and
-PMI/PMIx launchers run without extra wiring.
+For MPI, the agent sets the ``PMI_*``/``PMIX_*`` ranks (the latter with
+``--mpi=pmix``) and ``SPUR_PEER_NODES``, so PMI/PMIx launchers run without extra
+wiring.
+
+Distributed-training rendezvous variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Like Slurm, Spur does **not** set the PyTorch/torchrun rendezvous variables
+(``MASTER_ADDR``, ``MASTER_PORT``, ``WORLD_SIZE``, ``RANK``, ``LOCAL_RANK``,
+``LOCAL_WORLD_SIZE``, ``NODE_RANK``, ``NPROC_PER_NODE``). Any value you forward
+with ``--export`` is preserved. Derive them from the ``SPUR_*``/``SLURM_*``
+variables in your batch script, or let ``torchrun`` compute them:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Torch / ``env://`` variable
+     - Spur source
+   * - ``WORLD_SIZE``
+     - ``SPUR_NTASKS`` / ``SLURM_NTASKS``
+   * - ``RANK``
+     - ``SPUR_PROCID`` / ``SLURM_PROCID``
+   * - ``LOCAL_RANK``
+     - ``SPUR_LOCALID`` / ``SLURM_LOCALID``
+   * - ``NODE_RANK``
+     - ``SPUR_NODEID`` / ``SPUR_NODE_RANK``
+   * - ``NPROC_PER_NODE`` / ``LOCAL_WORLD_SIZE``
+     - ``SPUR_TASKS_PER_NODE``
+   * - ``MASTER_ADDR`` / ``MASTER_PORT``
+     - First host of ``SPUR_JOB_NODELIST`` / ``SPUR_PEER_NODES``, plus a port you choose
+
+.. code-block:: bash
+
+   export MASTER_ADDR=$(scontrol show hostnames "$SPUR_JOB_NODELIST" | head -n1)
+   export MASTER_PORT=29500
+   export WORLD_SIZE=$SPUR_NTASKS
+   export RANK=$SPUR_PROCID
 
 See Also
 --------

--- a/docs/user-guide/submitting-jobs.rst
+++ b/docs/user-guide/submitting-jobs.rst
@@ -372,10 +372,13 @@ variables in your batch script, or let ``torchrun`` compute them:
 
 .. code-block:: bash
 
-   export MASTER_ADDR=$(scontrol show hostnames "$SPUR_JOB_NODELIST" | head -n1)
-   export MASTER_PORT=29500
-   export WORLD_SIZE=$SPUR_NTASKS
-   export RANK=$SPUR_PROCID
+   # Respect anything forwarded with --export; otherwise derive from the
+   # allocation. The port is derived per job to avoid collisions between
+   # concurrent jobs on shared nodes.
+   export MASTER_ADDR="${MASTER_ADDR:-$(scontrol show hostnames "$SPUR_JOB_NODELIST" | head -n1)}"
+   export MASTER_PORT="${MASTER_PORT:-$((20000 + SPUR_JOB_ID % 20000))}"
+   export WORLD_SIZE="${WORLD_SIZE:-$SPUR_NTASKS}"
+   export RANK="${RANK:-$SPUR_PROCID}"
 
 See Also
 --------

--- a/plans/implementation-roadmap.md
+++ b/plans/implementation-roadmap.md
@@ -108,19 +108,18 @@ Jobs that can scale up/down while running. When nodes become available, add them
 
 Integration points:
 - **PyTorch Elastic (torchrun)**: Spur manages the rdzv backend, dynamically updates `--nnodes` range
-- **DeepSpeed**: Spur sets `MASTER_ADDR`, `MASTER_PORT`, `WORLD_SIZE`, `RANK` per node
+- **DeepSpeed / torchrun**: the launcher derives rendezvous from `SPUR_*`/`SLURM_*`; Spur does not own `MASTER_ADDR`/`MASTER_PORT`/`WORLD_SIZE`/`RANK` (matching Slurm)
 - **JAX**: Spur provides the coordinator address and device mesh info
 
-Environment variables injected by Spur (already partially implemented):
+Environment variables injected by Spur (the launcher maps these to torch's `MASTER_ADDR`/`MASTER_PORT`/`WORLD_SIZE`/`RANK`):
 ```
 SPUR_NNODES=4
 SPUR_TASK_OFFSET=0
 SPUR_PEER_NODES=10.44.0.2:6818,10.44.0.3:6818,...
-MASTER_ADDR=10.44.0.2       # first node in allocation
-MASTER_PORT=29500
-WORLD_SIZE=32                # num_nodes * tasks_per_node
-RANK=0                       # global rank (task_offset based)
-LOCAL_RANK=0                 # rank within this node
+SPUR_NTASKS=32               # -> WORLD_SIZE (total tasks)
+SPUR_PROCID=0                # -> RANK (global rank)
+SPUR_LOCALID=0               # -> LOCAL_RANK (rank within this node)
+SPUR_TASKS_PER_NODE=8        # -> NPROC_PER_NODE / LOCAL_WORLD_SIZE
 ```
 
 ### 12.2 Checkpoint-Aware Scheduling (L)

--- a/tests/native_host/e2e/fixtures/distributed_test.py
+++ b/tests/native_host/e2e/fixtures/distributed_test.py
@@ -24,8 +24,8 @@ import torch.multiprocessing as mp
 def get_spur_env():
     return {
         "job_id": os.environ.get("SPUR_JOB_ID", "0"),
-        "node_rank": int(os.environ.get("SPUR_NODE_RANK", os.environ.get("RANK", "0"))),
-        "num_nodes": int(os.environ.get("SPUR_NNODES", os.environ.get("WORLD_SIZE", "1"))),
+        "node_rank": int(os.environ.get("SPUR_NODE_RANK", "0")),
+        "num_nodes": int(os.environ.get("SPUR_NNODES", "1")),
         "task_offset": int(os.environ.get("SPUR_TASK_OFFSET", "0")),
         "peer_nodes": os.environ.get("SPUR_PEER_NODES", ""),
     }

--- a/tests/native_host/e2e/test_container.py
+++ b/tests/native_host/e2e/test_container.py
@@ -231,15 +231,16 @@ class TestContainerMultiNode:
         assert "SPUR_NNODES=2" in all_output, f"must see SPUR_NNODES=2\noutput:\n{all_output}"
 
     def test_two_node_container_env_vars(self, multi_container_cluster):
+        # Spur exposes allocation topology through SPUR_* inside containers; it
+        # does not inject the PyTorch rendezvous vars (matching Slurm).
         cluster = multi_container_cluster
         img = cluster.container_image
         out_path = f"{cluster.remote_dir}/ct-2n-env.out"
         script = cluster.write_file(
             "ct-2n-env.sh",
             "#!/bin/bash\n"
-            'echo "RANK=${RANK}"\n'
-            'echo "WORLD_SIZE=${WORLD_SIZE}"\n'
-            'echo "MASTER_ADDR=${MASTER_ADDR}"\n'
+            'echo "SPUR_NNODES=${SPUR_NNODES}"\n'
+            'echo "SPUR_NODE_RANK=${SPUR_NODE_RANK}"\n'
             'echo "SPUR_JOB_ID=${SPUR_JOB_ID}"\n'
             "echo CT_ENV_OK\n",
         )
@@ -253,13 +254,9 @@ class TestContainerMultiNode:
         wait_job(cluster, job_id, timeout=90)
         all_output = cluster.read_output_all_nodes(out_path)
         assert "CT_ENV_OK" in all_output, f"missing CT_ENV_OK:\n{all_output}"
-        assert "WORLD_SIZE=2" in all_output, f"missing WORLD_SIZE=2:\n{all_output}"
-        assert "RANK=0" in all_output, f"missing RANK=0:\n{all_output}"
-        assert "RANK=1" in all_output, f"missing RANK=1:\n{all_output}"
-        assert any(
-            line.startswith("MASTER_ADDR=") and line != "MASTER_ADDR="
-            for line in all_output.splitlines()
-        ), f"MASTER_ADDR should be non-empty:\n{all_output}"
+        assert "SPUR_NNODES=2" in all_output, f"missing SPUR_NNODES=2:\n{all_output}"
+        assert "SPUR_NODE_RANK=0" in all_output, f"missing rank 0:\n{all_output}"
+        assert "SPUR_NODE_RANK=1" in all_output, f"missing rank 1:\n{all_output}"
 
     def test_two_node_container_dns(self, multi_container_cluster):
         cluster = multi_container_cluster

--- a/tests/native_host/e2e/test_container.py
+++ b/tests/native_host/e2e/test_container.py
@@ -242,6 +242,9 @@ class TestContainerMultiNode:
             'echo "SPUR_NNODES=${SPUR_NNODES}"\n'
             'echo "SPUR_NODE_RANK=${SPUR_NODE_RANK}"\n'
             'echo "SPUR_JOB_ID=${SPUR_JOB_ID}"\n'
+            'echo "TORCH_RANK=[${RANK}]"\n'
+            'echo "TORCH_WORLD_SIZE=[${WORLD_SIZE}]"\n'
+            'echo "TORCH_MASTER_ADDR=[${MASTER_ADDR}]"\n'
             "echo CT_ENV_OK\n",
         )
         sb = cluster.sbatch([
@@ -257,6 +260,15 @@ class TestContainerMultiNode:
         assert "SPUR_NNODES=2" in all_output, f"missing SPUR_NNODES=2:\n{all_output}"
         assert "SPUR_NODE_RANK=0" in all_output, f"missing rank 0:\n{all_output}"
         assert "SPUR_NODE_RANK=1" in all_output, f"missing rank 1:\n{all_output}"
+        # The torch names must be empty inside the container too. Spur no
+        # longer injects them (matching Slurm).
+        assert "TORCH_RANK=[]" in all_output, f"RANK should be unset:\n{all_output}"
+        assert "TORCH_WORLD_SIZE=[]" in all_output, (
+            f"WORLD_SIZE should be unset:\n{all_output}"
+        )
+        assert "TORCH_MASTER_ADDR=[]" in all_output, (
+            f"MASTER_ADDR should be unset:\n{all_output}"
+        )
 
     def test_two_node_container_dns(self, multi_container_cluster):
         cluster = multi_container_cluster

--- a/tests/native_host/e2e/test_multi_node.py
+++ b/tests/native_host/e2e/test_multi_node.py
@@ -64,15 +64,20 @@ class TestMultiNodeDispatch:
         assert "SLURM_JOB_ID=" in all_output, f"missing SLURM_JOB_ID:\n{all_output}"
 
     def test_distributed_env_vars(self, multi_node_cluster):
+        # Spur does not inject the PyTorch rendezvous variables (MASTER_ADDR,
+        # MASTER_PORT, WORLD_SIZE, RANK) — Slurm never sets them either. It
+        # exposes the allocation topology through SPUR_*/SLURM_* instead.
         cluster = multi_node_cluster
         out_path = f"{cluster.remote_dir}/dist-env.out"
         script = cluster.write_file(
             "dist-env.sh",
             "#!/bin/bash\n"
-            'echo "RANK=${RANK}"\n'
-            'echo "WORLD_SIZE=${WORLD_SIZE}"\n'
-            'echo "MASTER_ADDR=${MASTER_ADDR}"\n'
-            'echo "MASTER_PORT=${MASTER_PORT}"\n'
+            'echo "SPUR_NNODES=${SPUR_NNODES}"\n'
+            'echo "SPUR_NODE_RANK=${SPUR_NODE_RANK}"\n'
+            'echo "SPUR_PEER_NODES=${SPUR_PEER_NODES}"\n'
+            'echo "TORCH_RANK=[${RANK}]"\n'
+            'echo "TORCH_WORLD_SIZE=[${WORLD_SIZE}]"\n'
+            'echo "TORCH_MASTER_PORT=[${MASTER_PORT}]"\n'
             "echo DIST_ENV_OK\n",
         )
         sb = cluster.sbatch(["-J", "dist-env", "-N", "2", "-o", out_path, script])
@@ -81,16 +86,53 @@ class TestMultiNodeDispatch:
 
         wait_job(cluster, job_id, timeout=90)
         all_output = cluster.read_output_all_nodes(out_path)
-        assert "WORLD_SIZE=2" in all_output
-        assert "RANK=0" in all_output
-        assert "RANK=1" in all_output
-        assert "MASTER_PORT=29500" in all_output
-        master_addr_lines = [
-            line for line in all_output.splitlines()
-            if line.startswith("MASTER_ADDR=") and line != "MASTER_ADDR="
-        ]
-        assert len(master_addr_lines) >= 2, (
-            f"MASTER_ADDR should be set on both ranks:\n{all_output}"
+        assert "SPUR_NNODES=2" in all_output, f"missing SPUR_NNODES=2:\n{all_output}"
+        assert "SPUR_NODE_RANK=0" in all_output, f"missing rank 0:\n{all_output}"
+        assert "SPUR_NODE_RANK=1" in all_output, f"missing rank 1:\n{all_output}"
+        assert any(
+            line.startswith("SPUR_PEER_NODES=") and len(line) > len("SPUR_PEER_NODES=")
+            for line in all_output.splitlines()
+        ), f"SPUR_PEER_NODES should be non-empty:\n{all_output}"
+        # The torch names must be empty because Spur no longer injects them.
+        assert "TORCH_RANK=[]" in all_output, f"RANK should be unset:\n{all_output}"
+        assert "TORCH_WORLD_SIZE=[]" in all_output, (
+            f"WORLD_SIZE should be unset:\n{all_output}"
+        )
+        assert "TORCH_MASTER_PORT=[]" in all_output, (
+            f"MASTER_PORT should be unset:\n{all_output}"
+        )
+
+    def test_user_rendezvous_env_preserved(self, multi_node_cluster):
+        # Regression for #783: a user-exported MASTER_PORT/WORLD_SIZE must
+        # survive on a multi-node job, not be overwritten by Spur.
+        cluster = multi_node_cluster
+        out_path = f"{cluster.remote_dir}/user-rdzv.out"
+        script = cluster.write_file(
+            "user-rdzv.sh",
+            "#!/bin/bash\n"
+            'echo "MASTER_PORT=${MASTER_PORT}"\n'
+            'echo "WORLD_SIZE=${WORLD_SIZE}"\n'
+            "echo USER_RDZV_OK\n",
+        )
+        cmd = (
+            f"SPUR_CONTROLLER_ADDR='{cluster.controller_addr}' "
+            f"PATH='{cluster.bin_dir}':$PATH "
+            f"MASTER_PORT=29999 WORLD_SIZE=16 "
+            f"'{cluster.bin_dir}/sbatch' -J user-rdzv -N 2 "
+            f"-o '{out_path}' --export=ALL '{script}'"
+        )
+        sb = cluster.nodes[0].exec(cmd)
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        wait_job(cluster, job_id, timeout=90)
+        all_output = cluster.read_output_all_nodes(out_path)
+        assert "USER_RDZV_OK" in all_output, f"missing USER_RDZV_OK:\n{all_output}"
+        assert "MASTER_PORT=29999" in all_output, (
+            f"user MASTER_PORT was overwritten:\n{all_output}"
+        )
+        assert "WORLD_SIZE=16" in all_output, (
+            f"user WORLD_SIZE was overwritten:\n{all_output}"
         )
 
 


### PR DESCRIPTION
Fixes #783

## What

Spur no longer injects the PyTorch/torchrun rendezvous environment variables into jobs: `MASTER_ADDR`, `MASTER_PORT`, `WORLD_SIZE`, `RANK`, `LOCAL_RANK`, `LOCAL_WORLD_SIZE`, `NPROC_PER_NODE`, `NODE_RANK`.

## Why

Slurm does not set these. They are torchrun conventions that job scripts derive from `SLURM_*` (or torchrun computes itself). Spur was injecting them after merging the user's environment, so it silently overwrote values the user forwarded, hardcoded `MASTER_PORT=29500` (colliding across concurrent jobs), and set `WORLD_SIZE` to the node count rather than total tasks (wrong process group whenever tasks-per-node > 1).

Since the goal is Slurm parity, Spur should behave like Slurm: expose the allocation topology through `SPUR_*`/`SLURM_*` and let the user or launcher own the rendezvous. That removes the silent-overwrite and port-collision classes entirely, and user-forwarded values now survive.

## Behavior change

Scripts that read `WORLD_SIZE`/`RANK`/`MASTER_*`/`LOCAL_RANK` without setting them now see them unset (or whatever `--export` forwarded). Map from the Spur/Slurm equivalents instead:

| torch / `env://` | source |
|---|---|
| `WORLD_SIZE` | `SPUR_NTASKS` / `SLURM_NTASKS` |
| `RANK` | `SPUR_PROCID` / `SLURM_PROCID` |
| `LOCAL_RANK` | `SPUR_LOCALID` / `SLURM_LOCALID` |
| `NODE_RANK` | `SPUR_NODEID` / `SPUR_NODE_RANK` |
| `NPROC_PER_NODE` / `LOCAL_WORLD_SIZE` | `SPUR_TASKS_PER_NODE` |
| `MASTER_ADDR` / `MASTER_PORT` | first host of `SPUR_JOB_NODELIST` / `SPUR_PEER_NODES`, plus a port you choose |

PMI/PMIx injection is unchanged.

## Changes

- Native agent (`spurd`) and K8s agent no longer set the eight names on batch, srun-step, or pod launch.
- Multi-task wrappers key off `SPUR_LOCALID` instead of exporting `LOCAL_RANK`.
- Docs updated with the mapping and a batch-script example.

## Testing

- Unit + clippy green.
- Bare-metal cluster: verified the eight names are absent, `SPUR_*`/`SLURM_*` twins correct across single-node, multi-node, and multi-task-per-node; user-exported `MASTER_PORT`/`WORLD_SIZE` preserved on a 2-node job; 2-node and single-node PyTorch gloo all-reduce pass with rendezvous wired from `SPUR_*`.