### PR TITLE
fix(spur-cli): render squeue %L (TIME_LEFT) instead of ?

### DIFF
--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -935,7 +935,7 @@ mod tests {
 
     /// Every documented squeue format letter must resolve to a real value, not
     /// the `?` fallback. Guards against a header/sort entry without a matching
-    /// render arm (the SPUR-245 %L regression).
+    /// render arm (for example, a %L time-left regression).
     #[test]
     fn every_header_letter_resolves() {
         let mut j = job(1, "default", P::JobRunning, 100);

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -208,6 +208,14 @@ fn resolve_job_field(job: &spur_proto::proto::JobInfo, spec: char) -> String {
         'T' => state_name(job.state),
         'M' => format_runtime(job),
         'l' => format_time_limit(job),
+        'L' => {
+            let secs = time_left_secs(job);
+            if secs == i64::MAX {
+                "UNLIMITED".into()
+            } else {
+                format_duration_hms(secs.max(0))
+            }
+        }
         'D' => job.num_nodes.to_string(),
         'R' => {
             if job.state == spur_proto::proto::JobState::JobPending as i32 {
@@ -889,5 +897,66 @@ mod tests {
         let mut jobs = vec![a, b, c];
         sort_jobs(&mut jobs, &parse_sort_arg("L").unwrap());
         assert_eq!(ids(&jobs), vec![3, 1, 2]);
+    }
+
+    #[test]
+    fn time_left_renders_remaining_duration() {
+        let mut j = job(1, "default", P::JobRunning, 0);
+        j.time_limit = Some(prost_types::Duration {
+            seconds: 3600,
+            nanos: 0,
+        });
+        j.run_time = Some(prost_types::Duration {
+            seconds: 600,
+            nanos: 0,
+        });
+        assert_eq!(resolve_job_field(&j, 'L'), "50:00");
+    }
+
+    #[test]
+    fn time_left_unlimited_when_no_limit() {
+        let j = job(1, "default", P::JobRunning, 0);
+        assert_eq!(resolve_job_field(&j, 'L'), "UNLIMITED");
+    }
+
+    #[test]
+    fn time_left_clamps_overrun_to_zero() {
+        let mut j = job(1, "default", P::JobRunning, 0);
+        j.time_limit = Some(prost_types::Duration {
+            seconds: 600,
+            nanos: 0,
+        });
+        j.run_time = Some(prost_types::Duration {
+            seconds: 900,
+            nanos: 0,
+        });
+        assert_eq!(resolve_job_field(&j, 'L'), "0:00");
+    }
+
+    /// Every documented squeue format letter must resolve to a real value, not
+    /// the `?` fallback. Guards against a header/sort entry without a matching
+    /// render arm (the SPUR-245 %L regression).
+    #[test]
+    fn every_header_letter_resolves() {
+        let mut j = job(1, "default", P::JobRunning, 100);
+        j.time_limit = Some(prost_types::Duration {
+            seconds: 3600,
+            nanos: 0,
+        });
+        j.run_time = Some(prost_types::Duration {
+            seconds: 600,
+            nanos: 0,
+        });
+        for c in b'!'..=b'~' {
+            let spec = c as char;
+            if format_engine::squeue_header(spec) == "?" {
+                continue;
+            }
+            assert_ne!(
+                resolve_job_field(&j, spec),
+                "?",
+                "spec %{spec} has a header but no render arm"
+            );
+        }
     }
 }

--- a/docs/migration-from-slurm.rst
+++ b/docs/migration-from-slurm.rst
@@ -61,8 +61,6 @@ noted as "accepted for compatibility" parse without error but have no effect yet
      - Accepted for compatibility; the job-id filter is not yet applied server-side.
    * - ``sacct`` ``ReqMem``
      - The ``ReqMem`` format field has no value yet and renders empty.
-   * - ``squeue`` format
-     - The ``%b`` (GRES) and ``%L`` (time-left) format fields are not yet resolved.
    * - ``sstat``
      - Per-process ``Ave*`` and ``Max*`` metrics (for example ``AveRSS``, ``MaxVMSize``) show ``N/A``.
    * - ``sprio``

--- a/docs/user-guide/monitoring-jobs.rst
+++ b/docs/user-guide/monitoring-jobs.rst
@@ -127,6 +127,10 @@ SUSPENDED, COMPLETING**.
      - END_TIME
    * - ``%Y``
      - SCHEDNODES
+     - ``%L``
+     - TIME_LEFT
+   * - ``%b``
+     - GRES
      -
      -
 


### PR DESCRIPTION
## What

`squeue -o "%L"` (the `TIME_LEFT` column) printed `?` for every job. The header rendered `TIME_LEFT` and `-S L` sorting worked, but the value was never displayed, so a user could sort by remaining time without being able to see it.

## Root cause

`squeue` keys three tables by format letter: the header (`squeue_header`), the sort comparator (`compare_field`), and the value renderer (`resolve_job_field`). `'L'` was present in the first two but missing from `resolve_job_field`, so it fell through to the `_ => "?"` catch-all.

## Fix

Add the `'L'` arm to `resolve_job_field`, reusing the existing `time_left_secs` and `format_duration_hms` helpers. No-limit jobs render `UNLIMITED` (consistent with `%l`); overrun (used > limit) clamps to `0:00`. Sorting is left unchanged.

Note: Slurm distinguishes `NOT_SET` from `UNLIMITED` for `%l`/`%L`, but Spur's model has no such distinction (a missing time limit means no limit), so `%L` follows the existing `%l` behavior.

## Tests

- Render tests for `%L`: remaining duration, `UNLIMITED`, and overrun clamp.
- Regression guard `every_header_letter_resolves`: asserts no `squeue_header` letter falls through to `?`, catching this whole class of header/render drift.

## Docs

- Add `%L` (TIME_LEFT) and `%b` (GRES) to the format-letter table in `monitoring-jobs.rst`.
- Drop the now-stale migration note claiming `%b`/`%L` are unresolved.

## Validation

- `cargo clippy -p spur-cli --all-targets --locked` clean; `cargo test -p spur-cli --locked` green.
- Smoke-tested on the 4-node bare-metal cluster: `%L` renders real values, matches `%l - %M`, and `-S L` / `-S -L` ordering is consistent with the displayed values.