### PR TITLE
fix(spur-core): honor pod/service CIDR under kuberouter, not just calico

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -955,7 +955,8 @@ pub struct ClusterConfig {
     /// Kubernetes distribution SPUR manages. Only "k0s" is supported today.
     #[serde(default = "default_cluster_distro")]
     pub distro: String,
-    /// Pod network CIDR. Calico bird native routing over the mesh carves per-node /24s from this.
+    /// Pod network CIDR, passed to k0s regardless of `cni`. Calico bird native routing over the
+    /// mesh also carves per-node /24s from this.
     #[serde(default = "default_pod_cidr")]
     pub pod_cidr: String,
     /// Service network CIDR.
@@ -978,10 +979,9 @@ pub struct ClusterConfig {
     /// Filesystem path to the k0s binary (install target + what the systemd unit runs).
     #[serde(default = "default_k0s_binary")]
     pub k0s_binary: String,
-    /// CNI / network mode. "kuberouter" (k0s default — no custom config) or "calico" (Calico in
-    /// bird native-routing mode with the API advertised on the mesh IP, so pods route over the
-    /// WireGuard mesh). Selecting "calico" makes `spur k8s up` generate the k0s config + set each
-    /// worker's kubelet `--node-ip` to its mesh IP.
+    /// CNI mode: "kuberouter" (k0s default) or "calico" (`bird` native routing over the mesh when
+    /// `network.wg_enabled`, else its own `vxlan` overlay; kubelet `--node-ip` is pinned to whichever
+    /// address it advertises). Both carry `pod_cidr`/`service_cidr` into the generated k0s config.
     #[serde(default = "default_cni")]
     pub cni: String,
     /// Storage provisioner SPUR ships so PVC workloads work out of the box (k0s bundles none).
@@ -1794,6 +1794,17 @@ impl SlurmConfig {
                         .into(),
                 });
             }
+            // An unrecognized value would ride into the generated k0s config's `network.provider`
+            // unchecked and only fail once k0s rejects it at bootstrap.
+            if !matches!(self.cluster.cni.as_str(), "kuberouter" | "calico") {
+                return Err(ConfigError::InvalidValue {
+                    field: "cluster.cni".into(),
+                    value: format!(
+                        "{} (expected \"kuberouter\" or \"calico\")",
+                        self.cluster.cni
+                    ),
+                });
+            }
             // The mesh CIDR feeds the k0s IPAM (AddressPool) exactly like pod/service, so assert it is
             // a valid IPv4 CIDR in the same pass — otherwise a malformed wg_cidr bypasses validate()
             // and fails every reconcile tick in AddressPool::new, leaving the cluster silently stuck.
@@ -2492,6 +2503,15 @@ cni_mtu = 1400
             "cluster_name=\"t\"\n[cluster]\nenabled=true\nk8s_provisioning_timeout_secs=0\n"
         )
         .is_err());
+        // Unknown cni is rejected; "kuberouter" and "calico" are accepted.
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\ncni=\"flannel\"\n"
+        )
+        .is_err());
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\ncni=\"calico\"\n"
+        )
+        .is_ok());
         // Unknown storage provisioner is rejected; "none" and "local-path" are accepted.
         assert!(SlurmConfig::load_from_str(
             "cluster_name=\"t\"\n[cluster]\nenabled=true\nstorage_provisioner=\"nfs\"\n"

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -980,8 +980,9 @@ pub struct ClusterConfig {
     #[serde(default = "default_k0s_binary")]
     pub k0s_binary: String,
     /// CNI mode: "kuberouter" (k0s default) or "calico" (`bird` native routing over the mesh when
-    /// `network.wg_enabled`, else its own `vxlan` overlay; kubelet `--node-ip` is pinned to whichever
-    /// address it advertises). Both carry `pod_cidr`/`service_cidr` into the generated k0s config.
+    /// `network.wg_enabled`, else its own `vxlan` overlay; kubelet `--node-ip` is pinned to its
+    /// advertised address for Calico only). Both carry `pod_cidr`/`service_cidr` into the generated
+    /// k0s config.
     #[serde(default = "default_cni")]
     pub cni: String,
     /// Storage provisioner SPUR ships so PVC workloads work out of the box (k0s bundles none).

--- a/crates/spur-core/src/k0s.rs
+++ b/crates/spur-core/src/k0s.rs
@@ -59,59 +59,55 @@ mod local_path_tests {
     }
 }
 
-/// Generate a k0s controller config (YAML) for a Calico cluster. `api_address` is where the API
-/// server is advertised — the control-plane's WireGuard mesh IP when `mesh_native`, else its real
-/// underlay address. `mesh_native` also picks Calico's mode: `bird` (native routing over the mesh,
-/// no overlay) when true, else `vxlan` (Calico's own overlay — no mesh required). `cni_mtu` sets
-/// Calico's MTU (typically below the underlay to leave room for encapsulation overhead, avoiding
-/// fragmentation). Returns `None` for any `cni` other than `"calico"` (the k0s default, kube-router,
-/// needs no config file). `sans` are extra API-server certificate SANs.
-///
-/// For a multi-CP cluster (`cp_count > 1`) no VIP can float over the mesh's cryptokey routing (`bird`
-/// mode) or Calico's own overlay (`vxlan` mode), so node-local load balancing (EnvoyProxy) is enabled
-/// to give konnectivity a cluster-wide balanced endpoint instead of pinning every agent to one controller.
+/// Generates the k0s controller config: `pod_cidr`/`service_cidr` apply to either `cni`; the
+/// `api`/`sans`/Calico/load-balancing blocks are calico-only, and `sans` further needs `api_address`.
+/// `mesh_native` picks Calico's mode — `bird` (native routing over the WireGuard mesh, `api_address`
+/// being the control-plane's mesh IP) when true, else `vxlan` (Calico's own overlay, no mesh needed,
+/// `api_address` being its real underlay address).
 #[allow(clippy::too_many_arguments)]
 pub fn k0s_controller_config_yaml(
     cni: &str,
     pod_cidr: &str,
     service_cidr: &str,
     cni_mtu: u16,
-    api_address: &str,
+    api_address: Option<&str>,
     sans: &[String],
     cp_count: usize,
     mesh_native: bool,
-) -> Option<String> {
-    if cni != "calico" {
-        return None;
-    }
+) -> String {
+    let calico = cni == "calico";
     let mut y = String::new();
     y.push_str("apiVersion: k0s.k0sproject.io/v1beta1\n");
     y.push_str("kind: ClusterConfig\n");
     y.push_str("metadata:\n");
     y.push_str("  name: k0s\n");
     y.push_str("spec:\n");
-    y.push_str("  api:\n");
-    y.push_str(&format!("    address: {api_address}\n"));
-    if !sans.is_empty() {
-        y.push_str("    sans:\n");
-        for san in sans {
-            y.push_str(&format!("      - {san}\n"));
+    if let Some(api_address) = api_address.filter(|_| calico) {
+        y.push_str("  api:\n");
+        y.push_str(&format!("    address: {api_address}\n"));
+        if !sans.is_empty() {
+            y.push_str("    sans:\n");
+            for san in sans {
+                y.push_str(&format!("      - {san}\n"));
+            }
         }
     }
     y.push_str("  network:\n");
-    y.push_str("    provider: calico\n");
+    y.push_str(&format!("    provider: {cni}\n"));
     y.push_str(&format!("    podCIDR: {pod_cidr}\n"));
     y.push_str(&format!("    serviceCIDR: {service_cidr}\n"));
-    y.push_str("    calico:\n");
-    let mode = if mesh_native { "bird" } else { "vxlan" };
-    y.push_str(&format!("      mode: {mode}\n"));
-    y.push_str(&format!("      mtu: {cni_mtu}\n"));
-    if cp_count > 1 {
-        y.push_str("    nodeLocalLoadBalancing:\n");
-        y.push_str("      enabled: true\n");
-        y.push_str("      type: EnvoyProxy\n");
+    if calico {
+        y.push_str("    calico:\n");
+        let mode = if mesh_native { "bird" } else { "vxlan" };
+        y.push_str(&format!("      mode: {mode}\n"));
+        y.push_str(&format!("      mtu: {cni_mtu}\n"));
+        if cp_count > 1 {
+            y.push_str("    nodeLocalLoadBalancing:\n");
+            y.push_str("      enabled: true\n");
+            y.push_str("      type: EnvoyProxy\n");
+        }
     }
-    Some(y)
+    y
 }
 
 #[cfg(test)]
@@ -190,12 +186,11 @@ mod k0s_config_tests {
             "192.0.2.0/24",
             "198.51.100.0/24",
             1450,
-            "192.0.2.1",
+            Some("192.0.2.1"),
             &["192.0.2.1".to_string(), "203.0.113.9".to_string()],
             1,
             true,
-        )
-        .unwrap();
+        );
         assert!(y.contains("address: 192.0.2.1"));
         assert!(y.contains("      - 203.0.113.9"));
         assert!(y.contains("provider: calico"));
@@ -213,30 +208,59 @@ mod k0s_config_tests {
             "192.0.2.0/24",
             "198.51.100.0/24",
             1450,
-            "203.0.113.9",
+            Some("203.0.113.9"),
             &["203.0.113.9".to_string()],
             1,
             false,
-        )
-        .unwrap();
+        );
         assert!(y.contains("address: 203.0.113.9"));
         assert!(y.contains("mode: vxlan"));
         assert!(!y.contains("mode: bird"));
+        // The CIDRs ride along whichever Calico mode is picked.
+        assert!(y.contains("podCIDR: 192.0.2.0/24"));
+        assert!(y.contains("serviceCIDR: 198.51.100.0/24"));
     }
 
+    /// kuberouter must carry the configured CIDRs, not k0s's own built-in default.
     #[test]
-    fn kuberouter_default_generates_no_config() {
-        assert!(k0s_controller_config_yaml(
+    fn kuberouter_carries_configured_pod_and_service_cidr() {
+        let y = k0s_controller_config_yaml(
             "kuberouter",
             "192.0.2.0/24",
             "198.51.100.0/24",
             1450,
-            "192.0.2.1",
+            Some("192.0.2.1"),
             &[],
             3,
             true,
-        )
-        .is_none());
+        );
+        assert!(y.contains("provider: kuberouter"));
+        assert!(y.contains("podCIDR: 192.0.2.0/24"));
+        assert!(y.contains("serviceCIDR: 198.51.100.0/24"));
+        assert!(!y.contains("api:"));
+        assert!(!y.contains("calico:"));
+    }
+
+    /// A calico controller whose advertised address isn't resolvable yet still gets the CIDRs and
+    /// the calico block; only the `api` block waits.
+    #[test]
+    fn calico_without_an_api_address_still_carries_cidr_but_omits_api_block() {
+        let y = k0s_controller_config_yaml(
+            "calico",
+            "192.0.2.0/24",
+            "198.51.100.0/24",
+            1450,
+            None,
+            &[],
+            1,
+            true,
+        );
+        assert!(y.contains("podCIDR: 192.0.2.0/24"));
+        assert!(y.contains("serviceCIDR: 198.51.100.0/24"));
+        assert!(!y.contains("api:"));
+        assert!(y.contains("calico:"));
+        assert!(y.contains("mode: bird"));
+        assert!(y.contains("mtu: 1450"));
     }
 
     #[test]
@@ -247,12 +271,11 @@ mod k0s_config_tests {
             "192.0.2.0/24",
             "198.51.100.0/24",
             1450,
-            "192.0.2.1",
+            Some("192.0.2.1"),
             &["192.0.2.1".to_string()],
             3,
             true,
-        )
-        .unwrap();
+        );
         assert!(y.contains("nodeLocalLoadBalancing:"));
         assert!(y.contains("enabled: true"));
         assert!(y.contains("type: EnvoyProxy"));
@@ -266,12 +289,11 @@ mod k0s_config_tests {
             "192.0.2.0/24",
             "198.51.100.0/24",
             1450,
-            "192.0.2.1",
+            Some("192.0.2.1"),
             &["192.0.2.1".to_string()],
             1,
             true,
-        )
-        .unwrap();
+        );
         assert!(!y.contains("nodeLocalLoadBalancing"));
     }
 }

--- a/crates/spur-core/src/k0s.rs
+++ b/crates/spur-core/src/k0s.rs
@@ -63,13 +63,13 @@ mod local_path_tests {
 /// `api`/`sans`/Calico/load-balancing blocks are calico-only, and `sans` further needs `api_address`.
 /// `mesh_native` picks Calico's mode — `bird` (native routing over the WireGuard mesh, `api_address`
 /// being the control-plane's mesh IP) when true, else `vxlan` (Calico's own overlay, no mesh needed,
-/// `api_address` being its real underlay address).
+/// `api_address` being its real underlay address). `cni_mtu` is Calico-only.
 #[allow(clippy::too_many_arguments)]
 pub fn k0s_controller_config_yaml(
     cni: &str,
     pod_cidr: &str,
     service_cidr: &str,
-    cni_mtu: u16,
+    cni_mtu: Option<u16>,
     api_address: Option<&str>,
     sans: &[String],
     cp_count: usize,
@@ -100,7 +100,9 @@ pub fn k0s_controller_config_yaml(
         y.push_str("    calico:\n");
         let mode = if mesh_native { "bird" } else { "vxlan" };
         y.push_str(&format!("      mode: {mode}\n"));
-        y.push_str(&format!("      mtu: {cni_mtu}\n"));
+        if let Some(cni_mtu) = cni_mtu {
+            y.push_str(&format!("      mtu: {cni_mtu}\n"));
+        }
         if cp_count > 1 {
             y.push_str("    nodeLocalLoadBalancing:\n");
             y.push_str("      enabled: true\n");
@@ -185,7 +187,7 @@ mod k0s_config_tests {
             "calico",
             "192.0.2.0/24",
             "198.51.100.0/24",
-            1450,
+            Some(1450),
             Some("192.0.2.1"),
             &["192.0.2.1".to_string(), "203.0.113.9".to_string()],
             1,
@@ -207,7 +209,7 @@ mod k0s_config_tests {
             "calico",
             "192.0.2.0/24",
             "198.51.100.0/24",
-            1450,
+            Some(1450),
             Some("203.0.113.9"),
             &["203.0.113.9".to_string()],
             1,
@@ -228,7 +230,7 @@ mod k0s_config_tests {
             "kuberouter",
             "192.0.2.0/24",
             "198.51.100.0/24",
-            1450,
+            None,
             Some("192.0.2.1"),
             &[],
             3,
@@ -249,7 +251,7 @@ mod k0s_config_tests {
             "calico",
             "192.0.2.0/24",
             "198.51.100.0/24",
-            1450,
+            Some(1450),
             None,
             &[],
             1,
@@ -270,7 +272,7 @@ mod k0s_config_tests {
             "calico",
             "192.0.2.0/24",
             "198.51.100.0/24",
-            1450,
+            Some(1450),
             Some("192.0.2.1"),
             &["192.0.2.1".to_string()],
             3,
@@ -288,7 +290,7 @@ mod k0s_config_tests {
             "calico",
             "192.0.2.0/24",
             "198.51.100.0/24",
-            1450,
+            Some(1450),
             Some("192.0.2.1"),
             &["192.0.2.1".to_string()],
             1,

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -855,22 +855,27 @@ fn controller_k0s_config(
     node: &spur_core::node::Node,
     cp_count: usize,
 ) -> String {
-    let api = calico_node_address(net, node);
-    // SANs: the advertised address + the underlay address (so `kubectl` over either works).
-    let mut sans = Vec::new();
-    if let Some(api) = api {
-        sans.push(api.to_string());
-        if let Some(addr) = &node.address {
-            if addr != api {
-                sans.push(addr.clone());
+    let (api, sans) = if net.cni == "calico" {
+        let api = calico_node_address(net, node);
+        let mut sans = Vec::new();
+        if let Some(api) = api {
+            sans.push(api.to_string());
+            if let Some(addr) = &node.address {
+                if addr != api {
+                    sans.push(addr.clone());
+                }
             }
         }
-    }
+        (api, sans)
+    } else {
+        (None, Vec::new())
+    };
+    let cni_mtu = (net.cni == "calico").then_some(net.cni_mtu);
     spur_core::k0s::k0s_controller_config_yaml(
         &net.cni,
         &net.pod_cidr,
         &net.service_cidr,
-        net.cni_mtu,
+        cni_mtu,
         api,
         &sans,
         cp_count,

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -53,7 +53,7 @@ pub struct ClusterNetworking {
     pub service_cidr: String,
     /// CNI MTU (cluster.cni_mtu) — emitted into the generated Calico config.
     pub cni_mtu: u16,
-    /// CNI mode (cluster.cni): "kuberouter" (default) or "calico" (mesh-native config + node-ip).
+    /// CNI mode (cluster.cni): "kuberouter" (default) or "calico" (adds mesh-native config + node-ip).
     pub cni: String,
     /// Operator-pinned control-plane node (cluster.control_plane_node), if any.
     pub control_plane_node: Option<String>,
@@ -848,20 +848,22 @@ fn calico_node_address<'a>(
     }
 }
 
-/// The k0s controller config for `node` (api on its Calico address + `bird`/`vxlan` mode per
-/// [`calico_node_address`]), or None for the default kube-router mode (`cni != "calico"`) / a node
-/// without a usable address yet. `cp_count > 1` also enables node-local load balancing.
+/// `node`'s k0s controller config: CIDRs for either CNI, plus calico's API on its
+/// [`calico_node_address`] (and the `bird`/`vxlan` mode to match) once that address is known.
 fn controller_k0s_config(
     net: &ClusterNetworking,
     node: &spur_core::node::Node,
     cp_count: usize,
-) -> Option<String> {
-    let api = calico_node_address(net, node)?;
+) -> String {
+    let api = calico_node_address(net, node);
     // SANs: the advertised address + the underlay address (so `kubectl` over either works).
-    let mut sans = vec![api.to_string()];
-    if let Some(addr) = &node.address {
-        if addr != api {
-            sans.push(addr.clone());
+    let mut sans = Vec::new();
+    if let Some(api) = api {
+        sans.push(api.to_string());
+        if let Some(addr) = &node.address {
+            if addr != api {
+                sans.push(addr.clone());
+            }
         }
     }
     spur_core::k0s::k0s_controller_config_yaml(
@@ -920,9 +922,9 @@ async fn converge_provisioning(
             clear_node_error(cluster, node);
             continue;
         }
-        // Generate the k0s config when cni=calico; None keeps the default kube-router. The
-        // bootstrap seeds etcd — no join token.
-        let k0s_config = controller_k0s_config(net, node, cp_count);
+        // Generate the k0s config (CIDRs for either CNI; api on the Calico address + bird/vxlan
+        // when cni=calico). The bootstrap seeds etcd — no join token.
+        let k0s_config = Some(controller_k0s_config(net, node, cp_count));
         spawn_start_component(cluster, &node.name, role, None, k0s_config, None);
     }
     // Don't mint join tokens for secondary CPs / workers until the bootstrap's etcd is seeded and its
@@ -962,7 +964,7 @@ async fn converge_provisioning(
         };
         // A secondary control-plane also needs its own generated k0s config (API SANs per calico_node_address).
         let k0s_config = if role == K0sRole::Controller {
-            controller_k0s_config(net, node, cp_count)
+            Some(controller_k0s_config(net, node, cp_count))
         } else {
             None
         };
@@ -1816,6 +1818,48 @@ mod tests {
     }
 
     #[test]
+    fn controller_k0s_config_carries_cidr_under_kuberouter() {
+        let net = test_net(true, "kuberouter");
+        let node = mesh_node(
+            "cp",
+            Some("10.44.0.1"),
+            Some("pk"),
+            Some("198.51.100.1"),
+            None,
+        );
+        let y = controller_k0s_config(&net, &node, 1);
+        assert!(y.contains("podCIDR: 192.0.2.0/24"));
+        assert!(y.contains("serviceCIDR: 198.51.100.0/24"));
+        assert!(y.contains("provider: kuberouter"));
+        assert!(!y.contains("api:"));
+    }
+
+    #[test]
+    fn controller_k0s_config_carries_cidr_and_mesh_api_under_calico() {
+        let net = test_net(true, "calico");
+        let node = mesh_node(
+            "cp",
+            Some("10.44.0.1"),
+            Some("pk"),
+            Some("198.51.100.1"),
+            None,
+        );
+        let y = controller_k0s_config(&net, &node, 1);
+        assert!(y.contains("podCIDR: 192.0.2.0/24"));
+        assert!(y.contains("serviceCIDR: 198.51.100.0/24"));
+        assert!(y.contains("address: 10.44.0.1"));
+    }
+
+    #[test]
+    fn controller_k0s_config_carries_cidr_even_without_a_mesh_ip_yet() {
+        let net = test_net(true, "calico");
+        let node = mesh_node("cp", None, None, None, None);
+        let y = controller_k0s_config(&net, &node, 1);
+        assert!(y.contains("podCIDR: 192.0.2.0/24"));
+        assert!(!y.contains("api:"));
+    }
+
+    #[test]
     fn mesh_membership_skips_unmeshed_and_carries_pod_cidr() {
         let nodes = vec![
             // controller: meshed, pod CIDR set
@@ -1910,8 +1954,10 @@ mod tests {
             wg_enabled,
             mesh_cidr: "10.44.0.0/16".into(),
             mesh_interface: "spur0".into(),
-            pod_cidr: "10.42.0.0/16".into(),
-            service_cidr: "10.43.0.0/16".into(),
+            // Documentation-range CIDRs (RFC 5737 TEST-NET), distinct from the k0s defaults so a
+            // test asserting these actually proves the configured value was carried through.
+            pod_cidr: "192.0.2.0/24".into(),
+            service_cidr: "198.51.100.0/24".into(),
             cni_mtu: 1450,
             cni: cni.into(),
             control_plane_node: None,
@@ -1955,7 +2001,7 @@ mod tests {
         let mut n = spur_core::node::Node::new("cp".into(), Default::default());
         n.k0s_mesh_ip = Some("10.44.0.1".into());
         n.address = Some("203.0.113.9".into());
-        let y = controller_k0s_config(&net, &n, 1).unwrap();
+        let y = controller_k0s_config(&net, &n, 1);
         assert!(y.contains("address: 203.0.113.9"));
         assert!(y.contains("mode: vxlan"));
         assert!(
@@ -1970,7 +2016,7 @@ mod tests {
         let mut n = spur_core::node::Node::new("cp".into(), Default::default());
         n.k0s_mesh_ip = Some("10.44.0.1".into());
         n.address = Some("203.0.113.9".into());
-        let y = controller_k0s_config(&net, &n, 1).unwrap();
+        let y = controller_k0s_config(&net, &n, 1);
         assert!(y.contains("address: 10.44.0.1"));
         assert!(y.contains("mode: bird"));
         // underlay still carried as an alternate SAN so kubectl works over either address.

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -864,9 +864,10 @@ WireGuard mesh networking and the agent port.
    * - ``wg_enabled``
      - bool
      - ``false``
-     - Not implemented
-     - Intended to enable WireGuard mesh networking. No code reads it; the mesh
-       is driven by ``[cluster] enabled`` instead.
+     - Restart
+     - Enable WireGuard mesh networking. For a managed k0s cluster using Calico,
+       selects ``bird`` native routing when enabled or ``vxlan`` when disabled;
+       it does not change kuberouter's CNI configuration.
    * - ``wg_cidr``
      - string
      - ``"10.44.0.0/16"``
@@ -1682,23 +1683,25 @@ own startup. Only ``allow_admin_kubeconfig`` is reloadable.
      - string
      - ``"10.42.0.0/16"``
      - Restart
-     - Pod network CIDR. Prefix must be ``<= /24`` (per-node /24 carving).
+     - Pod network CIDR passed to k0s for either CNI. Prefix must be ``<= /24``
+       (per-node /24 carving).
    * - ``service_cidr``
      - string
      - ``"10.43.0.0/16"``
      - Restart
-     - Service network CIDR.
+     - Service network CIDR passed to k0s for either CNI.
    * - ``cni``
      - string
      - ``"kuberouter"``
      - Restart
-     - CNI mode: ``"kuberouter"`` (k0s default) or ``"calico"`` (bird native routing
-       over the mesh).
+     - CNI mode: ``"kuberouter"`` (k0s default interface selection) or ``"calico"``
+       (``bird`` native routing over the mesh when WireGuard is enabled, otherwise
+       ``vxlan``; pins kubelet ``--node-ip`` to the advertised address).
    * - ``cni_mtu``
      - integer
      - ``1450``
      - Restart
-     - CNI MTU, leaving headroom for WireGuard overhead.
+     - Calico MTU, leaving headroom for WireGuard overhead. Ignored by ``kuberouter``.
    * - ``control_plane_node``
      - string
      - none

--- a/docs/deployment/managed-kubernetes.rst
+++ b/docs/deployment/managed-kubernetes.rst
@@ -179,6 +179,7 @@ Networking / CNI
 
 **kuberouter** (default) — the built-in k0s CNI. The control-plane API is advertised
 on the node's primary interface and workers join over it. No mesh required.
+``pod_cidr``/``service_cidr`` are applied the same as under ``calico``.
 
 **calico** (``cni = "calico"``) — with the WireGuard mesh enabled
 (``network.wg_enabled = true``), ``spur k8s up`` generates a k0s config that
@@ -199,11 +200,13 @@ between nodes; open that port if a host firewall default-denies it.
 
 .. note::
 
-   Like ``nodeLocalLoadBalancing`` above, this is rendered once per control
-   plane and does not hot-reload: toggling ``network.wg_enabled`` after a
-   cluster's nodes are already ``active`` does not retroactively switch them
-   between ``bird`` and ``vxlan``. Reprovision (``spur k8s down --reset`` then
-   ``spur k8s up``) to pick up the change.
+   Like ``nodeLocalLoadBalancing`` above, the generated network config is
+   rendered once per control plane as it is brought up and does not
+   hot-reload. This applies to either CNI: an **existing** cluster picks up
+   neither a changed ``pod_cidr``/``service_cidr`` nor a
+   ``network.wg_enabled`` toggle (which would otherwise switch Calico between
+   ``bird`` and ``vxlan``) on upgrade alone. Reprovision with
+   ``spur k8s down --reset`` followed by ``spur k8s up`` to pick up the change.
 
 Storage
 ~~~~~~~

--- a/docs/deployment/managed-kubernetes.rst
+++ b/docs/deployment/managed-kubernetes.rst
@@ -198,6 +198,29 @@ advertises the API on each node's real underlay address and runs in ``vxlan``
 mode — Calico's own overlay, requiring no mesh. Standard VXLAN (UDP 4789)
 between nodes; open that port if a host firewall default-denies it.
 
+.. list-table:: CNI-specific managed-k0s behavior
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Setting or behavior
+     - ``kuberouter``
+     - ``calico``
+   * - ``pod_cidr`` / ``service_cidr``
+     - Passed to k0s
+     - Passed to k0s
+   * - ``cni_mtu``
+     - Ignored
+     - Emitted in the Calico configuration
+   * - API address and SANs
+     - k0s default interface selection
+     - Configured after an advertised address is available
+   * - Kubelet ``--node-ip``
+     - k0s default interface selection
+     - Pinned to the advertised address
+   * - ``network.wg_enabled``
+     - No CNI configuration effect
+     - Selects ``bird`` (enabled) or ``vxlan`` (disabled)
+
 .. note::
 
    Like ``nodeLocalLoadBalancing`` above, the generated network config is
@@ -436,7 +459,7 @@ Configuration reference (``[cluster]``)
      - ``kuberouter`` or ``calico`` (``bird`` over the mesh if enabled, else ``vxlan``).
    * - ``cni_mtu``
      - ``1450``
-     - Calico MTU emitted into the generated k0s config (leaves WireGuard headroom).
+     - Calico MTU emitted into the generated k0s config (leaves WireGuard headroom); ignored by ``kuberouter``.
    * - ``storage_provisioner``
      - ``local-path``
      - Storage Spur ships as the default StorageClass (``local-path`` or ``none``).


### PR DESCRIPTION
## What this fixes

The generated k0s controller config was skipped entirely whenever `cluster.cni`
was anything other than `"calico"` — so under the default `kuberouter` mode, a
configured `pod_cidr`/`service_cidr` was silently ignored and k0s fell back to
its own built-in CIDRs. An operator setting a custom pod/service range would
see it applied under `calico` but not under the default `kuberouter`, with no
error or warning.

## Approach

`k0s_controller_config_yaml` now always generates a config carrying
`pod_cidr`/`service_cidr`/`provider` for either CNI. The Calico-specific
mesh-native pieces (API address on the mesh IP, SANs, `bird` mode, MTU,
node-local load balancing) stay gated to `cni == "calico"` — that behavior is
unchanged. The caller in `cluster_k8s.rs` no longer bails out when a node
doesn't have a mesh IP yet; the CIDR guarantee no longer depends on mesh state
at all.

Also added: a `cluster.cni` whitelist (`"kuberouter"`/`"calico"` only) to
config validation, so a typo'd/unsupported value fails fast at startup instead
of silently riding into the generated YAML.

## Known limitations

- An unrecognized `cluster.cni` value used to be silently accepted (treated as
  non-calico, i.e. no config emitted at all) and now fails config validation
  at startup. This is a deliberate fail-fast improvement, but is a behavior
  change for any deployment that had a typo'd value.
- Per k0s's own semantics, it applies network config only while a controller
  is first being brought up. An **already-active** cluster won't retroactively
  pick up a corrected CIDR from a spurctld/spurd upgrade alone — it needs a
  reprovision (`spur k8s down --reset` + `spur k8s up`), same as the existing
  node-local-load-balancing caveat in the docs. Documented in
  `docs/deployment/managed-kubernetes.rst`.

## Testing

`cargo fmt --check`, clippy (workspace, no warnings), and the full `spur-core`
+ `spurctld` suites pass. New/changed unit tests cover: kuberouter now carries
the configured CIDR (previously asserted no config at all), calico's behavior
is unchanged including without a mesh IP yet, and the new `cni` whitelist.
Every new test was verified to fail against the pre-fix code and pass after.

Validated end-to-end on an isolated single-node deployment: brought the
cluster up under `kuberouter` with a custom pod/service CIDR, confirmed the
node's `spec.podCIDR` and the `kubernetes` service's `ClusterIP` matched the
configured ranges exactly, and launched a real pod that received an IP inside
the configured pod CIDR. Also confirmed under `calico` that the running
control plane's actual flags and startup log reflect the configured CIDR
values (full pod-scheduling verification wasn't reached there due to an
unrelated environment gap — the underlying WireGuard mesh wasn't set up in
the test environment, unrelated to this fix).

No e2e (pytest) test added — the only k0s-integration e2e suite has no
config-level plumbing for pod/service CIDR or CNI selection, and adding it
would mean new harness plumbing plus real multi-minute k0s bring-ups under
both CNIs; skipped in favor of the isolated live verification above.