### PR TITLE
test(e2e): pull e2e postgres image from mirror.gcr.io

### DIFF
--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -1127,7 +1127,7 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
         node.exec(
             f"docker run -d --name '{self._pg_container}' "
             f"-e POSTGRES_USER=spur -e POSTGRES_PASSWORD=spur -e POSTGRES_DB=spur "
-            f"-p 0:5432 postgres:16-alpine"
+            f"-p 0:5432 mirror.gcr.io/library/postgres:16-alpine"
         )
         self._pg_port = parse_published_port(
             node.exec(


### PR DESCRIPTION
## Summary

- The native_host e2e cluster helper pulls `postgres:16-alpine` directly from DockerHub on the test node.
- Anonymous DockerHub pulls are rate-limited, which can intermittently fail e2e runs.
- Switch to `mirror.gcr.io/library/postgres:16-alpine`, Google's public mirror of the DockerHub image, to avoid the limit.

## Test plan

- [ ] Run the native_host e2e suite and confirm the postgres container starts via the mirror image.