### PR TITLE
fix(core)!: read `-t MM:SS` as minutes:seconds and accept bare `days-hours`

### DIFF
--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -1580,9 +1580,8 @@ async fn reconfigure(controller: &str) -> Result<()> {
 }
 
 /// Parse a reservation duration into minutes via the shared `--time` grammar
-/// (whole minutes, `HH:MM:SS`, `D-HH:MM:SS`, `90m`); rejects INFINITE. Quirk of
-/// that grammar: a bare `MM:SS` is read as `HH:MM` and bare `days-hours` is
-/// rejected, so prefer the unambiguous colon forms.
+/// (whole minutes, `MM:SS`, `HH:MM:SS`, `days-hours`, `D-HH:MM`, `D-HH:MM:SS`,
+/// `90m`); rejects INFINITE.
 fn parse_reservation_duration(s: &str) -> Result<u32> {
     spur_core::config::parse_time_minutes(s).ok_or_else(|| {
         anyhow::anyhow!(

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1968,9 +1968,11 @@ pub fn parse_partition_time(field: &str, s: &str) -> Result<Option<u32>, ConfigE
     }
 }
 
-/// Parse a time string to minutes: Slurm grammar (`60`, `H:MM`, `H:MM:SS`,
-/// `D-HH:MM:SS`, `INFINITE`/`UNLIMITED`) or a suffixed duration (`90m`, `1h`,
-/// `2d12h`, `30s`). Sub-minute remainders round up.
+/// Parse a time string to minutes. Accepts Slurm's documented `--time` grammar
+/// (`minutes`, `minutes:seconds`, `hours:minutes:seconds`, `days-hours`,
+/// `days-hours:minutes`, `days-hours:minutes:seconds`, `INFINITE`/`UNLIMITED`)
+/// or a suffixed duration (`90m`, `1h`, `2d12h`, `30s`). Sub-minute remainders
+/// round up.
 pub fn parse_time_minutes(s: &str) -> Option<u32> {
     let s = s.trim();
     if s.eq_ignore_ascii_case("INFINITE") || s.eq_ignore_ascii_case("UNLIMITED") {
@@ -1995,9 +1997,11 @@ fn parse_slurm_time_minutes(s: &str) -> Option<u32> {
     match parts.len() {
         1 => parts[0].parse().ok(),
         2 => {
-            let h: u32 = parts[0].parse().ok()?;
-            let m: u32 = parts[1].parse().ok()?;
-            h.checked_mul(60)?.checked_add(m)
+            // MM:SS — Slurm's two-field form is minutes:seconds. Sub-minute
+            // remainders round up, matching the suffixed-duration path.
+            let m: u32 = parts[0].parse().ok()?;
+            let sec: u32 = parts[1].parse().ok()?;
+            m.checked_add(if sec > 0 { 1 } else { 0 })
         }
         3 => parse_hms(s),
         _ => None,
@@ -2007,8 +2011,8 @@ fn parse_slurm_time_minutes(s: &str) -> Option<u32> {
 /// Parse a time string to total seconds (not minutes).
 ///
 /// Same accepted formats as [`parse_time_minutes`] (Slurm grammar plus suffixed
-/// durations), but with second granularity: "N" → N minutes, "H:MM" →
-/// hours+minutes, "H:MM:SS" → exact, "90s" → 90 seconds.
+/// durations), but with second granularity: "N" → N minutes, "MM:SS" →
+/// minutes+seconds, "H:MM:SS" → exact, "90s" → 90 seconds.
 pub fn parse_time_seconds(s: &str) -> Option<u64> {
     let s = s.trim();
     if s.eq_ignore_ascii_case("INFINITE") || s.eq_ignore_ascii_case("UNLIMITED") {
@@ -2034,10 +2038,10 @@ fn parse_slurm_time_seconds(s: &str) -> Option<u64> {
             mins.checked_mul(60)
         }
         2 => {
-            // HH:MM → hours and minutes (no seconds)
-            let h: u64 = parts[0].parse().ok()?;
-            let m: u64 = parts[1].parse().ok()?;
-            h.checked_mul(3600)?.checked_add(m.checked_mul(60)?)
+            // MM:SS — Slurm's two-field form is minutes:seconds, not hours:minutes.
+            let m: u64 = parts[0].parse().ok()?;
+            let sec: u64 = parts[1].parse().ok()?;
+            m.checked_mul(60)?.checked_add(sec)
         }
         3 => {
             // HH:MM:SS
@@ -2086,9 +2090,15 @@ fn parse_suffix_duration_seconds(s: &str) -> Option<u64> {
     Some(total)
 }
 
+/// Parse the part after `days-`: bare hours, `hours:minutes`, or
+/// `hours:minutes:seconds`. The bare-hours case backs Slurm's `days-hours`.
 fn parse_hms_seconds(s: &str) -> Option<u64> {
     let parts: Vec<&str> = s.split(':').collect();
     match parts.len() {
+        1 => {
+            let h: u64 = parts[0].parse().ok()?;
+            h.checked_mul(3600)
+        }
         2 => {
             let h: u64 = parts[0].parse().ok()?;
             let m: u64 = parts[1].parse().ok()?;
@@ -2106,13 +2116,19 @@ fn parse_hms_seconds(s: &str) -> Option<u64> {
     }
 }
 
+/// Parse the part after `days-`: bare hours, `hours:minutes`, or
+/// `hours:minutes:seconds`. The bare-hours case backs Slurm's `days-hours`.
 fn parse_hms(s: &str) -> Option<u32> {
     let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() != 3 && parts.len() != 2 {
+    if parts.len() > 3 {
         return None;
     }
     let h: u32 = parts[0].parse().ok()?;
-    let m: u32 = parts[1].parse().ok()?;
+    let m: u32 = if parts.len() >= 2 {
+        parts[1].parse().ok()?
+    } else {
+        0
+    };
     let s: u32 = if parts.len() == 3 {
         parts[2].parse().ok()?
     } else {
@@ -2603,10 +2619,27 @@ cni_mtu = 1400
     #[test]
     fn test_parse_time() {
         assert_eq!(parse_time_minutes("60"), Some(60));
-        assert_eq!(parse_time_minutes("1:30"), Some(90));
+        // MM:SS: 1m30s, rounded up to whole minutes.
+        assert_eq!(parse_time_minutes("1:30"), Some(2));
         assert_eq!(parse_time_minutes("72:00:00"), Some(4320));
         assert_eq!(parse_time_minutes("1-00:00:00"), Some(1440));
         assert_eq!(parse_time_minutes("INFINITE"), None);
+    }
+
+    /// Every form in Slurm's documented `--time` grammar, in minutes:
+    /// `minutes`, `minutes:seconds`, `hours:minutes:seconds`, `days-hours`,
+    /// `days-hours:minutes`, `days-hours:minutes:seconds`.
+    #[test]
+    fn parse_time_minutes_covers_the_documented_slurm_grammar() {
+        assert_eq!(parse_time_minutes("10"), Some(10));
+        assert_eq!(parse_time_minutes("4:00"), Some(4));
+        assert_eq!(parse_time_minutes("30:00"), Some(30));
+        assert_eq!(parse_time_minutes("0:30"), Some(1));
+        assert_eq!(parse_time_minutes("1:00:00"), Some(60));
+        assert_eq!(parse_time_minutes("2-12"), Some(3600));
+        assert_eq!(parse_time_minutes("1-0"), Some(1440));
+        assert_eq!(parse_time_minutes("2-12:30"), Some(3630));
+        assert_eq!(parse_time_minutes("2-12:30:15"), Some(3631));
     }
 
     #[test]
@@ -2614,9 +2647,9 @@ cni_mtu = 1400
         // "N" → N minutes in seconds
         assert_eq!(parse_time_seconds("1"), Some(60));
         assert_eq!(parse_time_seconds("60"), Some(3600));
-        // "H:MM" → exact seconds
-        assert_eq!(parse_time_seconds("1:30"), Some(5400)); // 1h30m
-                                                            // "H:MM:SS" → exact seconds (the key case)
+        // "MM:SS" → exact seconds
+        assert_eq!(parse_time_seconds("1:30"), Some(90));
+        // "H:MM:SS" → exact seconds (the key case)
         assert_eq!(parse_time_seconds("0:00:10"), Some(10));
         assert_eq!(parse_time_seconds("0:01:30"), Some(90));
         assert_eq!(parse_time_seconds("1:00:00"), Some(3600));
@@ -2626,6 +2659,22 @@ cni_mtu = 1400
         // limits
         assert_eq!(parse_time_seconds("INFINITE"), None);
         assert_eq!(parse_time_seconds("UNLIMITED"), None);
+    }
+
+    /// Every form in Slurm's documented `--time` grammar, in seconds. `4:00` is
+    /// four minutes, not four hours, and `2-12` is a limit rather than no limit.
+    #[test]
+    fn parse_time_seconds_covers_the_documented_slurm_grammar() {
+        assert_eq!(parse_time_seconds("10"), Some(600));
+        assert_eq!(parse_time_seconds("4:00"), Some(240));
+        assert_eq!(parse_time_seconds("30:00"), Some(1800));
+        assert_eq!(parse_time_seconds("0:30"), Some(30));
+        assert_eq!(parse_time_seconds("1:00:00"), Some(3600));
+        assert_eq!(parse_time_seconds("0:00:10"), Some(10));
+        assert_eq!(parse_time_seconds("2-12"), Some(216_000));
+        assert_eq!(parse_time_seconds("1-0"), Some(86_400));
+        assert_eq!(parse_time_seconds("2-12:30"), Some(217_800));
+        assert_eq!(parse_time_seconds("2-12:30:15"), Some(217_815));
     }
 
     #[test]
@@ -2976,8 +3025,11 @@ memory_mb = 1024000
         // Overflow on the `+ hms`, not the multiply: 2982616 days leaves only
         // 255 minutes of headroom and "05:00:00" is 300.
         assert_eq!(parse_time_minutes("2982616-05:00:00"), None);
-        // HH:MM arm.
-        assert_eq!(parse_time_minutes("71582789:00"), None);
+        // MM:SS arm. Minutes are now taken directly rather than multiplied, so
+        // overflow needs the sub-minute round-up to push past u32::MAX.
+        assert_eq!(parse_time_minutes("4294967295:01"), None);
+        // A minute count that does not fit u32 at all is rejected by the parse.
+        assert_eq!(parse_time_minutes("4294967296:00"), None);
         // u64 seconds overflow.
         assert_eq!(parse_time_seconds("213503982334602-00:00:00"), None);
         // The largest non-overflowing value is still accepted unchanged.

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1997,11 +1997,13 @@ fn parse_slurm_time_minutes(s: &str) -> Option<u32> {
     match parts.len() {
         1 => parts[0].parse().ok(),
         2 => {
-            // MM:SS — Slurm's two-field form is minutes:seconds. Sub-minute
-            // remainders round up, matching the suffixed-duration path.
-            let m: u32 = parts[0].parse().ok()?;
-            let sec: u32 = parts[1].parse().ok()?;
-            m.checked_add(if sec > 0 { 1 } else { 0 })
+            // MM:SS — Slurm's two-field form is minutes:seconds. Sum first, then
+            // round up, so an unnormalised seconds field like "1:90" carries into
+            // whole minutes rather than adding a flat one.
+            let m: u64 = parts[0].parse().ok()?;
+            let sec: u64 = parts[1].parse().ok()?;
+            let total = m.checked_mul(60)?.checked_add(sec)?;
+            u32::try_from(total.div_ceil(60)).ok()
         }
         3 => parse_hms(s),
         _ => None,
@@ -2116,8 +2118,10 @@ fn parse_hms_seconds(s: &str) -> Option<u64> {
     }
 }
 
-/// Parse the part after `days-`: bare hours, `hours:minutes`, or
-/// `hours:minutes:seconds`. The bare-hours case backs Slurm's `days-hours`.
+/// Parse an hours-first duration to minutes: bare hours, `hours:minutes`, or
+/// `hours:minutes:seconds`. Serves both the bare `hours:minutes:seconds` form
+/// and the part after `days-`, where the bare-hours case backs Slurm's
+/// `days-hours`. Any leftover seconds round up.
 fn parse_hms(s: &str) -> Option<u32> {
     let parts: Vec<&str> = s.split(':').collect();
     if parts.len() > 3 {
@@ -2640,6 +2644,17 @@ cni_mtu = 1400
         assert_eq!(parse_time_minutes("1-0"), Some(1440));
         assert_eq!(parse_time_minutes("2-12:30"), Some(3630));
         assert_eq!(parse_time_minutes("2-12:30:15"), Some(3631));
+    }
+
+    /// The seconds field is not constrained to 0..59, so it must carry into
+    /// whole minutes rather than contributing a flat one-minute round-up.
+    #[test]
+    fn parse_time_minutes_carries_an_unnormalised_seconds_field() {
+        assert_eq!(parse_time_seconds("1:90"), Some(150));
+        assert_eq!(parse_time_minutes("1:90"), Some(3)); // 150s
+        assert_eq!(parse_time_minutes("0:59"), Some(1));
+        assert_eq!(parse_time_minutes("0:60"), Some(1));
+        assert_eq!(parse_time_minutes("0:61"), Some(2));
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1992,7 +1992,6 @@ fn parse_slurm_time_minutes(s: &str) -> Option<u32> {
         return days.checked_mul(24 * 60)?.checked_add(hms);
     }
 
-    // hours:minutes:seconds or hours:minutes or just minutes
     let parts: Vec<&str> = s.split(':').collect();
     match parts.len() {
         1 => parts[0].parse().ok(),
@@ -2092,8 +2091,8 @@ fn parse_suffix_duration_seconds(s: &str) -> Option<u64> {
     Some(total)
 }
 
-/// Parse the part after `days-`: bare hours, `hours:minutes`, or
-/// `hours:minutes:seconds`. The bare-hours case backs Slurm's `days-hours`.
+/// Parse an hours-first duration to exact seconds: bare hours, `hours:minutes`,
+/// or `hours:minutes:seconds`. Also used by the minute-granularity parser.
 fn parse_hms_seconds(s: &str) -> Option<u64> {
     let parts: Vec<&str> = s.split(':').collect();
     match parts.len() {
@@ -2118,30 +2117,9 @@ fn parse_hms_seconds(s: &str) -> Option<u64> {
     }
 }
 
-/// Parse an hours-first duration to minutes: bare hours, `hours:minutes`, or
-/// `hours:minutes:seconds`. Serves both the bare `hours:minutes:seconds` form
-/// and the part after `days-`, where the bare-hours case backs Slurm's
-/// `days-hours`. Any leftover seconds round up.
+/// Parse an hours-first duration to minutes, rounding up leftover seconds.
 fn parse_hms(s: &str) -> Option<u32> {
-    let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() > 3 {
-        return None;
-    }
-    let h: u32 = parts[0].parse().ok()?;
-    let m: u32 = if parts.len() >= 2 {
-        parts[1].parse().ok()?
-    } else {
-        0
-    };
-    let s: u32 = if parts.len() == 3 {
-        parts[2].parse().ok()?
-    } else {
-        0
-    };
-    // Round up seconds
-    h.checked_mul(60)?
-        .checked_add(m)?
-        .checked_add(if s > 0 { 1 } else { 0 })
+    u32::try_from(parse_hms_seconds(s)?.div_ceil(60)).ok()
 }
 
 /// Format minutes as D-HH:MM:SS or HH:MM:SS.
@@ -2655,6 +2633,56 @@ cni_mtu = 1400
         assert_eq!(parse_time_minutes("0:59"), Some(1));
         assert_eq!(parse_time_minutes("0:60"), Some(1));
         assert_eq!(parse_time_minutes("0:61"), Some(2));
+    }
+
+    #[test]
+    fn parse_time_minutes_carries_hms_seconds() {
+        for (hms, seconds, minutes) in [
+            ("0:0:0", 0, 0),
+            ("0:0:59", 59, 1),
+            ("0:0:60", 60, 1),
+            ("0:0:61", 61, 2),
+            ("0:0:90", 90, 2),
+            ("0:0:120", 120, 2),
+            ("1:2:121", 3_841, 65),
+            ("0:0:4294967296", 4_294_967_296, 71_582_789),
+        ] {
+            for (input, expected_seconds, expected_minutes) in [
+                (hms.to_string(), seconds, minutes),
+                (format!("2-{hms}"), seconds + 172_800, minutes + 2_880),
+            ] {
+                assert_eq!(
+                    parse_time_seconds(&input),
+                    Some(expected_seconds),
+                    "{input}"
+                );
+                assert_eq!(
+                    parse_time_minutes(&input),
+                    Some(expected_minutes),
+                    "{input}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn parse_time_minutes_checks_hms_overflow() {
+        for prefix in ["", "0-"] {
+            for hms in [
+                "71582789:0:0",
+                "0:4294967295:1",
+                "0:0:257698037701",
+                "5124095576030431:0:0",
+                "0:307445734561825861:0",
+                "1:0:18446744073709551615",
+            ] {
+                let input = format!("{prefix}{hms}");
+                assert_eq!(parse_time_minutes(&input), None, "{input}");
+            }
+            let input = format!("{prefix}0:0:257698037640");
+            assert_eq!(parse_time_minutes(&input), Some(u32::MAX - 1), "{input}");
+        }
+        assert_eq!(parse_time_minutes("2982616-4:14:61"), None);
     }
 
     #[test]

--- a/crates/spur-tests/src/t52_config.rs
+++ b/crates/spur-tests/src/t52_config.rs
@@ -18,8 +18,14 @@ mod tests {
     }
 
     #[test]
-    fn t52_2_parse_hours_minutes() {
-        assert_eq!(parse_time_minutes("1:30"), Some(90));
+    fn t52_2_parse_minutes_seconds() {
+        // Slurm's two-field form is minutes:seconds; 1m30s rounds up to 2 min.
+        assert_eq!(parse_time_minutes("1:30"), Some(2));
+    }
+
+    #[test]
+    fn t52_2b_parse_days_hours() {
+        assert_eq!(parse_time_minutes("2-12"), Some(3600));
     }
 
     #[test]
@@ -151,7 +157,7 @@ priority_tier = 1
 [[partitions]]
 name = "debug"
 nodes = "node[001-002]"
-max_time = "1:00"
+max_time = "1:00:00"
 "#,
         )
         .unwrap();

--- a/crates/spur-tests/src/t52_config.rs
+++ b/crates/spur-tests/src/t52_config.rs
@@ -31,12 +31,14 @@ mod tests {
     #[test]
     fn t52_3_parse_hms() {
         assert_eq!(parse_time_minutes("72:00:00"), Some(4320));
+        assert_eq!(parse_time_minutes("0:0:90"), Some(2));
     }
 
     #[test]
     fn t52_4_parse_days_hms() {
         assert_eq!(parse_time_minutes("1-00:00:00"), Some(1440));
         assert_eq!(parse_time_minutes("7-00:00:00"), Some(10080));
+        assert_eq!(parse_time_minutes("2-0:0:90"), Some(2882));
     }
 
     #[test]

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -679,6 +679,22 @@ replicates to follower controllers, because ``reconfigure`` applies them through
 write-ahead log rather than the in-memory config swap. A partition still running
 jobs is skipped rather than deleted (see :ref:`reload-scope`).
 
+Time values for ``max_time`` and ``default_time`` accept ``minutes``,
+``minutes:seconds``, ``hours:minutes:seconds``, ``days-hours``,
+``days-hours:minutes``, and ``days-hours:minutes:seconds``, as well as suffixed
+durations and ``INFINITE`` / ``UNLIMITED``. Partition limits round up to whole
+minutes. Seconds fields carry into whole minutes before rounding: ``0:0:90`` is
+two minutes, and ``2-0:0:90`` is two days and two minutes.
+
+.. warning::
+
+   Two-field colon values now mean minutes:seconds, not hours:minutes. When
+   upgrading from the previous interpretation, replace values intended as
+   hours:minutes with explicit ``HH:MM:SS`` in partition configs and job
+   ``--time`` arguments. For example, use ``30:00:00`` for thirty hours;
+   ``30:00`` now means thirty minutes. Bare ``days-hours`` values such as
+   ``2-12`` now produce a finite duration of two days and twelve hours.
+
 .. list-table::
    :header-rows: 1
    :widths: 22 18 20 40

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -681,8 +681,8 @@ jobs is skipped rather than deleted (see :ref:`reload-scope`).
 
 Time values for ``max_time`` and ``default_time`` accept ``minutes``,
 ``minutes:seconds``, ``hours:minutes:seconds``, ``days-hours``,
-``days-hours:minutes``, and ``days-hours:minutes:seconds``, as well as suffixed
-durations and ``INFINITE`` / ``UNLIMITED``. Partition limits round up to whole
+``days-hours:minutes``, and ``days-hours:minutes:seconds``, as well as values
+with suffixes and ``INFINITE`` / ``UNLIMITED``. Partition limits round up to whole
 minutes. Seconds fields carry into whole minutes before rounding: ``0:0:90`` is
 two minutes, and ``2-0:0:90`` is two days and two minutes.
 
@@ -690,7 +690,7 @@ two minutes, and ``2-0:0:90`` is two days and two minutes.
 
    Two-field colon values now mean minutes:seconds, not hours:minutes. When
    upgrading from the previous interpretation, replace values intended as
-   hours:minutes with explicit ``HH:MM:SS`` in partition configs and job
+   hours:minutes with explicit ``HH:MM:SS`` in partition configuration and job
    ``--time`` arguments. For example, use ``30:00:00`` for thirty hours;
    ``30:00`` now means thirty minutes. Bare ``days-hours`` values such as
    ``2-12`` now produce a finite duration of two days and twelve hours.


### PR DESCRIPTION
Fixes #804.

## What was wrong

Slurm documents six accepted `--time` formats: `minutes`, `minutes:seconds`, `hours:minutes:seconds`, `days-hours`, `days-hours:minutes`, `days-hours:minutes:seconds`. Two were parsed incorrectly, and both failures were silent.

The two-field colon form was read as `hours:minutes`, so every such limit came out 60x longer than requested. `-t 4:00` means four minutes; it was granting four hours, and `scontrol show job` reported `TimeLimit=04:00:00`, which looks entirely deliberate.

Bare `days-hours` failed to parse at all. The remainder after `days-` went to a helper requiring at least two colon-separated fields, so `2-12` returned `None` — the same value that means `INFINITE` — producing a job with no time limit from a request for two and a half days.

Measured against the documented grammar before this change:

```
-t INPUT     PARSED AS              SLURM MEANS              RATIO
10           600s (10m0s)           600s (10m0s)                1x
4:00         14400s (4h0m)          240s (4m0s)                60x  <== MISMATCH
30:00        108000s (1d6h0m)       1800s (30m0s)              60x  <== MISMATCH
1:30         5400s (1h30m)          90s (1m30s)                60x  <== MISMATCH
0:30         1800s (30m0s)          30s (30s)                  60x  <== MISMATCH
1:00:00      3600s (1h0m)           3600s (1h0m)                1x
0:00:10      10s (10s)              10s (10s)                   1x
2-12         NO LIMIT               216000s (2d12h0m)          INF  <== MISMATCH
1-0          NO LIMIT               86400s (1d0h0m)            INF  <== MISMATCH
2-12:30      217800s (2d12h30m)     217800s (2d12h30m)          1x
2-12:30:15   217815s (2d12h30m)     217815s (2d12h30m)          1x
```

`days-hours:minutes` and `days-hours:minutes:seconds` were already correct, because a colon in the remainder satisfied that helper. Only the colon-less form fell through, which is why this went unnoticed.

## What this changes

- The two-field arm in both `parse_slurm_time_seconds` and `parse_slurm_time_minutes` now reads `MM:SS`. The minutes variant rounds a sub-minute remainder up, matching what the suffixed-duration path already did.
- `parse_hms_seconds` and `parse_hms` accept bare hours after `days-`, which is what `days-hours` needs. Both helpers are only reachable from the `days-` branch, so this does not affect other forms.
- Doc comments that described `H:MM` as intended are corrected, including `parse_reservation_duration` in `scontrol.rs`, whose comment documented the quirk as something to work around.

## Tests

Three existing assertions encoded the old reading and are updated: `config.rs` `test_parse_time` and `test_parse_time_seconds`, and `spur-tests` `t52_2`. Added a test per parser covering all six documented forms.

Two changes worth calling out for review:

- `t52_13_build_partitions` used a fixture of `max_time = "1:00"` while asserting 60 minutes — a config author writing the two-field form to mean one hour, which is exactly the mistake this change prevents. Changed to `"1:00:00"` so the fixture states the intent it always had.
- `parse_time_rejects_overflowing_slurm_durations` exercised overflow on the two-field arm with `"71582789:00"`, which only overflowed because minutes were multiplied by 3600. That arm now takes minutes directly, so the input no longer overflows; replaced with `"4294967295:01"`, where the round-up pushes past `u32::MAX`, plus a value that does not fit `u32` at all. I deliberately did not assert that `u32::MAX` minutes parses successfully, since `accounting::INFINITE` is `u32::MAX` and that would invite a sentinel collision.

`cargo test --workspace`, `cargo fmt --all --check` and `cargo clippy --workspace --all-targets` are clean.

## Breaking change

Two-field colon values now resolve to 1/60th of their previous duration. This affects `-t`/`--time` on `sbatch`, `srun` and `salloc`, and partition `MaxTime`/`DefaultTime`. Bare `days-hours` now produces a real limit where it previously produced an unlimited job.

The explicit `HH:MM:SS` form was and remains unambiguous, so that is the migration path for anything relying on the old reading. Partition configs are the case to flag in release notes: a site with `MaxTime = "30:00"` has been enforcing thirty hours and will start enforcing thirty minutes.

Worth considering as a follow-up, but deliberately not in this PR: a startup warning when a partition time value uses the two-field form, so operators are told rather than surprised.

## Deliberately out of scope

`parse_wall_time` in `sacctmgr.rs` is a third, independent implementation of the same grammar, serving QOS `grpwall`/`maxwall`. It has the same two-field bug, also rejects bare `days-hours`, and uses unchecked arithmetic. I left it alone because it is a different user-facing surface with its own migration story, and `docs/admin-guide/accounting.rst` currently documents its behaviour explicitly (`grpwall=600` and `grpwall=10:00` "both mean ten hours"). Happy to follow up there, or in this PR if you would rather it land together.

Longer term, three parallel implementations of one grammar is what allowed the same defect to exist in two of them. Consolidating them would prevent recurrence, but that felt like more than a bug fix should take on without maintainer input.
