### PR TITLE
fix(spurctld): make cni=calico work without the WireGuard mesh

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -299,3 +299,5 @@ pluggable
 torchrun
 backoff
 unapplied
+UDP
+VXLAN

--- a/crates/spur-core/src/k0s.rs
+++ b/crates/spur-core/src/k0s.rs
@@ -67,9 +67,9 @@ mod local_path_tests {
 /// fragmentation). Returns `None` for any `cni` other than `"calico"` (the k0s default, kube-router,
 /// needs no config file). `sans` are extra API-server certificate SANs.
 ///
-/// For a multi-CP cluster (`cp_count > 1`) no VIP can float over Calico's cryptokey/overlay routing,
-/// so node-local load balancing (EnvoyProxy) is enabled to give konnectivity a cluster-wide balanced
-/// endpoint instead of pinning every agent to one controller.
+/// For a multi-CP cluster (`cp_count > 1`) no VIP can float over the mesh's cryptokey routing (`bird`
+/// mode) or Calico's own overlay (`vxlan` mode), so node-local load balancing (EnvoyProxy) is enabled
+/// to give konnectivity a cluster-wide balanced endpoint instead of pinning every agent to one controller.
 #[allow(clippy::too_many_arguments)]
 pub fn k0s_controller_config_yaml(
     cni: &str,

--- a/crates/spur-core/src/k0s.rs
+++ b/crates/spur-core/src/k0s.rs
@@ -59,16 +59,18 @@ mod local_path_tests {
     }
 }
 
-/// Generate a k0s controller config (YAML) for a mesh-native cluster: the API server is advertised
-/// on `api_address` (the control-plane's WireGuard mesh IP) and Calico runs in `bird` mode (native
-/// routing, no overlay) so pod traffic rides the mesh. `cni_mtu` sets Calico's MTU (typically below
-/// the underlay to leave room for WireGuard's ~50-byte overhead, avoiding fragmentation). Returns
-/// `None` for any `cni` other than `"calico"` (the k0s default, kube-router, needs no config file).
-/// `sans` are extra API-server certificate SANs (e.g. the control-plane's mesh + underlay IPs).
+/// Generate a k0s controller config (YAML) for a Calico cluster. `api_address` is where the API
+/// server is advertised — the control-plane's WireGuard mesh IP when `mesh_native`, else its real
+/// underlay address. `mesh_native` also picks Calico's mode: `bird` (native routing over the mesh,
+/// no overlay) when true, else `vxlan` (Calico's own overlay — no mesh required). `cni_mtu` sets
+/// Calico's MTU (typically below the underlay to leave room for encapsulation overhead, avoiding
+/// fragmentation). Returns `None` for any `cni` other than `"calico"` (the k0s default, kube-router,
+/// needs no config file). `sans` are extra API-server certificate SANs.
 ///
-/// For a multi-CP cluster (`cp_count > 1`) no VIP can float over WireGuard cryptokey routing, so
-/// node-local load balancing (EnvoyProxy) is enabled to give konnectivity a cluster-wide balanced
+/// For a multi-CP cluster (`cp_count > 1`) no VIP can float over Calico's cryptokey/overlay routing,
+/// so node-local load balancing (EnvoyProxy) is enabled to give konnectivity a cluster-wide balanced
 /// endpoint instead of pinning every agent to one controller.
+#[allow(clippy::too_many_arguments)]
 pub fn k0s_controller_config_yaml(
     cni: &str,
     pod_cidr: &str,
@@ -77,6 +79,7 @@ pub fn k0s_controller_config_yaml(
     api_address: &str,
     sans: &[String],
     cp_count: usize,
+    mesh_native: bool,
 ) -> Option<String> {
     if cni != "calico" {
         return None;
@@ -100,7 +103,8 @@ pub fn k0s_controller_config_yaml(
     y.push_str(&format!("    podCIDR: {pod_cidr}\n"));
     y.push_str(&format!("    serviceCIDR: {service_cidr}\n"));
     y.push_str("    calico:\n");
-    y.push_str("      mode: bird\n");
+    let mode = if mesh_native { "bird" } else { "vxlan" };
+    y.push_str(&format!("      mode: {mode}\n"));
     y.push_str(&format!("      mtu: {cni_mtu}\n"));
     if cp_count > 1 {
         y.push_str("    nodeLocalLoadBalancing:\n");
@@ -189,6 +193,7 @@ mod k0s_config_tests {
             "192.0.2.1",
             &["192.0.2.1".to_string(), "203.0.113.9".to_string()],
             1,
+            true,
         )
         .unwrap();
         assert!(y.contains("address: 192.0.2.1"));
@@ -201,6 +206,25 @@ mod k0s_config_tests {
     }
 
     #[test]
+    fn calico_config_uses_vxlan_without_a_mesh() {
+        // Documentation-range addresses only (RFC 5737 TEST-NET); no real infrastructure IPs.
+        let y = k0s_controller_config_yaml(
+            "calico",
+            "192.0.2.0/24",
+            "198.51.100.0/24",
+            1450,
+            "203.0.113.9",
+            &["203.0.113.9".to_string()],
+            1,
+            false,
+        )
+        .unwrap();
+        assert!(y.contains("address: 203.0.113.9"));
+        assert!(y.contains("mode: vxlan"));
+        assert!(!y.contains("mode: bird"));
+    }
+
+    #[test]
     fn kuberouter_default_generates_no_config() {
         assert!(k0s_controller_config_yaml(
             "kuberouter",
@@ -210,6 +234,7 @@ mod k0s_config_tests {
             "192.0.2.1",
             &[],
             3,
+            true,
         )
         .is_none());
     }
@@ -225,6 +250,7 @@ mod k0s_config_tests {
             "192.0.2.1",
             &["192.0.2.1".to_string()],
             3,
+            true,
         )
         .unwrap();
         assert!(y.contains("nodeLocalLoadBalancing:"));
@@ -243,6 +269,7 @@ mod k0s_config_tests {
             "192.0.2.1",
             &["192.0.2.1".to_string()],
             1,
+            true,
         )
         .unwrap();
         assert!(!y.contains("nodeLocalLoadBalancing"));

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -830,16 +830,30 @@ async fn fetch_component_state(cluster: &ClusterManager, node: &str) -> Option<S
         .map(|(state, _)| state)
 }
 
-/// The mesh-native k0s controller config for `node` (api on its mesh IP + Calico bird), or None for
-/// the default kube-router mode (`cni != "calico"`) / a node without a mesh IP. `cp_count > 1` also
-/// enables node-local load balancing for konnectivity.
+/// The address Calico/kubelet should use for `node`: its mesh IP when the mesh is actually up
+/// (`net.wg_enabled`), else its real underlay address — a `k0s_mesh_ip` handed out with the mesh
+/// disabled is a pool-allocated address never bound to any interface, so it must not be used.
+fn calico_node_address<'a>(
+    net: &ClusterNetworking,
+    node: &'a spur_core::node::Node,
+) -> Option<&'a str> {
+    if net.wg_enabled {
+        node.k0s_mesh_ip.as_deref()
+    } else {
+        node.address.as_deref()
+    }
+}
+
+/// The k0s controller config for `node` (api on its Calico address + `bird`/`vxlan` mode per
+/// [`calico_node_address`]), or None for the default kube-router mode (`cni != "calico"`) / a node
+/// without a usable address yet. `cp_count > 1` also enables node-local load balancing.
 fn controller_k0s_config(
     net: &ClusterNetworking,
     node: &spur_core::node::Node,
     cp_count: usize,
 ) -> Option<String> {
-    let api = node.k0s_mesh_ip.as_deref()?;
-    // SANs: the mesh IP (advertised) + the underlay address (so `kubectl` over either works).
+    let api = calico_node_address(net, node)?;
+    // SANs: the advertised address + the underlay address (so `kubectl` over either works).
     let mut sans = vec![api.to_string()];
     if let Some(addr) = &node.address {
         if addr != api {
@@ -854,6 +868,7 @@ fn controller_k0s_config(
         api,
         &sans,
         cp_count,
+        net.wg_enabled,
     )
 }
 
@@ -901,8 +916,8 @@ async fn converge_provisioning(
             clear_node_error(cluster, node);
             continue;
         }
-        // Mesh-native cluster: generate the k0s config (api on the mesh IP + Calico bird) when
-        // cni=calico; None keeps the default kube-router. The bootstrap seeds etcd — no join token.
+        // Generate the k0s config when cni=calico; None keeps the default kube-router. The
+        // bootstrap seeds etcd — no join token.
         let k0s_config = controller_k0s_config(net, node, cp_count);
         spawn_start_component(cluster, &node.name, role, None, k0s_config, None);
     }
@@ -935,13 +950,13 @@ async fn converge_provisioning(
         } else {
             "worker"
         };
-        // For a native-routing CNI, pin the node's kubelet node-ip to its mesh IP.
+        // For Calico, pin the node's kubelet node-ip to whichever address it's actually running on.
         let node_ip = if net.cni == "calico" {
-            node.k0s_mesh_ip.clone()
+            calico_node_address(net, node).map(String::from)
         } else {
             None
         };
-        // A secondary control-plane also needs its own generated k0s config (API SANs on its mesh IP).
+        // A secondary control-plane also needs its own generated k0s config (API SANs per calico_node_address).
         let k0s_config = if role == K0sRole::Controller {
             controller_k0s_config(net, node, cp_count)
         } else {
@@ -1884,5 +1899,67 @@ mod tests {
             spur_net::mesh::peer_allowed_ips(&m.nodes[0]),
             "10.44.0.1/32"
         );
+    }
+
+    fn test_net(wg_enabled: bool, cni: &str) -> ClusterNetworking {
+        ClusterNetworking {
+            wg_enabled,
+            mesh_cidr: "10.44.0.0/16".into(),
+            mesh_interface: "spur0".into(),
+            pod_cidr: "10.42.0.0/16".into(),
+            service_cidr: "10.43.0.0/16".into(),
+            cni_mtu: 1450,
+            cni: cni.into(),
+            control_plane_node: None,
+            provisioning_timeout: Duration::from_secs(600),
+        }
+    }
+
+    #[test]
+    fn calico_node_address_uses_mesh_ip_when_meshed() {
+        let net = test_net(true, "calico");
+        let mut n = spur_core::node::Node::new("cp".into(), Default::default());
+        n.k0s_mesh_ip = Some("10.44.0.1".into());
+        n.address = Some("203.0.113.9".into());
+        assert_eq!(calico_node_address(&net, &n), Some("10.44.0.1"));
+    }
+
+    #[test]
+    fn calico_node_address_falls_back_to_underlay_without_mesh() {
+        let net = test_net(false, "calico");
+        let mut n = spur_core::node::Node::new("cp".into(), Default::default());
+        // A pool-allocated mesh IP can still be present (assigned regardless of wg_enabled), but it's
+        // never bound to a real interface here, so it must not be used.
+        n.k0s_mesh_ip = Some("10.44.0.1".into());
+        n.address = Some("203.0.113.9".into());
+        assert_eq!(calico_node_address(&net, &n), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn controller_k0s_config_picks_vxlan_and_underlay_api_without_mesh() {
+        let net = test_net(false, "calico");
+        let mut n = spur_core::node::Node::new("cp".into(), Default::default());
+        n.k0s_mesh_ip = Some("10.44.0.1".into());
+        n.address = Some("203.0.113.9".into());
+        let y = controller_k0s_config(&net, &n, 1).unwrap();
+        assert!(y.contains("address: 203.0.113.9"));
+        assert!(y.contains("mode: vxlan"));
+        assert!(
+            !y.contains("10.44.0.1"),
+            "the unbound mesh IP must not leak into the config"
+        );
+    }
+
+    #[test]
+    fn controller_k0s_config_keeps_bird_and_mesh_api_when_meshed() {
+        let net = test_net(true, "calico");
+        let mut n = spur_core::node::Node::new("cp".into(), Default::default());
+        n.k0s_mesh_ip = Some("10.44.0.1".into());
+        n.address = Some("203.0.113.9".into());
+        let y = controller_k0s_config(&net, &n, 1).unwrap();
+        assert!(y.contains("address: 10.44.0.1"));
+        assert!(y.contains("mode: bird"));
+        // underlay still carried as an alternate SAN so kubectl works over either address.
+        assert!(y.contains("203.0.113.9"));
     }
 }

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -830,9 +830,11 @@ async fn fetch_component_state(cluster: &ClusterManager, node: &str) -> Option<S
         .map(|(state, _)| state)
 }
 
-/// The address Calico/kubelet should use for `node`: its mesh IP when the mesh is actually up
+/// The address Calico/kubelet should use for `node`: its mesh IP when the mesh is configured
 /// (`net.wg_enabled`), else its real underlay address — a `k0s_mesh_ip` handed out with the mesh
 /// disabled is a pool-allocated address never bound to any interface, so it must not be used.
+/// `kubelet --node-ip` requires a literal IP (unlike `Node.address`, which may be an FQDN), so the
+/// underlay branch only returns a value that parses as one.
 fn calico_node_address<'a>(
     net: &ClusterNetworking,
     node: &'a spur_core::node::Node,
@@ -840,7 +842,9 @@ fn calico_node_address<'a>(
     if net.wg_enabled {
         node.k0s_mesh_ip.as_deref()
     } else {
-        node.address.as_deref()
+        node.address
+            .as_deref()
+            .filter(|addr| addr.parse::<std::net::IpAddr>().is_ok())
     }
 }
 
@@ -1933,6 +1937,16 @@ mod tests {
         n.k0s_mesh_ip = Some("10.44.0.1".into());
         n.address = Some("203.0.113.9".into());
         assert_eq!(calico_node_address(&net, &n), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn calico_node_address_rejects_an_fqdn_underlay_address() {
+        let net = test_net(false, "calico");
+        let mut n = spur_core::node::Node::new("cp".into(), Default::default());
+        // Node.address may be an FQDN (docs/deployment/native-host.rst), but kubelet --node-ip
+        // requires a literal IP -- must defer rather than pass a hostname through.
+        n.address = Some("cp.example.internal".into());
+        assert_eq!(calico_node_address(&net, &n), None);
     }
 
     #[test]

--- a/docs/deployment/managed-kubernetes.rst
+++ b/docs/deployment/managed-kubernetes.rst
@@ -180,17 +180,30 @@ Networking / CNI
 **kuberouter** (default) — the built-in k0s CNI. The control-plane API is advertised
 on the node's primary interface and workers join over it. No mesh required.
 
-**calico** (``cni = "calico"``) — mesh-native routing. ``spur k8s up`` generates a
-k0s config that advertises the API on the control-plane's **mesh IP** and runs
-Calico in ``bird`` (BGP, no overlay) mode, and sets each worker's kubelet
-``--node-ip`` to its mesh IP. Pod traffic then routes over the WireGuard mesh.
-This requires the ``spur0`` mesh to be up first (``spur net join``); membership
-reconciliation only maintains the peer set + ``AllowedIPs``, it does not create
-the tunnel.
+**calico** (``cni = "calico"``) — with the WireGuard mesh enabled
+(``network.wg_enabled = true``), ``spur k8s up`` generates a k0s config that
+advertises the API on the control-plane's **mesh IP** and runs Calico in
+``bird`` (BGP, no overlay) mode, setting each worker's kubelet ``--node-ip`` to
+its mesh IP so pod traffic routes over the WireGuard mesh. This requires the
+``spur0`` mesh to be up first (``spur net join``); membership reconciliation
+only maintains the peer set + ``AllowedIPs``, it does not create the tunnel.
 
 The controller continuously reconciles the full-mesh membership to every node
 (pruning peers for departed nodes), so a reboot, a WireGuard restart, or a
 control-plane failover self-heals.
+
+With the mesh disabled (``network.wg_enabled = false``), Calico instead
+advertises the API on each node's real underlay address and runs in ``vxlan``
+mode — Calico's own overlay, requiring no mesh. Standard VXLAN (UDP 4789)
+between nodes; open that port if a host firewall default-denies it.
+
+.. note::
+
+   Like ``nodeLocalLoadBalancing`` above, this is rendered once per control
+   plane and does not hot-reload: toggling ``network.wg_enabled`` after a
+   cluster's nodes are already ``active`` does not retroactively switch them
+   between ``bird`` and ``vxlan``. Reprovision (``spur k8s down --reset`` then
+   ``spur k8s up``) to pick up the change.
 
 Storage
 ~~~~~~~
@@ -417,7 +430,7 @@ Configuration reference (``[cluster]``)
      - Service network.
    * - ``cni``
      - ``kuberouter``
-     - ``kuberouter`` or ``calico`` (mesh-native bird routing).
+     - ``kuberouter`` or ``calico`` (``bird`` over the mesh if enabled, else ``vxlan``).
    * - ``cni_mtu``
      - ``1450``
      - Calico MTU emitted into the generated k0s config (leaves WireGuard headroom).

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -272,6 +272,37 @@ def k8s_multicp_cluster(ssh_nodes, remote_bin_dir):
 
 
 @pytest.fixture
+def k8s_calico_direct_cluster(ssh_nodes, remote_bin_dir):
+    """Native k0s, calico CNI, WireGuard mesh OFF (`network.wg_enabled` unset ->
+    False). A single control plane needs no etcd quorum, so this only needs 2
+    nodes — unlike ``k8s_multicp_cluster``'s HA scenarios."""
+    if len(ssh_nodes) < 2:
+        pytest.skip(
+            f"a single-CP k0s cluster needs at least 2 nodes (got {len(ssh_nodes)})"
+        )
+    c = SpurCluster(ssh_nodes, make_remote_dir(), remote_bin_dir)
+    c.provision()
+    c.root_agent_preflight()
+    _reset_k0s_all_nodes(c)
+    try:
+        c.start(
+            config_overrides={"cluster": {"enabled": True, "cni": "calico"}},
+            agent_as_root=True,
+        )
+    except Exception:
+        c.teardown()
+        raise
+    yield c
+    try:
+        c.k8s_down(reset=True)
+        c.wait_k8s_phase("down", timeout=180)
+    except Exception:
+        pass
+    c.teardown()
+    _reset_k0s_all_nodes(c)
+
+
+@pytest.fixture
 def accounting_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
     """
     Per-test fixture: a running cluster with Postgres on node 0.

--- a/tests/native_host/e2e/test_k8s_calico_direct.py
+++ b/tests/native_host/e2e/test_k8s_calico_direct.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end tests for `cni=calico` with the WireGuard mesh OFF.
+
+Calico's mesh-over-WireGuard scenarios live in `test_wg_k0s.py`; this file
+covers the other, non-mesh mode: the k0s API advertised on each node's real
+underlay address and Calico running its own `vxlan` overlay instead of `bird`
+native routing. Previously this combination hung forever (the API tried to
+bind a WireGuard mesh IP that was never assigned to any interface).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from wg_cluster import wait_until
+
+_IPV4_RE = re.compile(r"^\d{1,3}(?:\.\d{1,3}){3}$")
+
+
+def _internal_ips(c, cp_index: int) -> set[str]:
+    out = c.nodes[cp_index].exec_allow_fail(
+        f"{c._sudo_prefix()}k0s kubectl get nodes "
+        "-o jsonpath='{range .items[*]}{.status.addresses[?(@.type==\"InternalIP\")].address}{\"\\n\"}{end}'"
+    )
+    return {t for t in (line.strip() for line in out.splitlines()) if _IPV4_RE.match(t)}
+
+
+def _active_node_names(c) -> set[str]:
+    """Every node name whose `spur k8s status` row reports `active` — control
+    plane or worker. `phase` alone reaches `ready` on control-plane quorum
+    alone (partial-ready), so a stuck worker doesn't show up there; this does."""
+    names = set()
+    for line in c.k8s_status().splitlines():
+        fields = line.split()
+        if len(fields) >= 3 and fields[2] == "active":
+            names.add(fields[0])
+    return names
+
+
+@pytest.mark.k0s
+class TestCalicoWithoutMesh:
+    def test_cluster_reaches_ready_without_a_mesh(self, k8s_calico_direct_cluster):
+        c = k8s_calico_direct_cluster
+        out = c.k8s_up(["--control-plane-node", c.node_names[0]])
+        assert "provisioning requested" in out or "already" in out, out
+        c.wait_k8s_phase("ready", timeout=600)
+
+        # `ready` alone only proves control-plane quorum (partial-ready) -- the
+        # bug this fixture exercises left the worker stuck `inactive` forever
+        # even after that. Every node must actually become active.
+        wait_until(lambda: set(c.node_names) <= _active_node_names(c), timeout_s=180,
+                   desc="every node (not just the control plane) becomes active")
+
+    def test_node_internal_ip_is_the_real_underlay_address(self, k8s_calico_direct_cluster):
+        """Without a mesh, kubelet's --node-ip must be the node's real address,
+        not a WireGuard mesh IP that was never bound to any interface."""
+        c = k8s_calico_direct_cluster
+        c.k8s_up(["--control-plane-node", c.node_names[0]])
+        c.wait_k8s_phase("ready", timeout=600)
+
+        cps = c.k8s_control_planes()
+        assert cps, "no control-plane node reported"
+        cp_index = c.node_names.index(cps[0])
+
+        wait_until(lambda: len(_internal_ips(c, cp_index)) > 0, timeout_s=180,
+                   desc="kubelet InternalIPs registered with the k8s API")
+
+        underlay_hosts = {n.host for n in c.nodes}
+        internal_ips = _internal_ips(c, cp_index)
+        assert internal_ips <= underlay_hosts, (
+            f"InternalIPs must be real underlay addresses, got {internal_ips} "
+            f"(expected a subset of {underlay_hosts})"
+        )
+
+    def test_calico_pods_come_up_in_vxlan_mode(self, k8s_calico_direct_cluster):
+        c = k8s_calico_direct_cluster
+        c.k8s_up(["--control-plane-node", c.node_names[0]])
+        c.wait_k8s_phase("ready", timeout=600)
+        cps = c.k8s_control_planes()
+        cp_index = c.node_names.index(cps[0])
+
+        def calico_node_running() -> bool:
+            out = c.nodes[cp_index].exec_allow_fail(
+                f"{c._sudo_prefix()}k0s kubectl get pods -n kube-system "
+                "-l k8s-app=calico-node --no-headers 2>/dev/null"
+            )
+            lines = [ln for ln in out.splitlines() if ln.strip()]
+            return bool(lines) and all(
+                len(f := ln.split()) >= 3 and f[1] == "1/1" and f[2] == "Running"
+                for ln in lines
+            )
+
+        wait_until(calico_node_running, timeout_s=180,
+                   desc="calico-node DaemonSet Running (vxlan mode, no mesh)")
+
+        cfg = c.nodes[cp_index].exec_allow_fail(
+            f"{c._sudo_prefix()}cat /etc/k0s/k0s.yaml"
+        )
+        assert "mode: vxlan" in cfg, f"expected vxlan mode without a mesh, got:\n{cfg}"


### PR DESCRIPTION
## What

`spur k8s up` with `[cluster] cni = "calico"` always advertised the control-plane API on `node.k0s_mesh_ip` and configured Calico in `bird` (BGP native-routing, no overlay) mode — regardless of `[network] wg_enabled`. Mesh IPs are allocated from an address pool unconditionally (even with the mesh disabled), so without the mesh that address is fabricated and never bound to any real interface. The k0s control plane can't bind or reach it, and provisioning hangs indefinitely (`k0s status` can't find its own admin socket), with no clear error surfaced to the operator.

Calico doesn't actually need the mesh: its `vxlan` mode builds its own overlay over plain underlay addresses — the same as most non-Spur Calico deployments. The `bird`-over-mesh mode is a deliberate Spur choice for encrypted, native-routed pod traffic when the mesh is up, not a hard requirement of Calico itself.

## Approach

- `k0s_controller_config_yaml` (`spur-core/k0s.rs`) gained a `mesh_native: bool` parameter: `true` keeps the existing `mode: bird`, `false` emits `mode: vxlan` instead.
- A new `calico_node_address` helper (`spurctld/cluster_k8s.rs`) resolves which address a node should advertise for Calico: `node.k0s_mesh_ip` when `net.wg_enabled`, else `node.address` (the real underlay address) — since a mesh IP handed out with the mesh disabled is unusable.
- `controller_k0s_config` (the k0s config generator) and the kubelet `--node-ip` selection in the provisioning reconcile loop both now go through this helper instead of unconditionally reading the mesh IP.
- Updated `docs/deployment/managed-kubernetes.rst` to describe both modes, and extended the existing "config doesn't hot-reload" caveat to cover toggling `wg_enabled` on an already-provisioned cluster.

This is scoped to the two places that actually *use* the mesh IP for Calico/kubelet; it doesn't change the underlying mesh-IP allocation bookkeeping (`provision_assignments` still allocates one per node regardless of `wg_enabled` — cheap, harmless bookkeeping, just no longer blindly trusted as a real address downstream).

## Known limitations

- Toggling `network.wg_enabled` after a cluster's nodes are already `active` does not retroactively regenerate their config — consistent with how k0s config generation already behaves for other cluster-networking settings (documented; requires `spur k8s down --reset` + `spur k8s up` to pick up the change).
- A separate, pre-existing gap (not introduced by this change): a node that was meshed and then has the mesh disabled can retain a stale WireGuard public key from before, which the unrelated WireGuard full-mesh membership path (`build_mesh_membership`/`ApplyMesh`, untouched by this PR) doesn't currently account for. Worth its own follow-up; out of scope here since it touches a different subsystem and persisted node state semantics.

## Testing

Unit tests cover the config generator's `vxlan` branch, the `calico_node_address` fallback (both directions), and `controller_k0s_config`'s end-to-end address/mode selection with and without the mesh. Each behavioral test was verified red (bug simulated) then green.

Validated end-to-end on an isolated 2-node deployment: brought up a cluster with `wg_enabled=false, cni=calico` — previously hung indefinitely with the worker stuck unable to join; now reaches `ready`, generates a config with the real underlay address and `mode: vxlan`, and a test pod schedules, runs, and execs successfully. Also re-verified the existing `wg_enabled=true, cni=calico` path produces byte-identical output (mesh IP + `mode: bird`) to before this change, confirming no regression.

`cargo clippy --workspace --exclude spur-ffi --all-targets --locked` and `cargo fmt --all --check` are clean; targeted `cargo test -p spur-core -p spurctld --locked` passes (1010 tests, 28 pre-existing DB-backed ignores).