### PR TITLE
fix(deploy): give the operator readiness probe time to answer

### DIFF
--- a/examples/k8s/operator.yaml
+++ b/examples/k8s/operator.yaml
@@ -72,6 +72,11 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10
+            # /readyz makes two live round-trips (K8s API, then a fresh gRPC
+            # connect to spurctld), so the 1s default leaves no margin and the
+            # pod can never go Ready on a loaded cluster. The deadline is per
+            # probe, so a slow answer costs one interval, not readiness.
+            timeoutSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/k8s/e2e/manifests/operator.yaml
+++ b/tests/k8s/e2e/manifests/operator.yaml
@@ -60,6 +60,10 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10
+            # Shared runners are slow enough that the 1s default expires before
+            # /readyz finishes its two live round-trips, so the operator never
+            # goes Ready and every k8s test errors at fixture setup.
+            timeoutSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## What this fixes

The `spur-k8s-operator` Deployment can fail to ever become Ready, which makes every
`E2E / k8s` job error at fixture setup with `operator deployment not ready`. It is
intermittent â the same commit can pass and then fail an hour later.

## Cause

The `readinessProbe` sets `initialDelaySeconds` and `periodSeconds` but not
`timeoutSeconds`, so it takes Kubernetes' 1s default. That 1s has to cover the whole
of `/readyz`, which does two live network round-trips per call:

- `state.k8s_client.apiserver_version()` â a request to the API server
- `SlurmControllerClient::connect(url)` â a **new** gRPC connection to `spurctld`,
  built fresh on every probe rather than reused

Measured directly against a running operator, that path takes around 4s.

The part that turns slowness into a hard failure is that a probe deadline is **per
attempt, not cumulative**. Kubernetes does not accumulate progress across probes, so
once `/readyz` exceeds 1s the pod never flips to Ready and anything waiting on the
Deployment waits forever. Raising a *caller's* wait has no effect â the condition is
unreachable rather than slow.

It only shows up sometimes because when the API server and `spurctld` are warm both
round-trips finish inside 1s. There is no margin, so a single slow response is enough.

## Approach

Set `timeoutSeconds: 10` on the readiness probe in both the shipped example and the
E2E harness manifest. It equals `periodSeconds`, which is the largest value that
cannot overlap the next probe, so a slow answer costs one interval instead of
readiness. `/healthz` returns immediately and is left alone.

This is the minimal correct fix: it gives the existing endpoint enough headroom to
answer honestly, without changing what "ready" means.

## Trade-off and follow-up

Ten seconds is headroom for an endpoint that should not need it. The better fix is to
make `/readyz` cheap â reuse a controller client rather than reconnecting per probe,
so readiness reflects cached health instead of doing fresh I/O on every call. That is
a behavior change in the operator and belongs in its own PR; this one unblocks CI
without it.

Note this also explains why raising the E2E wait ceiling in [1] did not help: that
change assumed loaded runners were merely slow, which is consistent with the evidence
but not the cause.

[1] https://github.com/ROCm/spur/pull/763

## Testing

Verified on a live single-node cluster (k8s v1.30.14, operator built from this
branch's manifest values), reproducing the failure and then clearing it.

First, the premise — `/readyz` against the running operator, five consecutive calls:

```
/readyz  4.010s 200      /healthz  0.00055s 200
/readyz  4.011s 200      /healthz  0.00056s 200
/readyz  4.010s 200      /healthz  0.00054s 200
/readyz  4.011s 200
/readyz  4.010s 200
```

`/readyz` is consistently ~4s and never faster; `/healthz` is sub-millisecond, so the
cost is the two round-trips, not process health.

**Before** — with `timeoutSeconds` removed, so the probe takes the 1s default:

```
Readiness: http-get http://:8080/readyz delay=10s timeout=1s period=10s #success=1 #failure=3

Warning  Unhealthy  3s (x12 over 93s)  kubelet  Readiness probe failed:
  Get "http://10.244.0.16:8080/readyz": context deadline exceeded
  (Client.Timeout exceeded while awaiting headers)

Ready=False (ContainersNotReady)
```

The pod stayed `0/1` for the full 93s of observation across 12 consecutive probe
failures — it does not converge, matching the per-attempt-deadline reasoning above.

**After** — patching the probe with the block exactly as committed in
`tests/k8s/e2e/manifests/operator.yaml` on this branch, then deleting the pod so a
fresh one starts cold:

```
Readiness: http-get http://:8080/readyz delay=10s timeout=10s period=10s #success=1 #failure=3

t+6s   spur-k8s-operator-...-sq88t  0/1  Running
t+12s  spur-k8s-operator-...-sq88t  0/1  Running
t+18s  spur-k8s-operator-...-sq88t  1/1  Running
```

Ready within 18s of a cold start (10s of which is `initialDelaySeconds`), with no
`Unhealthy` events and `Ready=True`.

Both manifests also parse cleanly with the intended values (`timeoutSeconds=10`,
`periodSeconds=10`), and CI on this PR exercises the harness manifest directly.
