### PR TITLE
fix(spurd): kernel-enforced GPU device isolation across every launch path

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -314,3 +314,5 @@ VXLAN
 RCCL
 Apptainer
 tmpfs
+uncontained
+cgroup's

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -127,6 +127,7 @@ zstd
 AppArmor
 autouse
 BGP
+BPF
 checksums
 CIDRs
 CLI
@@ -310,3 +311,6 @@ backoff
 unapplied
 UDP
 VXLAN
+RCCL
+Apptainer
+tmpfs

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1479,6 +1479,17 @@ pub struct CgroupConfig {
     /// `OOMKillStep` defaults off; on here, since partial kills fail murkily.
     #[serde(default = "default_true_fn")]
     pub oom_kill_job: bool,
+    /// Restrict the job to its allocated device nodes (`ConstrainDevices`) with a
+    /// cgroup-v2 BPF device filter. Default-deny: a job allocated no devices keeps
+    /// only the base pseudo-devices (`/dev/null`, ptys, ...).
+    #[serde(default = "default_true_fn")]
+    pub constrain_devices: bool,
+    /// Extra device node paths every job on this node may open, on top of its
+    /// allocation and the built-in host-infrastructure list. The escape hatch for a
+    /// site device the defaults miss, short of turning the filter off. Paths that
+    /// are not device nodes are ignored.
+    #[serde(default)]
+    pub extra_device_paths: Vec<String>,
 }
 
 fn default_min_ram_mb() -> u64 {
@@ -1502,6 +1513,8 @@ impl Default for CgroupConfig {
             allowed_swap_percent: 0,
             min_ram_mb: default_min_ram_mb(),
             oom_kill_job: true,
+            constrain_devices: true,
+            extra_device_paths: Vec::new(),
         }
     }
 }
@@ -2379,6 +2392,48 @@ mod tests {
         let cfg = SlurmConfig::load_from_str("cluster_name = \"test\"").expect("parses");
         assert!(cfg.cgroup.enabled);
         assert_eq!(cfg.cgroup.allowed_swap_percent, 0);
+    }
+
+    #[test]
+    fn devices_are_constrained_unless_a_config_opts_out() {
+        // A `spur.conf` deployed before the field existed must still load, and must
+        // land on device isolation rather than silently skipping it. The `Default`
+        // impl and the serde default are separate paths that have to agree.
+        assert!(CgroupConfig::default().constrain_devices);
+
+        let upgraded =
+            SlurmConfig::load_from_str("cluster_name = \"t\"\n[cgroup]\nconstrain_swap = true\n")
+                .expect("parses");
+        assert!(
+            upgraded.cgroup.constrain_swap,
+            "the field the config does set still applies"
+        );
+        assert!(upgraded.cgroup.constrain_devices);
+
+        let opted_out = SlurmConfig::load_from_str(
+            "cluster_name = \"t\"\n[cgroup]\nconstrain_devices = false\n",
+        )
+        .expect("parses");
+        assert!(!opted_out.cgroup.constrain_devices);
+    }
+
+    #[test]
+    fn extra_device_paths_default_to_none_and_parse_as_a_list() {
+        assert!(CgroupConfig::default().extra_device_paths.is_empty());
+
+        let without =
+            SlurmConfig::load_from_str("cluster_name = \"t\"\n[cgroup]\nrequired = true\n")
+                .expect("parses");
+        assert!(
+            without.cgroup.extra_device_paths.is_empty(),
+            "a config written before the field existed must still load, granting nothing extra"
+        );
+
+        let with = SlurmConfig::load_from_str(
+            "cluster_name = \"t\"\n[cgroup]\nextra_device_paths = [\"/dev/site-accel0\"]\n",
+        )
+        .expect("parses");
+        assert_eq!(with.cgroup.extra_device_paths, ["/dev/site-accel0"]);
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1479,15 +1479,12 @@ pub struct CgroupConfig {
     /// `OOMKillStep` defaults off; on here, since partial kills fail murkily.
     #[serde(default = "default_true_fn")]
     pub oom_kill_job: bool,
-    /// Restrict the job to its allocated device nodes (`ConstrainDevices`) with a
-    /// cgroup-v2 BPF device filter. Default-deny: a job allocated no devices keeps
-    /// only the base pseudo-devices (`/dev/null`, ptys, ...).
+    /// Restrict the job to its allocated device nodes (`ConstrainDevices`) via a
+    /// cgroup-v2 BPF device filter. Default-deny: no allocation, pseudo-devices only.
     #[serde(default = "default_true_fn")]
     pub constrain_devices: bool,
-    /// Extra device node paths every job on this node may open, on top of its
-    /// allocation and the built-in host-infrastructure list. The escape hatch for a
-    /// site device the defaults miss, short of turning the filter off. Paths that
-    /// are not device nodes are ignored.
+    /// Extra device paths every job may open, on top of its allocation and the
+    /// host-infrastructure list: the escape hatch for a site device the defaults miss.
     #[serde(default)]
     pub extra_device_paths: Vec<String>,
 }
@@ -2396,9 +2393,8 @@ mod tests {
 
     #[test]
     fn devices_are_constrained_unless_a_config_opts_out() {
-        // A `spur.conf` deployed before the field existed must still load, and must
-        // land on device isolation rather than silently skipping it. The `Default`
-        // impl and the serde default are separate paths that have to agree.
+        // A `spur.conf` deployed before the field existed must still load, and land
+        // on isolation; the `Default` impl and the serde default must agree.
         assert!(CgroupConfig::default().constrain_devices);
 
         let upgraded =

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -149,7 +149,10 @@ async fn teardown_completed_job(
         return;
     }
 
-    crate::container::cleanup_rootfs(job_id, &completed.rootfs_mode);
+    crate::container::cleanup_rootfs(
+        &crate::container::job_rootfs_base(job_id),
+        &completed.rootfs_mode,
+    );
     crate::executor::cleanup_job_spool(job_id);
     if let Some(ref cgroup) = completed.cgroup {
         crate::executor::cleanup_cgroup(cgroup);
@@ -399,6 +402,23 @@ fn signal_step_tree(pid: u32, signal: i32) {
                     "failed to signal step (it may already have exited)"
                 );
             }
+        }
+    }
+}
+
+fn signal_step_process_group(pid: u32, signal: i32) {
+    let sig =
+        nix::sys::signal::Signal::try_from(signal).unwrap_or(nix::sys::signal::Signal::SIGTERM);
+    let leader = nix::unistd::Pid::from_raw(pid as i32);
+    if let Err(e) = nix::sys::signal::killpg(leader, sig) {
+        if let Err(kill_err) = nix::sys::signal::kill(leader, Some(sig)) {
+            warn!(
+                pid,
+                signal,
+                killpg = %e,
+                kill = %kill_err,
+                "step process group signal failed (step may already have exited)"
+            );
         }
     }
 }
@@ -718,6 +738,8 @@ async fn run_tokio_step_to_spool(
     step_files: crate::executor::StepOutputFiles,
     active_steps: &Arc<Mutex<HashMap<(u32, u32), ActiveStep>>>,
     step_key: (u32, u32),
+    cgroup: Option<&std::path::Path>,
+    cgroup_required: bool,
 ) -> Result<Option<std::process::ExitStatus>, Status> {
     use std::process::Stdio;
     let mut child = cmd
@@ -725,6 +747,16 @@ async fn run_tokio_step_to_spool(
         .stderr(Stdio::from(step_files.stderr))
         .spawn()
         .map_err(|e| Status::internal(format!("step command failed to spawn: {e}")))?;
+
+    // The pre-exec join reports whether it wrote `cgroup.procs`; this verifies the
+    // step actually landed there. Under `[cgroup] required` a step that did not is
+    // refused and its group killed rather than run outside the limits and filter.
+    if escaped_job_cgroup(cgroup_required, cgroup, child.id()) {
+        kill_step_process_group(&mut child).await;
+        return Err(Status::failed_precondition(
+            "[cgroup] required but the step did not join its cgroup",
+        ));
+    }
 
     if let Some(pid) = child.id() {
         let cancel_now = {
@@ -2934,7 +2966,7 @@ impl SlurmAgent for AgentService {
         // node already confirmed via LaunchJob (confirm_dispatch_on_nodes) — so a
         // miss is a wrong job/node pairing, not a launch race. The one uncovered
         // case is a spurd restart mid-job, which starts `running` empty.
-        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi, cgroup_path) = {
+        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi, job_entry) = {
             let jobs = self.running.lock().await;
             let tracked = jobs.get(&job_id).ok_or_else(|| {
                 Status::not_found(format!("job {} not running on this node", job_id))
@@ -2955,6 +2987,7 @@ impl SlurmAgent for AgentService {
                 uid: tracked.uid,
                 gid: tracked.gid,
                 work_dir: tracked.work_dir.clone(),
+                cgroup_path: tracked.cgroup_path.clone(),
             };
             (
                 tracked.gpu_devices.clone(),
@@ -2963,7 +2996,7 @@ impl SlurmAgent for AgentService {
                 tracked.memory_mb,
                 nodelist,
                 tracked.mpi.clone(),
-                tracked.cgroup_path.clone(),
+                entry,
             )
         };
 
@@ -3170,23 +3203,6 @@ impl SlurmAgent for AgentService {
         }
 
         let memlock = self.limits.memlock;
-        let cgroup_join = executor::CgroupJoin::for_cgroup(cgroup_path.as_deref());
-        let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
-        unsafe {
-            cmd.pre_exec(move || {
-                crate::executor::apply_memlock(memlock);
-                // Before the drop below: an unprivileged process cannot write
-                // another cgroup's `cgroup.procs`.
-                if let Some(ref join) = cgroup_join {
-                    join.join();
-                }
-                if let Some(ref pd) = priv_drop {
-                    pd.apply()
-                        .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
-                }
-                Ok(())
-            });
-        }
 
         info!(
             command = ?req.command,
@@ -3199,39 +3215,18 @@ impl SlurmAgent for AgentService {
             "RunCommand: executing step"
         );
 
-        use std::process::Stdio;
-
-        let mut child = cmd
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| Status::internal(format!("command failed: {}", e)))?;
-        // `spawn` only borrows, so the pre-exec closure and its dup'd log fd
-        // would otherwise stay alive for the whole step.
-        drop(cmd);
-        if escaped_job_cgroup(self.cgroup.required, cgroup_path.as_deref(), child.id()) {
-            // The user's work runs in descendants of the wrapper, and an escaped
-            // step is in no cgroup, so the group is the only handle reaching them.
-            kill_step_process_group(&mut child).await;
-            return Err(Status::failed_precondition(
-                "[cgroup] required but the step did not join its cgroup",
-            ));
-        }
-        if let Some(pid) = child.id() {
-            let cancel_now = {
-                let mut steps = self.active_steps.lock().await;
-                if let Some(step) = steps.get_mut(&step_key) {
-                    step.pid = Some(pid);
-                    step.cancel_requested
-                } else {
-                    false
-                }
-            };
-            if cancel_now {
-                signal_step_process_group(pid, nix::sys::signal::Signal::SIGTERM as i32);
-                let _ = child.kill().await;
-                let _ = child.wait_with_output().await;
-                return Ok(Response::new(cancelled_step_response()));
+        // Redirect the step's stdout/stderr to per-step spool files so
+        // stream_job_output can tail them live and output stays bounded on this
+        // node. Paths are recorded in active_steps so the tail can find them.
+        let step_files = crate::executor::open_step_output_files(job_id, step_id, req.uid, req.gid)
+            .map_err(|e| Status::internal(format!("step output files: {e}")))?;
+        let stdout_path = step_files.stdout_path.to_string_lossy().into_owned();
+        let stderr_path = step_files.stderr_path.to_string_lossy().into_owned();
+        {
+            let mut steps = self.active_steps.lock().await;
+            if let Some(step) = steps.get_mut(&step_key) {
+                step.stdout_path = stdout_path.clone();
+                step.stderr_path = stderr_path.clone();
             }
         }
 
@@ -3288,25 +3283,23 @@ impl SlurmAgent for AgentService {
             for (k, v) in env {
                 cmd.env(k, v);
             }
-            if plan.apply_priv_in_child {
-                if let Some(pd) = priv_drop {
-                    unsafe {
-                        cmd.pre_exec(move || {
-                            crate::executor::apply_memlock(memlock);
-                            pd.apply()
-                                .map_err(|e| std::io::Error::from_raw_os_error(e as i32))
-                        });
-                    }
-                }
-            } else {
-                unsafe {
-                    cmd.pre_exec(move || {
-                        crate::executor::apply_memlock(memlock);
-                        Ok(())
-                    });
-                }
+            unsafe {
+                cmd.pre_exec(move || {
+                    crate::executor::apply_memlock(memlock);
+                    Ok(())
+                });
             }
-            run_tokio_step_to_spool(cmd, step_files, &self.active_steps, step_key).await?
+            ChildContainment::for_plan(&plan, &job_entry, priv_drop, self.cgroup.required)
+                .register(&mut cmd);
+            run_tokio_step_to_spool(
+                cmd,
+                step_files,
+                &self.active_steps,
+                step_key,
+                job_entry.cgroup_path.as_deref(),
+                self.cgroup.required,
+            )
+            .await?
         } else if req.container.as_ref().is_some_and(|c| !c.image.is_empty()) {
             // Case 2: standalone srun --container-image with no running parent
             // container — set up a fresh rootfs for this step.
@@ -3455,26 +3448,35 @@ impl SlurmAgent for AgentService {
             }
             maybe_status
         } else {
-            // Case 3: no container — plain host process.
-            let mut cmd = tokio::process::Command::new(&program);
-            cmd.args(&program_args)
-                .current_dir(&work_dir)
-                .process_group(0);
+            // Case 3: no container — plain host process. Route through the same
+            // launch plan as the other arms so the child joins the job cgroup.
+            let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
+            let full_command: Vec<String> = std::iter::once(program.clone())
+                .chain(program_args.iter().cloned())
+                .collect();
+            let plan = build_launch_plan(&job_entry, priv_drop.as_ref(), &full_command);
+            let mut cmd = tokio::process::Command::new(&plan.program);
+            cmd.args(&plan.args).current_dir(&work_dir).process_group(0);
             for (k, v) in env {
                 cmd.env(k, v);
             }
-            let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
             unsafe {
                 cmd.pre_exec(move || {
                     crate::executor::apply_memlock(memlock);
-                    if let Some(ref pd) = priv_drop {
-                        pd.apply()
-                            .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
-                    }
                     Ok(())
                 });
             }
-            run_tokio_step_to_spool(cmd, step_files, &self.active_steps, step_key).await?
+            ChildContainment::for_plan(&plan, &job_entry, priv_drop, self.cgroup.required)
+                .register(&mut cmd);
+            run_tokio_step_to_spool(
+                cmd,
+                step_files,
+                &self.active_steps,
+                step_key,
+                job_entry.cgroup_path.as_deref(),
+                self.cgroup.required,
+            )
+            .await?
         };
 
         let status = match maybe_status {

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2696,10 +2696,14 @@ impl SlurmAgent for AgentService {
 
     /// Record a standalone-srun allocation on this node without launching a
     /// batch script.
+    ///
+    /// Controller-only: `uid` and `user` reach the tracked job straight from the wire, and the exec
+    /// paths authorize against `user` while executing as `uid` — a caller setting both is anyone.
     async fn register_job_allocation(
         &self,
         request: Request<RegisterJobAllocationRequest>,
     ) -> Result<Response<RegisterJobAllocationResponse>, Status> {
+        Self::require_controller(&request)?;
         let req = request.into_inner();
         if req.job_id == 0 {
             return Err(Status::invalid_argument("job_id is required"));
@@ -5686,6 +5690,38 @@ mod tests {
             .await
             .expect_err("a user token must not cancel jobs by dialing the agent directly");
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    /// The impersonation this gate exists to stop: `user` decides who owns the allocation and `uid`
+    /// decides who its steps run as, so a caller who sets both reaches any account on the node.
+    #[tokio::test]
+    async fn register_job_allocation_rejects_a_non_controller_caller() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let mut req = Request::new(RegisterJobAllocationRequest {
+            job_id: 49,
+            uid: 1234,
+            gid: 1234,
+            user: "attacker".into(),
+            cpus: 1,
+            ..Default::default()
+        });
+        req.extensions_mut().insert(user_identity("attacker"));
+
+        let err = svc
+            .register_job_allocation(req)
+            .await
+            .expect_err("a user token must not register an allocation on the agent directly");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert!(
+            svc.running.lock().await.is_empty(),
+            "a refused registration must not leave a job the exec paths would trust"
+        );
     }
 
     /// A launch aimed at another node's name must be refused: the agent only runs allocations

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -127,6 +127,33 @@ async fn cleanup_completed_job_mpi(job_id: u32, mpi: &str, mpi_host: &MpiPluginH
     }
 }
 
+/// Release what a finished run owned, once the monitor has dropped it from
+/// `running`. Skipped if the id is tracked again: it is all keyed by job id.
+async fn teardown_completed_job(
+    completed: &CompletedJob,
+    running: &RunningJobs,
+    allocation: &Arc<Mutex<NodeAllocation>>,
+    mpi_host: &MpiPluginHost,
+) {
+    let job_id = completed.job_id;
+    // Taken and released before `allocation`, the order commit_job uses.
+    if running.lock().await.contains_key(&job_id) {
+        warn!(
+            job_id,
+            "job id re-dispatched during teardown; leaving the new run's state alone"
+        );
+        return;
+    }
+
+    crate::container::cleanup_rootfs(job_id, &completed.rootfs_mode);
+    crate::executor::cleanup_job_spool(job_id);
+    if let Some(ref cgroup) = completed.cgroup {
+        crate::executor::cleanup_cgroup(cgroup);
+    }
+    allocation.lock().await.release_job(job_id);
+    cleanup_completed_job_mpi(job_id, &completed.mpi, mpi_host).await;
+}
+
 /// Enforced per-node budget: the controller's allocation wins, the spec is the
 /// fallback (every task on this node, and `--mem-per-cpu` when `--mem` is unset).
 fn resolve_cgroup_budget(
@@ -209,36 +236,43 @@ fn stat_shows_running(stat: &str) -> bool {
     !matches!(state, None | Some("Z" | "X"))
 }
 
-/// Drop a job from the running set and release the cgroup it still owns.
+/// Drop a job from the running set, handing back the cgroup it still owns.
 ///
 /// The single exit from `running` bar the monitor loop, which takes the cgroup
-/// itself to read `memory.events` first. Taking it here keeps the release single.
-fn remove_tracked_job(running: &mut HashMap<u32, TrackedJob>, job_id: u32) -> Option<TrackedJob> {
-    let mut tracked = running.remove(&job_id)?;
-    if let Some(cgroup) = tracked.take_cgroup() {
-        executor::cleanup_cgroup(&cgroup);
-    }
-    Some(tracked)
+/// itself to read `memory.events` first. Taking it here keeps the release
+/// single; the caller drops the guard once the `running` lock is gone, since
+/// removal SIGKILLs the cgroup's stragglers and then blocks retrying rmdir.
+fn remove_tracked_job(
+    running: &mut HashMap<u32, TrackedJob>,
+    job_id: u32,
+) -> (Option<TrackedJob>, executor::CgroupGuard) {
+    let Some(mut tracked) = running.remove(&job_id) else {
+        return (None, executor::CgroupGuard::new(None));
+    };
+    let cgroup = executor::CgroupGuard::new(tracked.take_cgroup());
+    (Some(tracked), cgroup)
 }
 
 /// Roll back a registration that cannot be enforced. Takes the held `running`
 /// map so the reservation is released under that lock, the order that keeps a
 /// reconcile pass from seeing the allocation committed with no tracked job.
+/// The refused job's cgroup comes back with the status for the caller to drop.
 fn refuse_allocation(
     job_id: u32,
     reservation: LaunchReservationGuard,
     running: &mut HashMap<u32, TrackedJob>,
     reason: &str,
-) -> Status {
+) -> (Status, executor::CgroupGuard) {
     error!(
         job_id,
         reason, "refusing an allocation that cannot be enforced"
     );
-    remove_tracked_job(running, job_id);
+    let (_, cgroup) = remove_tracked_job(running, job_id);
     drop(reservation);
-    Status::failed_precondition(format!(
+    let status = Status::failed_precondition(format!(
         "[cgroup] required but the allocation's cgroup could not be created: {reason}"
-    ))
+    ));
+    (status, cgroup)
 }
 
 /// Job ids this node holds, shared with the reporter so heartbeats carry them.
@@ -575,13 +609,45 @@ mod teardown_tests {
         let mut running = HashMap::new();
         running.insert(7, TrackedJob::allocation_only(Some(cgroup.clone())));
 
-        let removed = remove_tracked_job(&mut running, 7).expect("the job was tracked");
+        let (removed, release) = remove_tracked_job(&mut running, 7);
+        let removed = removed.expect("the job was tracked");
+        drop(release);
 
         assert!(!cgroup.exists(), "teardown must remove the job's cgroup");
         assert!(
             removed.cgroup_path.is_none(),
             "the released path must be taken off the job"
         );
+    }
+
+    // The removal is what blocks, so it belongs to the caller, to run once the
+    // map is unlocked. Taking the job out must not be what removes the cgroup.
+    #[tokio::test]
+    async fn the_cgroup_is_released_by_its_token_and_not_under_the_lock() {
+        let (_root, cgroup) = tracked_with_cgroup();
+        let running = super::new_running_jobs();
+        running
+            .lock()
+            .await
+            .insert(7, TrackedJob::allocation_only(Some(cgroup.clone())));
+
+        let (removed, release) = {
+            let mut jobs = running.lock().await;
+            let taken = remove_tracked_job(&mut jobs, 7);
+            assert!(
+                cgroup.exists(),
+                "the cgroup must outlive the removal that holds the lock"
+            );
+            taken
+        };
+
+        assert!(removed.is_some(), "the job was tracked");
+        assert!(
+            running.try_lock().is_ok(),
+            "the map must be unlocked before the cgroup is released"
+        );
+        drop(release);
+        assert!(!cgroup.exists(), "releasing the token removes the cgroup");
     }
 
     // A re-dispatched job derives the same job_<id> path, so a second teardown
@@ -591,11 +657,13 @@ mod teardown_tests {
         let (_root, cgroup) = tracked_with_cgroup();
         let mut running = HashMap::new();
         running.insert(7, TrackedJob::allocation_only(Some(cgroup.clone())));
-        let released = remove_tracked_job(&mut running, 7).expect("the job was tracked");
+        let (released, first) = remove_tracked_job(&mut running, 7);
+        drop(first);
 
         std::fs::create_dir_all(&cgroup).expect("successor cgroup");
-        running.insert(7, released);
-        remove_tracked_job(&mut running, 7);
+        running.insert(7, released.expect("the job was tracked"));
+        let (_, second) = remove_tracked_job(&mut running, 7);
+        drop(second);
 
         assert!(
             cgroup.exists(),
@@ -608,7 +676,9 @@ mod teardown_tests {
         let mut running = HashMap::new();
         running.insert(8, TrackedJob::allocation_only(None));
 
-        let removed = remove_tracked_job(&mut running, 8).expect("the job was tracked");
+        let (removed, release) = remove_tracked_job(&mut running, 8);
+        let removed = removed.expect("the job was tracked");
+        drop(release);
 
         assert!(removed.cgroup_path.is_none());
         assert!(running.is_empty(), "the job must still leave the map");
@@ -616,7 +686,9 @@ mod teardown_tests {
 
     #[test]
     fn removing_an_untracked_job_yields_nothing() {
-        assert!(remove_tracked_job(&mut HashMap::new(), 9).is_none());
+        let (removed, release) = remove_tracked_job(&mut HashMap::new(), 9);
+        drop(release);
+        assert!(removed.is_none());
     }
 }
 
@@ -1088,28 +1160,23 @@ impl AgentService {
 
                 for c in &completed {
                     jobs.remove(&c.job_id);
-                    crate::container::cleanup_rootfs(
-                        &crate::container::job_rootfs_base(c.job_id),
-                        &c.rootfs_mode,
-                    );
-                    crate::executor::cleanup_job_spool(c.job_id);
-                    if let Some(ref cgroup) = c.cgroup {
-                        crate::executor::cleanup_cgroup(cgroup);
-                    }
-                    allocation.lock().await.release_job(c.job_id);
-                    cleanup_completed_job_mpi(c.job_id, &c.mpi, &mpi_host).await;
+                }
+                // Teardown below SIGKILLs each cgroup and blocks retrying rmdir,
+                // then runs hooks and RPCs; none of it may hold this lock.
+                drop(jobs);
+
+                for c in &completed {
+                    teardown_completed_job(c, &running, &allocation, &mpi_host).await;
                 }
 
                 // Self-heal backstop: reclaim allocations with no tracked,
-                // non-launching job. `jobs` is held so the live set is a
-                // consistent snapshot that can't race a committing launch
-                // (commit_job takes the running lock first).
-                reconcile_orphaned_allocations(&jobs, &mut *allocation.lock().await);
-
-                // Release lock BEFORE network I/O — holding the lock during
-                // report_completion blocks new job launches and can lose
-                // completions if the RPC times out.
-                drop(jobs);
+                // non-launching job. `running` is re-taken before `allocation`,
+                // the order commit_job uses, so the live set the reclaim reads
+                // can't race a committing launch.
+                {
+                    let jobs = running.lock().await;
+                    reconcile_orphaned_allocations(&jobs, &mut *allocation.lock().await);
+                }
 
                 let local_hostname = hostname::get()
                     .map(|h| h.to_string_lossy().to_string())
@@ -2725,12 +2792,12 @@ impl SlurmAgent for AgentService {
                 None
             }
             AllocationCgroup::Refuse(reason) => {
-                return Err(refuse_allocation(
-                    req.job_id,
-                    reservation_guard,
-                    &mut jobs,
-                    &reason,
-                ));
+                let (status, cgroup) =
+                    refuse_allocation(req.job_id, reservation_guard, &mut jobs, &reason);
+                // Guard first, then the cgroup: removing it blocks retrying rmdir.
+                drop(jobs);
+                drop(cgroup);
+                return Err(status);
             }
         };
 
@@ -3928,11 +3995,19 @@ impl SlurmAgent for AgentService {
 
 impl AgentService {
     async fn drop_tracked_job(&self, job_id: u32) {
-        if remove_tracked_job(&mut *self.running.lock().await, job_id).is_some() {
-            self.allocation.lock().await.release_job(job_id);
-            if let Err(e) = self.mpi_host.stop_pmix_server(job_id) {
-                warn!(job_id, error = %e, "PMIx stop failed on job drop");
-            }
+        // Scoped so the guard is gone before `cgroup` is dropped below: removing
+        // a cgroup SIGKILLs its stragglers and then blocks retrying rmdir.
+        let (tracked, cgroup) = {
+            let mut jobs = self.running.lock().await;
+            remove_tracked_job(&mut jobs, job_id)
+        };
+        drop(cgroup);
+        if tracked.is_none() {
+            return;
+        }
+        self.allocation.lock().await.release_job(job_id);
+        if let Err(e) = self.mpi_host.stop_pmix_server(job_id) {
+            warn!(job_id, error = %e, "PMIx stop failed on job drop");
         }
     }
 
@@ -6942,11 +7017,14 @@ mod tests {
             let mut jobs = svc.running.lock().await;
             // Inserted so the rollback has something to undo.
             jobs.insert(42, TrackedJob::allocation_only(None));
-            let status = refuse_allocation(42, reservation, &mut jobs, "cgroup root unavailable");
+            let (status, cgroup) =
+                refuse_allocation(42, reservation, &mut jobs, "cgroup root unavailable");
             assert!(
                 !jobs.contains_key(&42),
                 "a refused allocation must leave no tracked job"
             );
+            drop(jobs);
+            drop(cgroup);
             status
         };
 
@@ -7492,6 +7570,102 @@ mod tests {
         assert!(
             !cgroup.exists(),
             "completion must remove the finished job's cgroup"
+        );
+    }
+
+    fn completed_job(job_id: u32, cgroup: std::path::PathBuf) -> CompletedJob {
+        CompletedJob {
+            job_id,
+            exit_code: 0,
+            signal: 0,
+            run_attempt: 0,
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            cgroup: Some(cgroup),
+            work_dir: "/tmp".into(),
+            uid: 0,
+            gid: 0,
+            partition: String::new(),
+            gpu_devices: Vec::new(),
+            cpus: 1,
+            memory_mb: 0,
+            nodelist: String::new(),
+            mpi: String::new(),
+        }
+    }
+
+    // The monitor drops the job from `running` before tearing it down, so the
+    // controller can re-dispatch the id into that window and own the same state.
+    #[tokio::test]
+    async fn teardown_spares_a_job_id_re_dispatched_during_the_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("job_907");
+        std::fs::create_dir(&cgroup).unwrap();
+
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let job_id = 907;
+        let completed = completed_job(job_id, cgroup.clone());
+
+        // The re-dispatch: tracked again under the same id, holding the GPU.
+        svc.insert_test_job(job_id, TrackedJob::allocation_only(Some(cgroup.clone())))
+            .await;
+        {
+            let mut alloc = svc.allocation.lock().await;
+            alloc.allocate_for_job(job_id, 1, 0, &[0]).unwrap();
+            alloc.commit_job(job_id);
+        }
+
+        teardown_completed_job(&completed, &svc.running, &svc.allocation, &svc.mpi_host).await;
+
+        assert!(
+            cgroup.exists(),
+            "teardown must not remove the cgroup the re-dispatched run is in"
+        );
+        assert_eq!(
+            svc.free_gpu_count().await,
+            0,
+            "teardown must not release the re-dispatched run's reservation"
+        );
+    }
+
+    // The counterpart: with no live run under the id, the same teardown must
+    // still release everything, so the guard above cannot just skip always.
+    #[tokio::test]
+    async fn teardown_releases_a_job_id_nothing_holds() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("job_908");
+        std::fs::create_dir(&cgroup).unwrap();
+
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let job_id = 908;
+        let completed = completed_job(job_id, cgroup.clone());
+        {
+            let mut alloc = svc.allocation.lock().await;
+            alloc.allocate_for_job(job_id, 1, 0, &[0]).unwrap();
+            alloc.commit_job(job_id);
+        }
+
+        teardown_completed_job(&completed, &svc.running, &svc.allocation, &svc.mpi_host).await;
+
+        assert!(
+            !cgroup.exists(),
+            "teardown must remove the finished run's cgroup"
+        );
+        assert_eq!(
+            svc.free_gpu_count().await,
+            1,
+            "teardown must release the finished run's reservation"
         );
     }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -798,6 +798,8 @@ async fn run_containerized_step(
     active_steps: &Arc<Mutex<HashMap<(u32, u32), ActiveStep>>>,
     step_key: (u32, u32),
     memlock: spur_core::config::MemlockLimit,
+    cgroup: Option<&std::path::Path>,
+    cgroup_required: bool,
 ) -> Result<(Option<std::process::ExitStatus>, i32), Status> {
     // Returns (exit_status, child_pid). The pid is 0 when the step was
     // cancelled before the fork completed. The caller uses it to set the
@@ -844,6 +846,10 @@ async fn run_containerized_step(
         }
     }
 
+    // Built parent-side (nothing between fork and exec may allocate); the child
+    // joins itself below while still root, and `required` is verified parent-side.
+    let cgroup_join = executor::CgroupJoin::for_cgroup(cgroup);
+
     match unsafe { nix::unistd::fork().map_err(|e| Status::internal(format!("fork failed: {e}")))? }
     {
         nix::unistd::ForkResult::Child => {
@@ -856,6 +862,12 @@ async fn run_containerized_step(
                 // Wire stdout/stderr to the per-step spool files.
                 libc::dup2(stdout_fd, libc::STDOUT_FILENO);
                 libc::dup2(stderr_fd, libc::STDERR_FILENO);
+            }
+
+            // Join while still root, before container_init's pivot_root hides the
+            // host cgroupfs and close_inherited_fds reaps the log fd.
+            if let Some(ref join) = cgroup_join {
+                let _ = join.join();
             }
 
             crate::container::close_inherited_fds(ready_w_fd);
@@ -946,6 +958,20 @@ async fn run_containerized_step(
                 return Err(Status::internal(format!(
                     "step container init failed: {msg}"
                 )));
+            }
+
+            // Verify the self-join above actually landed (it is best-effort in
+            // the child). Under `[cgroup] required` a step that missed its cgroup
+            // is refused and killed rather than run outside the limits and filter.
+            if escaped_job_cgroup(cgroup_required, cgroup, Some(child_pid.as_raw() as u32)) {
+                crate::executor::kill_process_tree(
+                    child_pid.as_raw(),
+                    nix::sys::signal::Signal::SIGKILL,
+                );
+                let _ = nix::sys::wait::waitpid(child_pid, None);
+                return Err(Status::failed_precondition(
+                    "[cgroup] required but the step did not join its cgroup",
+                ));
             }
 
             // Register PID for cancellation.
@@ -3441,6 +3467,8 @@ impl SlurmAgent for AgentService {
                 &self.active_steps,
                 step_key,
                 memlock,
+                job_entry.cgroup_path.as_deref(),
+                self.cgroup.required,
             )
             .await?;
             if child_pid != 0 {

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -88,6 +88,17 @@ pub(crate) struct TrackedJob {
     mpi: String,
     /// Run epoch; echoed on completion and guards the grace-period SIGKILL.
     run_attempt: u32,
+    /// The job's cgroup, owned here so every launch path into the job can reach
+    /// it. `None` when cgroup enforcement is off or no cgroup was created.
+    cgroup_path: Option<std::path::PathBuf>,
+}
+
+impl TrackedJob {
+    /// Take the cgroup path, leaving `None`. Whichever teardown path reaches
+    /// the job first takes it, so the removal it authorizes happens once.
+    fn take_cgroup(&mut self) -> Option<std::path::PathBuf> {
+        self.cgroup_path.take()
+    }
 }
 
 struct CompletedJob {
@@ -141,6 +152,93 @@ fn resolve_cgroup_budget(
         spec.memory_per_cpu_mb.saturating_mul(cpus as u64)
     };
     (cpus, memory_mb)
+}
+
+/// What to do with an allocation once its cgroup setup has been attempted.
+enum AllocationCgroup {
+    /// Enforcement is in place, or off by config; record the allocation.
+    Record(Option<std::path::PathBuf>),
+    /// Enforcement failed but is not required; record it unenforced.
+    Degraded(String),
+    /// Enforcement is required and failed; refuse the registration.
+    Refuse(String),
+}
+
+/// Fail closed: an allocation whose cgroup could not be created is refused when
+/// `[cgroup] required` is set, rather than recorded as one nothing can enforce.
+fn allocation_cgroup(
+    setup: anyhow::Result<Option<std::path::PathBuf>>,
+    required: bool,
+) -> AllocationCgroup {
+    match setup {
+        Ok(path) => AllocationCgroup::Record(path),
+        Err(e) if required => AllocationCgroup::Refuse(format!("{e:#}")),
+        Err(e) => AllocationCgroup::Degraded(format!("{e:#}")),
+    }
+}
+
+/// Whether a spawned child missed the job's cgroup, and so runs outside its
+/// limits and device filter. Only `required` makes that fatal.
+fn escaped_job_cgroup(required: bool, cgroup: Option<&std::path::Path>, pid: Option<u32>) -> bool {
+    if !required {
+        return false;
+    }
+    let (Some(cgroup), Some(pid)) = (cgroup, pid) else {
+        return false;
+    };
+    // A step that exits between the spawn and this probe leaves `cgroup.procs`
+    // too, and has escaped nothing — the normal wait path collects it.
+    !executor::cgroup_has_pid(cgroup, pid) && pid_is_running(pid)
+}
+
+/// Whether `pid` is still executing. A signal-0 probe cannot tell: an
+/// exited-but-unreaped child is a valid signal target, so `/proc` decides.
+fn pid_is_running(pid: u32) -> bool {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return false;
+    };
+    stat_shows_running(&stat)
+}
+
+/// Whether a `/proc/<pid>/stat` line describes a still-executing process.
+/// Read from the last ')': `comm` may itself contain spaces and ')'.
+fn stat_shows_running(stat: &str) -> bool {
+    let state = stat
+        .rsplit_once(')')
+        .and_then(|(_, rest)| rest.split_whitespace().next());
+    !matches!(state, None | Some("Z" | "X"))
+}
+
+/// Drop a job from the running set and release the cgroup it still owns.
+///
+/// The single exit from `running` bar the monitor loop, which takes the cgroup
+/// itself to read `memory.events` first. Taking it here keeps the release single.
+fn remove_tracked_job(running: &mut HashMap<u32, TrackedJob>, job_id: u32) -> Option<TrackedJob> {
+    let mut tracked = running.remove(&job_id)?;
+    if let Some(cgroup) = tracked.take_cgroup() {
+        executor::cleanup_cgroup(&cgroup);
+    }
+    Some(tracked)
+}
+
+/// Roll back a registration that cannot be enforced. Takes the held `running`
+/// map so the reservation is released under that lock, the order that keeps a
+/// reconcile pass from seeing the allocation committed with no tracked job.
+fn refuse_allocation(
+    job_id: u32,
+    reservation: LaunchReservationGuard,
+    running: &mut HashMap<u32, TrackedJob>,
+    reason: &str,
+) -> Status {
+    error!(
+        job_id,
+        reason, "refusing an allocation that cannot be enforced"
+    );
+    remove_tracked_job(running, job_id);
+    drop(reservation);
+    Status::failed_precondition(format!(
+        "[cgroup] required but the allocation's cgroup could not be created: {reason}"
+    ))
 }
 
 /// Job ids this node holds, shared with the reporter so heartbeats carry them.
@@ -267,6 +365,15 @@ fn signal_step_tree(pid: u32, signal: i32) {
     }
 }
 
+/// SIGKILL a step's whole process group, then reap the leader: every step shape
+/// runs the user's command in a descendant of the spawned wrapper.
+async fn kill_step_process_group(child: &mut tokio::process::Child) {
+    if let Some(pid) = child.id() {
+        signal_step_process_group(pid, nix::sys::signal::Signal::SIGKILL as i32);
+    }
+    let _ = child.kill().await;
+}
+
 #[cfg(test)]
 mod budget_tests {
     use super::resolve_cgroup_budget;
@@ -325,6 +432,191 @@ mod budget_tests {
     #[test]
     fn floors_cpus_at_one() {
         assert_eq!(resolve_cgroup_budget(None, &spec(0, 0, 0), 0), (1, 0));
+    }
+}
+
+#[cfg(test)]
+mod step_cgroup_tests {
+    use super::{escaped_job_cgroup, stat_shows_running};
+
+    fn cgroup_holding(pids: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("cgroup.procs"), pids).expect("cgroup.procs");
+        dir
+    }
+
+    #[test]
+    fn a_step_that_joined_the_job_cgroup_runs() {
+        let cgroup = cgroup_holding("17\n4242\n");
+        assert!(!escaped_job_cgroup(true, Some(cgroup.path()), Some(4242)));
+    }
+
+    #[test]
+    fn a_required_cgroup_catches_a_live_step_that_did_not_join() {
+        // The test process: certainly running, and an empty cgroup cannot
+        // contain it whatever pid the runner handed us.
+        let cgroup = cgroup_holding("");
+        assert!(escaped_job_cgroup(
+            true,
+            Some(cgroup.path()),
+            Some(std::process::id())
+        ));
+    }
+
+    // A step can exit between `spawn` returning and this probe. The zombie is
+    // absent from `cgroup.procs` without ever having escaped it.
+    #[test]
+    fn a_step_that_exited_before_the_probe_has_not_escaped() {
+        let cgroup = cgroup_holding("");
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn a short-lived child");
+        let pid = child.id();
+        let nix_pid = nix::unistd::Pid::from_raw(pid as i32);
+        // Blocks until the child exits, but WNOWAIT leaves it unreaped, so the
+        // assertion below runs against a genuine zombie.
+        nix::sys::wait::waitid(
+            nix::sys::wait::Id::Pid(nix_pid),
+            nix::sys::wait::WaitPidFlag::WEXITED | nix::sys::wait::WaitPidFlag::WNOWAIT,
+        )
+        .expect("child should reach a waitable state");
+        assert!(
+            nix::sys::signal::kill(nix_pid, None).is_ok(),
+            "a zombie answers a signal-0 probe, which is why liveness is read from /proc"
+        );
+
+        assert!(!escaped_job_cgroup(true, Some(cgroup.path()), Some(pid)));
+
+        child.wait().expect("reap the child");
+    }
+
+    #[test]
+    fn the_state_field_is_read_past_a_parenthesized_comm() {
+        assert!(stat_shows_running("4242 (weird ) name) S 1 4242 4242 0"));
+        assert!(!stat_shows_running("4242 (weird ) name) Z 1 4242 4242 0"));
+    }
+
+    #[test]
+    fn an_optional_cgroup_lets_an_unjoined_step_run() {
+        let cgroup = cgroup_holding("17\n");
+        assert!(!escaped_job_cgroup(false, Some(cgroup.path()), Some(4242)));
+    }
+
+    #[test]
+    fn a_job_with_no_cgroup_has_none_to_escape() {
+        // Config can disable enforcement outright; `required` then has no
+        // cgroup to check and must not refuse every step on the node.
+        assert!(!escaped_job_cgroup(true, None, Some(4242)));
+    }
+}
+
+#[cfg(test)]
+mod allocation_cgroup_tests {
+    use super::{allocation_cgroup, AllocationCgroup};
+
+    #[test]
+    fn a_created_cgroup_is_recorded_on_the_allocation() {
+        let path = std::path::PathBuf::from("/sys/fs/cgroup/spur/job_9");
+        let decision = allocation_cgroup(Ok(Some(path.clone())), true);
+        let AllocationCgroup::Record(recorded) = decision else {
+            panic!("a created cgroup must reach the tracked job");
+        };
+        assert_eq!(recorded, Some(path));
+    }
+
+    // `setup_cgroup` returns no path without an error only when `[cgroup]
+    // enabled` is off, which leaves `required` nothing to gate.
+    #[test]
+    fn a_cgroup_disabled_by_config_records_an_unenforced_allocation() {
+        assert!(matches!(
+            allocation_cgroup(Ok(None), true),
+            AllocationCgroup::Record(None)
+        ));
+    }
+
+    // Without a cgroup the allocation's steps escape the device filter, so a
+    // node that must enforce refuses the allocation rather than pretend.
+    #[test]
+    fn a_required_cgroup_refuses_an_allocation_it_cannot_enforce() {
+        let setup = Err(anyhow::anyhow!("cgroup root unavailable"));
+        let AllocationCgroup::Refuse(reason) = allocation_cgroup(setup, true) else {
+            panic!("required enforcement must refuse, not record");
+        };
+        assert!(reason.contains("cgroup root unavailable"));
+    }
+
+    #[test]
+    fn an_optional_cgroup_degrades_to_an_unenforced_allocation() {
+        let setup = Err(anyhow::anyhow!("cgroup creation failed (not root)"));
+        let AllocationCgroup::Degraded(reason) = allocation_cgroup(setup, false) else {
+            panic!("an optional cgroup must degrade, not refuse");
+        };
+        assert!(reason.contains("not root"));
+    }
+}
+
+#[cfg(test)]
+mod teardown_tests {
+    use super::{remove_tracked_job, TrackedJob};
+    use std::collections::HashMap;
+
+    // A temp directory stands in for the job's cgroup: cleanup takes a path, so
+    // the real removal runs without root or a cgroupfs.
+    fn tracked_with_cgroup() -> (tempfile::TempDir, std::path::PathBuf) {
+        let root = tempfile::tempdir().expect("tempdir");
+        let cgroup = root.path().join("job_7");
+        std::fs::create_dir(&cgroup).expect("cgroup dir");
+        (root, cgroup)
+    }
+
+    #[test]
+    fn removing_a_job_releases_its_cgroup() {
+        let (_root, cgroup) = tracked_with_cgroup();
+        let mut running = HashMap::new();
+        running.insert(7, TrackedJob::allocation_only(Some(cgroup.clone())));
+
+        let removed = remove_tracked_job(&mut running, 7).expect("the job was tracked");
+
+        assert!(!cgroup.exists(), "teardown must remove the job's cgroup");
+        assert!(
+            removed.cgroup_path.is_none(),
+            "the released path must be taken off the job"
+        );
+    }
+
+    // A re-dispatched job derives the same job_<id> path, so a second teardown
+    // pass over an already-released job would delete a live run's cgroup.
+    #[test]
+    fn a_released_cgroup_is_not_released_again() {
+        let (_root, cgroup) = tracked_with_cgroup();
+        let mut running = HashMap::new();
+        running.insert(7, TrackedJob::allocation_only(Some(cgroup.clone())));
+        let released = remove_tracked_job(&mut running, 7).expect("the job was tracked");
+
+        std::fs::create_dir_all(&cgroup).expect("successor cgroup");
+        running.insert(7, released);
+        remove_tracked_job(&mut running, 7);
+
+        assert!(
+            cgroup.exists(),
+            "a cgroup already released must not be released a second time"
+        );
+    }
+
+    #[test]
+    fn removing_a_job_without_a_cgroup_releases_nothing() {
+        let mut running = HashMap::new();
+        running.insert(8, TrackedJob::allocation_only(None));
+
+        let removed = remove_tracked_job(&mut running, 8).expect("the job was tracked");
+
+        assert!(removed.cgroup_path.is_none());
+        assert!(running.is_empty(), "the job must still leave the map");
+    }
+
+    #[test]
+    fn removing_an_untracked_job_yields_nothing() {
+        assert!(remove_tracked_job(&mut HashMap::new(), 9).is_none());
     }
 }
 
@@ -631,7 +923,12 @@ impl AgentService {
             device_registry,
             &spur_core::config::ClusterConfig::default(),
             spur_core::config::JobLimits { memlock },
-            CgroupConfig::default(),
+            // Enforcement off: `/sys/fs/cgroup/spur` is a real path, so a root
+            // runner would otherwise have these tests creating real cgroups.
+            CgroupConfig {
+                enabled: false,
+                ..CgroupConfig::default()
+            },
             MpiConfig::default(),
             new_running_jobs(),
             spur_core::config::AuthConfig::default().allow_root_jobs,
@@ -756,7 +1053,7 @@ impl AgentService {
                             // Disambiguate an OOM kill (cgroup memory.events) from
                             // a plain SIGKILL by OR'ing a sentinel into the reported
                             // signal; read before cleanup_cgroup removes the dir.
-                            let cgroup = tracked.job.take_cgroup();
+                            let cgroup = tracked.take_cgroup();
                             if let Some(ref cg) = cgroup {
                                 if crate::executor::cgroup_oom_killed(cg) {
                                     warn!(job_id, "job OOM-killed (cgroup oom_kill > 0)");
@@ -1209,6 +1506,118 @@ fn build_launch_plan(
             program: command[0].clone(),
             args: command[1..].to_vec(),
             apply_priv_in_child: true,
+        }
+    }
+}
+
+/// What a process launched into a running job applies to itself between fork
+/// and exec, for either spawn shape decided by [`build_launch_plan`].
+struct ChildContainment<'a> {
+    /// Both shapes join: on the nsenter shape the join lands before `nsenter`
+    /// execs, so the namespaces it enters inherit the membership.
+    cgroup: Option<&'a std::path::Path>,
+    /// `None` on the nsenter shape, which drops inside the namespace via
+    /// `setpriv` — dropping here as well would break the namespace entry.
+    priv_drop: Option<crate::privdrop::PrivDrop>,
+}
+
+impl<'a> ChildContainment<'a> {
+    fn for_plan(
+        plan: &LaunchPlan,
+        entry: &'a crate::job_entry::JobEntry,
+        priv_drop: Option<crate::privdrop::PrivDrop>,
+    ) -> Self {
+        Self {
+            cgroup: entry.cgroup_path.as_deref(),
+            priv_drop: if plan.apply_priv_in_child {
+                priv_drop
+            } else {
+                None
+            },
+        }
+    }
+
+    /// Register the child's hook. Both inputs are built parent-side: nothing
+    /// between fork and exec may allocate.
+    fn register(self, cmd: &mut tokio::process::Command) {
+        let cgroup_join = executor::CgroupJoin::for_cgroup(self.cgroup);
+        let priv_drop = self.priv_drop;
+        unsafe {
+            cmd.pre_exec(move || {
+                // Before the drop below: an unprivileged process cannot write
+                // another cgroup's `cgroup.procs`.
+                if let Some(ref join) = cgroup_join {
+                    join.join();
+                }
+                if let Some(ref pd) = priv_drop {
+                    pd.apply()
+                        .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+                }
+                Ok(())
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod child_containment_tests {
+    use super::{build_launch_plan, ChildContainment};
+    use crate::privdrop::PrivDrop;
+
+    const CGROUP: &str = "/sys/fs/cgroup/spur/job_7";
+
+    fn entry(namespaced: bool, cgroup: Option<&str>) -> crate::job_entry::JobEntry {
+        crate::job_entry::JobEntry {
+            pid: if namespaced { 1234 } else { 0 },
+            has_pid_namespace: namespaced,
+            has_user_namespace: false,
+            has_mount_namespace: namespaced,
+            uid: 1000,
+            gid: 1000,
+            work_dir: "/home/user".into(),
+            cgroup_path: cgroup.map(std::path::PathBuf::from),
+        }
+    }
+
+    #[test]
+    fn an_nsenter_launch_joins_the_cgroup_without_dropping_privilege_itself() {
+        let entry = entry(true, Some(CGROUP));
+        let pd = PrivDrop::for_test(1000, 1000);
+        let plan = build_launch_plan(&entry, Some(&pd), &["id".to_string()]);
+        assert!(!plan.apply_priv_in_child, "expected the nsenter shape");
+
+        let containment = ChildContainment::for_plan(&plan, &entry, Some(pd));
+
+        assert_eq!(containment.cgroup, Some(std::path::Path::new(CGROUP)));
+        // setpriv drops inside the namespace; dropping here too would leave the
+        // child unable to enter it.
+        assert!(containment.priv_drop.is_none());
+    }
+
+    #[test]
+    fn a_direct_launch_joins_the_cgroup_and_drops_privilege_itself() {
+        let entry = entry(false, Some(CGROUP));
+        let pd = PrivDrop::for_test(1000, 1000);
+        let plan = build_launch_plan(&entry, Some(&pd), &["id".to_string()]);
+        assert!(plan.apply_priv_in_child, "expected the direct-spawn shape");
+
+        let containment = ChildContainment::for_plan(&plan, &entry, Some(pd));
+
+        assert_eq!(containment.cgroup, Some(std::path::Path::new(CGROUP)));
+        assert!(containment.priv_drop.is_some());
+    }
+
+    #[test]
+    fn a_job_without_a_cgroup_leaves_the_child_nothing_to_join() {
+        // A non-root agent creates no cgroup, and the launch still has to run.
+        for namespaced in [true, false] {
+            let entry = entry(namespaced, None);
+            let pd = PrivDrop::for_test(1000, 1000);
+            let plan = build_launch_plan(&entry, Some(&pd), &["id".to_string()]);
+
+            assert!(ChildContainment::for_plan(&plan, &entry, Some(pd))
+                .cgroup
+                .is_none());
         }
     }
 }
@@ -1929,25 +2338,22 @@ impl SlurmAgent for AgentService {
                         warn!(job_id, error = %e, "PMIx stop failed after reclaimed reservation");
                     }
                     let _ = result.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
-                    let cgroup = result.job.take_cgroup();
+                    let cgroup = result.cgroup_path.take();
                     let running = self.running.clone();
                     tokio::spawn(async move {
                         reap_killed_job(result.job).await;
-                        // rootfs/spool paths are derived from job_id, so the
-                        // controller re-dispatching the same id to this node
-                        // would reuse them. Skip that cleanup if a live run for
-                        // job_id reappeared, or this reap would delete its files.
-                        // The cgroup handle is this launch's own, so it is always
-                        // safe to release.
+                        // rootfs, spool and the job_<id> cgroup all derive from
+                        // job_id, so a re-dispatch of that id reuses them: tearing
+                        // any of them down now would destroy the live run.
                         if !running.lock().await.contains_key(&job_id) {
                             crate::container::cleanup_rootfs(
                                 &crate::container::job_rootfs_base(job_id),
                                 &rootfs_mode,
                             );
                             crate::executor::cleanup_job_spool(job_id);
-                        }
-                        if let Some(ref cg) = cgroup {
-                            crate::executor::cleanup_cgroup(cg);
+                            if let Some(ref cg) = cgroup {
+                                crate::executor::cleanup_cgroup(cg);
+                            }
                         }
                     });
                     return Ok(Response::new(LaunchJobResponse {
@@ -1988,6 +2394,7 @@ impl SlurmAgent for AgentService {
                         nodelist: launch_cfg.nodelist,
                         mpi: spec.mpi.clone(),
                         run_attempt,
+                        cgroup_path: result.cgroup_path,
                     },
                 );
                 drop(jobs);
@@ -1995,6 +2402,8 @@ impl SlurmAgent for AgentService {
                 // older run. If its process ignored SIGTERM and outlived the
                 // requeue, kill and reap it here — the monitor loop no longer
                 // tracks it, so without this it would leak as an orphan/zombie.
+                // Its cgroup is deliberately left alone: the path is derived
+                // from job_id, so it is the cgroup the new run just joined.
                 if let Some(old) = displaced {
                     if old.run_attempt < run_attempt {
                         let _ = old.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
@@ -2198,20 +2607,12 @@ impl SlurmAgent for AgentService {
         let plan = build_launch_plan(&entry, priv_drop.as_ref(), &req.command);
         let mut cmd = tokio::process::Command::new(&plan.program);
         cmd.args(&plan.args);
-        // Direct-spawn path drops privilege in the child; the nsenter path
-        // already does it inside the namespace via setpriv.
         if plan.apply_priv_in_child {
+            // Direct spawn only: the parent applies this before exec, in the
+            // host's mount namespace, where a job's work_dir need not exist.
             cmd.current_dir(&entry.work_dir);
-            if let Some(pd) = priv_drop {
-                unsafe {
-                    cmd.pre_exec(move || {
-                        pd.apply()
-                            .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
-                        Ok(())
-                    });
-                }
-            }
         }
+        ChildContainment::for_plan(&plan, &entry, priv_drop).register(&mut cmd);
 
         let output = cmd
             .output()
@@ -2253,6 +2654,29 @@ impl SlurmAgent for AgentService {
         let cpus = allocated.map(|a| a.cpus).unwrap_or(req.cpus).max(1);
         let memory_mb = allocated.map(|a| a.memory_mb).unwrap_or(req.memory_mb);
 
+        // Resolved before the running lock and the reservation: this is the one
+        // step that awaits another lock, and failing here needs no release.
+        let device_paths = if controller_gpu_ids.is_empty() {
+            Vec::new()
+        } else {
+            let injection = self.device_registry.lock().await.build_job_injection_plans(
+                "gpu",
+                &controller_gpu_ids,
+                req.uid,
+                req.gid,
+            );
+            match injection {
+                Ok((host, _)) => host.device_paths,
+                Err(e) => {
+                    error!(job_id = req.job_id, error = %e, "device registry resolution failed");
+                    return Err(Status::failed_precondition(format!(
+                        "device resolution failed: {}",
+                        e
+                    )));
+                }
+            }
+        };
+
         // Hold the running lock across the duplicate check, reserve+commit, and
         // insert (running → allocation, as in commit) so the job is never
         // committed-but-absent-from-running, which the reclaim reads as stale.
@@ -2263,9 +2687,9 @@ impl SlurmAgent for AgentService {
                 req.job_id
             )));
         }
-        {
+        let alloc_result = {
             let mut alloc = self.allocation.lock().await;
-            alloc
+            let result = alloc
                 .allocate_for_job(req.job_id, cpus, memory_mb, &controller_gpu_ids)
                 .map_err(|e| match e {
                     AllocError::GpusUnavailable => Status::resource_exhausted(
@@ -2277,7 +2701,38 @@ impl SlurmAgent for AgentService {
                     )),
                 })?;
             let _ = alloc.commit_job(req.job_id);
-        }
+            result
+        };
+        // Releases the allocation on any exit that does not record the job,
+        // including a cancelled future; disarmed once it reaches `running`.
+        let mut reservation_guard =
+            LaunchReservationGuard::new(self.allocation.clone(), req.job_id);
+
+        // This allocation launches nothing, so its cgroup has to be created
+        // here or the first step arriving has none to join.
+        let setup = executor::setup_cgroup(
+            req.job_id,
+            &self.cgroup,
+            cpus,
+            memory_mb,
+            &alloc_result.cpu_ids,
+            &device_paths,
+        );
+        let cgroup_path = match allocation_cgroup(setup, self.cgroup.required) {
+            AllocationCgroup::Record(path) => path,
+            AllocationCgroup::Degraded(reason) => {
+                warn!(job_id = req.job_id, reason = %reason, "allocation registered without cgroup enforcement");
+                None
+            }
+            AllocationCgroup::Refuse(reason) => {
+                return Err(refuse_allocation(
+                    req.job_id,
+                    reservation_guard,
+                    &mut jobs,
+                    &reason,
+                ));
+            }
+        };
 
         info!(
             job_id = req.job_id,
@@ -2311,8 +2766,10 @@ impl SlurmAgent for AgentService {
                 // srun allocation-only jobs use their own cancel lifecycle;
                 // epoch 0 leaves the stale-report guard disabled for them.
                 run_attempt: 0,
+                cgroup_path,
             },
         );
+        reservation_guard.disarm();
         drop(jobs);
 
         Ok(Response::new(RegisterJobAllocationResponse {}))
@@ -2377,7 +2834,7 @@ impl SlurmAgent for AgentService {
         // node already confirmed via LaunchJob (confirm_dispatch_on_nodes) — so a
         // miss is a wrong job/node pairing, not a launch race. The one uncovered
         // case is a spurd restart mid-job, which starts `running` empty.
-        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi, job_entry) = {
+        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi, cgroup_path) = {
             let jobs = self.running.lock().await;
             let tracked = jobs.get(&job_id).ok_or_else(|| {
                 Status::not_found(format!("job {} not running on this node", job_id))
@@ -2406,7 +2863,7 @@ impl SlurmAgent for AgentService {
                 tracked.memory_mb,
                 nodelist,
                 tracked.mpi.clone(),
-                entry,
+                tracked.cgroup_path.clone(),
             )
         };
 
@@ -2613,6 +3070,23 @@ impl SlurmAgent for AgentService {
         }
 
         let memlock = self.limits.memlock;
+        let cgroup_join = executor::CgroupJoin::for_cgroup(cgroup_path.as_deref());
+        let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
+        unsafe {
+            cmd.pre_exec(move || {
+                crate::executor::apply_memlock(memlock);
+                // Before the drop below: an unprivileged process cannot write
+                // another cgroup's `cgroup.procs`.
+                if let Some(ref join) = cgroup_join {
+                    join.join();
+                }
+                if let Some(ref pd) = priv_drop {
+                    pd.apply()
+                        .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+                }
+                Ok(())
+            });
+        }
 
         info!(
             command = ?req.command,
@@ -2625,18 +3099,39 @@ impl SlurmAgent for AgentService {
             "RunCommand: executing step"
         );
 
-        // Redirect the step's stdout/stderr to per-step spool files so
-        // stream_job_output can tail them live and output stays bounded on this
-        // node. Paths are recorded in active_steps so the tail can find them.
-        let step_files = crate::executor::open_step_output_files(job_id, step_id, req.uid, req.gid)
-            .map_err(|e| Status::internal(format!("step output files: {e}")))?;
-        let stdout_path = step_files.stdout_path.to_string_lossy().into_owned();
-        let stderr_path = step_files.stderr_path.to_string_lossy().into_owned();
-        {
-            let mut steps = self.active_steps.lock().await;
-            if let Some(step) = steps.get_mut(&step_key) {
-                step.stdout_path = stdout_path.clone();
-                step.stderr_path = stderr_path.clone();
+        use std::process::Stdio;
+
+        let mut child = cmd
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| Status::internal(format!("command failed: {}", e)))?;
+        // `spawn` only borrows, so the pre-exec closure and its dup'd log fd
+        // would otherwise stay alive for the whole step.
+        drop(cmd);
+        if escaped_job_cgroup(self.cgroup.required, cgroup_path.as_deref(), child.id()) {
+            // The user's work runs in descendants of the wrapper, and an escaped
+            // step is in no cgroup, so the group is the only handle reaching them.
+            kill_step_process_group(&mut child).await;
+            return Err(Status::failed_precondition(
+                "[cgroup] required but the step did not join its cgroup",
+            ));
+        }
+        if let Some(pid) = child.id() {
+            let cancel_now = {
+                let mut steps = self.active_steps.lock().await;
+                if let Some(step) = steps.get_mut(&step_key) {
+                    step.pid = Some(pid);
+                    step.cancel_requested
+                } else {
+                    false
+                }
+            };
+            if cancel_now {
+                signal_step_process_group(pid, nix::sys::signal::Signal::SIGTERM as i32);
+                let _ = child.kill().await;
+                let _ = child.wait_with_output().await;
+                return Ok(Response::new(cancelled_step_response()));
             }
         }
 
@@ -3433,7 +3928,7 @@ impl SlurmAgent for AgentService {
 
 impl AgentService {
     async fn drop_tracked_job(&self, job_id: u32) {
-        if self.running.lock().await.remove(&job_id).is_some() {
+        if remove_tracked_job(&mut *self.running.lock().await, job_id).is_some() {
             self.allocation.lock().await.release_job(job_id);
             if let Err(e) = self.mpi_host.stop_pmix_server(job_id) {
                 warn!(job_id, error = %e, "PMIx stop failed on job drop");
@@ -3791,6 +4286,7 @@ impl AgentService {
             uid: tracked.uid,
             gid: tracked.gid,
             work_dir: tracked.work_dir.clone(),
+            cgroup_path: tracked.cgroup_path.clone(),
         })
     }
 
@@ -3999,9 +4495,9 @@ impl AgentService {
         let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(entry.uid, entry.gid);
 
         let plan = build_launch_plan(entry, priv_drop.as_ref(), &shell);
+        let containment = ChildContainment::for_plan(&plan, entry, priv_drop);
         let launch_cmd = plan.program;
         let launch_args = plan.args;
-        let apply_priv_in_child = plan.apply_priv_in_child;
 
         let mut cmd = tokio::process::Command::new(&launch_cmd);
         let work_dir = if entry.work_dir.is_empty() {
@@ -4039,17 +4535,12 @@ impl AgentService {
             master: master.as_raw_fd(),
             slave: slave.as_raw_fd(),
         };
-        let priv_drop_for_child = if apply_priv_in_child { priv_drop } else { None };
+        // Hooks run in registration order, so the child wires its PTY, then
+        // joins the job's cgroup, then drops privilege.
         unsafe {
-            cmd.pre_exec(move || {
-                raw.wire()?;
-                if let Some(ref pd) = priv_drop_for_child {
-                    pd.apply()
-                        .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
-                }
-                Ok(())
-            });
+            cmd.pre_exec(move || raw.wire());
         }
+        containment.register(&mut cmd);
 
         let child = cmd
             .spawn()
@@ -4107,10 +4598,16 @@ impl TrackedJob {
             .spawn()
             .expect("failed to spawn dummy process");
         Self {
-            job: executor::RunningJob::Managed {
-                child,
-                cgroup_path: None,
-            },
+            job: executor::RunningJob::Managed { child },
+            ..Self::allocation_only(None)
+        }
+    }
+
+    /// An allocation with no batch process, as salloc and standalone srun
+    /// register it.
+    fn allocation_only(cgroup_path: Option<std::path::PathBuf>) -> Self {
+        Self {
+            job: executor::RunningJob::AllocationOnly,
             rootfs_mode: crate::container::RootfsMode::Extracted,
             stdout_path: "/dev/null".into(),
             stderr_path: "/dev/null".into(),
@@ -4129,6 +4626,7 @@ impl TrackedJob {
             nodelist: String::new(),
             mpi: String::new(),
             run_attempt: 0,
+            cgroup_path,
         }
     }
 }
@@ -4193,6 +4691,7 @@ mod tests {
             uid,
             gid,
             work_dir: "/home/user".into(),
+            cgroup_path: None,
         }
     }
 
@@ -4328,6 +4827,7 @@ mod tests {
             uid: 1000,
             gid: 1000,
             work_dir: "/home/user".into(),
+            cgroup_path: None,
         };
         let pd = crate::privdrop::PrivDrop::for_test(1000, 1000);
         let plan = build_launch_plan(&entry, Some(&pd), &["echo".to_string(), "hi".to_string()]);
@@ -4352,6 +4852,7 @@ mod tests {
             uid: 0,
             gid: 0,
             work_dir: "/tmp".into(),
+            cgroup_path: None,
         };
         let (master, mut child, pid) =
             AgentService::spawn_pty_in_job(&entry, &["true".to_string()], 7, None)
@@ -4360,6 +4861,42 @@ mod tests {
         let status = child.wait().await.expect("child should be reapable");
         assert!(status.success(), "`true` should exit 0");
         drop(master);
+    }
+
+    // An attach that keeps spurd's cgroup reaches every device on the node,
+    // including ones the job was never allocated.
+    #[tokio::test]
+    async fn a_pty_attach_joins_the_job_cgroup() {
+        // A plain file stands in for `cgroup.procs`: the child opens and writes
+        // it exactly as it would the kernel's, so no root and no cgroupfs.
+        let cgroup = tempfile::tempdir().expect("tempdir");
+        std::fs::write(cgroup.path().join("cgroup.procs"), "").expect("cgroup.procs");
+
+        let entry = crate::job_entry::JobEntry {
+            pid: 0,
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
+            uid: 0,
+            gid: 0,
+            work_dir: "/tmp".into(),
+            cgroup_path: Some(cgroup.path().to_path_buf()),
+        };
+
+        let (master, mut child, pid) =
+            AgentService::spawn_pty_in_job(&entry, &["true".to_string()], 7, None)
+                .expect("spawn_pty_in_job should succeed for a direct /usr/bin/true");
+        let status = child.wait().await.expect("child should be reapable");
+        assert!(status.success(), "`true` should exit 0");
+        drop(master);
+
+        let joined =
+            std::fs::read_to_string(cgroup.path().join("cgroup.procs")).expect("read cgroup.procs");
+        assert_eq!(
+            joined.trim(),
+            pid.to_string(),
+            "the attached PTY child must join the job's cgroup"
+        );
     }
 
     #[test]
@@ -4374,6 +4911,7 @@ mod tests {
             uid: 1000,
             gid: 1000,
             work_dir: "/home/user".into(),
+            cgroup_path: None,
         };
         let pd = crate::privdrop::PrivDrop::for_test(1000, 1000);
         let plan = build_launch_plan(&entry, Some(&pd), &["id".to_string()]);
@@ -4878,6 +5416,47 @@ mod tests {
             .map(|e| e.code());
 
         assert_ne!(code, Some(tonic::Code::PermissionDenied));
+    }
+
+    // `spur exec` enters the job's namespaces; without this it keeps spurd's
+    // cgroup and so escapes the job's device filter.
+    #[tokio::test]
+    async fn exec_into_a_job_joins_its_cgroup() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        // A plain file stands in for `cgroup.procs`: the child opens and writes
+        // it exactly as it would the kernel's, so no root and no cgroupfs.
+        let cgroup = tempfile::tempdir().expect("tempdir");
+        std::fs::write(cgroup.path().join("cgroup.procs"), "").expect("cgroup.procs");
+        svc.insert_test_job(
+            46,
+            TrackedJob::allocation_only(Some(cgroup.path().to_path_buf())),
+        )
+        .await;
+
+        // `$$` is the exec'd shell's own pid, which is the pid the child wrote.
+        let resp = svc
+            .exec_in_job(Request::new(ExecInJobRequest {
+                job_id: 46,
+                command: vec!["sh".into(), "-c".into(), "echo $$".into()],
+                user: "testuser".into(),
+            }))
+            .await
+            .expect("the owner may exec into their own job")
+            .into_inner();
+        assert!(resp.success, "exec failed: {}", resp.stderr);
+
+        let joined =
+            std::fs::read_to_string(cgroup.path().join("cgroup.procs")).expect("read cgroup.procs");
+        assert_eq!(
+            joined.trim(),
+            resp.stdout.trim(),
+            "the exec'd child must join the job's cgroup"
+        );
     }
 
     fn user_identity(name: &str) -> spur_core::auth::Identity {
@@ -5523,6 +6102,38 @@ mod tests {
             .expect("process group did not exit after signal")
             .expect("wait failed");
         assert!(!status.success());
+    }
+
+    // The cgroup-escape path relies on this: the wrapper's descendants hold the
+    // user's work, and an escaped step is in no cgroup that could reach them.
+    #[tokio::test]
+    async fn kill_step_process_group_takes_descendants_with_the_wrapper() {
+        use std::time::Duration;
+        use tokio::io::AsyncReadExt;
+
+        // `echo` runs after both forks, so a read of it proves the descendants exist.
+        let mut child = tokio::process::Command::new("bash")
+            .arg("-c")
+            .arg("sleep 3600 & sleep 3600 & echo ready; wait")
+            .process_group(0)
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("failed to spawn process group");
+        let mut stdout = child.stdout.take().expect("stdout was piped");
+        let mut ready = [0u8; 6];
+        stdout
+            .read_exact(&mut ready)
+            .await
+            .expect("wrapper should report both children forked");
+
+        kill_step_process_group(&mut child).await;
+
+        // The `sleep`s inherited this pipe, so EOF means none of them is left.
+        let mut remaining = Vec::new();
+        tokio::time::timeout(Duration::from_secs(5), stdout.read_to_end(&mut remaining))
+            .await
+            .expect("descendants outlived the wrapper")
+            .expect("read failed");
     }
 
     // G1: the enforced budget — and therefore the cpuset — must cover every task
@@ -6258,7 +6869,9 @@ mod tests {
         let svc = AgentService::new(
             test_reporter_with_gpus(&[0]),
             HooksConfig::default(),
-            Arc::new(Mutex::new(DeviceRegistry::new())),
+            // Registration resolves the granted GPU against this registry and
+            // hard-fails when it cannot, so device 0 has to be known here.
+            Arc::new(Mutex::new(test_gpu_registry())),
             spur_core::config::MemlockLimit::Unlimited,
         );
 
@@ -6303,6 +6916,49 @@ mod tests {
         );
     }
 
+    // The refusal must undo the whole registration, not just return an error:
+    // a committed reservation with nothing in `running` reads as live to the
+    // node and as orphaned to the reconcile pass.
+    #[tokio::test]
+    async fn refusing_an_allocation_releases_it_and_drops_the_tracked_job() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(test_gpu_registry())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        // The state the handler is in when the cgroup setup fails: reserved,
+        // committed, guard armed, nothing recorded yet.
+        {
+            let mut alloc = svc.allocation.lock().await;
+            alloc.allocate_for_job(42, 1, 0, &[0]).unwrap();
+            alloc.commit_job(42);
+        }
+        let reservation = LaunchReservationGuard::new(svc.allocation.clone(), 42);
+        assert_eq!(svc.free_gpu_count().await, 0, "reservation holds the GPU");
+
+        let status = {
+            let mut jobs = svc.running.lock().await;
+            // Inserted so the rollback has something to undo.
+            jobs.insert(42, TrackedJob::allocation_only(None));
+            let status = refuse_allocation(42, reservation, &mut jobs, "cgroup root unavailable");
+            assert!(
+                !jobs.contains_key(&42),
+                "a refused allocation must leave no tracked job"
+            );
+            status
+        };
+
+        assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+        assert!(status.message().contains("cgroup root unavailable"));
+        assert_eq!(
+            svc.free_gpu_count().await,
+            1,
+            "a refusal must release the allocation it could not enforce"
+        );
+    }
+
     // The heartbeat's held-job source must report an allocation-only (srun/salloc)
     // job so the controller can reconcile it — the strand this fix addresses.
     #[tokio::test]
@@ -6335,7 +6991,12 @@ mod tests {
             Arc::new(Mutex::new(DeviceRegistry::new())),
             &spur_core::config::ClusterConfig::default(),
             spur_core::config::JobLimits::default(),
-            CgroupConfig::default(),
+            // Registration now creates the job's cgroup; keep this test off the
+            // runner's real cgroupfs.
+            CgroupConfig {
+                enabled: false,
+                ..CgroupConfig::default()
+            },
             MpiConfig::default(),
             running,
             false, // allow_root_jobs
@@ -6576,10 +7237,7 @@ mod tests {
             .spawn()
             .expect("failed to spawn SIGTERM-trapping process");
         let tracked = TrackedJob {
-            job: executor::RunningJob::Managed {
-                child,
-                cgroup_path: None,
-            },
+            job: executor::RunningJob::Managed { child },
             rootfs_mode: crate::container::RootfsMode::Extracted,
             stdout_path: "/dev/null".into(),
             stderr_path: "/dev/null".into(),
@@ -6598,6 +7256,7 @@ mod tests {
             nodelist: String::new(),
             mpi: String::new(),
             run_attempt: 0,
+            cgroup_path: None,
         };
         svc.insert_test_job(job_id, tracked).await;
 
@@ -6636,10 +7295,7 @@ mod tests {
                 .expect("spawn trap process");
             let pid = child.id().expect("pid") as i32;
             let t = TrackedJob {
-                job: executor::RunningJob::Managed {
-                    child,
-                    cgroup_path: None,
-                },
+                job: executor::RunningJob::Managed { child },
                 rootfs_mode: crate::container::RootfsMode::Extracted,
                 stdout_path: "/dev/null".into(),
                 stderr_path: "/dev/null".into(),
@@ -6658,6 +7314,7 @@ mod tests {
                 nodelist: String::new(),
                 mpi: String::new(),
                 run_attempt,
+                cgroup_path: None,
             };
             (t, pid)
         }
@@ -6741,7 +7398,6 @@ mod tests {
         let job = executor::RunningJob::Forked {
             pid,
             _pidfd: None,
-            cgroup_path: None,
             reaped: false,
         };
         reap_killed_job(job).await;
@@ -6806,6 +7462,98 @@ mod tests {
         );
     }
 
+    // A finished job's cgroup must be released exactly once, by the monitor
+    // loop taking it off the tracked job.
+    #[tokio::test]
+    async fn monitor_removes_the_job_cgroup_on_completion() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("job_904");
+        std::fs::create_dir(&cgroup).unwrap();
+
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        svc.start_monitor("http://127.0.0.1:1".into());
+
+        let job_id = 904;
+        let mut tracked = TrackedJob::dummy(0);
+        tracked.cgroup_path = Some(cgroup.clone());
+        svc.insert_test_job(job_id, tracked).await;
+
+        svc.send_explicit_signal(job_id, 9).await; // SIGKILL
+
+        assert!(
+            wait_job_reaped(&svc, job_id, 5_000).await,
+            "monitor should reap SIGKILL'd job within 5s"
+        );
+        assert!(
+            !cgroup.exists(),
+            "completion must remove the finished job's cgroup"
+        );
+    }
+
+    // An allocation never completes, so the monitor loop's teardown never runs
+    // for it. Cancelling is its only chance to release the cgroup.
+    #[tokio::test]
+    async fn cancelling_an_allocation_removes_its_cgroup() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("job_905");
+        std::fs::create_dir(&cgroup).unwrap();
+
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let job_id = 905;
+        svc.insert_test_job(job_id, TrackedJob::allocation_only(Some(cgroup.clone())))
+            .await;
+
+        svc.graceful_cancel(job_id).await;
+
+        assert!(
+            !svc.running.lock().await.contains_key(&job_id),
+            "cancelling an allocation must drop the tracked job"
+        );
+        assert!(
+            !cgroup.exists(),
+            "dropping an allocation must remove its cgroup"
+        );
+    }
+
+    // Re-dispatch inserts the new run under the same id and discards the
+    // displaced job. Both name the same job_<id> cgroup, which the new run has
+    // already joined, so discarding one must never release it.
+    #[tokio::test]
+    async fn displacing_a_tracked_job_leaves_its_cgroup_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("job_906");
+        std::fs::create_dir(&cgroup).unwrap();
+
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let job_id = 906;
+        svc.insert_test_job(job_id, TrackedJob::allocation_only(Some(cgroup.clone())))
+            .await;
+        svc.insert_test_job(job_id, TrackedJob::allocation_only(Some(cgroup.clone())))
+            .await;
+
+        assert!(
+            cgroup.exists(),
+            "displacing a run must not release the cgroup its successor is in"
+        );
+    }
+
     #[tokio::test]
     async fn job_entry_from_tracked_job() {
         let (svc, job_id) = run_command_test_setup().await;
@@ -6818,6 +7566,29 @@ mod tests {
         assert_eq!(entry.uid, 0);
         assert_eq!(entry.gid, 0);
         assert!(!entry.has_namespaces());
+    }
+
+    // An interactive allocation has no batch process, so its cgroup can only
+    // live on the tracked job — that is the one handle a step or exec has to
+    // reach the job's limits and device filter.
+    #[tokio::test]
+    async fn job_entry_carries_the_cgroup_of_an_allocation_only_job() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let job_id = 4242;
+        let cgroup = std::path::PathBuf::from("/sys/fs/cgroup/spur/job_4242");
+        svc.insert_test_job(job_id, TrackedJob::allocation_only(Some(cgroup.clone())))
+            .await;
+
+        let entry = svc
+            .job_entry(job_id)
+            .await
+            .expect("job_entry should succeed");
+        assert_eq!(entry.cgroup_path, Some(cgroup));
     }
 
     #[tokio::test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -131,11 +131,15 @@ async fn cleanup_completed_job_mpi(job_id: u32, mpi: &str, mpi_host: &MpiPluginH
 /// `running`. Skipped if the id is tracked again: it is all keyed by job id.
 async fn teardown_completed_job(
     completed: &CompletedJob,
+    lifecycle: &crate::job_lifecycle::JobLifecycle,
     running: &RunningJobs,
     allocation: &Arc<Mutex<NodeAllocation>>,
     mpi_host: &MpiPluginHost,
 ) {
     let job_id = completed.job_id;
+    // Held across the check below and every release under it, so a re-dispatch either
+    // lands before this and is seen, or waits and finds nothing of its own removed.
+    let _lifecycle = lifecycle.acquire(job_id).await;
     // Taken and released before `allocation`, the order commit_job uses.
     if running.lock().await.contains_key(&job_id) {
         warn!(
@@ -972,6 +976,8 @@ pub struct AgentService {
     k0s: Arc<crate::cluster::K0sAgent>,
     /// In-flight srun steps keyed by `(job_id, step_id)`.
     active_steps: Arc<Mutex<HashMap<(u32, u32), ActiveStep>>>,
+    /// Serializes setup against teardown for a job id, which a re-dispatch reuses.
+    lifecycle: crate::job_lifecycle::JobLifecycle,
     /// `[auth] allow_root_jobs` — when false (default) this agent refuses to execute as uid 0.
     allow_root_jobs: bool,
     /// Whether spurd runs as root. Stored (not queried per call) so tests can drive the refusal
@@ -1087,6 +1093,7 @@ impl AgentService {
             device_registry,
             k0s: Arc::new(crate::cluster::K0sAgent::from_config(cluster)),
             active_steps: Arc::new(Mutex::new(HashMap::new())),
+            lifecycle: crate::job_lifecycle::JobLifecycle::default(),
             allow_root_jobs,
             spurd_is_root: crate::privdrop::spurd_runs_as_root(),
         }
@@ -1112,6 +1119,7 @@ impl AgentService {
         let spank = self.spank.clone();
         let mpi_host = self.mpi_host.clone();
         let hooks = self.hooks.clone();
+        let lifecycle = self.lifecycle.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(2));
             loop {
@@ -1166,7 +1174,7 @@ impl AgentService {
                 drop(jobs);
 
                 for c in &completed {
-                    teardown_completed_job(c, &running, &allocation, &mpi_host).await;
+                    teardown_completed_job(c, &lifecycle, &running, &allocation, &mpi_host).await;
                 }
 
                 // Self-heal backstop: reclaim allocations with no tracked,
@@ -1586,6 +1594,9 @@ struct ChildContainment<'a> {
     /// `None` on the nsenter shape, which drops inside the namespace via
     /// `setpriv` — dropping here as well would break the namespace entry.
     priv_drop: Option<crate::privdrop::PrivDrop>,
+    /// Abort the exec if the cgroup join fails, rather than run the command
+    /// outside the job's device filter and limits.
+    cgroup_required: bool,
 }
 
 impl<'a> ChildContainment<'a> {
@@ -1593,6 +1604,7 @@ impl<'a> ChildContainment<'a> {
         plan: &LaunchPlan,
         entry: &'a crate::job_entry::JobEntry,
         priv_drop: Option<crate::privdrop::PrivDrop>,
+        cgroup_required: bool,
     ) -> Self {
         Self {
             cgroup: entry.cgroup_path.as_deref(),
@@ -1601,6 +1613,7 @@ impl<'a> ChildContainment<'a> {
             } else {
                 None
             },
+            cgroup_required,
         }
     }
 
@@ -1609,12 +1622,17 @@ impl<'a> ChildContainment<'a> {
     fn register(self, cmd: &mut tokio::process::Command) {
         let cgroup_join = executor::CgroupJoin::for_cgroup(self.cgroup);
         let priv_drop = self.priv_drop;
+        let required = self.cgroup_required;
         unsafe {
             cmd.pre_exec(move || {
-                // Before the drop below: an unprivileged process cannot write
-                // another cgroup's `cgroup.procs`.
+                // Before the drop: an unprivileged process cannot write another cgroup's
+                // `cgroup.procs`. Under `required` a failed join aborts rather than exec unfiltered.
                 if let Some(ref join) = cgroup_join {
-                    join.join();
+                    if !join.join() && required {
+                        return Err(std::io::Error::other(
+                            "[cgroup] required but the process did not join the job cgroup",
+                        ));
+                    }
                 }
                 if let Some(ref pd) = priv_drop {
                     pd.apply()
@@ -1653,7 +1671,7 @@ mod child_containment_tests {
         let plan = build_launch_plan(&entry, Some(&pd), &["id".to_string()]);
         assert!(!plan.apply_priv_in_child, "expected the nsenter shape");
 
-        let containment = ChildContainment::for_plan(&plan, &entry, Some(pd));
+        let containment = ChildContainment::for_plan(&plan, &entry, Some(pd), false);
 
         assert_eq!(containment.cgroup, Some(std::path::Path::new(CGROUP)));
         // setpriv drops inside the namespace; dropping here too would leave the
@@ -1668,7 +1686,7 @@ mod child_containment_tests {
         let plan = build_launch_plan(&entry, Some(&pd), &["id".to_string()]);
         assert!(plan.apply_priv_in_child, "expected the direct-spawn shape");
 
-        let containment = ChildContainment::for_plan(&plan, &entry, Some(pd));
+        let containment = ChildContainment::for_plan(&plan, &entry, Some(pd), false);
 
         assert_eq!(containment.cgroup, Some(std::path::Path::new(CGROUP)));
         assert!(containment.priv_drop.is_some());
@@ -1682,7 +1700,7 @@ mod child_containment_tests {
             let pd = PrivDrop::for_test(1000, 1000);
             let plan = build_launch_plan(&entry, Some(&pd), &["id".to_string()]);
 
-            assert!(ChildContainment::for_plan(&plan, &entry, Some(pd))
+            assert!(ChildContainment::for_plan(&plan, &entry, Some(pd), false)
                 .cgroup
                 .is_none());
         }
@@ -1986,6 +2004,10 @@ impl SlurmAgent for AgentService {
             warn!(job_id, uid = spec.uid, "{msg}");
             return Err(Status::permission_denied(msg));
         }
+
+        // Held until this run is tracked (or its half-built state is cleaned up), so a
+        // re-dispatch of the id never builds on top of the previous run's teardown.
+        let lifecycle = self.lifecycle.acquire(job_id).await;
 
         info!(
             job_id,
@@ -2407,7 +2429,10 @@ impl SlurmAgent for AgentService {
                     let _ = result.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
                     let cgroup = result.cgroup_path.take();
                     let running = self.running.clone();
+                    // The guard moves into the task: reaping can outlive this call, and
+                    // the id must stay closed to a re-dispatch until the state is gone.
                     tokio::spawn(async move {
+                        let _lifecycle = lifecycle;
                         reap_killed_job(result.job).await;
                         // rootfs, spool and the job_<id> cgroup all derive from
                         // job_id, so a re-dispatch of that id reuses them: tearing
@@ -2679,7 +2704,8 @@ impl SlurmAgent for AgentService {
             // host's mount namespace, where a job's work_dir need not exist.
             cmd.current_dir(&entry.work_dir);
         }
-        ChildContainment::for_plan(&plan, &entry, priv_drop).register(&mut cmd);
+        ChildContainment::for_plan(&plan, &entry, priv_drop, self.cgroup.required)
+            .register(&mut cmd);
 
         let output = cmd
             .output()
@@ -2708,6 +2734,9 @@ impl SlurmAgent for AgentService {
         if req.job_id == 0 {
             return Err(Status::invalid_argument("job_id is required"));
         }
+        // Creates this id's cgroup, so it must not run while a prior run's teardown
+        // still owns the directory.
+        let _lifecycle = self.lifecycle.acquire(req.job_id).await;
 
         let allocated = req.allocated.as_ref();
         let mut controller_gpu_ids: Vec<u32> = allocated
@@ -3762,8 +3791,13 @@ impl SlurmAgent for AgentService {
             return Err(Status::permission_denied(msg));
         }
 
-        let (master_fd, child, child_pid) =
-            Self::spawn_pty_in_job(&entry, &argv, init.job_id, winsize.as_ref())?;
+        let (master_fd, child, child_pid) = Self::spawn_pty_in_job(
+            &entry,
+            &argv,
+            init.job_id,
+            winsize.as_ref(),
+            self.cgroup.required,
+        )?;
 
         info!(
             job_id = init.job_id,
@@ -3999,6 +4033,9 @@ impl SlurmAgent for AgentService {
 
 impl AgentService {
     async fn drop_tracked_job(&self, job_id: u32) {
+        // The cgroup removal and the release below both key off the id, so a launch
+        // reusing it must not interleave with them.
+        let _lifecycle = self.lifecycle.acquire(job_id).await;
         // Scoped so the guard is gone before `cgroup` is dropped below: removing
         // a cgroup SIGKILLs its stragglers and then blocks retrying rmdir.
         let (tracked, cgroup) = {
@@ -4549,6 +4586,7 @@ impl AgentService {
         argv: &[String],
         job_id: u32,
         winsize: Option<&crate::pty::WindowSize>,
+        cgroup_required: bool,
     ) -> Result<(std::os::fd::OwnedFd, tokio::process::Child, i32), Status> {
         use std::os::fd::AsRawFd;
         use std::process::Stdio;
@@ -4574,7 +4612,7 @@ impl AgentService {
         let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(entry.uid, entry.gid);
 
         let plan = build_launch_plan(entry, priv_drop.as_ref(), &shell);
-        let containment = ChildContainment::for_plan(&plan, entry, priv_drop);
+        let containment = ChildContainment::for_plan(&plan, entry, priv_drop, cgroup_required);
         let launch_cmd = plan.program;
         let launch_args = plan.args;
 
@@ -4934,8 +4972,53 @@ mod tests {
             cgroup_path: None,
         };
         let (master, mut child, pid) =
-            AgentService::spawn_pty_in_job(&entry, &["true".to_string()], 7, None)
+            AgentService::spawn_pty_in_job(&entry, &["true".to_string()], 7, None, false)
                 .expect("spawn_pty_in_job should succeed for a direct /usr/bin/true");
+        assert!(pid > 0);
+        let status = child.wait().await.expect("child should be reapable");
+        assert!(status.success(), "`true` should exit 0");
+        drop(master);
+    }
+
+    // The device filter lives on the job cgroup, so a child that fails to join it runs
+    // unfiltered. Under `required` that must abort before exec, not exec and warn.
+    #[tokio::test]
+    async fn a_required_join_that_cannot_land_aborts_the_attach() {
+        let entry = crate::job_entry::JobEntry {
+            pid: 0,
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
+            uid: 0,
+            gid: 0,
+            work_dir: "/tmp".into(),
+            // A path with no cgroup.procs: the pre-exec open fails, so the join cannot land.
+            cgroup_path: Some("/nonexistent/spur-required/job_1".into()),
+        };
+
+        let err = AgentService::spawn_pty_in_job(&entry, &["true".to_string()], 1, None, true)
+            .expect_err("a required join that cannot land must fail the spawn");
+        assert_eq!(err.code(), tonic::Code::Internal);
+    }
+
+    // The same unjoinable cgroup without `required` is the degraded non-root-agent path:
+    // it must still run rather than refuse the user their shell.
+    #[tokio::test]
+    async fn a_best_effort_join_failure_still_runs_the_command() {
+        let entry = crate::job_entry::JobEntry {
+            pid: 0,
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
+            uid: 0,
+            gid: 0,
+            work_dir: "/tmp".into(),
+            cgroup_path: Some("/nonexistent/spur-besteffort/job_1".into()),
+        };
+
+        let (master, mut child, pid) =
+            AgentService::spawn_pty_in_job(&entry, &["true".to_string()], 1, None, false)
+                .expect("a best-effort join failure must still spawn the command");
         assert!(pid > 0);
         let status = child.wait().await.expect("child should be reapable");
         assert!(status.success(), "`true` should exit 0");
@@ -4963,7 +5046,7 @@ mod tests {
         };
 
         let (master, mut child, pid) =
-            AgentService::spawn_pty_in_job(&entry, &["true".to_string()], 7, None)
+            AgentService::spawn_pty_in_job(&entry, &["true".to_string()], 7, None, false)
                 .expect("spawn_pty_in_job should succeed for a direct /usr/bin/true");
         let status = child.wait().await.expect("child should be reapable");
         assert!(status.success(), "`true` should exit 0");
@@ -5538,6 +5621,45 @@ mod tests {
         );
     }
 
+    // The exec counterpart of the PTY required-join test: `spur exec` must refuse to
+    // run outside the job's device filter when `[cgroup] required` and the join fails.
+    #[tokio::test]
+    async fn a_required_join_that_cannot_land_aborts_the_exec() {
+        let svc = AgentService::with_cluster_config(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            &spur_core::config::ClusterConfig::default(),
+            spur_core::config::JobLimits::default(),
+            CgroupConfig {
+                enabled: false,
+                required: true,
+                ..CgroupConfig::default()
+            },
+            MpiConfig::default(),
+            new_running_jobs(),
+            false, // allow_root_jobs
+        )
+        .with_root_override(false);
+
+        // A path with no cgroup.procs: the pre-exec join open fails.
+        svc.insert_test_job(
+            47,
+            TrackedJob::allocation_only(Some("/nonexistent/spur-exec-required/job_47".into())),
+        )
+        .await;
+
+        let err = svc
+            .exec_in_job(Request::new(ExecInJobRequest {
+                job_id: 47,
+                command: vec!["true".into()],
+                user: "testuser".into(),
+            }))
+            .await
+            .expect_err("a required join that cannot land must fail the exec");
+        assert_eq!(err.code(), tonic::Code::Internal);
+    }
+
     fn user_identity(name: &str) -> spur_core::auth::Identity {
         spur_core::auth::Identity {
             user: name.into(),
@@ -5690,6 +5812,62 @@ mod tests {
             .await
             .expect_err("a user token must not cancel jobs by dialing the agent directly");
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    // The check inside teardown is only meaningful if a launch cannot land after it: the
+    // id's cgroup, spool and rootfs are all derived names the successor would recreate.
+    #[tokio::test]
+    async fn teardown_cannot_start_while_a_launch_holds_the_job_id() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let job_id = 910;
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("job_910");
+        std::fs::create_dir(&cgroup).unwrap();
+        let completed = completed_job(job_id, cgroup.clone());
+
+        // Stands in for a launch of the same id: it owns the id's state until it is done.
+        let launching = svc.lifecycle.acquire(job_id).await;
+
+        let torn_down = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let task = tokio::spawn({
+            let (lifecycle, running, allocation, mpi_host) = (
+                svc.lifecycle.clone(),
+                svc.running.clone(),
+                svc.allocation.clone(),
+                svc.mpi_host.clone(),
+            );
+            let flag = Arc::clone(&torn_down);
+            async move {
+                teardown_completed_job(&completed, &lifecycle, &running, &allocation, &mpi_host)
+                    .await;
+                flag.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        });
+
+        // Nudges rather than waits: the teardown body has no pending await of its own once
+        // it holds the id, so if it were not parked on the id it would finish in these.
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !torn_down.load(std::sync::atomic::Ordering::SeqCst),
+            "teardown must wait rather than run while the launch owns the id"
+        );
+        assert!(
+            cgroup.exists(),
+            "teardown must not remove state the launch is building on"
+        );
+
+        drop(launching);
+        task.await
+            .expect("teardown runs once the launch releases the id");
+        assert!(!cgroup.exists(), "teardown still runs after it waits");
     }
 
     /// The impersonation this gate exists to stop: `user` decides who owns the allocation and `uid`
@@ -7656,7 +7834,14 @@ mod tests {
             alloc.commit_job(job_id);
         }
 
-        teardown_completed_job(&completed, &svc.running, &svc.allocation, &svc.mpi_host).await;
+        teardown_completed_job(
+            &completed,
+            &svc.lifecycle,
+            &svc.running,
+            &svc.allocation,
+            &svc.mpi_host,
+        )
+        .await;
 
         assert!(
             cgroup.exists(),
@@ -7692,7 +7877,14 @@ mod tests {
             alloc.commit_job(job_id);
         }
 
-        teardown_completed_job(&completed, &svc.running, &svc.allocation, &svc.mpi_host).await;
+        teardown_completed_job(
+            &completed,
+            &svc.lifecycle,
+            &svc.running,
+            &svc.allocation,
+            &svc.mpi_host,
+        )
+        .await;
 
         assert!(
             !cgroup.exists(),

--- a/crates/spurd/src/device_cgroup.rs
+++ b/crates/spurd/src/device_cgroup.rs
@@ -1,0 +1,1175 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! cgroup-v2 device access control via a BPF_PROG_TYPE_CGROUP_DEVICE program.
+//!
+//! cgroup v2 dropped the `devices` controller; device access is filtered by an
+//! eBPF program attached to the cgroup. We build the program in-process and load
+//! it with the `bpf()` syscall, mirroring systemd's approach, so no eBPF build
+//! toolchain is needed.
+
+use std::ffi::CStr;
+use std::fs::File;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::path::Path;
+
+use anyhow::Context;
+
+pub const ACC_MKNOD: u8 = 1;
+pub const ACC_READ: u8 = 2;
+pub const ACC_WRITE: u8 = 4;
+const ACC_ALL: u8 = ACC_MKNOD | ACC_READ | ACC_WRITE;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DevType {
+    Char,
+    Block,
+}
+
+/// `None` major/minor matches any value, mirroring a `*` in cgroup-v1 `devices.allow`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceRule {
+    pub dev_type: DevType,
+    pub major: Option<u32>,
+    pub minor: Option<u32>,
+    pub access: u8,
+}
+
+impl DeviceRule {
+    fn char_dev(major: u32, minor: Option<u32>) -> Self {
+        Self {
+            dev_type: DevType::Char,
+            major: Some(major),
+            minor,
+            access: ACC_ALL,
+        }
+    }
+}
+
+/// Pseudo-devices every job must retain (mirrors systemd `DevicePolicy=closed`).
+/// Without these a default-deny filter would block `/dev/null`, ptys, etc. and
+/// break virtually every program.
+pub fn base_device_rules() -> Vec<DeviceRule> {
+    vec![
+        DeviceRule::char_dev(1, Some(3)), // /dev/null
+        DeviceRule::char_dev(1, Some(5)), // /dev/zero
+        DeviceRule::char_dev(1, Some(7)), // /dev/full
+        DeviceRule::char_dev(1, Some(8)), // /dev/random
+        DeviceRule::char_dev(1, Some(9)), // /dev/urandom
+        DeviceRule::char_dev(5, Some(0)), // /dev/tty
+        DeviceRule::char_dev(5, Some(1)), // /dev/console
+        DeviceRule::char_dev(5, Some(2)), // /dev/ptmx
+        DeviceRule::char_dev(136, None),  // /dev/pts/*
+    ]
+}
+
+/// Host-infrastructure device nodes: shared by every workload, owned by no
+/// allocation, so nothing puts them in a job's `device_paths`. Denying them breaks
+/// jobs that were never reaching for a GPU they do not hold.
+const HOST_INFRA_DEVICE_NODES: &[&str] = &[
+    "/dev/fuse", // Apptainer/Singularity run inside the batch job
+    // CUDA initialization; enumerating a GPU still needs /dev/nvidia<N>.
+    "/dev/nvidiactl",
+    "/dev/nvidia-uvm",
+    "/dev/nvidia-uvm-tools",
+    "/dev/nvidia-modeset",
+];
+
+/// Host-infra device directories. Entry names are per-host (`uverbs0`, `umad1`,
+/// `nvidia-cap2`, ...), so they are enumerated rather than listed.
+///
+/// `/dev/nvidia-caps` is granted wholesale only because a MIG instance is not
+/// individually allocatable here. Those nodes *are* NVIDIA's per-instance access
+/// control, so MIG allocation would have to move them behind the allocation.
+const HOST_INFRA_DEVICE_DIRS: &[&str] = &[
+    "/dev/infiniband",  // RDMA verbs: MPI, NCCL and RCCL over IB
+    "/dev/nvidia-caps", // MIG capability nodes
+];
+
+/// Every host-infra device path this node has. Majors for IB and NVIDIA are
+/// assigned dynamically, so these resolve by path like any allocated node; a node
+/// without that hardware simply has nothing to stat.
+///
+/// Per-GPU compute nodes (`/dev/nvidia<N>`, `/dev/kfd`, `/dev/dri/*`) are
+/// deliberately absent — gating those on the allocation is the security property.
+pub fn host_infra_device_paths() -> Vec<String> {
+    let mut paths: Vec<String> = HOST_INFRA_DEVICE_NODES
+        .iter()
+        .map(|p| (*p).to_string())
+        .collect();
+    for dir in HOST_INFRA_DEVICE_DIRS {
+        paths.extend(device_dir_entries(Path::new(dir)));
+    }
+    paths
+}
+
+/// Entries of a directory of device nodes, sorted so the rule order is the same on
+/// every launch. A directory that does not exist means the node has no such
+/// hardware, which is not an error.
+fn device_dir_entries(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut paths: Vec<String> = entries
+        .flatten()
+        .filter_map(|e| e.path().to_str().map(str::to_string))
+        .collect();
+    paths.sort();
+    paths
+}
+
+/// Every path a job's filter should resolve: host infrastructure, the operator's
+/// additions, then the job's own allocation. Order only affects rule order, and
+/// each rule is an independent allow, so it does not change any verdict.
+pub fn device_paths_for_job(allocated: &[String], extra: &[String]) -> Vec<String> {
+    let mut paths = host_infra_device_paths();
+    paths.extend(extra.iter().cloned());
+    paths.extend(allocated.iter().cloned());
+    paths
+}
+
+/// Build the job's device allow-list: base pseudo-devices plus the allocated
+/// device nodes. Paths that do not stat to a device node are skipped, so a
+/// zero-GPU job gets only the base rules and cannot open any GPU.
+pub fn rules_for_device_paths(
+    paths: &[String],
+    stat_dev: impl Fn(&str) -> Option<(DevType, u32, u32)>,
+) -> Vec<DeviceRule> {
+    let mut rules = base_device_rules();
+    for path in paths {
+        let Some((dev_type, major, minor)) = stat_dev(path) else {
+            continue;
+        };
+        rules.push(DeviceRule {
+            dev_type,
+            major: Some(major),
+            minor: Some(minor),
+            access: ACC_ALL,
+        });
+    }
+    rules
+}
+
+/// Production `stat_dev`: resolve a path to (type, major, minor) via `stat(2)`.
+pub fn stat_device_node(path: &str) -> Option<(DevType, u32, u32)> {
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+    let meta = std::fs::metadata(path).ok()?;
+    let ft = meta.file_type();
+    let dev_type = if ft.is_char_device() {
+        DevType::Char
+    } else if ft.is_block_device() {
+        DevType::Block
+    } else {
+        return None;
+    };
+    let rdev = meta.rdev();
+    let major = libc::major(rdev) as u32;
+    let minor = libc::minor(rdev) as u32;
+    Some((dev_type, major, minor))
+}
+
+/// The kernel `bpf_insn` ABI (uapi/linux/bpf.h) — loaded verbatim by `bpf()`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BpfInsn {
+    pub code: u8,
+    /// Destination register in the low nibble, source register in the high nibble.
+    pub regs: u8,
+    pub off: i16,
+    pub imm: i32,
+}
+
+// The kernel loads these verbatim from a pointer plus an instruction count, so
+// the 8-byte size is ABI, not an implementation detail.
+const _: () = assert!(std::mem::size_of::<BpfInsn>() == 8);
+
+// Instruction classes, operand sizes, sources and ops (uapi/linux/bpf.h,
+// uapi/linux/bpf_common.h). BPF_W and BPF_K are 0 but stay explicit so each
+// opcode reads the way the kernel headers spell it.
+const BPF_LDX: u8 = 0x01;
+const BPF_ALU: u8 = 0x04;
+const BPF_JMP: u8 = 0x05;
+const BPF_W: u8 = 0x00;
+const BPF_MEM: u8 = 0x60;
+const BPF_K: u8 = 0x00;
+const BPF_X: u8 = 0x08;
+const BPF_AND: u8 = 0x50;
+const BPF_RSH: u8 = 0x70;
+const BPF_MOV: u8 = 0xb0;
+const BPF_JNE: u8 = 0x50;
+const BPF_EXIT: u8 = 0x90;
+
+/// The only jump this module emits, so the offset patch pass can find every
+/// mismatch branch by opcode alone.
+const MISMATCH_JUMP: u8 = BPF_JMP | BPF_JNE | BPF_K;
+
+const R0: u8 = 0;
+const R1: u8 = 1; // ctx pointer on entry
+const R2: u8 = 2; // device type
+const R3: u8 = 3; // major
+const R4: u8 = 4; // minor
+const R5: u8 = 5; // requested access bits, live for every rule
+const R6: u8 = 6; // scratch for the per-rule access test
+
+// struct bpf_cgroup_dev_ctx. access_type packs the requested access bits above
+// the device type, so one field feeds both R2 and R5.
+const CTX_ACCESS_TYPE: i16 = 0;
+const CTX_MAJOR: i16 = 4;
+const CTX_MINOR: i16 = 8;
+const DEV_TYPE_MASK: i32 = 0xffff;
+const ACCESS_SHIFT: i32 = 16;
+
+const DEVCG_DEV_BLOCK: i32 = 1;
+const DEVCG_DEV_CHAR: i32 = 2;
+
+const ALLOW: i32 = 1;
+const DENY: i32 = 0;
+
+fn regs(dst: u8, src: u8) -> u8 {
+    (src << 4) | (dst & 0x0f)
+}
+
+fn ldx_w(dst: u8, src: u8, off: i16) -> BpfInsn {
+    BpfInsn {
+        code: BPF_LDX | BPF_MEM | BPF_W,
+        regs: regs(dst, src),
+        off,
+        imm: 0,
+    }
+}
+
+fn mov_imm(dst: u8, imm: i32) -> BpfInsn {
+    BpfInsn {
+        code: BPF_ALU | BPF_MOV | BPF_K,
+        regs: regs(dst, 0),
+        off: 0,
+        imm,
+    }
+}
+
+fn mov_reg(dst: u8, src: u8) -> BpfInsn {
+    BpfInsn {
+        code: BPF_ALU | BPF_MOV | BPF_X,
+        regs: regs(dst, src),
+        off: 0,
+        imm: 0,
+    }
+}
+
+fn and_imm(dst: u8, imm: i32) -> BpfInsn {
+    BpfInsn {
+        code: BPF_ALU | BPF_AND | BPF_K,
+        regs: regs(dst, 0),
+        off: 0,
+        imm,
+    }
+}
+
+fn rsh_imm(dst: u8, imm: i32) -> BpfInsn {
+    BpfInsn {
+        code: BPF_ALU | BPF_RSH | BPF_K,
+        regs: regs(dst, 0),
+        off: 0,
+        imm,
+    }
+}
+
+/// Mismatch branch with a placeholder offset; `rule_block` patches the target.
+fn jne_imm(dst: u8, imm: i32) -> BpfInsn {
+    BpfInsn {
+        code: MISMATCH_JUMP,
+        regs: regs(dst, 0),
+        off: 0,
+        imm,
+    }
+}
+
+fn exit() -> BpfInsn {
+    BpfInsn {
+        code: BPF_JMP | BPF_EXIT,
+        regs: 0,
+        off: 0,
+        imm: 0,
+    }
+}
+
+/// Default-deny `cgroup/dev` program: allow the listed rules, deny everything else.
+///
+/// Structure mirrors `samples/bpf/dev_cgroup` and systemd's `bpf-devices.c`: load
+/// the ctx fields once, then one compare-and-allow block per rule, then a
+/// trailing `return 0`.
+fn build_device_filter(rules: &[DeviceRule]) -> Vec<BpfInsn> {
+    let mut prog = vec![
+        // Both halves of access_type: R2 = device type, R5 = requested access.
+        ldx_w(R2, R1, CTX_ACCESS_TYPE),
+        and_imm(R2, DEV_TYPE_MASK),
+        ldx_w(R5, R1, CTX_ACCESS_TYPE),
+        rsh_imm(R5, ACCESS_SHIFT),
+        ldx_w(R3, R1, CTX_MAJOR),
+        ldx_w(R4, R1, CTX_MINOR),
+    ];
+
+    for rule in rules {
+        prog.extend(rule_block(rule));
+    }
+
+    prog.push(mov_imm(R0, DENY));
+    prog.push(exit());
+    prog
+}
+
+/// One rule's compare-and-allow block. Any mismatch jumps to the instruction
+/// just past the block, so the next rule — or the trailing deny — runs.
+fn rule_block(rule: &DeviceRule) -> Vec<BpfInsn> {
+    let type_imm = match rule.dev_type {
+        DevType::Char => DEVCG_DEV_CHAR,
+        DevType::Block => DEVCG_DEV_BLOCK,
+    };
+
+    let mut block = vec![jne_imm(R2, type_imm)];
+    if let Some(major) = rule.major {
+        block.push(jne_imm(R3, major as i32));
+    }
+    if let Some(minor) = rule.minor {
+        block.push(jne_imm(R4, minor as i32));
+    }
+    // The rule matches only if the request is a subset of the access it grants:
+    // `requested & !granted == 0`. The complement spans the whole 16-bit access
+    // field, so an access bit a future kernel adds is denied, not ignored.
+    block.push(mov_reg(R6, R5)); // scratch copy; R5 must survive for later rules
+    block.push(and_imm(R6, i32::from(!u16::from(rule.access))));
+    block.push(jne_imm(R6, 0));
+    block.push(mov_imm(R0, ALLOW));
+    block.push(exit());
+
+    // A taken jump resumes at `i + off + 1`, so `off = len - 1 - i` sends every
+    // mismatch to the first instruction after this block.
+    let len = block.len();
+    for (i, insn) in block.iter_mut().enumerate() {
+        if insn.code == MISMATCH_JUMP {
+            insn.off = (len - 1 - i) as i16;
+        }
+    }
+    block
+}
+
+const BPF_PROG_LOAD: i32 = 5;
+const BPF_PROG_ATTACH: i32 = 8;
+const BPF_PROG_TYPE_CGROUP_DEVICE: u32 = 15;
+const BPF_CGROUP_DEVICE: u32 = 6;
+
+/// The kernel reads this as a C string; a GPL-compatible license is what every
+/// in-tree device filter ships.
+const BPF_LICENSE: &CStr = c"GPL";
+
+/// Only allocated for the diagnostic retry after a load fails, so it can afford
+/// to be generous — a log the verifier overflows turns the real rejection into
+/// an opaque `ENOSPC`.
+const VERIFIER_LOG_SIZE: usize = 64 * 1024;
+
+/// The prefix of the kernel's `union bpf_attr` (uapi/linux/bpf.h) that one
+/// `bpf(2)` command reads. `bpf()` passes `size_of::<Self>()` and the kernel
+/// zero-fills the rest of the union, so a command's unread tail is not modeled.
+///
+/// # Safety
+///
+/// Implementors must be `#[repr(C)]` with every field at the offset the kernel
+/// reads it from for that command, and must contain no padding, so all the bytes
+/// the kernel copies are initialized by writing the fields.
+unsafe trait BpfAttr {}
+
+/// `BPF_PROG_LOAD`'s view of the union.
+#[repr(C)]
+#[derive(Default)]
+struct ProgLoadAttr {
+    prog_type: u32,
+    insn_cnt: u32,
+    insns: u64,
+    license: u64,
+    log_level: u32,
+    log_size: u32,
+    log_buf: u64,
+}
+
+// Offsets are ABI: the kernel reads each command's fields at a fixed offset from
+// the start of the union, and getting one wrong surfaces only as `EINVAL`. The
+// size assertion pins the absence of padding.
+const _: () = {
+    assert!(std::mem::align_of::<ProgLoadAttr>() == 8);
+    assert!(std::mem::size_of::<ProgLoadAttr>() == 40);
+    assert!(std::mem::offset_of!(ProgLoadAttr, prog_type) == 0);
+    assert!(std::mem::offset_of!(ProgLoadAttr, insn_cnt) == 4);
+    assert!(std::mem::offset_of!(ProgLoadAttr, insns) == 8);
+    assert!(std::mem::offset_of!(ProgLoadAttr, license) == 16);
+    assert!(std::mem::offset_of!(ProgLoadAttr, log_level) == 24);
+    assert!(std::mem::offset_of!(ProgLoadAttr, log_size) == 28);
+    assert!(std::mem::offset_of!(ProgLoadAttr, log_buf) == 32);
+};
+
+// SAFETY: `#[repr(C)]` at PROG_LOAD's offsets, both asserted above, and the
+// asserted size leaves no room for padding.
+unsafe impl BpfAttr for ProgLoadAttr {}
+
+/// `BPF_PROG_ATTACH`'s view of the union. `union bpf_attr` is 8-byte aligned in
+/// the uapi header, so the alignment is ABI even though every field here is four
+/// bytes wide.
+#[repr(C, align(8))]
+struct ProgAttachAttr {
+    target_fd: u32,
+    attach_bpf_fd: u32,
+    attach_type: u32,
+    attach_flags: u32,
+}
+
+const _: () = {
+    assert!(std::mem::align_of::<ProgAttachAttr>() == 8);
+    assert!(std::mem::size_of::<ProgAttachAttr>() == 16);
+    assert!(std::mem::offset_of!(ProgAttachAttr, target_fd) == 0);
+    assert!(std::mem::offset_of!(ProgAttachAttr, attach_bpf_fd) == 4);
+    assert!(std::mem::offset_of!(ProgAttachAttr, attach_type) == 8);
+    assert!(std::mem::offset_of!(ProgAttachAttr, attach_flags) == 12);
+};
+
+// SAFETY: as above, at PROG_ATTACH's offsets.
+unsafe impl BpfAttr for ProgAttachAttr {}
+
+/// Raw `bpf(2)`, handing the kernel `attr` as the command's `union bpf_attr`.
+///
+/// # Safety
+///
+/// `A` must be the attr type the kernel reads for `cmd`. The kernel reinterprets
+/// the same bytes as whichever `union bpf_attr` member `cmd` selects, so pairing a
+/// command with another command's attr can make it read a flag as a pointer.
+///
+/// Every pointer field set in `attr` must be valid for the access the kernel
+/// makes through it and must stay live for the duration of the call. The kernel
+/// dereferences those pointers directly and nothing ties them to `attr`.
+unsafe fn bpf<A: BpfAttr>(cmd: i32, attr: &mut A) -> libc::c_long {
+    // SAFETY: `attr` is uniquely borrowed for the whole call, and `BpfAttr`
+    // guarantees the `size_of::<A>()` bytes the kernel is told to read are
+    // padding-free, hence fully initialized by the fields written into it.
+    // Validity of the buffers those fields point at is the caller's precondition.
+    unsafe {
+        libc::syscall(
+            libc::SYS_bpf,
+            cmd,
+            attr as *mut A,
+            std::mem::size_of::<A>() as libc::c_uint,
+        )
+    }
+}
+
+/// One `BPF_PROG_LOAD` attempt. `log` is supplied only on the retry after a
+/// failure: with a log attached the verifier traces every instruction, and it
+/// fails the whole load if the trace does not fit.
+fn try_prog_load(prog: &[BpfInsn], log: Option<&mut [u8]>) -> std::io::Result<OwnedFd> {
+    // The kernel sizes its read through `insns` entirely from `insn_cnt`, so the
+    // count is derived here rather than passed in: the pointer and the length it
+    // is read with cannot then disagree.
+    let insn_cnt = u32::try_from(prog.len())
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let mut attr = ProgLoadAttr {
+        prog_type: BPF_PROG_TYPE_CGROUP_DEVICE,
+        insn_cnt,
+        insns: prog.as_ptr() as u64,
+        license: BPF_LICENSE.as_ptr() as u64,
+        ..ProgLoadAttr::default()
+    };
+    if let Some(log) = log {
+        // `log_size` is 32 bits of ABI: refuse a buffer that does not fit rather
+        // than silently handing the kernel a truncated size for it.
+        let log_size = u32::try_from(log.len())
+            .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+        attr.log_level = 1;
+        attr.log_size = log_size;
+        attr.log_buf = log.as_mut_ptr() as u64;
+    }
+
+    // SAFETY: `ProgLoadAttr` is the union member BPF_PROG_LOAD reads, and `insn_cnt`
+    // is derived from `prog.len()`, so the kernel reads exactly that slice and no
+    // further. `prog` is borrowed for this whole function, `log_buf` points into the
+    // `Vec` the caller owns across the call, and the license is a `'static` `CStr`.
+    let fd = unsafe { bpf(BPF_PROG_LOAD, &mut attr) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `bpf()` just created this descriptor for our process and returned
+    // sole ownership of it, so nothing else will close it.
+    Ok(unsafe { OwnedFd::from_raw_fd(fd as RawFd) })
+}
+
+/// Trim the kernel's NUL-terminated verifier log down to the text it wrote.
+fn verifier_log_text(buf: &[u8]) -> String {
+    let end = buf.iter().position(|b| *b == 0).unwrap_or(buf.len());
+    String::from_utf8_lossy(&buf[..end]).trim_end().to_string()
+}
+
+/// The `EPERM` diagnostic for a failed `bpf()` command. The kernel gates the load
+/// itself on `bpf_capable()`, so a capability-starved agent never reaches the
+/// attach and the hint has to be on both. `other_cause` names whatever else the
+/// command can return `EPERM` for, since the errno distinguishes neither.
+fn eperm_hint(err: &std::io::Error, other_cause: Option<&str>) -> String {
+    if err.raw_os_error() != Some(libc::EPERM) {
+        return String::new();
+    }
+    match other_cause {
+        Some(cause) => format!(" (spurd needs CAP_BPF or CAP_SYS_ADMIN, or {cause})"),
+        None => " (spurd needs CAP_BPF or CAP_SYS_ADMIN)".to_string(),
+    }
+}
+
+fn bpf_prog_load(prog: &[BpfInsn]) -> anyhow::Result<OwnedFd> {
+    let insn_cnt = u32::try_from(prog.len()).context("device filter is too large to load")?;
+    let err = match try_prog_load(prog, None) {
+        Ok(fd) => return Ok(fd),
+        Err(e) => e,
+    };
+
+    // Re-run the failed load with a log attached: on a real node the verifier's
+    // rejection message is the only diagnostic anyone gets. Discarding the retry's
+    // result is safe either way — a surprise success drops its fd here unattached.
+    let mut log = vec![0u8; VERIFIER_LOG_SIZE];
+    drop(try_prog_load(prog, Some(&mut log)));
+    let log = verifier_log_text(&log);
+    // No `other_cause`: the exclusive-attach conflict is an attach-time verdict,
+    // and naming it here would send the reader after the wrong thing.
+    let hint = eperm_hint(&err, None);
+    // `E2BIG` from exceeding BPF_MAXINSNS short-circuits before the verifier
+    // runs, so the count is the only clue that the rule list is what was too big.
+    if log.is_empty() {
+        anyhow::bail!("BPF_PROG_LOAD of {insn_cnt} instructions failed: {err}{hint}");
+    }
+    anyhow::bail!(
+        "BPF_PROG_LOAD of {insn_cnt} instructions failed: {err}{hint}; verifier log: {log}"
+    )
+}
+
+/// `attach_flags` stays zero: an exclusive attach is the stricter contract for a
+/// security filter, and it is what makes this the job cgroup's only device program.
+fn prog_attach_attr(prog_fd: RawFd, cgroup_fd: RawFd) -> ProgAttachAttr {
+    ProgAttachAttr {
+        target_fd: cgroup_fd as u32,
+        attach_bpf_fd: prog_fd as u32,
+        attach_type: BPF_CGROUP_DEVICE,
+        attach_flags: 0,
+    }
+}
+
+/// Typed owners rather than `RawFd`s so transposing them is a compile error and
+/// neither descriptor can be closed while the syscall is in flight.
+fn bpf_prog_attach(prog_fd: &OwnedFd, cgroup_dir: &File) -> anyhow::Result<()> {
+    let mut attr = prog_attach_attr(prog_fd.as_raw_fd(), cgroup_dir.as_raw_fd());
+    // SAFETY: `ProgAttachAttr` is the union member BPF_PROG_ATTACH reads, and it
+    // holds only descriptors and flags, so the kernel dereferences nothing and
+    // there is no buffer to keep alive.
+    if unsafe { bpf(BPF_PROG_ATTACH, &mut attr) } < 0 {
+        let err = std::io::Error::last_os_error();
+        // The two causes need opposite responses: grant a capability, or find and
+        // relax the ancestor.
+        let hint = eperm_hint(
+            &err,
+            Some("an ancestor cgroup already holds an exclusive device program"),
+        );
+        anyhow::bail!("BPF_PROG_ATTACH failed: {err}{hint}");
+    }
+    Ok(())
+}
+
+/// Compile `rules` into a default-deny device filter and attach it to `cgroup_dir`.
+///
+/// Both descriptors are dropped before returning. The attachment holds its own
+/// kernel reference, so it is then the program's only owner and removing the
+/// cgroup directory at teardown detaches and frees it — there is nothing to detach.
+pub fn install_device_filter(cgroup_dir: &Path, rules: &[DeviceRule]) -> anyhow::Result<()> {
+    let prog = build_device_filter(rules);
+    let prog_fd = bpf_prog_load(&prog)?;
+    let cgroup_fd = File::open(cgroup_dir)
+        .with_context(|| format!("open cgroup dir {}", cgroup_dir.display()))?;
+    bpf_prog_attach(&prog_fd, &cgroup_fd)
+        .with_context(|| format!("attach device filter to {}", cgroup_dir.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_rules_include_standard_pseudo_devices() {
+        let rules = base_device_rules();
+        // Exact minors, so no single wildcard rule can satisfy several of these
+        // at once and hide a rule set that is missing devices.
+        let has = |maj: u32, min: u32| {
+            rules.iter().any(|r| {
+                matches!(r.dev_type, DevType::Char) && r.major == Some(maj) && r.minor == Some(min)
+            })
+        };
+        assert!(has(1, 3), "/dev/null");
+        assert!(has(1, 5), "/dev/zero");
+        assert!(has(1, 8), "/dev/random");
+        assert!(has(1, 9), "/dev/urandom");
+        assert!(has(5, 0), "/dev/tty");
+        assert!(has(5, 2), "/dev/ptmx");
+        assert!(
+            rules.iter().any(|r| matches!(r.dev_type, DevType::Char)
+                && r.major == Some(136)
+                && r.minor.is_none()),
+            "/dev/pts/* must be a wildcard minor: pty numbers are allocated at runtime"
+        );
+    }
+
+    #[test]
+    fn adds_rules_for_allocated_device_nodes_only() {
+        let paths = vec![
+            "/dev/kfd".to_string(),
+            "/dev/dri/renderD128".to_string(),
+            "/dev/nvme0n1".to_string(),
+            "/dev/does-not-exist".to_string(),
+        ];
+        let fake_stat = |p: &str| match p {
+            "/dev/kfd" => Some((DevType::Char, 234u32, 0u32)),
+            "/dev/dri/renderD128" => Some((DevType::Char, 226u32, 128u32)),
+            "/dev/nvme0n1" => Some((DevType::Block, 259u32, 0u32)),
+            _ => None,
+        };
+        let rules = rules_for_device_paths(&paths, fake_stat);
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.major == Some(1) && r.minor == Some(3)),
+            "base /dev/null rule retained"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.major == Some(234) && r.minor == Some(0)),
+            "/dev/kfd allowed"
+        );
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.major == Some(226) && r.minor == Some(128)),
+            "/dev/dri/renderD128 allowed"
+        );
+        assert_eq!(
+            rules.iter().filter(|r| r.major == Some(226)).count(),
+            1,
+            "the allocated render node adds exactly one rule"
+        );
+        assert_eq!(
+            &rules[base_device_rules().len()..],
+            &[
+                DeviceRule {
+                    dev_type: DevType::Char,
+                    major: Some(234),
+                    minor: Some(0),
+                    access: ACC_ALL,
+                },
+                DeviceRule {
+                    dev_type: DevType::Char,
+                    major: Some(226),
+                    minor: Some(128),
+                    access: ACC_ALL,
+                },
+                DeviceRule {
+                    dev_type: DevType::Block,
+                    major: Some(259),
+                    minor: Some(0),
+                    access: ACC_ALL,
+                },
+            ],
+            "only the resolvable paths add rules, in input order, keeping each node's type"
+        );
+    }
+
+    #[test]
+    fn zero_gpu_job_gets_only_base_rules() {
+        let rules = rules_for_device_paths(&[], |_| None);
+        assert_eq!(rules, base_device_rules());
+    }
+
+    #[test]
+    fn host_infra_list_covers_the_shared_nodes_no_allocation_grants() {
+        let paths = host_infra_device_paths();
+        for expected in [
+            "/dev/fuse",
+            "/dev/nvidiactl",
+            "/dev/nvidia-uvm",
+            "/dev/nvidia-uvm-tools",
+            "/dev/nvidia-modeset",
+        ] {
+            assert!(
+                paths.iter().any(|p| p == expected),
+                "{expected} is host infrastructure, not an allocatable device"
+            );
+        }
+        assert!(
+            HOST_INFRA_DEVICE_DIRS.contains(&"/dev/infiniband"),
+            "RDMA verbs nodes must be enumerated; a non-GPU MPI job needs them"
+        );
+        assert!(
+            HOST_INFRA_DEVICE_DIRS.contains(&"/dev/nvidia-caps"),
+            "MIG capability nodes must be enumerated"
+        );
+    }
+
+    /// The whole point of the filter is that a compute node needs an allocation.
+    /// Listing one here would hand every job on the node a GPU.
+    #[test]
+    fn host_infra_list_excludes_per_gpu_compute_nodes() {
+        let paths = host_infra_device_paths();
+        for forbidden in [
+            "/dev/kfd",
+            "/dev/nvidia0",
+            "/dev/dri",
+            "/dev/dri/renderD128",
+        ] {
+            assert!(
+                !paths.iter().any(|p| p == forbidden),
+                "{forbidden} is allocation-gated and must not be granted unconditionally"
+            );
+        }
+        for dir in HOST_INFRA_DEVICE_DIRS {
+            assert_ne!(*dir, "/dev/dri", "render/card nodes stay allocation-gated");
+        }
+    }
+
+    #[test]
+    fn device_dir_entries_lists_a_directorys_nodes_and_tolerates_a_missing_one() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("uverbs1"), b"").unwrap();
+        std::fs::write(dir.path().join("uverbs0"), b"").unwrap();
+
+        let entries = device_dir_entries(dir.path());
+        let names: Vec<&str> = entries
+            .iter()
+            .filter_map(|p| p.rsplit('/').next())
+            .collect();
+        assert_eq!(
+            names,
+            ["uverbs0", "uverbs1"],
+            "sorted for a stable rule order"
+        );
+
+        assert_eq!(
+            device_dir_entries(&dir.path().join("absent")),
+            Vec::<String>::new(),
+            "a node without that hardware has no entries, not an error"
+        );
+    }
+
+    #[test]
+    fn operator_extra_paths_become_rules() {
+        let extra = vec!["/dev/site-accel0".to_string()];
+        let paths = device_paths_for_job(&[], &extra);
+        assert!(
+            paths.iter().any(|p| p == "/dev/site-accel0"),
+            "extra_device_paths must reach the resolver"
+        );
+
+        let rules = rules_for_device_paths(&paths, |p| match p {
+            "/dev/site-accel0" => Some((DevType::Char, 511, 3)),
+            _ => None,
+        });
+        assert_eq!(
+            &rules[base_device_rules().len()..],
+            &[DeviceRule {
+                dev_type: DevType::Char,
+                major: Some(511),
+                minor: Some(3),
+                access: ACC_ALL,
+            }],
+            "an operator's device is allowed without declaring it as GRES"
+        );
+    }
+
+    #[test]
+    fn allocated_paths_survive_alongside_host_infra_and_extras() {
+        let allocated = vec!["/dev/dri/renderD128".to_string()];
+        let extra = vec!["/dev/site-accel0".to_string()];
+        let paths = device_paths_for_job(&allocated, &extra);
+        assert!(paths.iter().any(|p| p == "/dev/dri/renderD128"));
+        assert!(paths.iter().any(|p| p == "/dev/site-accel0"));
+        assert!(paths.iter().any(|p| p == "/dev/nvidiactl"));
+    }
+
+    #[test]
+    fn acc_constants_match_kernel_devcg_values() {
+        assert_eq!(ACC_MKNOD, 1, "BPF_DEVCG_ACC_MKNOD");
+        assert_eq!(ACC_READ, 2, "BPF_DEVCG_ACC_READ");
+        assert_eq!(ACC_WRITE, 4, "BPF_DEVCG_ACC_WRITE");
+        assert_eq!(ACC_ALL, 7, "read | write | mknod");
+    }
+
+    #[test]
+    fn base_rules_grant_full_access() {
+        for rule in base_device_rules() {
+            assert_eq!(
+                rule.access, ACC_ALL,
+                "{rule:?} must grant read/write/mknod on a pseudo-device"
+            );
+        }
+    }
+
+    /// Synthetic `struct bpf_cgroup_dev_ctx`. The type/access packing is spelled
+    /// out from the kernel ABI instead of reusing the codegen constants, so the
+    /// tests pin the layout independently of the code under test.
+    #[derive(Clone, Copy)]
+    struct DevCtx {
+        access_type: u32,
+        major: u32,
+        minor: u32,
+    }
+
+    fn dev_ctx(dev_type: DevType, access: u8, major: u32, minor: u32) -> DevCtx {
+        let type_bits: u32 = match dev_type {
+            DevType::Block => 1,
+            DevType::Char => 2,
+        };
+        DevCtx {
+            access_type: (u32::from(access) << 16) | type_bits,
+            major,
+            minor,
+        }
+    }
+
+    /// Sentinel ctx address: every load must be derived from the pointer in R1,
+    /// so clobbering R1 makes the interpreter fault instead of reading the ctx.
+    const CTX_BASE: u64 = 0x1000;
+    const STEP_LIMIT: usize = 4096;
+
+    /// Minimal BPF interpreter covering exactly the opcodes `build_device_filter`
+    /// emits, so the tests exercise the generated instruction stream rather than
+    /// trusting a hand-rolled encoding. Anything else panics: a mis-encoded
+    /// program that always allows would otherwise look like a healthy cluster.
+    fn run_filter(prog: &[BpfInsn], ctx: DevCtx) -> u32 {
+        // Opcode bytes are written out from uapi/linux/bpf.h rather than reusing
+        // the module's constants, so a typo there cannot make codegen and
+        // interpreter agree on a wrong encoding.
+        const LDX_W: u8 = 0x61; // BPF_LDX | BPF_MEM | BPF_W
+        const MOV_IMM: u8 = 0xb4; // BPF_ALU | BPF_MOV | BPF_K
+        const MOV_REG: u8 = 0xbc; // BPF_ALU | BPF_MOV | BPF_X
+        const AND_IMM: u8 = 0x54; // BPF_ALU | BPF_AND | BPF_K
+        const RSH_IMM: u8 = 0x74; // BPF_ALU | BPF_RSH | BPF_K
+        const JNE_IMM: u8 = 0x55; // BPF_JMP | BPF_JNE | BPF_K
+        const EXIT: u8 = 0x95; // BPF_JMP | BPF_EXIT
+
+        let mut regs = [0u64; 11];
+        regs[1] = CTX_BASE;
+        let mut pc = 0usize;
+        for _ in 0..STEP_LIMIT {
+            let insn = *prog
+                .get(pc)
+                .unwrap_or_else(|| panic!("pc {pc} ran past the end of the program"));
+            let dst = usize::from(insn.regs & 0x0f);
+            let src = usize::from(insn.regs >> 4);
+            let at = pc;
+            pc += 1;
+            match insn.code {
+                LDX_W => {
+                    let addr = regs[src].wrapping_add_signed(i64::from(insn.off));
+                    regs[dst] = u64::from(match addr.wrapping_sub(CTX_BASE) {
+                        0 => ctx.access_type,
+                        4 => ctx.major,
+                        8 => ctx.minor,
+                        _ => panic!("insn {at} loads outside struct bpf_cgroup_dev_ctx"),
+                    });
+                }
+                MOV_IMM => regs[dst] = u64::from(insn.imm as u32),
+                MOV_REG => regs[dst] = u64::from(regs[src] as u32),
+                AND_IMM => regs[dst] = u64::from(regs[dst] as u32 & insn.imm as u32),
+                RSH_IMM => regs[dst] = u64::from((regs[dst] as u32) >> (insn.imm as u32 & 31)),
+                JNE_IMM => {
+                    if regs[dst] != i64::from(insn.imm) as u64 {
+                        pc = pc.wrapping_add_signed(isize::from(insn.off));
+                    }
+                }
+                EXIT => return regs[0] as u32,
+                code => panic!("insn {at}: unsupported opcode {code:#04x}"),
+            }
+        }
+        panic!("program did not reach EXIT within {STEP_LIMIT} steps");
+    }
+
+    /// Allow-list for a job allocated exactly one device node, char 234:0.
+    fn one_gpu_rules() -> Vec<DeviceRule> {
+        rules_for_device_paths(&["/dev/kfd".to_string()], |_| Some((DevType::Char, 234, 0)))
+    }
+
+    #[test]
+    fn filter_allows_an_allocated_device_node() {
+        let prog = build_device_filter(&one_gpu_rules());
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Char, ACC_READ, 234, 0)),
+            1,
+            "the job's own /dev/kfd must be readable"
+        );
+    }
+
+    #[test]
+    fn filter_denies_a_device_the_job_was_not_allocated() {
+        let prog = build_device_filter(&one_gpu_rules());
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Char, ACC_READ, 226, 129)),
+            0,
+            "another job's render node must be denied"
+        );
+    }
+
+    #[test]
+    fn filter_allows_base_pseudo_devices() {
+        let prog = build_device_filter(&base_device_rules());
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Char, ACC_READ | ACC_WRITE, 1, 3)),
+            1,
+            "/dev/null must stay read/write"
+        );
+    }
+
+    #[test]
+    fn filter_distinguishes_block_from_char_devices() {
+        let prog = build_device_filter(&base_device_rules());
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Block, ACC_READ, 1, 3)),
+            0,
+            "block 1:3 must not inherit the char 1:3 (/dev/null) rule"
+        );
+    }
+
+    /// Pins where a mismatch jump resumes: overshooting by one would skip the
+    /// next rule's device-type check, undershooting would exit the block early.
+    #[test]
+    fn a_mismatched_rule_resumes_at_the_next_rules_type_check() {
+        let rules = vec![
+            DeviceRule {
+                dev_type: DevType::Char,
+                major: Some(99),
+                minor: Some(0),
+                access: ACC_ALL,
+            },
+            DeviceRule {
+                dev_type: DevType::Block,
+                major: Some(234),
+                minor: Some(0),
+                access: ACC_ALL,
+            },
+        ];
+        let prog = build_device_filter(&rules);
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Char, ACC_READ, 234, 0)),
+            0,
+            "char 234:0 must not be allowed by the block rule reached after rule 1 mismatched"
+        );
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Block, ACC_READ, 234, 0)),
+            1,
+            "block 234:0 is allowed, so a rule-1 mismatch must still reach rule 2"
+        );
+    }
+
+    #[test]
+    fn filter_honors_wildcard_minor_rules() {
+        let prog = build_device_filter(&base_device_rules());
+        for minor in [0, 4095] {
+            assert_eq!(
+                run_filter(
+                    &prog,
+                    dev_ctx(DevType::Char, ACC_READ | ACC_WRITE, 136, minor)
+                ),
+                1,
+                "/dev/pts/{minor} must match the wildcard-minor rule"
+            );
+        }
+    }
+
+    #[test]
+    fn filter_treats_requested_access_as_a_subset_test() {
+        let read_only = DeviceRule {
+            dev_type: DevType::Char,
+            major: Some(234),
+            minor: Some(0),
+            access: ACC_READ,
+        };
+        let prog = build_device_filter(&[read_only]);
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Char, ACC_READ, 234, 0)),
+            1,
+            "read is granted"
+        );
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Char, ACC_WRITE, 234, 0)),
+            0,
+            "write is not granted"
+        );
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Char, ACC_MKNOD, 234, 0)),
+            0,
+            "mknod is not granted"
+        );
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Char, ACC_READ | ACC_WRITE, 234, 0)),
+            0,
+            "a request must be a subset of the rule, not merely overlap it"
+        );
+    }
+
+    /// The access complement must cover the full 16-bit access field: masking it
+    /// to the three bits that exist today would make an unknown bit AND to zero
+    /// and be allowed by every rule.
+    #[test]
+    fn filter_denies_an_access_bit_no_rule_can_grant() {
+        const UNKNOWN_ACC: u8 = 8; // one past ACC_WRITE
+        let prog = build_device_filter(&base_device_rules());
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Char, ACC_READ, 1, 3)),
+            1,
+            "/dev/null is readable, so the deny below is about the extra bit"
+        );
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Char, ACC_READ | UNKNOWN_ACC, 1, 3)),
+            0,
+            "an access bit outside ACC_* must fail closed even on an ACC_ALL rule"
+        );
+    }
+
+    #[test]
+    fn filter_with_no_rules_denies_everything() {
+        let prog = build_device_filter(&[]);
+        for ctx in [
+            dev_ctx(DevType::Char, ACC_READ, 1, 3),
+            dev_ctx(DevType::Char, ACC_READ, 234, 0),
+            dev_ctx(DevType::Block, ACC_WRITE, 8, 0),
+        ] {
+            assert_eq!(
+                run_filter(&prog, ctx),
+                0,
+                "an empty allow-list must deny every device"
+            );
+        }
+    }
+
+    #[test]
+    fn program_is_nonempty_and_deny_by_default() {
+        let prog = build_device_filter(&[]);
+        assert!(prog.len() >= 2, "must at least load-deny-and-exit");
+        let last = prog.last().copied().unwrap();
+        assert_eq!(last.code, BPF_JMP | BPF_EXIT, "program must end with EXIT");
+        let deny = prog[prog.len() - 2];
+        assert_eq!(
+            deny.code,
+            BPF_ALU | BPF_MOV | BPF_K,
+            "deny must be a MOV imm"
+        );
+        assert_eq!(deny.imm, 0, "the fall-through must return 0 (deny)");
+    }
+
+    #[test]
+    fn more_rules_produce_more_instructions() {
+        let few = build_device_filter(&base_device_rules());
+        let many = build_device_filter(&one_gpu_rules());
+        assert!(
+            many.len() > few.len(),
+            "each allocated node adds compare instructions"
+        );
+    }
+
+    #[test]
+    fn every_mismatch_jump_lands_inside_the_program() {
+        let rules = one_gpu_rules();
+        let prog = build_device_filter(&rules);
+        let mut jumps = 0;
+        for (i, insn) in prog.iter().enumerate() {
+            if insn.code != MISMATCH_JUMP {
+                continue;
+            }
+            jumps += 1;
+            let target = i as i64 + i64::from(insn.off) + 1;
+            assert!(
+                target > i as i64 && target < prog.len() as i64,
+                "jump at {i} targets {target}, outside the program body"
+            );
+        }
+        assert!(
+            jumps >= rules.len(),
+            "every rule must emit at least one mismatch jump; found {jumps} for {} rules",
+            rules.len()
+        );
+    }
+
+    #[test]
+    fn stat_device_node_rejects_paths_that_are_not_device_nodes() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let regular = dir.path().join("regular-file");
+        std::fs::write(&regular, b"not a device").unwrap();
+        assert_eq!(
+            stat_device_node(regular.to_str().unwrap()),
+            None,
+            "regular file is not a device node"
+        );
+
+        let missing = dir.path().join("does-not-exist");
+        assert_eq!(
+            stat_device_node(missing.to_str().unwrap()),
+            None,
+            "nonexistent path is not a device node"
+        );
+    }
+
+    /// Both descriptors are `RawFd`, so only this pins which one is the attach
+    /// target; the offset assertions cover where each lands in the union.
+    #[test]
+    fn attach_targets_the_cgroup_with_the_program_as_the_attached_fd() {
+        let attr = prog_attach_attr(7, 11);
+        assert_eq!(attr.target_fd, 11, "the cgroup is what is attached to");
+        assert_eq!(attr.attach_bpf_fd, 7, "the program is what is attached");
+        assert_eq!(attr.attach_type, BPF_CGROUP_DEVICE);
+        assert_eq!(
+            attr.attach_flags, 0,
+            "no BPF_F_ALLOW_MULTI: one exclusive filter per job cgroup"
+        );
+    }
+
+    /// The kernel rejects a capability-starved agent at load, so the load path is
+    /// where the hint is actually read — and there it must not send anyone hunting
+    /// for an ancestor cgroup that has nothing to do with it.
+    #[test]
+    fn eperm_names_the_capability_on_every_path_and_the_ancestor_only_on_attach() {
+        let eperm = std::io::Error::from_raw_os_error(libc::EPERM);
+
+        let load = eperm_hint(&eperm, None);
+        assert!(load.contains("CAP_BPF"), "load hint names the capability");
+        assert!(
+            !load.contains("ancestor"),
+            "the exclusive-attach conflict cannot cause a failed load: {load}"
+        );
+
+        let attach = eperm_hint(&eperm, Some("an ancestor cgroup already holds it"));
+        assert!(attach.contains("CAP_BPF"));
+        assert!(attach.contains("an ancestor cgroup already holds it"));
+
+        assert_eq!(
+            eperm_hint(&std::io::Error::from_raw_os_error(libc::EINVAL), None),
+            "",
+            "a capability hint on EINVAL would misdirect"
+        );
+    }
+
+    #[test]
+    fn verifier_log_stops_at_the_kernels_terminator() {
+        let mut buf = vec![0u8; 64];
+        buf[..14].copy_from_slice(b"invalid insn\n\0");
+        assert_eq!(verifier_log_text(&buf), "invalid insn");
+        assert_eq!(
+            verifier_log_text(&[0u8; 64]),
+            "",
+            "an unwritten log is empty"
+        );
+        assert_eq!(
+            verifier_log_text(b"no terminator"),
+            "no terminator",
+            "a full buffer is still readable"
+        );
+    }
+}

--- a/crates/spurd/src/device_cgroup.rs
+++ b/crates/spurd/src/device_cgroup.rs
@@ -3,10 +3,8 @@
 
 //! cgroup-v2 device access control via a BPF_PROG_TYPE_CGROUP_DEVICE program.
 //!
-//! cgroup v2 dropped the `devices` controller; device access is filtered by an
-//! eBPF program attached to the cgroup. We build the program in-process and load
-//! it with the `bpf()` syscall, mirroring systemd's approach, so no eBPF build
-//! toolchain is needed.
+//! cgroup v2 dropped the `devices` controller. The program is built in-process and
+//! loaded with `bpf()`, as systemd does, so no eBPF build toolchain is needed.
 
 use std::ffi::CStr;
 use std::fs::File;
@@ -46,9 +44,8 @@ impl DeviceRule {
     }
 }
 
-/// Pseudo-devices every job must retain (mirrors systemd `DevicePolicy=closed`).
-/// Without these a default-deny filter would block `/dev/null`, ptys, etc. and
-/// break virtually every program.
+/// Pseudo-devices every job must retain (systemd's `DevicePolicy=closed`): without
+/// them a default-deny filter blocks `/dev/null` and ptys, breaking most programs.
 pub fn base_device_rules() -> Vec<DeviceRule> {
     vec![
         DeviceRule::char_dev(1, Some(3)), // /dev/null
@@ -63,9 +60,8 @@ pub fn base_device_rules() -> Vec<DeviceRule> {
     ]
 }
 
-/// Host-infrastructure device nodes: shared by every workload, owned by no
-/// allocation, so nothing puts them in a job's `device_paths`. Denying them breaks
-/// jobs that were never reaching for a GPU they do not hold.
+/// Shared by every workload and owned by no allocation, so nothing puts them in a
+/// job's `device_paths`; denying them breaks jobs not reaching for a GPU at all.
 const HOST_INFRA_DEVICE_NODES: &[&str] = &[
     "/dev/fuse", // Apptainer/Singularity run inside the batch job
     // CUDA initialization; enumerating a GPU still needs /dev/nvidia<N>.
@@ -75,20 +71,17 @@ const HOST_INFRA_DEVICE_NODES: &[&str] = &[
     "/dev/nvidia-modeset",
 ];
 
-/// Host-infra device directories. Entry names are per-host (`uverbs0`, `umad1`,
-/// `nvidia-cap2`, ...), so they are enumerated rather than listed.
+/// Entry names are per-host (`uverbs0`, `nvidia-cap2`, ...), so these are enumerated.
 ///
 /// `/dev/nvidia-caps` is granted wholesale only because a MIG instance is not
-/// individually allocatable here. Those nodes *are* NVIDIA's per-instance access
-/// control, so MIG allocation would have to move them behind the allocation.
+/// individually allocatable here; MIG support must move those behind allocation.
 const HOST_INFRA_DEVICE_DIRS: &[&str] = &[
     "/dev/infiniband",  // RDMA verbs: MPI, NCCL and RCCL over IB
     "/dev/nvidia-caps", // MIG capability nodes
 ];
 
-/// Every host-infra device path this node has. Majors for IB and NVIDIA are
-/// assigned dynamically, so these resolve by path like any allocated node; a node
-/// without that hardware simply has nothing to stat.
+/// IB and NVIDIA majors are assigned dynamically, so these resolve by path like any
+/// allocated node; a node without that hardware has nothing to stat.
 ///
 /// Per-GPU compute nodes (`/dev/nvidia<N>`, `/dev/kfd`, `/dev/dri/*`) are
 /// deliberately absent — gating those on the allocation is the security property.
@@ -103,9 +96,8 @@ pub fn host_infra_device_paths() -> Vec<String> {
     paths
 }
 
-/// Entries of a directory of device nodes, sorted so the rule order is the same on
-/// every launch. A directory that does not exist means the node has no such
-/// hardware, which is not an error.
+/// Sorted so the rule order is the same on every launch. A missing directory means
+/// the node has no such hardware, which is not an error.
 fn device_dir_entries(dir: &Path) -> Vec<String> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Vec::new();
@@ -118,9 +110,8 @@ fn device_dir_entries(dir: &Path) -> Vec<String> {
     paths
 }
 
-/// Every path a job's filter should resolve: host infrastructure, the operator's
-/// additions, then the job's own allocation. Order only affects rule order, and
-/// each rule is an independent allow, so it does not change any verdict.
+/// Host infrastructure, the operator's additions, then the job's own allocation.
+/// Each rule is an independent allow, so the order changes no verdict.
 pub fn device_paths_for_job(allocated: &[String], extra: &[String]) -> Vec<String> {
     let mut paths = host_infra_device_paths();
     paths.extend(extra.iter().cloned());
@@ -128,9 +119,8 @@ pub fn device_paths_for_job(allocated: &[String], extra: &[String]) -> Vec<Strin
     paths
 }
 
-/// Build the job's device allow-list: base pseudo-devices plus the allocated
-/// device nodes. Paths that do not stat to a device node are skipped, so a
-/// zero-GPU job gets only the base rules and cannot open any GPU.
+/// Base pseudo-devices plus the allocated nodes. Paths that do not stat to a device
+/// node are skipped, so a zero-GPU job gets only the base rules.
 pub fn rules_for_device_paths(
     paths: &[String],
     stat_dev: impl Fn(&str) -> Option<(DevType, u32, u32)>,
@@ -184,9 +174,8 @@ pub struct BpfInsn {
 // the 8-byte size is ABI, not an implementation detail.
 const _: () = assert!(std::mem::size_of::<BpfInsn>() == 8);
 
-// Instruction classes, operand sizes, sources and ops (uapi/linux/bpf.h,
-// uapi/linux/bpf_common.h). BPF_W and BPF_K are 0 but stay explicit so each
-// opcode reads the way the kernel headers spell it.
+// BPF_W and BPF_K are 0 but stay explicit so each opcode reads the way the kernel
+// headers spell it.
 const BPF_LDX: u8 = 0x01;
 const BPF_ALU: u8 = 0x04;
 const BPF_JMP: u8 = 0x05;
@@ -295,10 +284,6 @@ fn exit() -> BpfInsn {
 }
 
 /// Default-deny `cgroup/dev` program: allow the listed rules, deny everything else.
-///
-/// Structure mirrors `samples/bpf/dev_cgroup` and systemd's `bpf-devices.c`: load
-/// the ctx fields once, then one compare-and-allow block per rule, then a
-/// trailing `return 0`.
 fn build_device_filter(rules: &[DeviceRule]) -> Vec<BpfInsn> {
     let mut prog = vec![
         // Both halves of access_type: R2 = device type, R5 = requested access.
@@ -334,9 +319,8 @@ fn rule_block(rule: &DeviceRule) -> Vec<BpfInsn> {
     if let Some(minor) = rule.minor {
         block.push(jne_imm(R4, minor as i32));
     }
-    // The rule matches only if the request is a subset of the access it grants:
-    // `requested & !granted == 0`. The complement spans the whole 16-bit access
-    // field, so an access bit a future kernel adds is denied, not ignored.
+    // Subset test: `requested & !granted == 0`. The complement spans the whole
+    // 16-bit access field, so an access bit a future kernel adds fails closed.
     block.push(mov_reg(R6, R5)); // scratch copy; R5 must survive for later rules
     block.push(and_imm(R6, i32::from(!u16::from(rule.access))));
     block.push(jne_imm(R6, 0));
@@ -363,20 +347,17 @@ const BPF_CGROUP_DEVICE: u32 = 6;
 /// in-tree device filter ships.
 const BPF_LICENSE: &CStr = c"GPL";
 
-/// Only allocated for the diagnostic retry after a load fails, so it can afford
-/// to be generous — a log the verifier overflows turns the real rejection into
-/// an opaque `ENOSPC`.
+/// Only allocated for the diagnostic retry after a failed load, so it can afford to
+/// be generous — an overflowed log turns the real rejection into an opaque `ENOSPC`.
 const VERIFIER_LOG_SIZE: usize = 64 * 1024;
 
-/// The prefix of the kernel's `union bpf_attr` (uapi/linux/bpf.h) that one
-/// `bpf(2)` command reads. `bpf()` passes `size_of::<Self>()` and the kernel
-/// zero-fills the rest of the union, so a command's unread tail is not modeled.
+/// The prefix of `union bpf_attr` that one `bpf(2)` command reads. `bpf()` passes
+/// `size_of::<Self>()` and the kernel zero-fills the rest, so the tail is unmodeled.
 ///
 /// # Safety
 ///
-/// Implementors must be `#[repr(C)]` with every field at the offset the kernel
-/// reads it from for that command, and must contain no padding, so all the bytes
-/// the kernel copies are initialized by writing the fields.
+/// Implementors must be `#[repr(C)]` and padding-free, with every field at the
+/// offset the kernel reads for that command, so writing them initializes all bytes.
 unsafe trait BpfAttr {}
 
 /// `BPF_PROG_LOAD`'s view of the union.
@@ -392,9 +373,8 @@ struct ProgLoadAttr {
     log_buf: u64,
 }
 
-// Offsets are ABI: the kernel reads each command's fields at a fixed offset from
-// the start of the union, and getting one wrong surfaces only as `EINVAL`. The
-// size assertion pins the absence of padding.
+// Offsets are ABI and getting one wrong surfaces only as `EINVAL`; the size
+// assertion pins the absence of padding.
 const _: () = {
     assert!(std::mem::align_of::<ProgLoadAttr>() == 8);
     assert!(std::mem::size_of::<ProgLoadAttr>() == 40);
@@ -411,9 +391,8 @@ const _: () = {
 // asserted size leaves no room for padding.
 unsafe impl BpfAttr for ProgLoadAttr {}
 
-/// `BPF_PROG_ATTACH`'s view of the union. `union bpf_attr` is 8-byte aligned in
-/// the uapi header, so the alignment is ABI even though every field here is four
-/// bytes wide.
+/// `BPF_PROG_ATTACH`'s view of the union. `union bpf_attr` is 8-byte aligned in the
+/// uapi header, so the alignment is ABI even though every field here is 4 bytes.
 #[repr(C, align(8))]
 struct ProgAttachAttr {
     target_fd: u32,
@@ -438,18 +417,14 @@ unsafe impl BpfAttr for ProgAttachAttr {}
 ///
 /// # Safety
 ///
-/// `A` must be the attr type the kernel reads for `cmd`. The kernel reinterprets
-/// the same bytes as whichever `union bpf_attr` member `cmd` selects, so pairing a
-/// command with another command's attr can make it read a flag as a pointer.
+/// `A` must be the attr type the kernel reads for `cmd`: the same bytes are
+/// reinterpreted per command, so a mismatch can make it read a flag as a pointer.
 ///
-/// Every pointer field set in `attr` must be valid for the access the kernel
-/// makes through it and must stay live for the duration of the call. The kernel
-/// dereferences those pointers directly and nothing ties them to `attr`.
+/// Every pointer field in `attr` must be valid and stay live for the call — the
+/// kernel dereferences them directly and nothing ties them to `attr`.
 unsafe fn bpf<A: BpfAttr>(cmd: i32, attr: &mut A) -> libc::c_long {
-    // SAFETY: `attr` is uniquely borrowed for the whole call, and `BpfAttr`
-    // guarantees the `size_of::<A>()` bytes the kernel is told to read are
-    // padding-free, hence fully initialized by the fields written into it.
-    // Validity of the buffers those fields point at is the caller's precondition.
+    // SAFETY: `attr` is uniquely borrowed for the call and padding-free per
+    // `BpfAttr`, so its bytes are initialized; the caller guarantees the buffers.
     unsafe {
         libc::syscall(
             libc::SYS_bpf,
@@ -460,13 +435,11 @@ unsafe fn bpf<A: BpfAttr>(cmd: i32, attr: &mut A) -> libc::c_long {
     }
 }
 
-/// One `BPF_PROG_LOAD` attempt. `log` is supplied only on the retry after a
-/// failure: with a log attached the verifier traces every instruction, and it
-/// fails the whole load if the trace does not fit.
+/// `log` is supplied only on the retry after a failure: with a log attached the
+/// verifier traces every instruction and fails the load if the trace does not fit.
 fn try_prog_load(prog: &[BpfInsn], log: Option<&mut [u8]>) -> std::io::Result<OwnedFd> {
-    // The kernel sizes its read through `insns` entirely from `insn_cnt`, so the
-    // count is derived here rather than passed in: the pointer and the length it
-    // is read with cannot then disagree.
+    // Derived here rather than passed in: the kernel sizes its read through `insns`
+    // entirely from `insn_cnt`, so pointer and length cannot disagree.
     let insn_cnt = u32::try_from(prog.len())
         .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
     let mut attr = ProgLoadAttr {
@@ -486,10 +459,8 @@ fn try_prog_load(prog: &[BpfInsn], log: Option<&mut [u8]>) -> std::io::Result<Ow
         attr.log_buf = log.as_mut_ptr() as u64;
     }
 
-    // SAFETY: `ProgLoadAttr` is the union member BPF_PROG_LOAD reads, and `insn_cnt`
-    // is derived from `prog.len()`, so the kernel reads exactly that slice and no
-    // further. `prog` is borrowed for this whole function, `log_buf` points into the
-    // `Vec` the caller owns across the call, and the license is a `'static` `CStr`.
+    // SAFETY: `ProgLoadAttr` is BPF_PROG_LOAD's union member and `insn_cnt` comes
+    // from `prog.len()`; `prog`, `log` and the `'static` license all outlive the call.
     let fd = unsafe { bpf(BPF_PROG_LOAD, &mut attr) };
     if fd < 0 {
         return Err(std::io::Error::last_os_error());
@@ -505,10 +476,8 @@ fn verifier_log_text(buf: &[u8]) -> String {
     String::from_utf8_lossy(&buf[..end]).trim_end().to_string()
 }
 
-/// The `EPERM` diagnostic for a failed `bpf()` command. The kernel gates the load
-/// itself on `bpf_capable()`, so a capability-starved agent never reaches the
-/// attach and the hint has to be on both. `other_cause` names whatever else the
-/// command can return `EPERM` for, since the errno distinguishes neither.
+/// The load is gated on `bpf_capable()`, so both paths need the capability hint;
+/// `other_cause` names whatever else returns `EPERM`, since the errno cannot.
 fn eperm_hint(err: &std::io::Error, other_cause: Option<&str>) -> String {
     if err.raw_os_error() != Some(libc::EPERM) {
         return String::new();
@@ -526,9 +495,8 @@ fn bpf_prog_load(prog: &[BpfInsn]) -> anyhow::Result<OwnedFd> {
         Err(e) => e,
     };
 
-    // Re-run the failed load with a log attached: on a real node the verifier's
-    // rejection message is the only diagnostic anyone gets. Discarding the retry's
-    // result is safe either way — a surprise success drops its fd here unattached.
+    // The verifier's rejection message is the only diagnostic a real node gets.
+    // Discarding the retry is safe: a surprise success drops its fd unattached.
     let mut log = vec![0u8; VERIFIER_LOG_SIZE];
     drop(try_prog_load(prog, Some(&mut log)));
     let log = verifier_log_text(&log);
@@ -560,13 +528,12 @@ fn prog_attach_attr(prog_fd: RawFd, cgroup_fd: RawFd) -> ProgAttachAttr {
 /// neither descriptor can be closed while the syscall is in flight.
 fn bpf_prog_attach(prog_fd: &OwnedFd, cgroup_dir: &File) -> anyhow::Result<()> {
     let mut attr = prog_attach_attr(prog_fd.as_raw_fd(), cgroup_dir.as_raw_fd());
-    // SAFETY: `ProgAttachAttr` is the union member BPF_PROG_ATTACH reads, and it
-    // holds only descriptors and flags, so the kernel dereferences nothing and
-    // there is no buffer to keep alive.
+    // SAFETY: `ProgAttachAttr` is BPF_PROG_ATTACH's union member and holds only
+    // descriptors and flags, so the kernel dereferences nothing.
     if unsafe { bpf(BPF_PROG_ATTACH, &mut attr) } < 0 {
         let err = std::io::Error::last_os_error();
-        // The two causes need opposite responses: grant a capability, or find and
-        // relax the ancestor.
+        // The two causes need opposite responses: grant a capability, or relax the
+        // ancestor.
         let hint = eperm_hint(
             &err,
             Some("an ancestor cgroup already holds an exclusive device program"),
@@ -578,9 +545,8 @@ fn bpf_prog_attach(prog_fd: &OwnedFd, cgroup_dir: &File) -> anyhow::Result<()> {
 
 /// Compile `rules` into a default-deny device filter and attach it to `cgroup_dir`.
 ///
-/// Both descriptors are dropped before returning. The attachment holds its own
-/// kernel reference, so it is then the program's only owner and removing the
-/// cgroup directory at teardown detaches and frees it — there is nothing to detach.
+/// Both descriptors drop before returning, leaving the attachment the program's only
+/// owner: removing the cgroup at teardown frees it, so there is nothing to detach.
 pub fn install_device_filter(cgroup_dir: &Path, rules: &[DeviceRule]) -> anyhow::Result<()> {
     let prog = build_device_filter(rules);
     let prog_fd = bpf_prog_load(&prog)?;
@@ -812,9 +778,8 @@ mod tests {
         }
     }
 
-    /// Synthetic `struct bpf_cgroup_dev_ctx`. The type/access packing is spelled
-    /// out from the kernel ABI instead of reusing the codegen constants, so the
-    /// tests pin the layout independently of the code under test.
+    /// Synthetic `struct bpf_cgroup_dev_ctx`. The packing is spelled out from the
+    /// kernel ABI, not the codegen constants, so the layout is pinned independently.
     #[derive(Clone, Copy)]
     struct DevCtx {
         access_type: u32,
@@ -839,14 +804,11 @@ mod tests {
     const CTX_BASE: u64 = 0x1000;
     const STEP_LIMIT: usize = 4096;
 
-    /// Minimal BPF interpreter covering exactly the opcodes `build_device_filter`
-    /// emits, so the tests exercise the generated instruction stream rather than
-    /// trusting a hand-rolled encoding. Anything else panics: a mis-encoded
-    /// program that always allows would otherwise look like a healthy cluster.
+    /// Runs the generated instruction stream rather than a hand-rolled encoding. An
+    /// unhandled opcode panics: a mis-encoded always-allow program would look healthy.
     fn run_filter(prog: &[BpfInsn], ctx: DevCtx) -> u32 {
-        // Opcode bytes are written out from uapi/linux/bpf.h rather than reusing
-        // the module's constants, so a typo there cannot make codegen and
-        // interpreter agree on a wrong encoding.
+        // Re-derived from the kernel headers rather than the module's constants, so
+        // a typo cannot make codegen and interpreter agree on a wrong encoding.
         const LDX_W: u8 = 0x61; // BPF_LDX | BPF_MEM | BPF_W
         const MOV_IMM: u8 = 0xb4; // BPF_ALU | BPF_MOV | BPF_K
         const MOV_REG: u8 = 0xbc; // BPF_ALU | BPF_MOV | BPF_X
@@ -1014,9 +976,8 @@ mod tests {
         );
     }
 
-    /// The access complement must cover the full 16-bit access field: masking it
-    /// to the three bits that exist today would make an unknown bit AND to zero
-    /// and be allowed by every rule.
+    /// Masking the complement to the three bits that exist today would make an
+    /// unknown bit AND to zero and be allowed by every rule.
     #[test]
     fn filter_denies_an_access_bit_no_rule_can_grant() {
         const UNKNOWN_ACC: u8 = 8; // one past ACC_WRITE
@@ -1131,9 +1092,8 @@ mod tests {
         );
     }
 
-    /// The kernel rejects a capability-starved agent at load, so the load path is
-    /// where the hint is actually read — and there it must not send anyone hunting
-    /// for an ancestor cgroup that has nothing to do with it.
+    /// The load path is where the hint is actually read, and there it must not send
+    /// anyone hunting for an ancestor cgroup that has nothing to do with it.
     #[test]
     fn eperm_names_the_capability_on_every_path_and_the_ancestor_only_on_attach() {
         let eperm = std::io::Error::from_raw_os_error(libc::EPERM);

--- a/crates/spurd/src/device_cgroup.rs
+++ b/crates/spurd/src/device_cgroup.rs
@@ -476,15 +476,18 @@ fn verifier_log_text(buf: &[u8]) -> String {
     String::from_utf8_lossy(&buf[..end]).trim_end().to_string()
 }
 
-/// The load is gated on `bpf_capable()`, so both paths need the capability hint;
-/// `other_cause` names whatever else returns `EPERM`, since the errno cannot.
+/// Both the load and, on pre-CAP_BPF kernels, the attach gate on capabilities, so both
+/// paths carry this hint; `other_cause` names whatever else returns `EPERM`, as errno cannot.
 fn eperm_hint(err: &std::io::Error, other_cause: Option<&str>) -> String {
     if err.raw_os_error() != Some(libc::EPERM) {
         return String::new();
     }
+    // CGROUP_DEVICE is a net-admin program type, so the load needs CAP_BPF *and*
+    // CAP_NET_ADMIN, or CAP_SYS_ADMIN alone; older kernels also gate attach on CAP_NET_ADMIN.
+    const CAPS: &str = "CAP_BPF and CAP_NET_ADMIN, or CAP_SYS_ADMIN";
     match other_cause {
-        Some(cause) => format!(" (spurd needs CAP_BPF or CAP_SYS_ADMIN, or {cause})"),
-        None => " (spurd needs CAP_BPF or CAP_SYS_ADMIN)".to_string(),
+        Some(cause) => format!(" (spurd needs {CAPS}; or {cause})"),
+        None => format!(" (spurd needs {CAPS})"),
     }
 }
 
@@ -879,6 +882,29 @@ mod tests {
         );
     }
 
+    // The core of GPU isolation: render nodes share major 226 and differ only by minor,
+    // so a filter matching on major alone would hand a one-GPU job every GPU on the node.
+    #[test]
+    fn filter_denies_a_same_major_different_minor_device() {
+        let rules = rules_for_device_paths(&["/dev/dri/renderD128".to_string()], |_| {
+            Some((DevType::Char, 226, 128))
+        });
+        let prog = build_device_filter(&rules);
+        assert_eq!(
+            run_filter(
+                &prog,
+                dev_ctx(DevType::Char, ACC_READ | ACC_WRITE, 226, 128)
+            ),
+            1,
+            "the allocated render node (226:128) must be usable"
+        );
+        assert_eq!(
+            run_filter(&prog, dev_ctx(DevType::Char, ACC_READ, 226, 129)),
+            0,
+            "a sibling GPU on the same major (226:129) must be denied"
+        );
+    }
+
     #[test]
     fn filter_allows_base_pseudo_devices() {
         let prog = build_device_filter(&base_device_rules());
@@ -1100,13 +1126,18 @@ mod tests {
 
         let load = eperm_hint(&eperm, None);
         assert!(load.contains("CAP_BPF"), "load hint names the capability");
+        // CGROUP_DEVICE is a net-admin program type, so CAP_BPF on its own does not load it.
+        assert!(
+            load.contains("CAP_NET_ADMIN"),
+            "the hint must not imply CAP_BPF alone suffices: {load}"
+        );
         assert!(
             !load.contains("ancestor"),
             "the exclusive-attach conflict cannot cause a failed load: {load}"
         );
 
         let attach = eperm_hint(&eperm, Some("an ancestor cgroup already holds it"));
-        assert!(attach.contains("CAP_BPF"));
+        assert!(attach.contains("CAP_BPF") && attach.contains("CAP_NET_ADMIN"));
         assert!(attach.contains("an ancestor cgroup already holds it"));
 
         assert_eq!(

--- a/crates/spurd/src/device_cgroup.rs
+++ b/crates/spurd/src/device_cgroup.rs
@@ -64,11 +64,6 @@ pub fn base_device_rules() -> Vec<DeviceRule> {
 /// job's `device_paths`; denying them breaks jobs not reaching for a GPU at all.
 const HOST_INFRA_DEVICE_NODES: &[&str] = &[
     "/dev/fuse", // Apptainer/Singularity run inside the batch job
-    // CUDA initialization; enumerating a GPU still needs /dev/nvidia<N>.
-    "/dev/nvidiactl",
-    "/dev/nvidia-uvm",
-    "/dev/nvidia-uvm-tools",
-    "/dev/nvidia-modeset",
 ];
 
 /// Entry names are per-host (`uverbs0`, `nvidia-cap2`, ...), so these are enumerated.
@@ -83,8 +78,9 @@ const HOST_INFRA_DEVICE_DIRS: &[&str] = &[
 /// IB and NVIDIA majors are assigned dynamically, so these resolve by path like any
 /// allocated node; a node without that hardware has nothing to stat.
 ///
-/// Per-GPU compute nodes (`/dev/nvidia<N>`, `/dev/kfd`, `/dev/dri/*`) are
-/// deliberately absent — gating those on the allocation is the security property.
+/// GPU nodes are deliberately absent — per-GPU compute (`/dev/nvidia<N>`, `/dev/kfd`,
+/// `/dev/dri/*`) and vendor control (`nvidiactl`, `nvidia-uvm`) alike arrive through the
+/// allocation's CDI edits, so a job with no GPU gets none. Gating them there is the point.
 pub fn host_infra_device_paths() -> Vec<String> {
     let mut paths: Vec<String> = HOST_INFRA_DEVICE_NODES
         .iter()
@@ -661,16 +657,16 @@ mod tests {
     #[test]
     fn host_infra_list_covers_the_shared_nodes_no_allocation_grants() {
         let paths = host_infra_device_paths();
-        for expected in [
-            "/dev/fuse",
-            "/dev/nvidiactl",
-            "/dev/nvidia-uvm",
-            "/dev/nvidia-uvm-tools",
-            "/dev/nvidia-modeset",
-        ] {
+        assert!(
+            paths.iter().any(|p| p == "/dev/fuse"),
+            "/dev/fuse is host infrastructure, not an allocatable device"
+        );
+        // Vendor control nodes now arrive through the allocation's CDI edits; a job
+        // with no GPU must not receive them from the host-infrastructure set.
+        for denied in ["/dev/nvidiactl", "/dev/nvidia-uvm", "/dev/nvidia-modeset"] {
             assert!(
-                paths.iter().any(|p| p == expected),
-                "{expected} is host infrastructure, not an allocatable device"
+                !paths.iter().any(|p| p == denied),
+                "{denied} must come from the allocation, not host infrastructure"
             );
         }
         assert!(
@@ -760,7 +756,7 @@ mod tests {
         let paths = device_paths_for_job(&allocated, &extra);
         assert!(paths.iter().any(|p| p == "/dev/dri/renderD128"));
         assert!(paths.iter().any(|p| p == "/dev/site-accel0"));
-        assert!(paths.iter().any(|p| p == "/dev/nvidiactl"));
+        assert!(paths.iter().any(|p| p == "/dev/fuse"));
     }
 
     #[test]

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1230,12 +1230,18 @@ pub fn cgroup_oom_killed(cgroup_path: &Path) -> bool {
     })
 }
 
-/// Owns a job's cgroup between creation and the point a successful launch hands
-/// it to the caller. Every error return in between would otherwise strand the
-/// directory.
-struct CgroupGuard(Option<PathBuf>);
+/// Owns a job's cgroup until something else takes responsibility: a launch hands
+/// it to the caller, a teardown removes it. Error returns would strand it.
+#[must_use = "the cgroup is removed when this guard drops; bind it to choose when"]
+pub(crate) struct CgroupGuard(Option<PathBuf>);
 
 impl CgroupGuard {
+    /// Take over a cgroup already detached from its job. Removal is deferred to
+    /// the drop, so the holder picks a point where blocking is acceptable.
+    pub(crate) fn new(path: Option<PathBuf>) -> Self {
+        Self(path)
+    }
+
     fn path(&self) -> Option<&Path> {
         self.0.as_deref()
     }
@@ -1254,8 +1260,8 @@ impl Drop for CgroupGuard {
     }
 }
 
-/// Bounded to 200ms: the monitor loop holds the running-jobs lock across cleanup,
-/// and the next `setup_cgroup` clears any directory this gives up on.
+/// Bounded to 200ms: cleanup sits on the completion-reporting path, and the next
+/// `setup_cgroup` clears any directory this gives up on.
 const CGROUP_REMOVE_ATTEMPTS: u32 = 20;
 const CGROUP_REMOVE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
 

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -178,6 +178,9 @@ pub struct LaunchResult {
     pub stderr_path: String,
     /// Master fd of the PTY (only set when `io_mode == LaunchIo::Pty`).
     pub pty_master: Option<OwnedFd>,
+    /// The job's cgroup, released to the caller now that the launch succeeded.
+    /// The caller owns its removal from here on.
+    pub cgroup_path: Option<PathBuf>,
 }
 
 /// Owns the resolved fds for a job's stdio, built once and consumed by both
@@ -301,16 +304,12 @@ impl JobIoRaw {
 /// A running job process — either a tokio-managed child or a raw-forked container.
 pub enum RunningJob {
     /// Non-container jobs managed by tokio::process::Child.
-    Managed {
-        child: tokio::process::Child,
-        cgroup_path: Option<PathBuf>,
-    },
+    Managed { child: tokio::process::Child },
     /// Container jobs: raw fork with optional pidfd for PID-recycling safety.
     Forked {
         pid: i32,
         /// Holds a kernel reference preventing PID recycling. None on kernels < 5.3.
         _pidfd: Option<OwnedFd>,
-        cgroup_path: Option<PathBuf>,
         reaped: bool,
     },
     /// Allocation registered without a batch process (standalone srun).
@@ -438,14 +437,6 @@ impl RunningJob {
                 Ok(())
             }
             RunningJob::AllocationOnly => Ok(()),
-        }
-    }
-
-    pub fn take_cgroup(&mut self) -> Option<PathBuf> {
-        match self {
-            RunningJob::Managed { cgroup_path, .. } => cgroup_path.take(),
-            RunningJob::Forked { cgroup_path, .. } => cgroup_path.take(),
-            RunningJob::AllocationOnly => None,
         }
     }
 }
@@ -673,12 +664,13 @@ async fn spawn_job_process(
                 "stdin redirection is not supported for container jobs, ignoring"
             );
         }
-        let (job, pty_master) = launch_container_job(cfg, ctn, &env, job_io, cgroup_path).await?;
+        let (job, pty_master) = launch_container_job(cfg, ctn, &env, job_io, &cgroup_path).await?;
         return Ok(LaunchResult {
             job,
             stdout_path: stdout_resolved,
             stderr_path: stderr_resolved,
             pty_master,
+            cgroup_path: cgroup_path.into_inner(),
         });
     }
 
@@ -906,13 +898,11 @@ async fn spawn_job_process(
     );
 
     Ok(LaunchResult {
-        job: RunningJob::Managed {
-            child,
-            cgroup_path: cgroup_path.into_inner(),
-        },
+        job: RunningJob::Managed { child },
         stdout_path: stdout_resolved,
         stderr_path: stderr_resolved,
         pty_master,
+        cgroup_path: cgroup_path.into_inner(),
     })
 }
 
@@ -955,7 +945,7 @@ fn allocated_device_paths(plan: Option<&spur_devices::inject::HostInjectionPlan>
 }
 
 /// Set up a cgroups v2 hierarchy for a job.
-fn setup_cgroup(
+pub(crate) fn setup_cgroup(
     job_id: JobId,
     cgroup: &CgroupConfig,
     cpus: u32,
@@ -1178,9 +1168,47 @@ fn dup_cloexec(fd: RawFd) -> RawFd {
     unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 3) }
 }
 
+/// A child's pre-built cgroup join, ready to run from `pre_exec`. Built
+/// parent-side because nothing between fork and exec may allocate.
+pub(crate) struct CgroupJoin {
+    procs: CString,
+    log_fd: RawFd,
+}
+
+impl CgroupJoin {
+    /// `None` when the job has no cgroup, which leaves the child uncontained
+    /// rather than unlaunched — the degrade a non-root agent already produces.
+    pub(crate) fn for_cgroup(cgroup_path: Option<&Path>) -> Option<Self> {
+        let procs = CString::new(cgroup_path?.join("cgroup.procs").as_os_str().as_bytes()).ok()?;
+        // fd 2 is the child's own stdio by the time pre_exec runs, so warn on a
+        // dup of spurd's stderr instead of into the job's output.
+        let log_fd = dup_cloexec(libc::STDERR_FILENO);
+        Some(Self { procs, log_fd })
+    }
+
+    /// Call from `pre_exec`, while the child is still root: an unprivileged
+    /// process cannot write another cgroup's `cgroup.procs`.
+    pub(crate) fn join(&self) {
+        join_cgroup_self(&self.procs, self.log_fd);
+    }
+
+    #[cfg(test)]
+    fn procs_path(&self) -> &std::ffi::CStr {
+        &self.procs
+    }
+}
+
+impl Drop for CgroupJoin {
+    fn drop(&mut self) {
+        if self.log_fd >= 0 {
+            unsafe { libc::close(self.log_fd) };
+        }
+    }
+}
+
 /// Whether `pid` is in the job's cgroup. The child joins itself pre-exec, so
 /// this verifies the join rather than performing it.
-fn cgroup_has_pid(cgroup_path: &Path, pid: u32) -> bool {
+pub(crate) fn cgroup_has_pid(cgroup_path: &Path, pid: u32) -> bool {
     let Ok(procs) = std::fs::read_to_string(cgroup_path.join("cgroup.procs")) else {
         return false;
     };
@@ -1199,8 +1227,9 @@ pub fn cgroup_oom_killed(cgroup_path: &Path) -> bool {
     })
 }
 
-/// Owns a job's cgroup between creation and the point the running job takes it
-/// over. Every error return in between would otherwise strand the directory.
+/// Owns a job's cgroup between creation and the point a successful launch hands
+/// it to the caller. Every error return in between would otherwise strand the
+/// directory.
 struct CgroupGuard(Option<PathBuf>);
 
 impl CgroupGuard {
@@ -1731,7 +1760,7 @@ async fn launch_container_job(
     ctn: &ContainerLaunchConfig,
     env: &HashMap<String, String>,
     job_io: JobIo,
-    cgroup_path: CgroupGuard,
+    cgroup_path: &CgroupGuard,
 ) -> anyhow::Result<(RunningJob, Option<OwnedFd>)> {
     let job_id = cfg.job_id;
 
@@ -1919,7 +1948,6 @@ async fn launch_container_job(
                 RunningJob::Forked {
                     pid: child_pid,
                     _pidfd: pidfd,
-                    cgroup_path: cgroup_path.into_inner(),
                     reaped: false,
                 },
                 pty_master,
@@ -2082,6 +2110,29 @@ mod cpuset_tests {
     fn keeps_the_full_set_when_the_parent_permits_it() {
         assert_eq!(permitted_cores(&[0, 1, 2, 3], "0-3"), vec![0, 1, 2, 3]);
         assert_eq!(permitted_cores(&[2, 3], "0-1,2-3"), vec![2, 3]);
+    }
+}
+
+#[cfg(test)]
+mod cgroup_join_tests {
+    use super::CgroupJoin;
+    use std::path::Path;
+
+    #[test]
+    fn a_job_with_a_cgroup_is_wired_to_join_its_procs_file() {
+        let join = CgroupJoin::for_cgroup(Some(Path::new("/sys/fs/cgroup/spur/job_7")))
+            .expect("a job with a cgroup must be wired to join it");
+        assert_eq!(
+            join.procs_path().to_bytes(),
+            b"/sys/fs/cgroup/spur/job_7/cgroup.procs"
+        );
+    }
+
+    #[test]
+    fn a_job_without_a_cgroup_has_nothing_to_join() {
+        // Degraded, not fatal: a non-root agent creates no cgroup, and the
+        // child still has to run.
+        assert!(CgroupJoin::for_cgroup(None).is_none());
     }
 }
 

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -770,7 +770,8 @@ async fn spawn_job_process(
         let log_fd = cgroup_log_fd;
         unsafe {
             cmd.pre_exec(move || {
-                join_cgroup_self(&procs, log_fd);
+                // Best-effort here; `required` is enforced parent-side below via cgroup_has_pid.
+                let _ = join_cgroup_self(&procs, log_fd);
                 Ok(())
             });
         }
@@ -990,22 +991,19 @@ pub(crate) fn setup_cgroup(
             degrade(&format!("controller {ctrl} not delegated"));
         }
     }
-    // A leaked dir keeps its device program, which a job installing no filter of
-    // its own would inherit. `rmdir` fails EBUSY on a live cgroup, so only stale ones go.
-    let _ = std::fs::remove_dir(&cgroup_path);
-    if let Err(e) = std::fs::create_dir_all(&cgroup_path) {
-        if nix::unistd::geteuid().is_root() {
-            anyhow::bail!("cgroup creation failed as root: {}", e);
+    if let Err(e) = claim_cgroup_dir(&cgroup_path) {
+        match classify_cgroup_claim_failure(
+            &e,
+            nix::unistd::geteuid().is_root(),
+            cgroup.required,
+            &cgroup_path,
+        ) {
+            CgroupClaim::Fatal(msg) => anyhow::bail!(msg),
+            CgroupClaim::Degrade => {
+                warn!(job_id, error = %e, "cgroup unavailable; job runs without isolation");
+                return Ok(None);
+            }
         }
-        if cgroup.required {
-            anyhow::bail!("[cgroup] required but the job cgroup could not be created: {e}");
-        }
-        warn!(
-            job_id,
-            error = %e,
-            "cgroup creation failed (not root), running without isolation"
-        );
-        return Ok(None);
     }
 
     // Core ids come from a synthesized 0..n range, which can name cores this
@@ -1121,9 +1119,10 @@ fn permitted_cores(requested: &[u32], parent_effective: &str) -> Vec<u32> {
         .collect()
 }
 
-/// Join the calling process to a cgroup (its pid → `cgroup.procs`). Runs post-fork
-/// pre-exec so it's async-signal-safe (raw syscalls only); best-effort, warns to `log_fd`.
-fn join_cgroup_self(procs_path: &std::ffi::CStr, log_fd: RawFd) {
+/// Join the calling process to a cgroup (pid → `cgroup.procs`), returning whether it landed.
+/// Async-signal-safe (raw syscalls only) for post-fork pre-exec use; warns to `log_fd` on failure.
+#[must_use]
+fn join_cgroup_self(procs_path: &std::ffi::CStr, log_fd: RawFd) -> bool {
     let pid = unsafe { libc::getpid() };
 
     let mut buf = [0u8; 24];
@@ -1143,14 +1142,17 @@ fn join_cgroup_self(procs_path: &std::ffi::CStr, log_fd: RawFd) {
         let fd = libc::open(procs_path.as_ptr(), libc::O_WRONLY);
         if fd < 0 {
             warn_cgroup_join_failed(log_fd);
-            return;
+            return false;
         }
         let written = libc::write(fd, digits.as_ptr() as *const libc::c_void, digits.len());
         libc::close(fd);
-        if written < 0 {
+        // cgroup.procs takes the whole pid in one write or errors; a short count is a failure.
+        if written != digits.len() as isize {
             warn_cgroup_join_failed(log_fd);
+            return false;
         }
     }
+    true
 }
 
 /// Async-signal-safe warning for a failed cgroup join: a fixed message to
@@ -1189,10 +1191,10 @@ impl CgroupJoin {
         Some(Self { procs, log_fd })
     }
 
-    /// Call from `pre_exec`, while the child is still root: an unprivileged
-    /// process cannot write another cgroup's `cgroup.procs`.
-    pub(crate) fn join(&self) {
-        join_cgroup_self(&self.procs, self.log_fd);
+    /// Call from `pre_exec`, while the child is still root: an unprivileged process
+    /// cannot write another cgroup's `cgroup.procs`. Returns whether the join landed.
+    pub(crate) fn join(&self) -> bool {
+        join_cgroup_self(&self.procs, self.log_fd)
     }
 
     #[cfg(test)]
@@ -1264,6 +1266,48 @@ impl Drop for CgroupGuard {
 /// `setup_cgroup` clears any directory this gives up on.
 const CGROUP_REMOVE_ATTEMPTS: u32 = 20;
 const CGROUP_REMOVE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+
+/// Take a job's cgroup directory, clearing a leftover one first. `AlreadyExists` means the
+/// leftover could not be removed, which the caller refuses to adopt: it may carry another
+/// run's processes, limits and device filter.
+fn claim_cgroup_dir(cgroup_path: &Path) -> std::io::Result<()> {
+    if cgroup_path.exists() {
+        cleanup_cgroup(cgroup_path);
+    }
+    std::fs::create_dir(cgroup_path)
+}
+
+/// Whether a failed cgroup claim must fail the launch or may run without isolation.
+enum CgroupClaim {
+    Fatal(String),
+    Degrade,
+}
+
+/// A surviving or uncreatable cgroup is never adopted; the choice is only fail vs. run
+/// unconstrained. Fail closed for root (a survival means live processes it should reap) or
+/// `required`; else degrade, so a root-owned leftover a non-root agent cannot remove never wedges.
+fn classify_cgroup_claim_failure(
+    err: &std::io::Error,
+    is_root: bool,
+    required: bool,
+    cgroup_path: &Path,
+) -> CgroupClaim {
+    if is_root {
+        if err.kind() == std::io::ErrorKind::AlreadyExists {
+            return CgroupClaim::Fatal(format!(
+                "job cgroup {} could not be cleared for reuse (live processes still in it)",
+                cgroup_path.display()
+            ));
+        }
+        return CgroupClaim::Fatal(format!("cgroup creation failed as root: {err}"));
+    }
+    if required {
+        return CgroupClaim::Fatal(format!(
+            "[cgroup] required but the job cgroup could not be created: {err}"
+        ));
+    }
+    CgroupClaim::Degrade
+}
 
 /// Kill any leftover processes in the job's cgroup and remove the directory.
 pub fn cleanup_cgroup(cgroup_path: &Path) {
@@ -1844,9 +1888,10 @@ async fn launch_container_job(
             }
 
             // Join while still root, before pivot_root hides the host cgroupfs and
-            // before close_inherited_fds reaps the log fd.
+            // before close_inherited_fds reaps the log fd. `required` is verified
+            // parent-side after readiness, so a failure here is best-effort.
             if let Some(ref procs) = cgroup_procs {
-                join_cgroup_self(procs, cgroup_log_fd);
+                let _ = join_cgroup_self(procs, cgroup_log_fd);
             }
 
             crate::container::close_inherited_fds(ready_w);
@@ -2654,6 +2699,71 @@ mod tests {
     }
 
     #[test]
+    fn claiming_a_cgroup_dir_creates_it_when_nothing_is_there() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("job_1");
+        claim_cgroup_dir(&path).expect("a fresh id must get its directory");
+        assert!(path.is_dir());
+    }
+
+    #[test]
+    fn claiming_a_cgroup_dir_clears_an_empty_leftover() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("job_1");
+        std::fs::create_dir(&path).unwrap();
+        std::fs::write(path.join("marker"), "stale").unwrap();
+        std::fs::remove_file(path.join("marker")).unwrap();
+
+        claim_cgroup_dir(&path).expect("an empty leftover must be cleared and remade");
+        assert!(path.is_dir());
+    }
+
+    // A directory outliving its cleanup is how a live cgroup presents: rmdir fails while
+    // processes remain, and adopting it would hand them this run's limits and filter.
+    #[test]
+    fn claiming_refuses_a_leftover_that_survives_cleanup() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("job_1");
+        std::fs::create_dir(&path).unwrap();
+        std::fs::write(path.join("occupant"), "still here").unwrap();
+
+        let err = claim_cgroup_dir(&path).expect_err("a surviving cgroup must not be adopted");
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+    }
+
+    // A non-root agent inheriting a root-owned leftover cgroup it cannot remove gets EEXIST from
+    // the claim. Under required=false that must degrade to no isolation, not refuse the launch.
+    #[test]
+    fn a_nonroot_agent_degrades_when_a_leftover_cgroup_cannot_be_cleared() {
+        let eexist = std::io::Error::from(std::io::ErrorKind::AlreadyExists);
+        assert!(matches!(
+            classify_cgroup_claim_failure(&eexist, false, false, Path::new("/x/job_1")),
+            CgroupClaim::Degrade
+        ));
+        // A plain creation error degrades the same way for a non-root, non-required agent.
+        let eperm = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        assert!(matches!(
+            classify_cgroup_claim_failure(&eperm, false, false, Path::new("/x/job_1")),
+            CgroupClaim::Degrade
+        ));
+    }
+
+    // The safety directions the degrade must not weaken: a root agent that cannot clear a
+    // leftover has live processes to reckon with, and `required` means enforce or refuse.
+    #[test]
+    fn a_root_or_required_agent_still_fails_on_an_unclaimable_cgroup() {
+        let eexist = std::io::Error::from(std::io::ErrorKind::AlreadyExists);
+        assert!(matches!(
+            classify_cgroup_claim_failure(&eexist, true, false, Path::new("/x/job_1")),
+            CgroupClaim::Fatal(_)
+        ));
+        assert!(matches!(
+            classify_cgroup_claim_failure(&eexist, false, true, Path::new("/x/job_1")),
+            CgroupClaim::Fatal(_)
+        ));
+    }
+
+    #[test]
     fn write_job_scratch_is_executable_and_private() {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();
@@ -3195,18 +3305,24 @@ mod tests {
         std::fs::write(&path, "").unwrap();
         let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
 
-        join_cgroup_self(&c_path, -1);
+        assert!(
+            join_cgroup_self(&c_path, -1),
+            "a successful write must report joined"
+        );
 
         let written = std::fs::read_to_string(&path).unwrap();
         assert_eq!(written, std::process::id().to_string());
     }
 
     #[test]
-    fn join_cgroup_self_is_silent_when_the_path_is_missing() {
-        // Best-effort: a non-existent cgroup.procs must not panic, so a failed
-        // placement degrades to an unconstrained job instead of aborting launch.
+    fn join_cgroup_self_reports_failure_when_the_path_is_missing() {
+        // A non-existent cgroup.procs must not panic and must report the miss, so the
+        // caller can degrade (best-effort) or abort (`required`) as it chooses.
         let c_path = CString::new("/nonexistent/spur-test/cgroup.procs").unwrap();
-        join_cgroup_self(&c_path, -1);
+        assert!(
+            !join_cgroup_self(&c_path, -1),
+            "a missing cgroup must report not joined"
+        );
     }
 
     #[test]
@@ -3218,7 +3334,10 @@ mod tests {
         let (read_fd, write_fd) = (fds[0], fds[1]);
         let c_path = CString::new("/nonexistent/spur-test/cgroup.procs").unwrap();
 
-        join_cgroup_self(&c_path, write_fd);
+        assert!(
+            !join_cgroup_self(&c_path, write_fd),
+            "the failed join must be reported"
+        );
         unsafe { libc::close(write_fd) };
 
         let mut buf = [0u8; 128];

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -19,6 +19,8 @@ use spur_core::config::{CgroupConfig, CgroupLimits, MemlockLimit};
 use spur_core::job::JobId;
 use spur_spank::{SpankContext, SpankHandle, SpankHost};
 
+use crate::device_cgroup;
+
 /// Typed launch errors so callers can distinguish a broken node from a job that
 /// simply cannot run here.
 pub enum LaunchError {
@@ -505,7 +507,15 @@ async fn spawn_job_process(
     info!(job_id, work_dir, "launching job");
 
     // Set up cgroup for isolation
-    let cgroup_path = CgroupGuard(setup_cgroup(job_id, &cfg.cgroup, cpus, memory_mb, cpu_ids)?);
+    let device_paths = allocated_device_paths(cfg.host_device_plan.as_ref());
+    let cgroup_path = CgroupGuard(setup_cgroup(
+        job_id,
+        &cfg.cgroup,
+        cpus,
+        memory_mb,
+        cpu_ids,
+        device_paths,
+    )?);
 
     // Ensure work_dir exists on this node (the submitted path may only exist on the submitting
     // node). If creation fails (e.g. path is under another user's home), fall back to /tmp so
@@ -938,6 +948,13 @@ fn cgroup_limit_files(limits: &CgroupLimits) -> Vec<(&'static str, String)> {
     files
 }
 
+/// Device nodes the job's allocation granted. No injection plan means no devices
+/// were allocated, which must stay an empty list: the device filter allows exactly
+/// what it is handed, so anything else here would hand a zero-GPU job a GPU.
+fn allocated_device_paths(plan: Option<&spur_devices::inject::HostInjectionPlan>) -> &[String] {
+    plan.map(|p| p.device_paths.as_slice()).unwrap_or(&[])
+}
+
 /// Set up a cgroups v2 hierarchy for a job.
 fn setup_cgroup(
     job_id: JobId,
@@ -945,6 +962,7 @@ fn setup_cgroup(
     cpus: u32,
     memory_mb: u64,
     cpu_ids: &[u32],
+    device_paths: &[String],
 ) -> anyhow::Result<Option<PathBuf>> {
     let Some(mut limits) = cgroup.limits_for(cpus, memory_mb, cpu_ids) else {
         debug!(job_id, "cgroup enforcement disabled by config");
@@ -1045,6 +1063,17 @@ fn setup_cgroup(
         // every core on the node — the clamp above can empty a non-empty set.
         warn!(job_id, "no cores to pin; job runs without a CPU bound");
         degrade("no cores to pin");
+    }
+
+    // Attach before any of the job's processes join: the filter is consulted at
+    // open(2), so a device a process already holds open stays readable regardless.
+    if cgroup.constrain_devices {
+        let paths = device_cgroup::device_paths_for_job(device_paths, &cgroup.extra_device_paths);
+        let rules = device_cgroup::rules_for_device_paths(&paths, device_cgroup::stat_device_node);
+        if let Err(e) = device_cgroup::install_device_filter(&cgroup_path, &rules) {
+            warn!(job_id, error = %e, "device filter not installed; job runs without device isolation");
+            degrade("device filter not installed");
+        }
     }
 
     if let Some(reason) = degraded {
@@ -1924,18 +1953,30 @@ fn build_namespace_wrapper(
     visible_device_paths: &[String],
     script_path: &Path,
 ) -> String {
-    let gpu_mounts = visible_device_paths
+    let dri_nodes: Vec<&str> = visible_device_paths
         .iter()
         .filter(|p| p.starts_with("/dev/dri/"))
-        .map(|path| {
-            let basename = path.rsplit('/').next().unwrap_or("");
-            format!(
-                "  if [ -e $SPUR_HOST_DRI/{b} ]; then\n    cp -a $SPUR_HOST_DRI/{b} /dev/dri/{b} 2>/dev/null || true\n  fi\n",
-                b = basename,
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("");
+        .filter_map(|p| p.rsplit('/').next())
+        .filter(|b| !b.is_empty())
+        .collect();
+    let stash_dri = dri_nodes
+        .iter()
+        .map(|b| format!("  cp -a /dev/dri/{b} $SPUR_HOST_DRI/{b} 2>/dev/null || true\n"))
+        .collect::<String>();
+
+    // The restore is gated on the mount: without the tmpfs it would land on the
+    // host's real /dev/dri, and `cp` unlinks a special file before recreating it.
+    // A failed mount stays non-fatal — it just skips the restore.
+    const MOUNT_DRI: &str = "mount -t tmpfs tmpfs /dev/dri 2>/dev/null";
+    let mount_and_restore_dri = if dri_nodes.is_empty() {
+        format!("  {MOUNT_DRI} || true\n")
+    } else {
+        let restore = dri_nodes
+            .iter()
+            .map(|b| format!("    cp -a $SPUR_HOST_DRI/{b} /dev/dri/{b} 2>/dev/null || true\n"))
+            .collect::<String>();
+        format!("  if {MOUNT_DRI}; then\n{restore}  fi\n")
+    };
 
     let final_exec = if uid > 0 {
         format!(
@@ -1954,16 +1995,19 @@ fn build_namespace_wrapper(
             "# Namespace isolation wrapper — all mounts best-effort\n",
             "mount -t proc proc /proc 2>/dev/null || true\n",
             "mount -t tmpfs tmpfs /dev/shm 2>/dev/null || true\n",
-            "# GPU device restriction: save original /dev/dri, replace with\n",
-            "# tmpfs, then selectively copy only allocated devices back.\n",
+            "# GPU device restriction: stash the allocated /dev/dri nodes, replace\n",
+            "# the directory with a tmpfs, then copy only those back. Staging any\n",
+            "# other node would mknod a device the cgroup device filter denies.\n",
             "SPUR_HOST_DRI=$(mktemp -d /tmp/.spur_dri_XXXXXX 2>/dev/null || echo /tmp/.spur_dri)\n",
-            "if [ -d /dev/dri ] && cp -a /dev/dri/. $SPUR_HOST_DRI/ 2>/dev/null; then\n",
-            "  mount -t tmpfs tmpfs /dev/dri 2>/dev/null || true\n",
-            "{gpu_mounts}",
+            "if [ -d /dev/dri ]; then\n",
+            "  mkdir -p $SPUR_HOST_DRI 2>/dev/null || true\n",
+            "{stash_dri}",
+            "{mount_and_restore_dri}",
             "fi\n",
             "{final_exec}",
         ),
-        gpu_mounts = gpu_mounts,
+        stash_dri = stash_dri,
+        mount_and_restore_dri = mount_and_restore_dri,
         final_exec = final_exec,
     )
 }
@@ -2815,6 +2859,78 @@ mod tests {
 
         assert!(wrapper.contains("renderD128"));
         assert!(!wrapper.contains("nvidia"));
+    }
+
+    /// A bulk `cp -a /dev/dri/.` recreates every host node with `mknod(2)`, which
+    /// the device filter denies for nodes this job does not hold — and a failure
+    /// there must never be able to skip the tmpfs that hides them.
+    #[test]
+    fn test_namespace_wrapper_stages_only_allocated_dri_nodes() {
+        let script = PathBuf::from("/work/.spur_job_9.sh");
+        let paths = vec!["/dev/dri/renderD128".into()];
+        let wrapper = build_namespace_wrapper(1000, 1000, &paths, &script);
+
+        assert!(
+            !wrapper.contains("/dev/dri/."),
+            "no bulk copy of the host directory:\n{wrapper}"
+        );
+        assert!(
+            wrapper.contains("cp -a /dev/dri/renderD128 $SPUR_HOST_DRI/renderD128"),
+            "the job's own node is staged:\n{wrapper}"
+        );
+        assert!(
+            wrapper.contains("cp -a $SPUR_HOST_DRI/renderD128 /dev/dri/renderD128"),
+            "and restored onto the tmpfs:\n{wrapper}"
+        );
+        let mount = wrapper
+            .find("mount -t tmpfs tmpfs /dev/dri")
+            .expect("missing /dev/dri tmpfs mount");
+        let restore = wrapper
+            .find("cp -a $SPUR_HOST_DRI/")
+            .expect("missing restore");
+        assert!(
+            mount < restore,
+            "the tmpfs must be mounted before nodes are restored onto it:\n{wrapper}"
+        );
+        assert!(
+            wrapper.contains("if mount -t tmpfs tmpfs /dev/dri 2>/dev/null; then"),
+            "and the restore must be gated on that mount: against the host's real \
+             /dev/dri, `cp` unlinks the node before recreating it:\n{wrapper}"
+        );
+    }
+
+    /// A job allocated no render nodes must still get the empty tmpfs; skipping the
+    /// mount would leave every GPU on the node visible in `/dev/dri`.
+    #[test]
+    fn test_namespace_wrapper_mounts_empty_dri_tmpfs_without_gpus() {
+        let script = PathBuf::from("/work/.spur_job_10.sh");
+        let wrapper = build_namespace_wrapper(1000, 1000, &[], &script);
+
+        assert!(
+            wrapper.contains("mount -t tmpfs tmpfs /dev/dri"),
+            "zero-GPU job must still hide the host's /dev/dri:\n{wrapper}"
+        );
+        assert!(
+            !wrapper.contains("cp -a"),
+            "nothing is staged for a job with no allocated nodes:\n{wrapper}"
+        );
+    }
+
+    /// The security-critical direction: a job launched without an injection plan
+    /// was allocated nothing, so the filter must be built from an empty list.
+    #[test]
+    fn no_injection_plan_yields_no_device_paths() {
+        assert!(allocated_device_paths(None).is_empty());
+
+        let plan = spur_devices::inject::HostInjectionPlan {
+            device_paths: vec!["/dev/dri/renderD128".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(
+            allocated_device_paths(Some(&plan)),
+            ["/dev/dri/renderD128"],
+            "a plan's paths reach the filter unchanged"
+        );
     }
 
     #[tokio::test]

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -990,6 +990,9 @@ pub(crate) fn setup_cgroup(
             degrade(&format!("controller {ctrl} not delegated"));
         }
     }
+    // A leaked dir keeps its device program, which a job installing no filter of
+    // its own would inherit. `rmdir` fails EBUSY on a live cgroup, so only stale ones go.
+    let _ = std::fs::remove_dir(&cgroup_path);
     if let Err(e) = std::fs::create_dir_all(&cgroup_path) {
         if nix::unistd::geteuid().is_root() {
             anyhow::bail!("cgroup creation failed as root: {}", e);
@@ -1251,6 +1254,11 @@ impl Drop for CgroupGuard {
     }
 }
 
+/// Bounded to 200ms: the monitor loop holds the running-jobs lock across cleanup,
+/// and the next `setup_cgroup` clears any directory this gives up on.
+const CGROUP_REMOVE_ATTEMPTS: u32 = 20;
+const CGROUP_REMOVE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+
 /// Kill any leftover processes in the job's cgroup and remove the directory.
 pub fn cleanup_cgroup(cgroup_path: &Path) {
     // Kill any remaining processes
@@ -1262,9 +1270,17 @@ pub fn cleanup_cgroup(cgroup_path: &Path) {
         }
     }
 
-    // Remove cgroup directory
-    if let Err(e) = std::fs::remove_dir(cgroup_path) {
-        warn!(error = %e, path = %cgroup_path.display(), "failed to remove cgroup");
+    // `kill` returning does not mean the process has left the cgroup, and rmdir
+    // fails EBUSY until it has. An abandoned dir strands its device program.
+    for attempt in 1..=CGROUP_REMOVE_ATTEMPTS {
+        match std::fs::remove_dir(cgroup_path) {
+            Ok(()) => return,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+            Err(e) if attempt == CGROUP_REMOVE_ATTEMPTS => {
+                warn!(error = %e, path = %cgroup_path.display(), "failed to remove cgroup");
+            }
+            Err(_) => std::thread::sleep(CGROUP_REMOVE_INTERVAL),
+        }
     }
 }
 
@@ -2138,7 +2154,7 @@ mod cgroup_join_tests {
 
 #[cfg(test)]
 mod cgroup_guard_tests {
-    use super::CgroupGuard;
+    use super::{cleanup_cgroup, CgroupGuard};
 
     #[test]
     fn dropping_the_guard_removes_the_cgroup() {
@@ -2169,6 +2185,35 @@ mod cgroup_guard_tests {
     #[test]
     fn a_disabled_cgroup_is_a_no_op() {
         drop(CgroupGuard(None));
+    }
+
+    #[test]
+    fn cleanup_removes_an_empty_cgroup() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("job_3");
+        std::fs::create_dir(&cgroup).unwrap();
+
+        cleanup_cgroup(&cgroup);
+        assert!(!cgroup.exists());
+    }
+
+    #[test]
+    fn cleanup_gives_up_on_a_cgroup_that_never_empties() {
+        // A non-empty dir fails rmdir the way a busy cgroup does, so this exhausts
+        // the retry budget; reaching the assert at all is the property under test.
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("job_4");
+        std::fs::create_dir(&cgroup).unwrap();
+        std::fs::write(cgroup.join("cgroup.procs"), "not-a-pid\n").unwrap();
+
+        cleanup_cgroup(&cgroup);
+        assert!(cgroup.exists());
+    }
+
+    #[test]
+    fn cleanup_of_a_missing_cgroup_is_a_no_op() {
+        let dir = tempfile::tempdir().unwrap();
+        cleanup_cgroup(&dir.path().join("job_5"));
     }
 }
 

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -948,9 +948,8 @@ fn cgroup_limit_files(limits: &CgroupLimits) -> Vec<(&'static str, String)> {
     files
 }
 
-/// Device nodes the job's allocation granted. No injection plan means no devices
-/// were allocated, which must stay an empty list: the device filter allows exactly
-/// what it is handed, so anything else here would hand a zero-GPU job a GPU.
+/// No injection plan means no devices were allocated, and must stay an empty list:
+/// the filter allows exactly what it is handed.
 fn allocated_device_paths(plan: Option<&spur_devices::inject::HostInjectionPlan>) -> &[String] {
     plan.map(|p| p.device_paths.as_slice()).unwrap_or(&[])
 }
@@ -1964,9 +1963,8 @@ fn build_namespace_wrapper(
         .map(|b| format!("  cp -a /dev/dri/{b} $SPUR_HOST_DRI/{b} 2>/dev/null || true\n"))
         .collect::<String>();
 
-    // The restore is gated on the mount: without the tmpfs it would land on the
-    // host's real /dev/dri, and `cp` unlinks a special file before recreating it.
-    // A failed mount stays non-fatal — it just skips the restore.
+    // Gated on the mount: without the tmpfs the restore lands on the host's real
+    // /dev/dri, where `cp` unlinks the node before recreating it.
     const MOUNT_DRI: &str = "mount -t tmpfs tmpfs /dev/dri 2>/dev/null";
     let mount_and_restore_dri = if dri_nodes.is_empty() {
         format!("  {MOUNT_DRI} || true\n")
@@ -2861,9 +2859,8 @@ mod tests {
         assert!(!wrapper.contains("nvidia"));
     }
 
-    /// A bulk `cp -a /dev/dri/.` recreates every host node with `mknod(2)`, which
-    /// the device filter denies for nodes this job does not hold — and a failure
-    /// there must never be able to skip the tmpfs that hides them.
+    /// A bulk `cp -a /dev/dri/.` recreates every host node with `mknod(2)`, which the
+    /// filter denies — and that failure must not skip the tmpfs that hides them.
     #[test]
     fn test_namespace_wrapper_stages_only_allocated_dri_nodes() {
         let script = PathBuf::from("/work/.spur_job_9.sh");

--- a/crates/spurd/src/job_entry.rs
+++ b/crates/spurd/src/job_entry.rs
@@ -1,8 +1,10 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Namespace and isolation metadata for a tracked job, used to build the
-/// correct `nsenter` arguments for entering the job's execution context.
+use std::path::PathBuf;
+
+/// Namespace, cgroup, and isolation metadata for a tracked job, used to build
+/// the correct `nsenter` arguments for entering the job's execution context.
 #[derive(Debug, Clone)]
 pub struct JobEntry {
     pub pid: i32,
@@ -12,6 +14,9 @@ pub struct JobEntry {
     pub uid: u32,
     pub gid: u32,
     pub work_dir: String,
+    /// The job's cgroup, when one exists. It carries the job's resource limits
+    /// and device filter, so anything launched into the job belongs in it.
+    pub cgroup_path: Option<PathBuf>,
 }
 
 impl JobEntry {
@@ -74,6 +79,7 @@ mod tests {
             uid: 1000,
             gid: 1000,
             work_dir: "/home/user".into(),
+            cgroup_path: None,
         };
         let args = entry.nsenter_args();
         assert_eq!(
@@ -97,6 +103,7 @@ mod tests {
             uid: 0,
             gid: 0,
             work_dir: "/".into(),
+            cgroup_path: None,
         };
         let args = entry.nsenter_args();
         assert_eq!(
@@ -121,6 +128,7 @@ mod tests {
             uid: 1000,
             gid: 1000,
             work_dir: "/tmp".into(),
+            cgroup_path: None,
         };
         assert!(!entry.has_namespaces());
         let args = entry.nsenter_args();
@@ -137,6 +145,7 @@ mod tests {
             uid: 1000,
             gid: 1000,
             work_dir: "/".into(),
+            cgroup_path: None,
         };
         let args = entry.nsenter_args();
         assert_eq!(

--- a/crates/spurd/src/job_lifecycle.rs
+++ b/crates/spurd/src/job_lifecycle.rs
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-job-id serialization of the phases that create and destroy a job's state.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+type Entry = Arc<AsyncMutex<()>>;
+type Registry = Arc<Mutex<HashMap<u32, Entry>>>;
+
+/// Serializes setup and teardown for a given job id. A job's cgroup, spool dir and rootfs
+/// all derive from its id and the controller reuses that id on re-dispatch, so without
+/// this a launch and the previous run's teardown each act on the other's files.
+#[derive(Clone, Default)]
+pub(crate) struct JobLifecycle {
+    entries: Registry,
+}
+
+impl JobLifecycle {
+    pub(crate) async fn acquire(&self, job_id: u32) -> JobLifecycleGuard {
+        let entry = lock_registry(&self.entries)
+            .entry(job_id)
+            .or_default()
+            .clone();
+        let held = entry.lock_owned().await;
+        JobLifecycleGuard {
+            job_id,
+            entries: Arc::clone(&self.entries),
+            held: Some(held),
+        }
+    }
+}
+
+/// Poisoning means some holder panicked, not that the map is torn: it is only ever
+/// inserted into and removed from. Refusing it here would wedge every later launch.
+fn lock_registry(entries: &Registry) -> MutexGuard<'_, HashMap<u32, Entry>> {
+    entries.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Held for as long as the caller owns the job id's state. Nothing else may set up or
+/// tear down that id until it drops.
+#[must_use = "the lifecycle is serialized only while this guard is held"]
+pub(crate) struct JobLifecycleGuard {
+    job_id: u32,
+    entries: Registry,
+    held: Option<OwnedMutexGuard<()>>,
+}
+
+impl Drop for JobLifecycleGuard {
+    fn drop(&mut self) {
+        // Release first so this guard's own reference is not counted below.
+        self.held.take();
+        let mut entries = lock_registry(&self.entries);
+        // The sole remaining reference is the map's, so no one is waiting on this id
+        // and the entry can go rather than accumulating one per job the node ever ran.
+        if entries
+            .get(&self.job_id)
+            .is_some_and(|e| Arc::strong_count(e) == 1)
+        {
+            entries.remove(&self.job_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JobLifecycle;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn a_second_acquire_of_the_same_id_waits_for_the_first() {
+        let lifecycle = JobLifecycle::default();
+        let first = lifecycle.acquire(7).await;
+
+        let second_ran = Arc::new(AtomicBool::new(false));
+        let task = tokio::spawn({
+            let (lifecycle, ran) = (lifecycle.clone(), Arc::clone(&second_ran));
+            async move {
+                let _guard = lifecycle.acquire(7).await;
+                ran.store(true, Ordering::SeqCst);
+            }
+        });
+
+        tokio::task::yield_now().await;
+        assert!(
+            !second_ran.load(Ordering::SeqCst),
+            "teardown must not run while a launch of the same id holds the id"
+        );
+
+        drop(first);
+        task.await.expect("the waiter runs once the id is free");
+        assert!(second_ran.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn different_ids_do_not_block_each_other() {
+        let lifecycle = JobLifecycle::default();
+        let _held = lifecycle.acquire(1).await;
+        // Would hang if the registry serialized across ids rather than per id.
+        let _other = lifecycle.acquire(2).await;
+    }
+
+    #[tokio::test]
+    async fn a_released_id_leaves_nothing_behind() {
+        let lifecycle = JobLifecycle::default();
+        for job_id in 0..64 {
+            drop(lifecycle.acquire(job_id).await);
+        }
+        assert!(
+            super::lock_registry(&lifecycle.entries).is_empty(),
+            "a node that ran many jobs must not keep an entry per id"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_id_with_a_waiter_keeps_its_entry() {
+        let lifecycle = JobLifecycle::default();
+        let held = lifecycle.acquire(9).await;
+        let waiter = tokio::spawn({
+            let lifecycle = lifecycle.clone();
+            async move { lifecycle.acquire(9).await }
+        });
+        tokio::task::yield_now().await;
+
+        drop(held);
+        let still_held = waiter.await.expect("the waiter acquires");
+        assert_eq!(
+            super::lock_registry(&lifecycle.entries).len(),
+            1,
+            "pruning must not drop an entry another holder is using"
+        );
+        drop(still_held);
+        assert!(super::lock_registry(&lifecycle.entries).is_empty());
+    }
+}

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -8,6 +8,7 @@ pub mod container;
 mod device_cgroup;
 mod executor;
 pub(crate) mod job_entry;
+pub(crate) mod job_lifecycle;
 mod landlock;
 mod mpi_plugin;
 pub(crate) mod privdrop;

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -31,9 +31,8 @@ use reporter::NodeReporter;
 
 /// Raise spurd's own `RLIMIT_MEMLOCK` as high as it is allowed to go.
 ///
-/// Kernels before 5.11 charge a BPF program's memory against this limit instead
-/// of the memory cgroup, and the usual default admits only a handful of programs.
-/// Best-effort: on 5.11+ the limit does not gate BPF at all.
+/// Kernels before 5.11 charge BPF program memory against this limit instead of the
+/// memory cgroup, and the default admits only a handful. On 5.11+ it does not gate.
 fn raise_own_memlock_rlimit() {
     let unlimited = libc::rlimit {
         rlim_cur: libc::RLIM_INFINITY,
@@ -216,9 +215,8 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    // Raised before anything reads or inherits the limit, so a spawned helper and a
-    // `memlock = "inherit"` job both see the final value rather than depending on
-    // whether a BPF load happened to run first. Needs the subscriber for its log.
+    // Raised before anything reads or inherits it, so a `memlock = "inherit"` job
+    // does not depend on whether a BPF load ran first. Needs the subscriber to log.
     raise_own_memlock_rlimit();
 
     let hostname = args.hostname.unwrap_or_else(|| {

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -5,6 +5,7 @@ mod agent_server;
 mod auth_middleware;
 mod cluster;
 pub mod container;
+mod device_cgroup;
 mod executor;
 pub(crate) mod job_entry;
 mod landlock;
@@ -27,6 +28,44 @@ use spur_devices::cdi::cache::CdiCache;
 use spur_devices::DeviceRegistry;
 
 use reporter::NodeReporter;
+
+/// Raise spurd's own `RLIMIT_MEMLOCK` as high as it is allowed to go.
+///
+/// Kernels before 5.11 charge a BPF program's memory against this limit instead
+/// of the memory cgroup, and the usual default admits only a handful of programs.
+/// Best-effort: on 5.11+ the limit does not gate BPF at all.
+fn raise_own_memlock_rlimit() {
+    let unlimited = libc::rlimit {
+        rlim_cur: libc::RLIM_INFINITY,
+        rlim_max: libc::RLIM_INFINITY,
+    };
+    // SAFETY: each call below reads or writes only the local `rlimit` it is
+    // handed, which outlives the call.
+    if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &unlimited) } == 0 {
+        return;
+    }
+    // Without CAP_SYS_RESOURCE the hard limit will not move, but the soft one can
+    // still be raised to meet it.
+    let mut current = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    if unsafe { libc::getrlimit(libc::RLIMIT_MEMLOCK, &mut current) } == 0 {
+        let to_hard = libc::rlimit {
+            rlim_cur: current.rlim_max,
+            rlim_max: current.rlim_max,
+        };
+        if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &to_hard) } == 0 {
+            return;
+        }
+    }
+    // Visible at the default log level: this changes what jobs can do, and the
+    // operator docs promise the agent says so when it cannot raise the limit.
+    warn!(
+        error = %std::io::Error::last_os_error(),
+        "could not raise RLIMIT_MEMLOCK; BPF program loads may fail on kernels before 5.11"
+    );
+}
 
 fn log_memlock_status(memlock: spur_core::config::MemlockLimit) {
     use spur_core::config::MemlockLimit;
@@ -60,7 +99,7 @@ fn log_memlock_status(memlock: spur_core::config::MemlockLimit) {
 /// bounded at all, and the agent log is the only place that shows what it booted with.
 fn log_cgroup_status(cgroup: &spur_core::config::CgroupConfig) {
     if !cgroup.enabled {
-        warn!("[cgroup] enforcement disabled; jobs run with no cpu or memory bound");
+        warn!("[cgroup] enforcement disabled; jobs run with no cpu, memory or device bound");
         return;
     }
     info!(
@@ -73,6 +112,8 @@ fn log_cgroup_status(cgroup: &spur_core::config::CgroupConfig) {
         allowed_swap_percent = cgroup.allowed_swap_percent,
         min_ram_mb = cgroup.min_ram_mb,
         oom_kill_job = cgroup.oom_kill_job,
+        constrain_devices = cgroup.constrain_devices,
+        extra_device_paths = ?cgroup.extra_device_paths,
         "cgroup enforcement"
     );
     // An unprivileged agent cannot create the cgroup root, so `required` turns every
@@ -174,6 +215,11 @@ async fn main() -> anyhow::Result<()> {
                 .unwrap_or_else(|_| args.log_level.parse().unwrap()),
         )
         .init();
+
+    // Raised before anything reads or inherits the limit, so a spawned helper and a
+    // `memlock = "inherit"` job both see the final value rather than depending on
+    // whether a BPF load happened to run first. Needs the subscriber for its log.
+    raise_own_memlock_rlimit();
 
     let hostname = args.hostname.unwrap_or_else(|| {
         hostname::get()

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -1355,15 +1355,14 @@ isolation boundary and worth knowing:
   out per job, so no allocation can ever grant them: ``/dev/fuse`` (used by
   Apptainer and Singularity, which run *inside* the batch job), everything under
   ``/dev/infiniband/`` (RDMA verbs, for MPI and for NCCL or RCCL over InfiniBand),
-  the vendor control nodes a GPU runtime initializes through (``/dev/nvidiactl``,
-  ``/dev/nvidia-uvm``, ``/dev/nvidia-uvm-tools``, ``/dev/nvidia-modeset``), and the
-  MIG capability nodes under ``/dev/nvidia-caps/``. Every one is resolved by path
-  when the filter is built, so a node without that hardware grants nothing extra.
+  and the MIG capability nodes under ``/dev/nvidia-caps/``. Every one is resolved by
+  path when the filter is built, so a node without that hardware grants nothing extra.
 
-Granting the vendor control nodes to a job with no GPUs is deliberate: they let a
-GPU runtime initialize, but enumerating an actual device still needs that device's
-own node, so the job still sees zero GPUs. This matches what container runtimes
-inject as shared edits.
+The vendor control nodes a GPU runtime initializes through — ``/dev/nvidiactl``,
+``/dev/nvidia-uvm`` and the like — are **not** in this set. They reach a job through
+its allocation's CDI device edits, the same path as the per-GPU compute nodes, so a
+job with no GPU never gets them. A node configured through GRES rather than a CDI
+spec does not enumerate them as devices, so name them in ``extra_device_paths`` there.
 
 **The per-GPU compute nodes are not in that set.** ``/dev/nvidia<N>``, ``/dev/kfd``
 and the ``/dev/dri`` render and card nodes reach a job only through its allocation —

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -1193,10 +1193,10 @@ unaffected: there the kubelet owns the cgroups.
 
 .. warning::
 
-   These limits bound the batch payload only. ``srun`` steps, ``spur exec``, and
+   These settings bound the batch payload only. ``srun`` steps, ``spur exec``, and
    interactive attaches into a running job currently run outside the job cgroup,
-   so they are not bounded by these settings and this section is not a security
-   boundary between users sharing a node. See
+   so they get neither the resource limits nor the device filter, and this section
+   is not a security boundary between users sharing a node. See
    :ref:`cgroup-containment-gaps` for the full list.
 
 .. note::
@@ -1273,6 +1273,23 @@ unaffected: there the kubelet owns the cgroups.
      - ``true``
      - On OOM, kill every process in the job (``memory.oom.group``) instead of
        letting the kernel pick one.
+   * - ``constrain_devices``
+     - bool
+     - ``true``
+     - Restrict the job to the device nodes its allocation granted, using a
+       cgroup-v2 BPF device filter. Default-deny: a job allocated no GPUs can open
+       only the nodes listed under :ref:`device-filter-implicit-allow` below, and
+       opening an unallocated GPU fails with ``EPERM`` whatever the job sets
+       ``ROCR_VISIBLE_DEVICES`` to. Attaching the filter needs ``CAP_BPF`` or
+       ``CAP_SYS_ADMIN``; without them the job runs with no device isolation.
+   * - ``extra_device_paths``
+     - [string]
+     - ``[]``
+     - Additional device node paths **every** job on this node may open, on top of
+       its allocation and the implicit set below. The escape hatch for a site
+       device the defaults miss, short of turning the filter off. A path that is
+       not a device node is ignored, so an entry for hardware this node lacks is
+       harmless. Read once at agent startup, like the rest of ``[cgroup]``.
 
 A job submitted without ``--mem`` has no memory budget, so ``memory.max``,
 ``memory.high``, and ``memory.swap.max`` are all left at the kernel default.
@@ -1315,13 +1332,44 @@ combined RAM+swap total, so the sum a job can reach stays bounded.
 Every ceiling is floored at ``min_ram_mb``, and ``memory.high`` never exceeds
 ``memory.max``.
 
+.. _device-filter-implicit-allow:
+
+What the device filter allows without an allocation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A job's allow-list is its allocated device nodes plus two fixed sets. Both are
+granted to every job, including one that requested no GPUs, so they are part of the
+isolation boundary and worth knowing:
+
+- **Base pseudo-devices**, which virtually every program needs: ``/dev/null``,
+  ``/dev/zero``, ``/dev/full``, ``/dev/random``, ``/dev/urandom``, ``/dev/tty``,
+  ``/dev/console``, ``/dev/ptmx`` and ``/dev/pts/*``.
+- **Host infrastructure** — device nodes shared by the whole node rather than handed
+  out per job, so no allocation can ever grant them: ``/dev/fuse`` (used by
+  Apptainer and Singularity, which run *inside* the batch job), everything under
+  ``/dev/infiniband/`` (RDMA verbs, for MPI and for NCCL or RCCL over InfiniBand),
+  the vendor control nodes a GPU runtime initializes through (``/dev/nvidiactl``,
+  ``/dev/nvidia-uvm``, ``/dev/nvidia-uvm-tools``, ``/dev/nvidia-modeset``), and the
+  MIG capability nodes under ``/dev/nvidia-caps/``. Every one is resolved by path
+  when the filter is built, so a node without that hardware grants nothing extra.
+
+Granting the vendor control nodes to a job with no GPUs is deliberate: they let a
+GPU runtime initialize, but enumerating an actual device still needs that device's
+own node, so the job still sees zero GPUs. This matches what container runtimes
+inject as shared edits.
+
+**The per-GPU compute nodes are not in that set.** ``/dev/nvidia<N>``, ``/dev/kfd``
+and the ``/dev/dri`` render and card nodes reach a job only through its allocation —
+that gating is the entire point of the filter. Putting one of them in
+``extra_device_paths`` hands every job on the node a GPU.
+
 When enforcement fails
 ~~~~~~~~~~~~~~~~~~~~~~
 
 By default every step degrades to a warning: a controller that could not be
-delegated, a rejected control-file write, a cpuset that did not apply, or a
-process that could not join the cgroup all leave the job **running
-unconstrained**. Grep the
+delegated, a rejected control-file write, a cpuset that did not apply, a device
+filter that could not be attached, or a process that could not join the cgroup
+all leave the job **running unconstrained**. Grep the
 agent log for these to find silently-unenforced nodes:
 
 .. code-block:: text
@@ -1329,6 +1377,7 @@ agent log for these to find silently-unenforced nodes:
    failed to delegate cgroup controller
    failed to write cgroup control file
    cpuset not applied; job runs without a CPU bound
+   device filter not installed; job runs without device isolation
    failed to move process to cgroup
 
 Set ``required = true`` to refuse the launch instead. The job fails rather than
@@ -1355,6 +1404,7 @@ Verify what a running job actually got:
    cat /sys/fs/cgroup/spur/job_1234/memory.max        # hard ceiling, bytes
    cat /sys/fs/cgroup/spur/job_1234/memory.high       # reclaim threshold
    cat /sys/fs/cgroup/spur/job_1234/memory.swap.max   # swap ceiling
+   bpftool cgroup show /sys/fs/cgroup/spur/job_1234   # attached device filter
 
 Migrating from ``cgroup.conf``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1372,6 +1422,11 @@ them, so a site's existing percentages carry over directly.
    * - ``ConstrainCores``
      - ``constrain_cores``
      -
+   * - ``ConstrainDevices``
+     - ``constrain_devices``
+     - Both deny by ``major:minor``. Slurm takes the allow-list from
+       ``gres.conf``; Spur takes it from the device registry's injection plan,
+       plus the implicit set above and ``extra_device_paths``.
    * - ``ConstrainRAMSpace``
      - ``constrain_ram_space``
      -
@@ -1393,11 +1448,12 @@ them, so a site's existing percentages carry over directly.
 
 Deliberate differences from Slurm:
 
-- **Spur constrains cores and RAM by default.** Every Slurm ``Constrain*``
-  defaults to ``no``, so a job that overran ``--mem`` under a stock Slurm
-  configuration will be reclaimed against, or killed, on Spur. Swap is the
-  exception and stays off, matching Slurm: bounding it turns a job that
-  completed slowly into one that is killed outright.
+- **Spur constrains cores, RAM, and devices by default.** Every Slurm
+  ``Constrain*`` defaults to ``no``, so a job that overran ``--mem`` under a stock
+  Slurm configuration will be reclaimed against, or killed, on Spur, and one that
+  reached a GPU it was not allocated now gets ``EPERM``. Swap is the exception and
+  stays off, matching Slurm: bounding it turns a job that completed slowly into
+  one that is killed outright.
 - **``allowed_ram_percent = 0`` is rejected**, where Slurm would accept it and
   floor every job at ``MinRAMSpace``. That silently caps a whole cluster at
   30 MiB per job, so Spur treats it as the typo it almost certainly is. Every

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -1185,19 +1185,22 @@ Job isolation layers.
 ``[cgroup]``
 ------------
 
-cgroup-v2 resource enforcement that ``spurd`` applies to native-host jobs. The
-job's batch payload runs in a cgroup at ``/sys/fs/cgroup/spur/job_<id>``, and the
-limits are derived from the **per-node budget the controller allocated** — not
-from the ``--cpus-per-task`` / ``--mem`` the user requested. Kubernetes jobs are
-unaffected: there the kubelet owns the cgroups.
+cgroup-v2 resource enforcement that ``spurd`` applies to native-host jobs. Every
+process the agent starts for a job — the batch payload, ``srun`` steps, ``spur
+exec``, and interactive attach — runs in a cgroup at
+``/sys/fs/cgroup/spur/job_<id>``, and the limits are derived from the **per-node
+budget the controller allocated** — not from the ``--cpus-per-task`` / ``--mem``
+the user requested. Kubernetes jobs are unaffected: there the kubelet owns the
+cgroups.
 
 .. warning::
 
-   These settings bound the batch payload only. ``srun`` steps, ``spur exec``, and
-   interactive attaches into a running job currently run outside the job cgroup,
-   so they get neither the resource limits nor the device filter, and this section
-   is not a security boundary between users sharing a node. See
-   :ref:`cgroup-containment-gaps` for the full list.
+   These settings bound a job only when ``spurd`` runs as root, and with the
+   default ``required = false`` a host that cannot apply a constraint — no
+   ``CAP_BPF`` for the device filter, say — logs a warning and runs the work
+   unconstrained. Set ``required = true`` to make that case fail closed instead.
+   See :ref:`cgroup-containment-gaps` for what remains even then: per-step
+   granularity, and the site-supplied task hooks that run outside the job cgroup.
 
 .. note::
 

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -1196,8 +1196,8 @@ cgroups.
 .. warning::
 
    These settings bound a job only when ``spurd`` runs as root, and with the
-   default ``required = false`` a host that cannot apply a constraint — no
-   ``CAP_BPF`` for the device filter, say — logs a warning and runs the work
+   default ``required = false`` a host that cannot apply a constraint — missing
+   ``CAP_NET_ADMIN`` for the device filter, say — logs a warning and runs the work
    unconstrained. Set ``required = true`` to make that case fail closed instead.
    See :ref:`cgroup-containment-gaps` for what remains even then: per-step
    granularity, and the site-supplied task hooks that run outside the job cgroup.
@@ -1286,8 +1286,9 @@ cgroups.
        cgroup-v2 BPF device filter. Default-deny: a job allocated no GPUs can open
        only the nodes listed under :ref:`device-filter-implicit-allow` below, and
        opening an unallocated GPU fails with ``EPERM`` whatever the job sets
-       ``ROCR_VISIBLE_DEVICES`` to. Attaching the filter needs ``CAP_BPF`` or
-       ``CAP_SYS_ADMIN``; without them the job runs with no device isolation.
+       ``ROCR_VISIBLE_DEVICES`` to. Installing the filter needs ``CAP_BPF`` and
+       ``CAP_NET_ADMIN`` (or ``CAP_SYS_ADMIN``) — ``CAP_BPF`` alone is insufficient for a
+       cgroup-device program; without them the job runs with no device isolation.
    * - ``extra_device_paths``
      - [string]
      - ``[]``

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -1223,8 +1223,11 @@ unaffected: there the kubelet owns the cgroups.
    * - ``required``
      - bool
      - ``false``
-     - Refuse to launch a job when a requested constraint cannot be applied,
-       instead of warning and running it unconstrained. See the note below.
+     - Refuse the work when a requested constraint cannot be applied, instead of
+       warning and running it unconstrained. This gates a batch launch, the
+       registration of an interactive allocation (``salloc``, standalone
+       ``srun``), and a step that did not end up in its job's cgroup. See the
+       note below.
    * - ``constrain_cores``
      - bool
      - ``true``
@@ -1378,11 +1381,15 @@ agent log for these to find silently-unenforced nodes:
    failed to write cgroup control file
    cpuset not applied; job runs without a CPU bound
    device filter not installed; job runs without device isolation
-   failed to move process to cgroup
+   allocation registered without cgroup enforcement
+   failed to join cgroup; job runs without resource limits
 
-Set ``required = true`` to refuse the launch instead. The job fails rather than
-running outside its limits, which is the right trade on a shared node where the
-limits are the isolation boundary. It also means a host that cannot enforce
+Set ``required = true`` to refuse the work instead. A batch launch fails, an
+interactive allocation is refused at registration (so ``salloc`` and standalone
+``srun`` error out rather than handing back an unenforceable allocation), and a
+step that did not join its job's cgroup is killed and refused. Each fails rather
+than running outside its limits, which is the right trade on a shared node where
+the limits are the isolation boundary. It also means a host that cannot enforce
 stops accepting work, so roll it out only once the agent runs as root and the
 cgroup tree is confirmed writable.
 

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -969,9 +969,10 @@ Spur restricts a job to its allocated GPUs in two layers:
 
 The filter is attached to the job's cgroup, so it covers every process the agent
 starts for the job: the batch payload, ``srun`` steps, ``spur exec``, and
-interactive attach alike. Attaching it needs ``CAP_BPF`` or ``CAP_SYS_ADMIN`` — an
-agent without them logs a warning and runs the job with no device isolation,
-unless ``[cgroup] required`` is set, which refuses the job instead. See
+interactive attach alike. Installing it needs ``CAP_BPF`` and ``CAP_NET_ADMIN`` (or
+``CAP_SYS_ADMIN``) — a cgroup-device program is a net-admin program type, so ``CAP_BPF``
+alone is not enough. An agent without them logs a warning and runs the job with no
+device isolation, unless ``[cgroup] required`` is set, which refuses the job instead. See
 :ref:`cgroup-containment-gaps`.
 
 See Also

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -967,9 +967,12 @@ Spur restricts a job to its allocated GPUs in two layers:
   job was not allocated fails with ``EPERM`` in the kernel, whatever the
   environment says.
 
-The filter is attached to the job cgroup, so it bounds the batch payload only:
-``srun`` steps and ``spur exec`` shells run outside that cgroup and keep host-wide
-device access. See :ref:`cgroup-containment-gaps`.
+The filter is attached to the job's cgroup, so it covers every process the agent
+starts for the job: the batch payload, ``srun`` steps, ``spur exec``, and
+interactive attach alike. Attaching it needs ``CAP_BPF`` or ``CAP_SYS_ADMIN`` — an
+agent without them logs a warning and runs the job with no device isolation,
+unless ``[cgroup] required`` is set, which refuses the job instead. See
+:ref:`cgroup-containment-gaps`.
 
 See Also
 --------

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -392,8 +392,32 @@ The default can be changed in ``spur.conf``:
    ``LimitMEMLOCK=infinity`` on the systemd unit in that case: systemd applies
    it before dropping to ``User=``. See MPI (PMIx) below.
 
-CPU and Memory Limits (cgroups)
--------------------------------
+.. note::
+
+   ``spurd`` also raises its **own** ``RLIMIT_MEMLOCK`` at startup, because kernels
+   before 5.11 charge the memory for a job's BPF device filter against it rather
+   than against the memory cgroup.
+
+   This raise is **unconditional**: it happens before the configuration is read, so
+   a node with ``constrain_devices = false``, or with ``[cgroup]`` off entirely,
+   still gets it. That is deliberate — the agent's limit is then the same value
+   whether or not a BPF load ever happens — but it does mean that deferring the
+   device filter does **not** defer the change described next.
+
+   This changes what ``memlock = "inherit"`` yields. ``"inherit"`` means "do not
+   call ``setrlimit``, keep whatever ``spurd`` has", so an ``inherit`` job now
+   inherits the raised limit instead of the one the systemd unit granted. The
+   default ``"unlimited"`` sets the job's limit outright and is unaffected, so only
+   a site that explicitly chose ``"inherit"`` sees a difference.
+
+   A site that would rather own the value can set ``LimitMEMLOCK=infinity`` on the
+   ``spurd`` unit and get the same effective limit from systemd. That is also the
+   fallback when ``spurd`` cannot raise it itself: lifting the *hard* limit needs
+   ``CAP_SYS_RESOURCE``, and without it the agent can only raise the soft limit to
+   meet the existing hard one and logs that it could not go further.
+
+CPU, Memory, and Device Limits (cgroups)
+----------------------------------------
 
 ``spurd`` puts the payload it launches for a job into a cgroup-v2 group at
 ``/sys/fs/cgroup/spur/job_<id>`` and enforces the **per-node budget the controller
@@ -415,6 +439,12 @@ Out of the box the batch payload gets:
   ``--mem`` a hard cap.
 - ``memory.oom.group`` set, so an OOM kills the whole job rather than one process.
 - ``pids.max`` as a fork-bomb guard.
+- A default-deny BPF device filter attached to the cgroup, so the job can open its
+  allocated device nodes, the base pseudo-devices, and the shared host-infrastructure
+  nodes (RDMA verbs and vendor control nodes) listed under
+  :ref:`device-filter-implicit-allow` — and nothing else. Name any device the list
+  misses in ``extra_device_paths``, or turn the filter off with
+  ``constrain_devices``.
 
 A job submitted without ``--mem`` has no memory budget, so the memory ceilings are
 left unset.
@@ -427,6 +457,7 @@ Inspect what a running job actually got:
    cat /sys/fs/cgroup/spur/job_1234/cpuset.cpus
    cat /sys/fs/cgroup/spur/job_1234/memory.max
    cat /sys/fs/cgroup/spur/job_1234/memory.swap.max
+   bpftool cgroup show /sys/fs/cgroup/spur/job_1234   # the device filter, if attached
 
 Enforcement requires ``spurd`` to run as root. An unprivileged agent logs a warning
 and runs jobs unconstrained. Every knob — including turning enforcement off
@@ -441,7 +472,8 @@ What is not contained yet
 
 Only the payload launched through the agent's ``LaunchJob`` path joins
 ``job_<id>``. These paths start processes that stay outside it, in ``spurd``'s own
-cgroup, and are therefore **not** bounded by the job's limits:
+cgroup, and are therefore **not** bounded by the job's limits and **not** subject
+to its device filter:
 
 .. list-table::
    :header-rows: 1
@@ -463,11 +495,18 @@ cgroup, and are therefore **not** bounded by the job's limits:
      - The allocation is recorded for accounting, but its steps run through the
        ``srun`` step path above.
 
-Practically: a job cannot exceed its memory or core budget through its batch
-script, but it can through ``srun`` steps or an interactive shell. Closing this
-needs per-step cgroups nested under the job, which is planned but not implemented.
-Until then, do not rely on these limits as a security boundary between users on a
-shared node.
+Device isolation shares this gap exactly, and it is worth stating plainly because
+the enforcement is otherwise kernel-level and absolute. The filter is attached to
+the **cgroup**, not to the job's processes, so a process that never joins
+``job_<id>`` is never checked against it and can open **any** device node on the
+host — including a GPU allocated to another user's job. A user who runs ``srun``
+inside their own job, or who enters it with ``spur exec``, is not device-filtered.
+
+Practically: a job cannot exceed its memory or core budget, or reach a GPU it was
+not allocated, through its batch script — but it can through ``srun`` steps or an
+interactive shell. Closing this needs per-step cgroups nested under the job, which
+is planned but not implemented. Until then, do not rely on these limits or on the
+device filter as a security boundary between users on a shared node.
 
 MPI (PMIx)
 ----------
@@ -900,9 +939,24 @@ Each node in a multi-node job receives:
 GPU Isolation
 -------------
 
-Spur automatically restricts GPU visibility per job by exporting the allocated
-device ordinals into the standard GPU runtime variables:
-``ROCR_VISIBLE_DEVICES``, ``CUDA_VISIBLE_DEVICES``, and ``GPU_DEVICE_ORDINAL``.
+Spur restricts a job to its allocated GPUs in two layers:
+
+- **Visibility.** The allocated device ordinals are exported into the standard GPU
+  runtime variables — ``ROCR_VISIBLE_DEVICES``, ``CUDA_VISIBLE_DEVICES``, and
+  ``GPU_DEVICE_ORDINAL``. This layer is advisory: a job that overwrites them sees
+  every GPU on the node again. A root ``spurd`` additionally runs the batch payload
+  in a mount namespace where ``/dev/dri`` is replaced by a tmpfs carrying only the
+  job's own render nodes, so a job allocated no GPUs finds that directory empty.
+  Every mount there is best-effort and none of it is a boundary — that is the next
+  layer's job.
+- **Access.** With ``[cgroup] constrain_devices`` (on by default) the job's cgroup
+  carries a default-deny BPF device filter, so opening the device node of a GPU the
+  job was not allocated fails with ``EPERM`` in the kernel, whatever the
+  environment says.
+
+The filter is attached to the job cgroup, so it bounds the batch payload only:
+``srun`` steps and ``spur exec`` shells run outside that cgroup and keep host-wide
+device access. See :ref:`cgroup-containment-gaps`.
 
 See Also
 --------

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -419,17 +419,20 @@ The default can be changed in ``spur.conf``:
 CPU, Memory, and Device Limits (cgroups)
 ----------------------------------------
 
-``spurd`` puts the payload it launches for a job into a cgroup-v2 group at
+``spurd`` puts the processes it starts for a job into a cgroup-v2 group at
 ``/sys/fs/cgroup/spur/job_<id>`` and enforces the **per-node budget the controller
 allocated** — the cores and memory the scheduler actually granted this node, not
 what the job asked for.
 
-This covers the batch payload: ``sbatch`` scripts, ``--pty`` jobs, and
-containerized jobs (a container's process tree inherits the job cgroup). It does
-**not** yet cover every process a job can start — see
-:ref:`cgroup-containment-gaps` below.
+This covers every process the agent starts for a job: ``sbatch`` scripts,
+``--pty`` jobs, containerized jobs (a container's process tree inherits the job
+cgroup), ``srun`` steps, ``spur exec``, and interactive attach. An interactive
+allocation (``salloc``, standalone ``srun``) launches no payload of its own, so
+its cgroup is created when the allocation is registered — the first step to
+arrive then has one to join. What is left outside it is narrow, and is described
+under :ref:`cgroup-containment-gaps` below.
 
-Out of the box the batch payload gets:
+Out of the box the job's cgroup gets:
 
 - ``cpuset.cpus`` pinned to its allocated cores.
 - ``memory.max`` at its allocated memory, with ``memory.high`` at the same value so
@@ -470,43 +473,53 @@ Slurm's ``cgroup.conf``.
 What is not contained yet
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Only the payload launched through the agent's ``LaunchJob`` path joins
-``job_<id>``. These paths start processes that stay outside it, in ``spurd``'s own
-cgroup, and are therefore **not** bounded by the job's limits and **not** subject
-to its device filter:
+Every process the agent starts for a job joins ``job_<id>`` — the batch payload,
+``srun`` steps, ``spur exec``, and interactive attach alike — so all of them are
+bounded by the job's limits and checked against its device filter. What remains
+is a granularity gap *inside* the job rather than a hole between jobs:
 
 .. list-table::
    :header-rows: 1
    :widths: 32 68
 
-   * - Path
-     - Why it escapes
-   * - ``srun`` steps inside a job
-     - Steps are spawned directly by the agent rather than through the batch
-       launch path.
-   * - ``spur exec`` into a running job
-     - Enters the job's *namespaces* via ``nsenter``; namespaces are not cgroups,
-       so the process keeps ``spurd``'s cgroup.
-   * - Interactive attach to a running job
-     - Same namespace-entry path as ``spur exec``. This covers every ``--pty``
-       shell: the job's batch payload is contained, but the attached shell is
-       spawned alongside it and is not.
-   * - Standalone ``srun`` allocations
-     - The allocation is recorded for accounting, but its steps run through the
-       ``srun`` step path above.
+   * - What is missing
+     - Where it stands
+   * - Per-step limits and accounting
+     - Steps join the **job's** cgroup, not one of their own, so every step in a
+       job draws on one shared budget and there is no per-step CPU or memory
+       reading to attribute. Nested ``job_<id>/step_<n>`` cgroups are planned; a
+       BPF device filter attached at ``job_<id>`` is inherited by descendant
+       cgroups, so the filter will keep working unchanged when they arrive.
+   * - Precise kill-by-step
+     - Cancelling one step signals its process group rather than a cgroup of its
+       own, so a step process that leaves that group (``setsid``) is missed.
+       Cancelling the whole *job* is exact, because that is a cgroup operation.
+   * - ``task_prolog`` / ``task_epilog``
+     - Run by ``spurd`` around each step, as root and in ``spurd``'s own cgroup.
+       They are site-supplied rather than user code, but they are neither
+       resource-bounded nor device-filtered.
 
-Device isolation shares this gap exactly, and it is worth stating plainly because
-the enforcement is otherwise kernel-level and absolute. The filter is attached to
-the **cgroup**, not to the job's processes, so a process that never joins
-``job_<id>`` is never checked against it and can open **any** device node on the
-host — including a GPU allocated to another user's job. A user who runs ``srun``
-inside their own job, or who enters it with ``spur exec``, is not device-filtered.
+Node-level ``prolog`` and ``epilog`` also run uncontained, and that is by design:
+they run before the job's cgroup exists and after it is gone, and their purpose is
+node-wide setup and teardown.
 
-Practically: a job cannot exceed its memory or core budget, or reach a GPU it was
-not allocated, through its batch script — but it can through ``srun`` steps or an
-interactive shell. Closing this needs per-step cgroups nested under the job, which
-is planned but not implemented. Until then, do not rely on these limits or on the
-device filter as a security boundary between users on a shared node.
+.. note::
+
+   **A step now counts against the job's budget.** An ``srun`` step used to run
+   outside ``job_<id>``, with no memory ceiling and no CPU pinning of its own; it
+   now shares the job's ``memory.max``, ``memory.high``, and ``cpuset.cpus``. A
+   site whose steps routinely overrun what the job asked for will start seeing
+   OOM kills where the same workload previously ran. Size ``--mem`` for the whole
+   job — steps included — or raise ``allowed_ram_percent`` to open a headroom
+   band above the allocation.
+
+Practically: a user cannot exceed their job's memory or core budget, or reach a
+GPU the job was not allocated, from *any* process the agent starts for them —
+batch script, step, or interactive shell. That holds only where enforcement
+actually applied, though: an unprivileged agent, or one that could not create the
+cgroup, runs the job unenforced with a warning. Set ``[cgroup] required = true``
+to refuse the work instead, which is what makes these limits a boundary you can
+rely on between users on a shared node.
 
 MPI (PMIx)
 ----------

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -444,7 +444,7 @@ Out of the box the job's cgroup gets:
 - ``pids.max`` as a fork-bomb guard.
 - A default-deny BPF device filter attached to the cgroup, so the job can open its
   allocated device nodes, the base pseudo-devices, and the shared host-infrastructure
-  nodes (RDMA verbs and vendor control nodes) listed under
+  nodes (RDMA verbs, MIG capability nodes) listed under
   :ref:`device-filter-implicit-allow` — and nothing else. Name any device the list
   misses in ``extra_device_paths``, or turn the filter off with
   ``constrain_devices``.

--- a/docs/deployment/upgrading.rst
+++ b/docs/deployment/upgrading.rst
@@ -362,9 +362,10 @@ To defer the change entirely:
    [cgroup]
    constrain_devices = false
 
-Attaching the filter needs ``CAP_BPF`` or ``CAP_SYS_ADMIN``. An agent without them
-logs ``device filter not installed`` and runs the job with no device isolation, so
-an unprivileged ``spurd`` behaves as before — unless ``required = true``, which
+Installing the filter needs ``CAP_BPF`` and ``CAP_NET_ADMIN`` (or ``CAP_SYS_ADMIN``);
+a cgroup-device program is a net-admin program type, so ``CAP_BPF`` alone is not enough.
+An agent without them logs ``device filter not installed`` and runs the job with no
+device isolation, so an unprivileged ``spurd`` behaves as before — unless ``required = true``, which
 turns that degradation into a refused launch.
 
 See Also

--- a/docs/deployment/upgrading.rst
+++ b/docs/deployment/upgrading.rst
@@ -322,6 +322,51 @@ restart — ``scontrol reconfigure`` will not apply it afterwards.
 Rolling back is safe with the section left in place: older binaries do not know
 ``[cgroup]`` and ignore it.
 
+Job device access (``constrain_devices``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The release introducing ``constrain_devices`` attaches a default-deny BPF device
+filter to every job cgroup, and it defaults to **on** — including for a
+``spur.conf`` with no ``[cgroup]`` section, or one written before the field
+existed.
+
+**Effect:** a batch payload can open only the device nodes its allocation granted,
+plus the base pseudo-devices and a built-in host-infrastructure set. A job that had
+been reaching a GPU it was not allocated — by re-exporting ``ROCR_VISIBLE_DEVICES``,
+or because it never read the variable — now fails that ``open`` with ``EPERM``.
+
+**A job can also be denied a host device node its allocation never covered**, and
+that is the risk to plan the rollout around. Some device nodes belong to the node
+rather than to any job, so no allocation hands them out and nothing puts them in the
+allow-list. The known cases are RDMA/InfiniBand verbs under ``/dev/infiniband/`` —
+needed by MPI, and by NCCL or RCCL over InfiniBand, which makes this reach
+**non-GPU** jobs — and the vendor control nodes a GPU runtime initializes through,
+such as ``/dev/nvidiactl`` and ``/dev/nvidia-uvm``, which a node configured through
+GRES rather than a CDI spec does not list as devices. Both are allowed by default,
+so the common cases keep working with no configuration; see
+:ref:`device-filter-implicit-allow` for the full implicit set.
+
+A site whose jobs open some other host device node will still see ``EPERM``. Name
+those paths rather than turning the filter off:
+
+.. code-block:: toml
+
+   [cgroup]
+   extra_device_paths = ["/dev/some-site-device"]
+
+Roll the agent out node by node and watch job output for ``EPERM`` on device paths.
+To defer the change entirely:
+
+.. code-block:: toml
+
+   [cgroup]
+   constrain_devices = false
+
+Attaching the filter needs ``CAP_BPF`` or ``CAP_SYS_ADMIN``. An agent without them
+logs ``device filter not installed`` and runs the job with no device isolation, so
+an unprivileged ``spurd`` behaves as before — unless ``required = true``, which
+turns that degradation into a refused launch.
+
 See Also
 --------
 

--- a/docs/deployment/upgrading.rst
+++ b/docs/deployment/upgrading.rst
@@ -338,13 +338,16 @@ or because it never read the variable — now fails that ``open`` with ``EPERM``
 **A job can also be denied a host device node its allocation never covered**, and
 that is the risk to plan the rollout around. Some device nodes belong to the node
 rather than to any job, so no allocation hands them out and nothing puts them in the
-allow-list. The known cases are RDMA/InfiniBand verbs under ``/dev/infiniband/`` —
+allow-list. The main case is RDMA/InfiniBand verbs under ``/dev/infiniband/`` —
 needed by MPI, and by NCCL or RCCL over InfiniBand, which makes this reach
-**non-GPU** jobs — and the vendor control nodes a GPU runtime initializes through,
-such as ``/dev/nvidiactl`` and ``/dev/nvidia-uvm``, which a node configured through
-GRES rather than a CDI spec does not list as devices. Both are allowed by default,
-so the common cases keep working with no configuration; see
-:ref:`device-filter-implicit-allow` for the full implicit set.
+**non-GPU** jobs. These are allowed by default, so the common cases keep working with
+no configuration; see :ref:`device-filter-implicit-allow` for the full implicit set.
+
+The vendor control nodes a GPU runtime initializes through, such as ``/dev/nvidiactl``
+and ``/dev/nvidia-uvm``, reach a job through its allocation's CDI device edits. A node
+configured through GRES rather than a CDI spec does not list them as devices, so a GPU
+job there fails with ``EPERM`` on those nodes until they are named in
+``extra_device_paths``.
 
 A site whose jobs open some other host device node will still see ``EPERM``. Name
 those paths rather than turning the filter off:

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -163,6 +163,15 @@ constrain_swap = true
 # required = false           # refuse to launch when limits cannot be applied,
                              # instead of warning and running the job unconstrained
 # cpu_quota = false          # add a CFS quota on top of the cpuset; off as in Slurm
+# constrain_devices = true   # a job may open only the device nodes its allocation
+                             # granted, enforced by the kernel. On by default, and
+                             # the one setting here that can deny a device a running
+                             # job used to open — roll it out node by node and watch
+                             # job output for EPERM on device paths
+# extra_device_paths = []    # device nodes every job on this node may open on top
+                             # of its allocation, e.g. ["/dev/site-accel0"]. Reach
+                             # for this when the filter denies a device your jobs
+                             # need, rather than turning it off
 
 # Lifecycle hook scripts. All optional; a fully-qualified path enables the hook.
 # job_submit (shell) and job_submit_lua both run on the controller at submission

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -1378,17 +1378,38 @@ def parse_job_id(sbatch_output: str) -> int | None:
     return None
 
 
+# Every canonical ST code (mirrors JobState::code in spur-core).
+_JOB_STATE_CODES = frozenset(
+    {"PD", "R", "CG", "CD", "F", "CA", "TO", "NF", "PR", "S", "DL", "OOM", "RQ"}
+)
+
+# Codes that end a run for good (mirrors JobState::is_terminal). PR/RQ requeue
+# back to pending, so they are deliberately not terminal.
+_TERMINAL_STATE_CODES = frozenset({"CD", "F", "CA", "TO", "NF", "DL", "OOM"})
+
+# The default `%.2t` squeue column truncates the only three-character code.
+_TRUNCATED_STATE_CODES = {"OO": "OOM"}
+
+
 def job_state(squeue_output: str, job_id: int) -> str | None:
     """Parse job state from squeue -t all output."""
-    valid_states = {"PD", "R", "CD", "CG", "F", "CA", "TO", "NF", "PR", "S", "RQ"}
+    lines = squeue_output.splitlines()
+    if not lines:
+        return None
+    try:
+        state_index = lines[0].split().index("ST")
+    except ValueError:
+        return None
+
     id_str = str(job_id)
-    for line in squeue_output.splitlines()[1:]:
+    for line in lines[1:]:
         fields = line.split()
         if not fields or fields[0] != id_str:
             continue
-        for field in fields[1:]:
-            if field in valid_states:
-                return field
+        if state_index >= len(fields):
+            return None
+        state = _TRUNCATED_STATE_CODES.get(fields[state_index], fields[state_index])
+        return state if state in _JOB_STATE_CODES else None
     return None
 
 
@@ -1419,7 +1440,7 @@ def wait_job(cluster: SpurCluster, job_id: int, timeout: int = 120) -> str:
     while time.time() < deadline:
         sq = cluster.squeue_all()
         state = job_state(sq, job_id)
-        if state in ("CD", "F", "CA", "TO"):
+        if state in _TERMINAL_STATE_CODES:
             return state
         if state is None:
             if seen:

--- a/tests/native_host/e2e/test_cgroup_limits.py
+++ b/tests/native_host/e2e/test_cgroup_limits.py
@@ -237,6 +237,128 @@ class TestCgroupSwapOnly:
         assert probe.values["memory.swap.max"] == "0", probe.context()
 
 
+# A child grows a heap string until the cgroup kills it; the parent records only
+# whether it outlived the child, which `memory.oom.group` decides.
+def _oom_probe(marker: str) -> str:
+    return (
+        "#!/bin/bash\n"
+        f'marker="{marker}"\n'
+        'rm -f "$marker" 2>/dev/null\n'
+        "grow() { local a; a=$(head -c 1048576 /dev/zero | tr '\\0' x); "
+        'while :; do a="$a$a"; done; }\n'
+        "grow &\n"
+        "child=$!\n"
+        'wait "$child"\n'
+        "# Reached only if this shell was not group-killed alongside the child.\n"
+        'echo "PARENT_SURVIVED rc=$?" > "$marker"\n'
+    )
+
+
+def _run_oom_job(cluster, name: str) -> tuple[int, str, str]:
+    """Submit the OOM probe pinned to node 0 under a 64 MiB ceiling and return
+    (job_id, terminal state, survivor-marker contents)."""
+    marker = f"{cluster.remote_dir}/{name}-survivor.txt"
+    script = cluster.write_file(f"{name}.sh", _oom_probe(marker))
+    sb = cluster.sbatch(
+        ["-J", name, "-N", "1", "-w", cluster.node_names[0], "-t", "1",
+         "--cpus-per-task=1", "--mem=64", script]
+    )
+    job_id = parse_job_id(sb)
+    assert job_id is not None, f"sbatch failed: {sb}"
+    state = wait_job(cluster, job_id, timeout=120)
+    return job_id, state, cluster.nodes[0].read_file(marker)
+
+
+# A step marks that it launched, then allocates far past the job ceiling. The
+# second marker is written only if that allocation was never bounded.
+def _step_mem_probe(marker: str) -> str:
+    return (
+        "#!/bin/bash\n"
+        f'marker="{marker}"\n'
+        'echo STEP_STARTED > "$marker"\n'
+        "a=$(head -c $((160*1024*1024)) /dev/zero | tr '\\0' x)\n"
+        'echo "STEP_OK len=${#a}" >> "$marker"\n'
+    )
+
+
+class TestCgroupOomGroupKill:
+    # Default `oom_kill_job = true`: the existing tests assert memory.oom.group
+    # reads 1; this asserts the effect.
+    def test_oom_kill_group_takes_the_whole_job(self, cgroup_cluster):
+        # oom.group kills every process in the cgroup, so the parent dies with the
+        # child and never records that it survived; the job ends OUT_OF_MEMORY.
+        job_id, state, marker = _run_oom_job(cgroup_cluster, "cg-oom-group")
+        assert state == "OOM", (
+            f"a job that exceeds memory.max must end OUT_OF_MEMORY, got {state}\n"
+            f"{cgroup_cluster.debug_job(job_id)}"
+        )
+        assert "PARENT_SURVIVED" not in marker, (
+            f"oom.group must kill the parent too, but it survived:\n{marker!r}"
+        )
+
+
+class TestCgroupOomSingleKill:
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {"cgroup": {"oom_kill_job": False}}
+
+    def test_oom_kill_disabled_spares_the_siblings(self, cgroup_cluster):
+        # Only the offending process is killed, so the parent outlives the child's
+        # OOM. The job is still OUT_OF_MEMORY (a kill happened); the surviving
+        # parent's marker is what proves the knob spared it.
+        job_id, state, marker = _run_oom_job(cgroup_cluster, "cg-oom-single")
+        assert "PARENT_SURVIVED" in marker, (
+            f"with oom_kill_job = false only the child dies, so the parent must "
+            f"outlive its OOM; marker was:\n{marker!r}\n"
+            f"{cgroup_cluster.debug_job(job_id)}"
+        )
+        assert state == "OOM", (
+            f"an OOM kill still marks the job OUT_OF_MEMORY, got {state}\n"
+            f"{cgroup_cluster.debug_job(job_id)}"
+        )
+
+
+class TestCgroupStepMemoryBudget:
+    """Phase 2a puts an ``srun`` step in the job's own cgroup, so a step's memory
+    counts against the job's ``memory.max``. Before it, a step ran cgroup-free and
+    could allocate past the job's ceiling unchecked.
+    """
+
+    def test_a_step_is_bound_by_the_jobs_memory_max(self, cgroup_cluster):
+        cluster = cgroup_cluster
+        marker = f"{cluster.remote_dir}/cg-step-mem-marker.txt"
+        step = cluster.write_file("cg-step-mem-probe.sh", _step_mem_probe(marker))
+        # The batch parent stays tiny; only the step allocates, so an OOM here can
+        # only be the step's 160 MiB charged to the job's 64 MiB memory.max.
+        script = cluster.write_file(
+            "cg-step-mem.sh", "#!/bin/bash\n" f"srun bash {step}\n"
+        )
+        sb = cluster.sbatch(
+            ["-J", "cg-step-mem", "-N", "1", "-w", cluster.node_names[0], "-t", "2",
+             "--cpus-per-task=1", "--mem=64", script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch failed: {sb}"
+        state = wait_job(cluster, job_id, timeout=120)
+        marker_out = cluster.nodes[0].read_file(marker)
+
+        assert "STEP_STARTED" in marker_out, (
+            f"the srun step never launched, so nothing was tested\n"
+            f"{cluster.debug_job(job_id)}\nmarker:\n{marker_out!r}"
+        )
+        assert "STEP_OK" not in marker_out, (
+            f"a step's memory must count against the job's memory.max: its 160 MiB "
+            f"allocation completed under a 64 MiB ceiling (state {state})\n"
+            f"marker:\n{marker_out!r}"
+        )
+        # The step shares the job cgroup, so oom.group takes the whole job: it ends
+        # OUT_OF_MEMORY rather than the over-budget step dying alone.
+        assert state == "OOM", (
+            f"the job must end OUT_OF_MEMORY when its step exceeds memory.max, got "
+            f"{state}\n{cluster.debug_job(job_id)}"
+        )
+
+
 class TestCgroupDisabled:
     @pytest.fixture
     def cluster_config_overrides(self):
@@ -254,6 +376,112 @@ class TestCgroupDisabled:
         assert not probe.values["CGROUP_PATH"].startswith("/spur/job_"), (
             probe.context()
         )
+
+    def test_disabled_does_not_bound_memory(self, cgroup_cluster):
+        # Contrast to the OOM tests: the allocation that gets OOM-killed under a
+        # 64 MiB ceiling completes when disabled, since no memory.max is written.
+        name = "cg-off-mem"
+        marker = f"{cgroup_cluster.remote_dir}/{name}-done.txt"
+        script = cgroup_cluster.write_file(
+            f"{name}.sh",
+            "#!/bin/bash\n"
+            # A bounded 128 MiB — over a 64 MiB ceiling, but far under node RAM,
+            # so nothing here can OOM the node when the ceiling is absent.
+            "a=$(head -c $((128*1024*1024)) /dev/zero | tr '\\0' x)\n"
+            f'echo "ALLOC_DONE len=${{#a}}" > "{marker}"\n',
+        )
+        sb = cgroup_cluster.sbatch(
+            ["-J", name, "-N", "1", "-w", cgroup_cluster.node_names[0], "-t", "2",
+             "--cpus-per-task=1", "--mem=64", script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch failed: {sb}"
+        state = wait_job(cgroup_cluster, job_id, timeout=120)
+
+        assert state == "CD", (
+            f"with cgroups disabled a 128 MiB allocation under --mem=64 must not "
+            f"be OOM-killed, got {state}\n{cgroup_cluster.debug_job(job_id)}"
+        )
+        assert "ALLOC_DONE" in cgroup_cluster.nodes[0].read_file(marker), (
+            "the job must have allocated past the (unenforced) ceiling"
+        )
+
+
+class TestCgroupLeftover:
+    """A rootful job (or a crash) can leave a root-owned
+    ``/sys/fs/cgroup/spur/job_<id>`` that a non-root agent reusing that id cannot
+    remove. The launch must degrade to no isolation and complete, not fail on
+    every retry — the exact regression that once left jobs stuck PENDING.
+    """
+
+    def test_a_leftover_root_owned_cgroup_does_not_wedge_the_launch(self, cluster):
+        node = cluster.nodes[0]
+        if "OK" not in node.exec_allow_fail("sudo -n true 2>/dev/null && echo OK"):
+            pytest.skip("planting a root-owned cgroup needs passwordless sudo on node 0")
+        if "cgroup2fs" not in node.exec_allow_fail("stat -fc %T /sys/fs/cgroup").strip():
+            pytest.skip("node 0 is not cgroup v2")
+        if cluster.spurd_agent_user(0) == "root":
+            pytest.skip("this regression is specific to a non-root agent")
+
+        # A root-owned cgroup root is what lets the non-root agent reach the claim
+        # path at all: it can traverse the directory but not create inside it.
+        node.exec("sudo -n mkdir -p /sys/fs/cgroup/spur")
+
+        # Job ids are handed out in order, so plant leftovers across the window the
+        # next submission will land in, then submit into it.
+        prime_script = cluster.write_file("cg-leftover-prime.sh", "#!/bin/bash\ntrue\n")
+        prime = parse_job_id(
+            cluster.sbatch(
+                ["-J", "cg-leftover-prime", "-N", "1", "-w", cluster.node_names[0],
+                 prime_script]
+            )
+        )
+        assert prime is not None
+        planted = list(range(prime + 1, prime + 6))
+        for jid in planted:
+            node.exec_allow_fail(f"sudo -n mkdir -p /sys/fs/cgroup/spur/job_{jid}")
+
+        try:
+            script = cluster.write_file(
+                "cg-leftover.sh", "#!/bin/bash\necho LEFTOVER_RAN\n"
+            )
+            out_path = f"{cluster.remote_dir}/cg-leftover.out"
+            job_id = parse_job_id(
+                cluster.sbatch(
+                    ["-J", "cg-leftover", "-N", "1", "-w", cluster.node_names[0],
+                     "-o", out_path, script]
+                )
+            )
+            assert job_id is not None
+            assert job_id in planted, (
+                f"job {job_id} landed outside the planted window {planted}; "
+                f"widen it"
+            )
+
+            # Before the fix this stuck PENDING forever ("outlived its cleanup"),
+            # so wait_job would raise TimeoutError.
+            state = wait_job(cluster, job_id, timeout=90)
+            assert state == "CD", (
+                f"a job whose leftover cgroup a non-root agent cannot remove must "
+                f"degrade and complete, got {state}\n{cluster.debug_job(job_id)}"
+            )
+            assert "LEFTOVER_RAN" in cluster.read_output_on_any_node(out_path), (
+                "the degraded job must still run its payload"
+            )
+            # Prove the agent actually hit the unremovable-leftover (EEXIST) path
+            # and degraded, so a run that never reached it cannot pass silently.
+            log = cluster.spurd_log(0)
+            assert "File exists" in log and "cgroup unavailable" in log, (
+                f"expected a degrade-on-EEXIST for the planted leftover\n"
+                f"spurd log tail:\n{log[-2000:]}"
+            )
+            assert "outlived its cleanup" not in log, (
+                "the old fatal path must be gone"
+            )
+        finally:
+            for jid in planted:
+                node.exec_allow_fail(f"sudo -n rmdir /sys/fs/cgroup/spur/job_{jid} 2>/dev/null")
+            node.exec_allow_fail("sudo -n rmdir /sys/fs/cgroup/spur 2>/dev/null")
 
 
 class TestCgroupRequired:

--- a/tests/native_host/e2e/test_cgroup_limits.py
+++ b/tests/native_host/e2e/test_cgroup_limits.py
@@ -541,3 +541,38 @@ class TestCgroupConfigValidation:
         assert "allowed_ram_percent" in out, (
             f"startup failure must name the offending field:\n{out}"
         )
+
+
+class TestCgroupContainerStep:
+    """A standalone ``srun --container-image`` step takes the fork + pivot_root
+    container path (``run_containerized_step``), distinct from a batch container,
+    a plain step, and an nsenter step. It must still join the job cgroup.
+    """
+
+    def test_container_step_runs_inside_the_job_cgroup(self, cgroup_cluster, tmp_path):
+        cluster = cgroup_cluster
+        cluster.container_preflight()
+        image = cluster.build_container_image(tmp_path)
+
+        # A *standalone* srun --container-image is what takes the fork + pivot_root
+        # container path; its own allocation is non-container. (The same flag on a
+        # step inside an allocation stays a plain host step.)
+        code, out = cluster.srun_with_exit(
+            ["-w", cluster.node_names[0], "--mem=256", f"--container-image={image}",
+             "sh", "-c",
+             "cat /proc/self/cgroup; "
+             "test -e /etc/os-release && echo IS_HOST || echo IS_CONTAINER"]
+        )
+
+        # /etc/os-release exists on the host but not in the minimal image, so this
+        # proves the step ran inside the pivoted rootfs (arm 2), not on the host —
+        # otherwise it would join the cgroup regardless and prove nothing.
+        assert "IS_CONTAINER" in out, (
+            f"the step must run inside the container rootfs (exit {code})\noutput:\n{out}"
+        )
+        # The container's /proc still reports the host cgroup path (no cgroup-ns
+        # remap), so a joined step reads /spur/job_<id>; an uncontained one would
+        # read spurd's own cgroup instead.
+        assert "0::/spur/job_" in out, (
+            f"a container step must join the job cgroup (exit {code})\noutput:\n{out}"
+        )

--- a/tests/native_host/e2e/test_cgroup_limits.py
+++ b/tests/native_host/e2e/test_cgroup_limits.py
@@ -15,7 +15,7 @@ from typing import NamedTuple
 
 import pytest
 
-from cluster import parse_job_id, wait_job
+from cluster import parse_job_id, wait_job, wait_job_state
 
 MIB = 1024 * 1024
 
@@ -575,4 +575,66 @@ class TestCgroupContainerStep:
         # read spurd's own cgroup instead.
         assert "0::/spur/job_" in out, (
             f"a container step must join the job cgroup (exit {code})\noutput:\n{out}"
+        )
+
+
+def _hold_running_job(cluster, name: str) -> int:
+    """Submit a long sleep pinned to node 0 and return its id once RUNNING, so
+    exec/attach/step have a live job cgroup to enter."""
+    script = cluster.write_file(f"{name}.sh", "#!/bin/bash\nsleep 300\n")
+    job_id = parse_job_id(
+        cluster.sbatch(
+            ["-J", name, "-N", "1", "-w", cluster.node_names[0], "-t", "5",
+             "--cpus-per-task=1", "--mem=256", script]
+        )
+    )
+    assert job_id is not None, "sbatch failed to return a job id"
+    wait_job_state(cluster, job_id, "R", timeout=90)
+    return job_id
+
+
+class TestCgroupEntryPathMembership:
+    """A plain srun step, ``spur exec``, and a ``--pty`` attach each enter a
+    running job's cgroup via the same pre-exec join. The device-filter tests that
+    cover them use ``gpu_cluster`` and skip on a GPU-less node, so verify the
+    membership directly through ``/proc/self/cgroup`` instead.
+    """
+
+    def test_a_step_runs_inside_the_job_cgroup(self, cgroup_cluster):
+        cluster = cgroup_cluster
+        job_id = _hold_running_job(cluster, "cg-step-member")
+        try:
+            code, out = cluster.srun_in_allocation(job_id, ["cat", "/proc/self/cgroup"])
+        finally:
+            cluster.scancel(str(job_id))
+        assert f"0::/spur/job_{job_id}" in out, (
+            f"an srun step must join the job cgroup (exit {code})\noutput:\n{out}"
+        )
+
+    def test_exec_runs_inside_the_job_cgroup(self, cgroup_cluster):
+        cluster = cgroup_cluster
+        job_id = _hold_running_job(cluster, "cg-exec-member")
+        try:
+            out = cluster.cli_allow_fail(
+                ["spur", "exec", str(job_id), "cat", "/proc/self/cgroup"]
+            )
+        finally:
+            cluster.scancel(str(job_id))
+        assert f"0::/spur/job_{job_id}" in out, (
+            f"spur exec must join the job cgroup\noutput:\n{out}"
+        )
+
+    def test_pty_attach_runs_inside_the_job_cgroup(self, cgroup_cluster):
+        cluster = cgroup_cluster
+        job_id = _hold_running_job(cluster, "cg-pty-member")
+        try:
+            # `--pty` streams over a PTY, so the cgroup line may carry a trailing
+            # CR; match it as a substring rather than a whole line.
+            code, out = cluster.srun_with_exit(
+                ["--jobid", str(job_id), "--overlap", "--pty", "cat", "/proc/self/cgroup"]
+            )
+        finally:
+            cluster.scancel(str(job_id))
+        assert f"0::/spur/job_{job_id}" in out, (
+            f"a --pty attach must join the job cgroup (exit {code})\noutput:\n{out}"
         )

--- a/tests/native_host/e2e/test_device_isolation.py
+++ b/tests/native_host/e2e/test_device_isolation.py
@@ -160,6 +160,40 @@ class TestDeviceIsolation:
             f"a job allocated a GPU must be able to open {KFD}\noutput:\n{content}"
         )
 
+    def test_partial_gpu_allocation_hides_the_other_gpus(self, gpu_cluster):
+        # The rootful tmpfs wrapper stages only the allocated render node; the device
+        # filter is the backstop, so the job sees and reaches just its own GPU.
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+        _require_unfiltered_access(cluster)
+        if cluster.node_gpu_count(cluster.node_names[0]) < 2:
+            pytest.skip("need >= 2 GPUs on node 0 to prove the siblings are hidden")
+
+        content = _run_probe(
+            cluster,
+            "dev-iso-partial",
+            "n=0\n"
+            'for d in /dev/dri/renderD*; do [ -e "$d" ] || continue; '
+            'n=$((n+1)); probe_open "$d"; done\n'
+            'echo "RENDER_COUNT=$n"\n'
+            f"probe_open {KFD}\n",
+            ["--gres=gpu:1"],
+        ).output
+
+        assert "RENDER_COUNT=1" in content, (
+            f"a gpu:1 job on a multi-GPU node must see exactly its one render "
+            f"node, not the siblings\noutput:\n{content}"
+        )
+        assert not any("renderD" in ln and "EPERM" in ln for ln in content.splitlines()), (
+            f"the one render node the job was given must be usable, not denied\n"
+            f"output:\n{content}"
+        )
+        assert f"{KFD}=OPEN" in content, (
+            f"the allocated job must still reach the GPU control node\n"
+            f"output:\n{content}"
+        )
+
     def test_visible_devices_override_does_not_restore_access(self, gpu_cluster):
         # Re-exporting the selector is how a job defeats an advisory sentinel; it
         # must not move a kernel filter.
@@ -187,9 +221,9 @@ class TestDeviceIsolation:
 @pytest.mark.rootful
 class TestStepAndExecDeviceIsolation:
     """The filter is attached to the job's cgroup, so it only reaches a process
-    that is in it. ``srun`` steps and ``spur exec`` are not batch payloads and
-    have to join it themselves; each of these opened ``/dev/kfd`` freely from
-    inside a zero-GPU job before that join existed.
+    that is in it. ``srun`` steps, ``spur exec``, and interactive ``--pty``
+    attaches are not batch payloads and have to join it themselves; each of these
+    opened ``/dev/kfd`` freely from inside a zero-GPU job before that join existed.
     """
 
     def test_step_in_a_zero_gpu_job_is_denied_the_gpu_control_node(self, gpu_cluster):
@@ -290,6 +324,37 @@ class TestStepAndExecDeviceIsolation:
         assert f"{KFD}=EPERM" in out, (
             f"spur exec into a zero-GPU job must be denied {KFD} by the kernel\n"
             f"output:\n{out}"
+        )
+
+    def test_pty_attach_into_a_zero_gpu_job_is_denied_the_gpu_control_node(
+        self, gpu_cluster
+    ):
+        # `srun --pty` opens an interactive PTY step via spawn_pty_in_job, a path
+        # of its own — not a batch payload, a run_command step, or spur exec.
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+        _require_unfiltered_access(cluster)
+
+        job_id = _hold_job(cluster, "dev-iso-pty-zero", [])
+        probe = cluster.write_file(
+            "dev-iso-pty-zero-probe.sh", _probe_script(f"probe_open {KFD}\n")
+        )
+        try:
+            code, out = cluster.srun_with_exit(
+                ["--jobid", str(job_id), "--overlap", "--pty", "bash", probe]
+            )
+        finally:
+            cluster.scancel(str(job_id))
+
+        # !r so the PTY's CRLFs and any control bytes are legible on failure.
+        assert "DEVICE_PROBE_OK" in out, (
+            f"the pty attach did not run the probe to completion (exit {code})\n"
+            f"{cluster.debug_job(job_id)}\noutput:\n{out!r}"
+        )
+        assert f"{KFD}=EPERM" in out, (
+            f"a pty attach into a zero-GPU job must be denied {KFD} by the kernel\n"
+            f"output:\n{out!r}"
         )
 
     def test_a_step_lands_in_the_job_cgroup(self, gpu_cluster):
@@ -407,4 +472,41 @@ class TestDeviceFilterLifecycle:
         assert after == baseline, (
             f"cgroup_device programs went from {baseline} to {after}; the filter "
             f"is not being released with the job cgroup"
+        )
+
+
+@pytest.mark.rootful
+class TestContainerDeviceIsolation:
+    """A native container's process tree lives in the job's cgroup, so the filter
+    reaches it too. A zero-GPU container must not reach the GPU — whether the
+    control node is simply absent from its ``/dev`` or the filter denies the open.
+    """
+
+    def test_zero_gpu_container_cannot_reach_the_gpu(self, gpu_cluster, tmp_path):
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+        _require_unfiltered_access(cluster)
+        cluster.container_preflight()
+        image = cluster.build_container_image(tmp_path)
+
+        content = _run_probe(
+            cluster,
+            "dev-iso-ctr-zero",
+            f"probe_open {KFD}\n"
+            "probe_open /dev/null\n",
+            [f"--container-image={image}"],
+        ).output
+
+        assert f"{KFD}=OPEN" not in content, (
+            f"a zero-GPU container must not be able to open {KFD}\noutput:\n{content}"
+        )
+        assert f"{KFD}=EPERM" in content or f"{KFD}=ENOENT" in content, (
+            f"{KFD} must be denied by the filter or absent from the container's "
+            f"/dev\noutput:\n{content}"
+        )
+        # Guards against a filter that just denies everything, which would also
+        # break a container that has no business losing its base devices.
+        assert "/dev/null=OPEN" in content, (
+            f"base devices must still work inside the container\noutput:\n{content}"
         )

--- a/tests/native_host/e2e/test_device_isolation.py
+++ b/tests/native_host/e2e/test_device_isolation.py
@@ -15,7 +15,7 @@ from typing import NamedTuple
 
 import pytest
 
-from cluster import parse_job_id, wait_job
+from cluster import parse_job_id, wait_job, wait_job_state
 
 KFD = "/dev/kfd"
 
@@ -68,6 +68,24 @@ def _run_probe(cluster, name: str, body: str, sbatch_args: list[str]) -> _Probe:
         f"output:\n{content}"
     )
     return _Probe(content, job_id)
+
+
+def _hold_job(cluster, name: str, sbatch_args: list[str]) -> int:
+    """Submit a long-lived job pinned to node 0 and return its id once RUNNING.
+
+    Steps and ``spur exec`` need a job that is still running to enter, which the
+    run-to-completion shape of :func:`_run_probe` cannot give them. Pinned for
+    the same reason: the allow-list is per node.
+    """
+    hold = cluster.write_file(f"{name}-hold.sh", "#!/bin/bash\nsleep 300\n")
+    sb = cluster.sbatch(
+        ["-J", name, "-N", "1", "-w", cluster.node_names[0]] + sbatch_args + [hold]
+    )
+    job_id = parse_job_id(sb)
+    assert job_id is not None, f"sbatch failed: {sb}"
+
+    wait_job_state(cluster, job_id, "R", timeout=120)
+    return job_id
 
 
 def _require_rootful(cluster) -> None:
@@ -163,6 +181,145 @@ class TestDeviceIsolation:
         assert f"{KFD}=EPERM" in content, (
             f"re-exporting the GPU selectors must not restore access to {KFD}\n"
             f"output:\n{content}"
+        )
+
+
+@pytest.mark.rootful
+class TestStepAndExecDeviceIsolation:
+    """The filter is attached to the job's cgroup, so it only reaches a process
+    that is in it. ``srun`` steps and ``spur exec`` are not batch payloads and
+    have to join it themselves; each of these opened ``/dev/kfd`` freely from
+    inside a zero-GPU job before that join existed.
+    """
+
+    def test_step_in_a_zero_gpu_job_is_denied_the_gpu_control_node(self, gpu_cluster):
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+        _require_unfiltered_access(cluster)
+
+        job_id = _hold_job(cluster, "dev-iso-step-zero", [])
+        probe = cluster.write_file(
+            "dev-iso-step-zero-probe.sh", _probe_script(f"probe_open {KFD}\n")
+        )
+        try:
+            code, out = cluster.srun_in_allocation(job_id, [probe])
+        finally:
+            cluster.scancel(str(job_id))
+
+        assert "DEVICE_PROBE_OK" in out, (
+            f"the step did not run to completion (exit {code})\n"
+            f"{cluster.debug_job(job_id)}\noutput:\n{out}"
+        )
+        assert f"{KFD}=EPERM" in out, (
+            f"a step in a zero-GPU job must be denied {KFD} by the kernel\n"
+            f"output:\n{out}"
+        )
+
+    def test_step_in_an_allocated_gpu_job_can_open_the_control_node(self, gpu_cluster):
+        # Isolation must not cost a step the hardware its job was granted.
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+        _require_unfiltered_access(cluster)
+
+        job_id = _hold_job(cluster, "dev-iso-step-alloc", ["--gres=gpu:1"])
+        probe = cluster.write_file(
+            "dev-iso-step-alloc-probe.sh", _probe_script(f"probe_open {KFD}\n")
+        )
+        try:
+            code, out = cluster.srun_in_allocation(job_id, [probe])
+        finally:
+            cluster.scancel(str(job_id))
+
+        assert f"{KFD}=OPEN" in out, (
+            f"a step in a job allocated a GPU must be able to open {KFD} "
+            f"(exit {code})\noutput:\n{out}"
+        )
+
+    def test_step_in_a_zero_gpu_interactive_allocation_is_denied_the_control_node(
+        self, gpu_cluster
+    ):
+        # An interactive allocation launches no payload, so its cgroup exists
+        # only because registration created one — nothing later would.
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+        _require_unfiltered_access(cluster)
+
+        probe = cluster.write_file(
+            "dev-iso-salloc-probe.sh", _probe_script(f"probe_open {KFD}\n")
+        )
+        out_path = f"{cluster.remote_dir}/dev-iso-salloc.out"
+        code, out = cluster.salloc_run(
+            f"'{cluster.bin_dir}/srun' '{probe}' > '{out_path}' 2>&1",
+            salloc_args=["-N", "1", "-w", cluster.node_names[0], "-t", "0:05"],
+        )
+        assert code == 0, f"salloc failed (exit {code}):\n{out}"
+
+        content = cluster.nodes[0].read_file(out_path)
+        assert "DEVICE_PROBE_OK" in content, (
+            f"the step did not run to completion\noutput:\n{content}\nsalloc:\n{out}"
+        )
+        assert f"{KFD}=EPERM" in content, (
+            f"a step in a zero-GPU interactive allocation must be denied {KFD}\n"
+            f"output:\n{content}"
+        )
+
+    def test_exec_into_a_zero_gpu_job_is_denied_the_gpu_control_node(self, gpu_cluster):
+        # `spur exec` enters the job's namespaces, and namespaces are not
+        # cgroups: entry alone would leave it holding spurd's own cgroup.
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+        _require_unfiltered_access(cluster)
+
+        job_id = _hold_job(cluster, "dev-iso-exec-zero", [])
+        probe = cluster.write_file(
+            "dev-iso-exec-zero-probe.sh", _probe_script(f"probe_open {KFD}\n")
+        )
+        try:
+            out = cluster.cli_allow_fail(["spur", "exec", str(job_id), "bash", probe])
+        finally:
+            cluster.scancel(str(job_id))
+
+        assert "DEVICE_PROBE_OK" in out, (
+            f"spur exec did not run the probe\n{cluster.debug_job(job_id)}\n"
+            f"output:\n{out}"
+        )
+        assert f"{KFD}=EPERM" in out, (
+            f"spur exec into a zero-GPU job must be denied {KFD} by the kernel\n"
+            f"output:\n{out}"
+        )
+
+    def test_a_step_lands_in_the_job_cgroup(self, gpu_cluster):
+        # Membership is the mechanism every deny above rests on, so assert it
+        # directly. Read from inside the step: a read from the test would race
+        # the step's exit, which drops the pid from cgroup.procs.
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+
+        job_id = _hold_job(cluster, "dev-iso-step-cgroup", [])
+        procs = f"/sys/fs/cgroup/spur/job_{job_id}/cgroup.procs"
+        probe = cluster.write_file(
+            "dev-iso-step-cgroup-probe.sh",
+            f"""#!/bin/bash
+if grep -qx "$$" {procs} 2>/dev/null; then
+  echo STEP_CGROUP=JOINED
+else
+  echo STEP_CGROUP=OUTSIDE
+fi
+echo "STEP_PID=$$ PROCS=$(tr '\\n' ' ' < {procs} 2>/dev/null)"
+""",
+        )
+        try:
+            code, out = cluster.srun_in_allocation(job_id, [probe])
+        finally:
+            cluster.scancel(str(job_id))
+
+        assert "STEP_CGROUP=JOINED" in out, (
+            f"the step's pid must appear in {procs} (exit {code})\noutput:\n{out}"
         )
 
 

--- a/tests/native_host/e2e/test_device_isolation.py
+++ b/tests/native_host/e2e/test_device_isolation.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for kernel-enforced device isolation (cgroup-v2 BPF device filter).
+
+spurd attaches a default-deny ``BPF_PROG_TYPE_CGROUP_DEVICE`` program to each
+job's cgroup, so a job may open only the device nodes its allocation covers.
+Unlike the ``*_VISIBLE_DEVICES`` deny in ``test_gpu_deny.py``, which a job can
+undo by re-exporting the variable, this one is enforced by the kernel.
+
+These assert on ``/dev/kfd`` rather than on ``/dev/dri/renderD*``. It is the
+right probe for two reasons: it reaches a job's allow-list only through an
+actual GPU allocation (the injection plan adds it as a shared edit), and it
+lives outside ``/dev/dri``, which the namespace wrapper replaces with a tmpfs.
+A denial on a render node could therefore be the tmpfs hiding it, while a
+denial on ``/dev/kfd`` can only be the filter.
+
+The filter is installed by a rootful agent, so every test here is
+``@pytest.mark.rootful``; ``gpu_cluster`` skips the file entirely on nodes
+without GPU device nodes.
+"""
+
+from typing import NamedTuple
+
+import pytest
+
+from cluster import parse_job_id, wait_job
+
+KFD = "/dev/kfd"
+
+# Opening a device reports one of these. EPERM is the filter denying the open;
+# EACCES is ordinary file permissions and would mask the filter, which is why
+# _require_unfiltered_access skips rather than letting a test pass vacuously.
+_PROBE_HELPER = """\
+probe_open() {
+  local p="$1" err
+  if err=$( { : < "$p"; } 2>&1 ); then
+    echo "$p=OPEN"
+  else
+    case "$err" in
+      *"Operation not permitted"*) echo "$p=EPERM" ;;
+      *"Permission denied"*)       echo "$p=EACCES" ;;
+      *"No such file or directory"*) echo "$p=ENOENT" ;;
+      *) echo "$p=OTHER[$err]" ;;
+    esac
+  fi
+}
+"""
+
+
+def _probe_script(body: str) -> str:
+    return f"#!/bin/bash\n{_PROBE_HELPER}{body}echo DEVICE_PROBE_OK\n"
+
+
+class _Probe(NamedTuple):
+    output: str
+    job_id: int
+
+
+def _run_probe(cluster, name: str, body: str, sbatch_args: list[str]) -> _Probe:
+    """Submit a probe pinned to node 0 and return its output and job id.
+
+    Pinned because the allocation, and therefore the allow-list, is per node;
+    an unpinned job could land somewhere the assertion was not written for.
+    """
+    script = cluster.write_file(f"{name}.sh", _probe_script(body))
+    out_path = f"{cluster.remote_dir}/{name}.out"
+    sb = cluster.sbatch(
+        ["-J", name, "-N", "1", "-w", cluster.node_names[0], "-o", out_path]
+        + sbatch_args
+        + [script]
+    )
+    job_id = parse_job_id(sb)
+    assert job_id is not None, f"sbatch failed: {sb}"
+
+    wait_job(cluster, job_id, timeout=120)
+    content = cluster.wait_output(out_path, "DEVICE_PROBE_OK", timeout=120)
+    assert "DEVICE_PROBE_OK" in content, (
+        f"probe did not run to completion\n{cluster.debug_job(job_id)}\n"
+        f"output:\n{content}"
+    )
+    return _Probe(content, job_id)
+
+
+def _require_rootful(cluster) -> None:
+    user = cluster.spurd_agent_user(0)
+    assert user == "root", (
+        f"the device filter needs a rootful agent to load and attach the BPF "
+        f"program, got user {user!r}"
+    )
+
+
+def _require_unfiltered_access(cluster) -> None:
+    """Skip unless the node has /dev/kfd and the test user can already open it.
+
+    If file permissions alone deny the open, every deny assertion below would
+    pass for the wrong reason.
+    """
+    node = cluster.nodes[0]
+    if not node.exec_allow_fail(f"ls {KFD} 2>/dev/null").strip():
+        pytest.skip(f"node 0 has no {KFD} (not an AMD GPU node)")
+    probe = node.exec_allow_fail(
+        f'if : < {KFD} 2>/dev/null; then echo OPEN; else echo DENIED; fi'
+    ).strip()
+    if "OPEN" not in probe:
+        pytest.skip(
+            f"{KFD} is not openable by the test user outside a job, so file "
+            f"permissions would mask the device filter"
+        )
+
+
+@pytest.mark.rootful
+class TestDeviceIsolation:
+    def test_zero_gpu_job_is_denied_the_gpu_control_node(self, gpu_cluster):
+        # The SPUR-192 case: a job that was allocated no GPU shares the node with
+        # jobs that were, and must not be able to reach the hardware.
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+        _require_unfiltered_access(cluster)
+
+        content = _run_probe(
+            cluster,
+            "dev-iso-zero",
+            f"probe_open {KFD}\n"
+            'head -c 8 /dev/urandom > /dev/null && echo urandom=OPEN\n'
+            'echo x > /dev/null && echo null=OPEN\n',
+            [],
+        ).output
+
+        assert f"{KFD}=EPERM" in content, (
+            f"a zero-GPU job must be denied {KFD} by the kernel\noutput:\n{content}"
+        )
+        # Without these the test would also pass against a filter that denies
+        # everything, which would break every job on the node.
+        assert "urandom=OPEN" in content, (
+            f"base pseudo-devices must stay reachable\noutput:\n{content}"
+        )
+        assert "null=OPEN" in content, (
+            f"base pseudo-devices must stay reachable\noutput:\n{content}"
+        )
+
+    def test_allocated_gpu_job_can_open_the_control_node(self, gpu_cluster):
+        # The other half of the property: isolation must not cost a job the
+        # hardware it was actually given.
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+        _require_unfiltered_access(cluster)
+
+        content = _run_probe(
+            cluster, "dev-iso-alloc", f"probe_open {KFD}\n", ["--gres=gpu:1"]
+        ).output
+
+        assert f"{KFD}=OPEN" in content, (
+            f"a job allocated a GPU must be able to open {KFD}\noutput:\n{content}"
+        )
+
+    def test_visible_devices_override_does_not_restore_access(self, gpu_cluster):
+        # What Phase 0's env-var deny could not provide: re-exporting the
+        # selector is how a job defeats an advisory sentinel, and it must not
+        # move a kernel filter.
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+        _require_unfiltered_access(cluster)
+
+        content = _run_probe(
+            cluster,
+            "dev-iso-reexport",
+            "export ROCR_VISIBLE_DEVICES=0\n"
+            "export HIP_VISIBLE_DEVICES=0\n"
+            "export CUDA_VISIBLE_DEVICES=0\n"
+            f"probe_open {KFD}\n",
+            [],
+        ).output
+
+        assert f"{KFD}=EPERM" in content, (
+            f"re-exporting the GPU selectors must not restore access to {KFD}\n"
+            f"output:\n{content}"
+        )
+
+
+@pytest.mark.rootful
+class TestDeviceIsolationConfig:
+    def test_constrain_devices_false_leaves_the_node_reachable(self, gpu_cluster):
+        # Proves the deny in the tests above is the filter and not some other
+        # layer: the only thing that changes here is the switch.
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+        _require_unfiltered_access(cluster)
+
+        cluster.stop()
+        cluster.start({"cgroup": {"constrain_devices": False}}, agent_as_root=True)
+
+        content = _run_probe(
+            cluster, "dev-iso-off", f"probe_open {KFD}\n", []
+        ).output
+
+        assert f"{KFD}=OPEN" in content, (
+            f"with constrain_devices = false a zero-GPU job must still reach "
+            f"{KFD}\noutput:\n{content}"
+        )
+
+    def test_extra_device_paths_allows_an_unallocated_node(self, gpu_cluster):
+        # The operator escape hatch for a device the allocation does not cover
+        # and the built-in host-infrastructure list does not name.
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+        _require_unfiltered_access(cluster)
+
+        cluster.stop()
+        cluster.start({"cgroup": {"extra_device_paths": [KFD]}}, agent_as_root=True)
+
+        content = _run_probe(
+            cluster, "dev-iso-extra", f"probe_open {KFD}\n", []
+        ).output
+
+        assert f"{KFD}=OPEN" in content, (
+            f"{KFD} listed in extra_device_paths must be allowed even for a "
+            f"zero-GPU job\noutput:\n{content}"
+        )
+
+
+@pytest.mark.rootful
+class TestDeviceFilterLifecycle:
+    def test_filter_is_released_when_the_job_cgroup_goes_away(self, gpu_cluster):
+        """Nothing detaches the filter explicitly.
+
+        The program is freed because removing the cgroup directory drops the
+        kernel's last reference to it, so a leak here would accumulate one
+        program per job for the lifetime of the agent.
+        """
+        cluster = gpu_cluster
+        cluster.gpu_preflight(1)
+        _require_rootful(cluster)
+
+        node = cluster.nodes[0]
+        if not node.exec_allow_fail("command -v bpftool").strip():
+            pytest.skip("bpftool is not installed on node 0")
+        # Without a working non-interactive sudo the count below would always
+        # read 0 and the assertion would hold for the wrong reason.
+        if "PROBE_OK" not in node.exec_allow_fail(
+            "sudo -n bpftool prog show >/dev/null 2>&1 && echo PROBE_OK"
+        ):
+            pytest.skip("bpftool needs passwordless sudo on node 0 to list programs")
+
+        def loaded() -> int:
+            out = node.exec_allow_fail(
+                "sudo -n bpftool prog show 2>/dev/null | grep -c cgroup_device"
+            ).strip()
+            return int(out) if out.isdigit() else -1
+
+        baseline = loaded()
+        assert baseline >= 0, "could not read the loaded cgroup_device program count"
+
+        probe = _run_probe(cluster, "dev-iso-life", "true\n", ["--gres=gpu:1"])
+        cgroup = f"/sys/fs/cgroup/spur/job_{probe.job_id}"
+
+        # Scoped to this job's cgroup rather than every job_* directory, so a
+        # job belonging to another test cannot decide this one.
+        assert not node.exec_allow_fail(f"ls -d {cgroup} 2>/dev/null").strip(), (
+            f"{cgroup} outlived its job, so its filter is still attached"
+        )
+        after = loaded()
+        assert after == baseline, (
+            f"cgroup_device programs went from {baseline} to {after}; the filter "
+            f"is not being released with the job cgroup"
+        )

--- a/tests/native_host/e2e/test_device_isolation.py
+++ b/tests/native_host/e2e/test_device_isolation.py
@@ -4,20 +4,11 @@
 """E2E tests for kernel-enforced device isolation (cgroup-v2 BPF device filter).
 
 spurd attaches a default-deny ``BPF_PROG_TYPE_CGROUP_DEVICE`` program to each
-job's cgroup, so a job may open only the device nodes its allocation covers.
-Unlike the ``*_VISIBLE_DEVICES`` deny in ``test_gpu_deny.py``, which a job can
-undo by re-exporting the variable, this one is enforced by the kernel.
-
-These assert on ``/dev/kfd`` rather than on ``/dev/dri/renderD*``. It is the
-right probe for two reasons: it reaches a job's allow-list only through an
-actual GPU allocation (the injection plan adds it as a shared edit), and it
-lives outside ``/dev/dri``, which the namespace wrapper replaces with a tmpfs.
-A denial on a render node could therefore be the tmpfs hiding it, while a
-denial on ``/dev/kfd`` can only be the filter.
-
-The filter is installed by a rootful agent, so every test here is
-``@pytest.mark.rootful``; ``gpu_cluster`` skips the file entirely on nodes
-without GPU device nodes.
+job's cgroup, so unlike the ``*_VISIBLE_DEVICES`` deny in ``test_gpu_deny.py``
+no re-exported variable can undo it. ``/dev/kfd`` is the probe because it
+reaches a job's allow-list only through a real allocation and lives outside the
+``/dev/dri`` the namespace wrapper swaps for a tmpfs, so a denial there can
+only be the filter. Loading it needs root, hence ``@pytest.mark.rootful``.
 """
 
 from typing import NamedTuple
@@ -28,9 +19,8 @@ from cluster import parse_job_id, wait_job
 
 KFD = "/dev/kfd"
 
-# Opening a device reports one of these. EPERM is the filter denying the open;
-# EACCES is ordinary file permissions and would mask the filter, which is why
-# _require_unfiltered_access skips rather than letting a test pass vacuously.
+# EPERM is the filter denying the open; EACCES is ordinary file permissions, which
+# would mask it — hence the _require_unfiltered_access skip.
 _PROBE_HELPER = """\
 probe_open() {
   local p="$1" err
@@ -58,10 +48,8 @@ class _Probe(NamedTuple):
 
 
 def _run_probe(cluster, name: str, body: str, sbatch_args: list[str]) -> _Probe:
-    """Submit a probe pinned to node 0 and return its output and job id.
-
-    Pinned because the allocation, and therefore the allow-list, is per node;
-    an unpinned job could land somewhere the assertion was not written for.
+    """Submit a probe pinned to node 0: the allow-list is per node, so an unpinned
+    job could land somewhere the assertion was not written for.
     """
     script = cluster.write_file(f"{name}.sh", _probe_script(body))
     out_path = f"{cluster.remote_dir}/{name}.out"
@@ -91,10 +79,8 @@ def _require_rootful(cluster) -> None:
 
 
 def _require_unfiltered_access(cluster) -> None:
-    """Skip unless the node has /dev/kfd and the test user can already open it.
-
-    If file permissions alone deny the open, every deny assertion below would
-    pass for the wrong reason.
+    """Skip unless the test user can already open /dev/kfd: if file permissions
+    alone deny it, every deny assertion below passes for the wrong reason.
     """
     node = cluster.nodes[0]
     if not node.exec_allow_fail(f"ls {KFD} 2>/dev/null").strip():
@@ -112,8 +98,8 @@ def _require_unfiltered_access(cluster) -> None:
 @pytest.mark.rootful
 class TestDeviceIsolation:
     def test_zero_gpu_job_is_denied_the_gpu_control_node(self, gpu_cluster):
-        # The SPUR-192 case: a job that was allocated no GPU shares the node with
-        # jobs that were, and must not be able to reach the hardware.
+        # A job allocated no GPU shares the node with jobs that were, and must not
+        # be able to reach the hardware.
         cluster = gpu_cluster
         cluster.gpu_preflight(1)
         _require_rootful(cluster)
@@ -157,9 +143,8 @@ class TestDeviceIsolation:
         )
 
     def test_visible_devices_override_does_not_restore_access(self, gpu_cluster):
-        # What Phase 0's env-var deny could not provide: re-exporting the
-        # selector is how a job defeats an advisory sentinel, and it must not
-        # move a kernel filter.
+        # Re-exporting the selector is how a job defeats an advisory sentinel; it
+        # must not move a kernel filter.
         cluster = gpu_cluster
         cluster.gpu_preflight(1)
         _require_rootful(cluster)
@@ -227,11 +212,8 @@ class TestDeviceIsolationConfig:
 @pytest.mark.rootful
 class TestDeviceFilterLifecycle:
     def test_filter_is_released_when_the_job_cgroup_goes_away(self, gpu_cluster):
-        """Nothing detaches the filter explicitly.
-
-        The program is freed because removing the cgroup directory drops the
-        kernel's last reference to it, so a leak here would accumulate one
-        program per job for the lifetime of the agent.
+        """Nothing detaches the filter: removing the cgroup directory drops the
+        kernel's last reference. A leak would accumulate one program per job.
         """
         cluster = gpu_cluster
         cluster.gpu_preflight(1)

--- a/tests/native_host/e2e/test_multi_node.py
+++ b/tests/native_host/e2e/test_multi_node.py
@@ -264,8 +264,11 @@ class TestBackfillReservation:
         cluster = multi_node_cluster
         n0, n1 = cluster.node_names[0], cluster.node_names[1]
 
+        # Must still hold n0 when the reservation is asserted below: if the filler
+        # exits on its own first, big dispatches early and clears the reservation,
+        # racing the check. Cancelled right after the assert so big can then run.
         filler_script = cluster.write_file(
-            "backfill-filler.sh", "#!/bin/bash\nsleep 8\n"
+            "backfill-filler.sh", "#!/bin/bash\nsleep 45\n"
         )
         filler_id = parse_job_id(
             cluster.sbatch(
@@ -321,7 +324,10 @@ class TestBackfillReservation:
             f"n1's State= should carry the PLANNED overlay flag:\n{n1_show}"
         )
 
+        # Free the reserved slot (small) and n0 (filler) so big can finally
+        # dispatch — it must not stay starved.
         cluster.scancel(str(small_id))
+        cluster.scancel(str(filler_id))
 
         wait_job(cluster, big_id, timeout=90)
         big_content = cluster.read_output_on_any_node(big_out)

--- a/tests/native_host/e2e/test_single_node.py
+++ b/tests/native_host/e2e/test_single_node.py
@@ -8,6 +8,14 @@ import time
 from cluster import parse_job_id, job_state, wait_job
 
 
+def test_job_state_normalizes_truncated_out_of_memory():
+    output = """\
+             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+                 1   default cg-oom-s       ci OO       0:01      1 node-1
+"""
+    assert job_state(output, 1) == "OOM"
+
+
 class TestClusterHealth:
     def test_sinfo_returns_output(self, cluster):
         out = cluster.sinfo()


### PR DESCRIPTION
## What this fixes

A job could open any GPU device node on its node, including one allocated to
another user's job. The existing `*_VISIBLE_DEVICES` deny was advisory — a job
could re-export the variable and regain access.

Closing it took two things: the kernel has to do the denying, and every process
a job runs has to be subject to it. Only the batch payload was in the job's
cgroup at all — `srun` steps, `spur exec`, and interactive attach ran in
spurd's own cgroup, so a filter attached to the job would have missed them.

## Approach

`spurd` attaches a default-deny `BPF_PROG_TYPE_CGROUP_DEVICE` program to each
job's cgroup. The instructions are generated in-process and loaded through the
raw `bpf()` syscall — the technique systemd uses — so there is no eBPF build
step and no nightly toolchain. The allow-list is the job's allocated device
paths, plus standard pseudo-devices, plus host-infrastructure nodes that are
never per-job allocatable.

Containment was then extended so the filter actually covers everything.
Interactive allocations create the cgroup at `RegisterJobAllocation`, and every
process the agent starts joins it from `pre_exec` while still privileged, since
an unprivileged process cannot write another cgroup's `cgroup.procs`. That
includes both spawn shapes of `spur exec`, one of which had no `pre_exec` hook
at all because it drops privilege inside the namespace via `setpriv`.

Container jobs come along for free — they already live in the same `job_N`
cgroup, so there is no container-specific device code.

## Design choices

- **Per-job program load, no BPF map.** Matches Slurm's `cgroup/v2` plugin. A
  map-based design would trade one `BPF_PROG_LOAD` for `MAP_CREATE` plus
  `MAP_UPDATE` and a hand-encoded lookup: more `unsafe` for no measured win on
  a path dwarfed by fork/exec.
- **No detach call.** `BPF_PROG_ATTACH` takes its own kernel reference, so
  removing the cgroup at teardown frees the program. Both descriptors drop
  before install returns; holding one would pin a program per job for spurd's
  lifetime.
- **Access is a subset test** (`requested & !granted == 0`), with the complement
  spanning the full 16-bit access field so an access bit a future kernel adds
  fails closed rather than being ignored.
- **Per-GPU compute nodes are deliberately absent from the host-infrastructure
  list** — gating those on the allocation is the security property. What is on
  it (InfiniBand verbs, NVIDIA control/UVM/MIG, `/dev/fuse`) is shared by every
  workload and owned by no allocation, so denying it breaks jobs that were never
  reaching for a GPU.
- **Steps share the job cgroup rather than getting nested ones.** Correct for
  device isolation and much simpler; the cost is no per-step limits or
  accounting.

## Behavior changes

[1] `constrain_devices` defaults on, so a job can no longer open a device node
its allocation does not cover. A site needing an extra node can list it in
`[cgroup] extra_device_paths` instead of disabling the filter.

[2] A step now counts against the job's `memory.max` and cpuset, where it
previously ran unbounded. A site whose `srun` steps routinely overrun what the
job asked for will start seeing OOM kills.

[3] `[cgroup] required` now also gates allocation registration, not just launch.

[4] `spurd` raises its own `RLIMIT_MEMLOCK` at startup, since kernels before
5.11 charge BPF program memory against it. A job configured
`rlimits.memlock = "inherit"` therefore inherits the raised value; the
`"unlimited"` default is unaffected.

## Testing

Unit tests execute the real generated instruction stream through a minimal BPF
interpreter rather than asserting structure, because the kernel verifier is not
reachable from CI. That caught a jump-overshoot bug where a mismatched rule
skipped the next rule's device-type check — a silent isolation hole that
structural assertions would have passed.

Validated on a bare-metal node using synthetic character devices in the local
major range declared as GRES, which separates the filter from a missing driver:
an allowed open fails `ENXIO`, a filtered one fails `EPERM`. A zero-GPU job was
denied both devices while `/dev/urandom` still worked; a one-GPU job opened its
own and was denied the other (same major, different minor); re-exporting
`ROCR_VISIBLE_DEVICES` did not restore access; the program was freed when the
cgroup went away, with no leak across twelve back-to-back jobs; and
`required = true` refused a launch when the filter could not be installed.

Workspace suite is at 3558 tests. The e2e suite adds 11 device-isolation cases,
which skip without GPU hardware.

## Follow-ups

- Nested per-step cgroups, for per-step limits and accounting. A filter attached
  at `job_N` is inherited by descendants, so it keeps working unchanged.
- seccomp and Landlock still reach only the batch path.
- `cleanup_cgroup` calls `remove_dir` straight after SIGKILL, which returns
  `EBUSY` until processes are reaped, so cancelling an allocation with live
  steps can strand the directory and its program.
- `required` is not verified on `spur exec` and attach; making the join fatal in
  the child would close that race-free.