### PR TITLE
test(e2e): cover fair-share preemption, same-QOS allow-list, and exempt-time precedence

### DIFF
--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -1151,6 +1151,20 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
             time.sleep(2)
         raise RuntimeError("Postgres did not become ready in time")
 
+    def psql(self, sql: str) -> str:
+        """Run *sql* against the accounting database and return stdout.
+
+        Lets a test plant accounting rows that would otherwise take real
+        workload hours to accumulate — fair-share usage in particular.
+        """
+        if not self.accounting_enabled:
+            raise RuntimeError("psql() requires the accounting_cluster fixture")
+        escaped = sql.replace("'", "'\"'\"'")
+        return self.nodes[0].exec(
+            f"docker exec '{self._pg_container}' "
+            f"psql -U spur -d spur -tAc '{escaped}'"
+        )
+
     def _stop_postgres(self):
         node = self.nodes[0]
         node.exec_allow_fail(f"docker rm -f '{self._pg_container}' 2>/dev/null || true")

--- a/tests/native_host/e2e/test_preemption_exempt_precedence.py
+++ b/tests/native_host/e2e/test_preemption_exempt_precedence.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Black-box end-to-end tests for preempt-exempt-time precedence.
+
+The effective exempt window for a running job resolves QOS > partition > global,
+returning on the first level that is set. Two consequences are easy to get wrong
+and are covered here:
+
+  - A QOS value wins outright, even when it is *shorter* than the partition's.
+    It is an override, not a floor.
+  - Clearing the QOS value must fall back to the partition, not to zero.
+
+The distinction matters because a cluster whose global `preempt_exempt_time` is
+unset resolves the bottom of that chain to 0 — no protection at all — so a QOS
+override that fails to clear correctly silently strips the window rather than
+restoring the partition default.
+
+Existing coverage stops short of this: test_preemption_qos_hierarchy.py exercises
+the *global* scheduler value and a partition value set via scontrol, but nothing
+exercises the QOS level or the precedence between levels.
+
+Requires:
+  - Postgres on node 0 (accounting_cluster fixture, skips when Docker is absent)
+"""
+
+import time
+
+import pytest
+
+from cluster import job_state, parse_job_id, wait_job, wait_job_state
+
+_SLEEP_SCRIPT = "#!/bin/bash\nsleep 600\n"
+_QUICK_SCRIPT = "#!/bin/bash\nsleep 5\n"
+
+# Partition window, deliberately far longer than the QOS override so the two
+# levels cannot be confused for one another by a timing coincidence.
+_PARTITION_EXEMPT_SECS = 90
+# QOS override, short enough that the victim is eligible almost immediately.
+_QOS_EXEMPT_SECS = 5
+
+# Long enough to clear the 5s QOS window, short enough to stay well inside the
+# 90s partition window — the gap between the two is what each test reads.
+_SETTLE_SECS = 12
+_GUARD_SECS = 15
+_WAIT_PREEMPT = 60
+
+# QOS cache refreshes on the accounting interval; a sacctmgr change needs a
+# cycle before the scheduler acts on it.
+_CACHE_WARMUP_SECS = 15
+
+_BASE_CONFIG = {
+    "partitions": [
+        {
+            "name": "default",
+            "state": "UP",
+            "default": True,
+            "nodes": "ALL",
+            "max_time": "24:00:00",
+            "default_time": "10:00",
+            "preempt_mode": "cancel",
+            "preempt_exempt_time": _PARTITION_EXEMPT_SECS,
+        }
+    ],
+    "scheduler": {
+        "preempt_type": "qos_priority",
+    },
+    # Required when the test runner SSHes in as root: spurd refuses to execute
+    # jobs as uid 0 unless this is explicitly enabled.
+    "auth": {"plugin": "none", "allow_root_jobs": True},
+}
+
+
+def _assert_scontrol_state(cluster, job_id: int, expected: str, label: str = "") -> None:
+    """Assert JobState=<expected> appears in scontrol show job output."""
+    show = cluster.scontrol("show", "job", str(job_id))
+    assert f"JobState={expected}" in show, (
+        f"{label or 'job'} {job_id}: expected JobState={expected} in scontrol output:\n{show}"
+    )
+
+
+def _create_qos_pair(cluster) -> None:
+    """Victim QOS plus a hunter QOS permitted to preempt it.
+
+    The allow-list entry is applied by modify rather than at creation: CreateQos
+    validates every name against the QOS table first, so the victim QOS has to
+    exist before the hunter may reference it.
+    """
+    cluster.sacctmgr(["add", "qos", "name=exempt-victim", "priority=100",
+                      "preemptmode=cancel"])
+    cluster.sacctmgr(["add", "qos", "name=exempt-hunter", "priority=10000"])
+    cluster.sacctmgr(["modify", "qos", "name=exempt-hunter", "set",
+                      "preempt=exempt-victim"])
+
+
+def _run_victim(cluster, node: str, prefix: str) -> int:
+    script = cluster.write_file(f"{prefix}-victim.sh", _SLEEP_SCRIPT)
+    victim_id = parse_job_id(
+        cluster.sbatch([
+            "-N1", "--exclusive", f"--nodelist={node}", "-q", "exempt-victim", script,
+        ])
+    )
+    assert victim_id is not None, "victim submit failed"
+    wait_job_state(cluster, victim_id, "R", timeout=30)
+    _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim initial")
+    return victim_id
+
+
+def _queue_hunter(cluster, node: str, prefix: str, script_body: str) -> int:
+    script = cluster.write_file(f"{prefix}-hunter.sh", script_body)
+    hunter_id = parse_job_id(
+        cluster.sbatch([
+            "-N1", "--exclusive", f"--nodelist={node}", "-q", "exempt-hunter", script,
+        ])
+    )
+    assert hunter_id is not None, "hunter submit failed"
+    return hunter_id
+
+
+class TestQosExemptTimeOverridesPartition:
+    """A QOS preemptexempttime shorter than the partition's must win.
+
+    The victim is eligible once its own QOS window elapses, well before the
+    partition would have released it. If the partition value were taking
+    precedence the victim would survive, and this test fails.
+    """
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return _BASE_CONFIG
+
+    def test_qos_exempt_time_wins_over_longer_partition_window(self, accounting_cluster):
+        c = accounting_cluster
+        node = c.node_names[0]
+
+        _create_qos_pair(c)
+        c.sacctmgr(["modify", "qos", "name=exempt-victim", "set",
+                    f"preemptexempttime={_QOS_EXEMPT_SECS}"])
+        time.sleep(_CACHE_WARMUP_SECS)
+
+        shown = c.sacctmgr(["show", "qos", "format=Name,PreemptExemptTime", "-P"])
+        assert f"exempt-victim|{_QOS_EXEMPT_SECS}" in shown, (
+            f"QOS preemptexempttime was not stored:\n{shown}"
+        )
+
+        victim_id = None
+        hunter_id = None
+        try:
+            victim_id = _run_victim(c, node, "qos-wins")
+
+            # Past the 5s QOS window, far short of the 90s partition window.
+            time.sleep(_SETTLE_SECS)
+            hunter_id = _queue_hunter(c, node, "qos-wins", _QUICK_SCRIPT)
+
+            terminal = wait_job(c, victim_id, timeout=_WAIT_PREEMPT)
+            assert terminal in ("CA", "GONE"), (
+                f"victim should be preemptable {_SETTLE_SECS}s in, because its QOS "
+                f"sets a {_QOS_EXEMPT_SECS}s window that overrides the partition's "
+                f"{_PARTITION_EXEMPT_SECS}s; got {terminal!r}"
+            )
+            if terminal != "GONE":
+                _assert_scontrol_state(c, victim_id, "CANCELLED", "victim after preemption")
+
+            wait_job_state(c, hunter_id, "R", timeout=30)
+            _assert_scontrol_state(c, hunter_id, "RUNNING", "hunter after preemption")
+        finally:
+            for jid in (victim_id, hunter_id):
+                if jid is not None:
+                    c.cli_allow_fail(["scancel", str(jid)])
+
+
+class TestClearQosExemptTimeRevertsToPartition:
+    """clearpreemptexempttime must restore the partition window, not drop to zero.
+
+    Falling through to the global default would be catastrophic on a cluster that
+    leaves scheduler.preempt_exempt_time unset, since that resolves to 0 and the
+    victim would be preemptable immediately.
+    """
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return _BASE_CONFIG
+
+    def test_clearing_qos_exempt_time_falls_back_to_partition(self, accounting_cluster):
+        c = accounting_cluster
+        node = c.node_names[0]
+
+        _create_qos_pair(c)
+        # Set, then clear: reaching the partition value by way of an override
+        # proves the fallback, where never setting one would not.
+        c.sacctmgr(["modify", "qos", "name=exempt-victim", "set",
+                    f"preemptexempttime={_QOS_EXEMPT_SECS}"])
+        c.sacctmgr(["modify", "qos", "name=exempt-victim", "set",
+                    "clearpreemptexempttime=1"])
+        time.sleep(_CACHE_WARMUP_SECS)
+
+        shown = c.sacctmgr(["show", "qos", "format=Name,PreemptExemptTime", "-P"])
+        assert "exempt-victim|" in shown and f"exempt-victim|{_QOS_EXEMPT_SECS}" not in shown, (
+            f"QOS preemptexempttime should read blank after clearing:\n{shown}"
+        )
+
+        victim_id = None
+        hunter_id = None
+        try:
+            victim_id = _run_victim(c, node, "qos-cleared")
+
+            time.sleep(_SETTLE_SECS)
+            hunter_id = _queue_hunter(c, node, "qos-cleared", _SLEEP_SCRIPT)
+            wait_job_state(c, hunter_id, "PD", timeout=30)
+
+            # Total elapsed stays well inside the 90s partition window, so the
+            # victim must survive. Were the cleared QOS value falling through to
+            # the global default of 0, it would already be gone.
+            time.sleep(_GUARD_SECS)
+            sq = c.squeue_all()
+            assert job_state(sq, victim_id) == "R", (
+                "clearing the QOS exempt time must fall back to the partition's "
+                f"{_PARTITION_EXEMPT_SECS}s window; the victim was evicted "
+                f"~{_SETTLE_SECS + _GUARD_SECS}s in, which means the window "
+                "collapsed to the global default of 0"
+            )
+            _assert_scontrol_state(c, victim_id, "RUNNING", "victim after guard")
+            assert job_state(sq, hunter_id) == "PD", (
+                "the hunter must wait out the partition exempt window"
+            )
+        finally:
+            for jid in (victim_id, hunter_id):
+                if jid is not None:
+                    c.cli_allow_fail(["scancel", str(jid)])

--- a/tests/native_host/e2e/test_preemption_fairshare.py
+++ b/tests/native_host/e2e/test_preemption_fairshare.py
@@ -1,0 +1,276 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Black-box end-to-end tests for fair-share's influence on preemption eligibility.
+
+Preemption fires on a gap in *effective* priority, and effective priority is a
+product:
+
+    effective = base x min(fair_share, 10.0) x age_factor x max(partition_tier, 1)
+    base      = explicit --priority, else 1000 + qos.priority
+
+Because the terms multiply, fair-share does not merely break ties between jobs
+of equal QOS — it can overturn the QOS ordering outright. Fair-share spans
+roughly 33x in practice (capped at 10.0 above, sinking toward the account's
+target share below) while a QOS priority of 10000 against 100 spans only 10x
+(base 11000 against 1100). The wider range wins.
+
+These tests pin that behaviour down so a change to the priority model is a
+deliberate decision rather than an accident.
+
+Requires:
+  - Postgres on node 0 (accounting_cluster fixture, skips when Docker is absent)
+
+Note the fixtures deliberately leave scheduler.preempt_type unset, so it
+defaults to `none` and the per-QOS `preempt` allow-list is not consulted. That
+is the configuration under test: eligibility rests entirely on the priority gap.
+"""
+
+import time
+
+import pytest
+
+from cluster import job_state, parse_job_id, wait_job, wait_job_state
+
+_SLEEP_SCRIPT = "#!/bin/bash\nsleep 600\n"
+_QUICK_SCRIPT = "#!/bin/bash\nsleep 5\n"
+
+_WAIT_PREEMPT = 60
+_GUARD_SECS = 12
+
+# fairshare_refresh_secs is 10 in the harness config and FairshareCache clamps
+# its interval to a 10s floor, so a planted usage row needs two cycles plus
+# slack before the scheduler is guaranteed to see it.
+_FAIRSHARE_REFRESH_SECS = 30
+
+# Required when the test runner SSHes in as root: spurd refuses to execute jobs
+# as uid 0 unless this is explicitly enabled.
+_AUTH_ROOT = {"auth": {"plugin": "none", "allow_root_jobs": True}}
+
+_CANCEL_PARTITION = {
+    "partitions": [
+        {
+            "name": "default",
+            "state": "UP",
+            "default": True,
+            "nodes": "ALL",
+            "max_time": "24:00:00",
+            "default_time": "10:00",
+            "preempt_mode": "cancel",
+        }
+    ],
+}
+
+
+def _assert_scontrol_state(cluster, job_id: int, expected: str, label: str = "") -> None:
+    """Assert JobState=<expected> appears in scontrol show job output."""
+    show = cluster.scontrol("show", "job", str(job_id))
+    assert f"JobState={expected}" in show, (
+        f"{label or 'job'} {job_id}: expected JobState={expected} in scontrol output:\n{show}"
+    )
+
+
+def _seed_usage(cluster, user: str, account: str, cpu_seconds: int) -> None:
+    """Plant a decayed-usage row so fair-share has history to divide by.
+
+    period_start is NOW() so exponential decay is negligible, keeping the
+    resulting factor predictable rather than a function of test runtime.
+    """
+    cluster.psql(
+        "INSERT INTO usage "
+        "(user_name, account, period_start, period_end, cpu_seconds, gpu_seconds, job_count) "
+        f"VALUES ('{user}', '{account}', NOW(), NOW(), {cpu_seconds}, 0, 1) "
+        "ON CONFLICT (user_name, account, period_start) "
+        "DO UPDATE SET cpu_seconds = EXCLUDED.cpu_seconds"
+    )
+
+
+class TestFairShareOverturnsQosPriority:
+    """A QOS priority of 100 must not be able to evict a QOS priority of 10000 —
+    yet it does, because fair-share is multiplied into the same number that gates
+    preemption.
+
+    Reproduces a production pattern where burst-QOS jobs (priority 100)
+    repeatedly cancelled team-QOS jobs (priority 10000) whose owners had drifted
+    over their fair-share target.
+
+    Arithmetic, with both accounts on the default partition (tier 1) and both
+    jobs freshly submitted (age_factor ~1.0):
+
+      target_share(heavy) = 1 / 11  = 0.0909      (fairshare weight 1 of 11)
+      target_share(light) = 10 / 11 = 0.909       (fairshare weight 10 of 11)
+
+      heavy holds ~all recorded usage  -> actual ~1.0  -> fs ~0.0909
+      light holds ~none                -> actual clamped to the 0.001 epsilon
+                                       -> fs 909, capped to 100, then to 10.0
+
+      victim  (team,  base 11000) effective ~ 11000 x 0.0909 =  1000
+      pending (burst, base  1100) effective ~  1100 x 10.0   = 11000
+
+      preemption fires when victim < pending / 2, i.e. 1000 < 5500. True, with
+      a 5.5x margin so the assertion does not sit on the threshold.
+    """
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {**_CANCEL_PARTITION, **_AUTH_ROOT}
+
+    def test_low_qos_priority_preempts_high_qos_priority_via_fairshare(
+        self, accounting_cluster
+    ):
+        c = accounting_cluster
+        node = c.node_names[0]
+        user = c.nodes[0].user
+
+        # Unequal fair-share weights give the two accounts very different
+        # targets; planted usage then drives their actual shares apart.
+        c.sacctmgr(["add", "account", "name=fs-heavy", "fairshare=1"])
+        c.sacctmgr(["add", "account", "name=fs-light", "fairshare=10"])
+        c.sacctmgr(["add", "user", f"name={user}", "account=fs-heavy"])
+        c.sacctmgr(["add", "user", f"name={user}", "account=fs-light"])
+
+        # The victim outranks the aggressor by 100x on QOS priority alone.
+        c.sacctmgr(["add", "qos", "name=fs-team", "priority=10000", "preemptmode=cancel"])
+        c.sacctmgr(["add", "qos", "name=fs-burst", "priority=100", "preemptmode=cancel"])
+
+        _seed_usage(c, user, "fs-heavy", 999_000_000)
+        _seed_usage(c, user, "fs-light", 1)
+        time.sleep(_FAIRSHARE_REFRESH_SECS)
+
+        victim_id = None
+        aggressor_id = None
+        try:
+            victim_script = c.write_file("fs-victim.sh", _SLEEP_SCRIPT)
+            victim_id = parse_job_id(
+                c.sbatch([
+                    "-N1", "--exclusive", f"--nodelist={node}",
+                    "-A", "fs-heavy", "-q", "fs-team", victim_script,
+                ])
+            )
+            assert victim_id is not None, "victim submit failed"
+            wait_job_state(c, victim_id, "R", timeout=30)
+            _assert_scontrol_state(c, victim_id, "RUNNING", "victim initial")
+
+            # Sample the counter before the aggressor exists: the scheduler runs
+            # on a sub-second cycle and can preempt while the submit call is
+            # still returning, so a baseline taken any later may already include
+            # the preemption this test is trying to observe.
+            preempted_before = c.sdiag_jobs_preempted()
+
+            aggressor_script = c.write_file("fs-aggressor.sh", _QUICK_SCRIPT)
+            aggressor_id = parse_job_id(
+                c.sbatch([
+                    "-N1", "--exclusive", f"--nodelist={node}",
+                    "-A", "fs-light", "-q", "fs-burst", aggressor_script,
+                ])
+            )
+            assert aggressor_id is not None, "aggressor submit failed"
+
+            terminal = wait_job(c, victim_id, timeout=_WAIT_PREEMPT)
+            assert terminal in ("CA", "GONE"), (
+                "a QOS priority of 100 evicted a QOS priority of 10000 in production; "
+                "this test asserts that behaviour still reproduces, so that a change to "
+                f"the priority model is caught here. got {terminal!r}"
+            )
+            if terminal != "GONE":
+                _assert_scontrol_state(c, victim_id, "CANCELLED", "victim after preemption")
+
+            # preempt_mode=cancel lands the victim in CANCELLED, which is also
+            # where an ordinary scancel would leave it. The scheduler's own
+            # counter is what distinguishes a preemption from any other
+            # termination, so assert the decision, not just the end state.
+            assert c.sdiag_jobs_preempted() > preempted_before, (
+                "victim reached a terminal state but the scheduler recorded no "
+                "preemption; it died for some other reason and this test would "
+                "otherwise pass for the wrong reason"
+            )
+
+            wait_job_state(c, aggressor_id, "R", timeout=30)
+            _assert_scontrol_state(c, aggressor_id, "RUNNING", "aggressor after preemption")
+        finally:
+            for jid in (victim_id, aggressor_id):
+                if jid is not None:
+                    c.cli_allow_fail(["scancel", str(jid)])
+
+
+class TestEqualFairShareLeavesQosPriorityIntact:
+    """The control for the test above: with fair-share neutral on both sides, the
+    QOS priority ordering holds and the low-priority job cannot evict anyone.
+
+    Without this, the inversion test could pass for the wrong reason — a bug that
+    let *any* pending job preempt would satisfy it just as well.
+    """
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {**_CANCEL_PARTITION, **_AUTH_ROOT}
+
+    def test_low_qos_cannot_preempt_high_qos_without_fairshare_divergence(
+        self, accounting_cluster
+    ):
+        c = accounting_cluster
+        node = c.node_names[0]
+        user = c.nodes[0].user
+
+        # Identical weights and identical planted usage: both accounts land on
+        # the same fair-share factor, so only QOS priority separates the jobs.
+        c.sacctmgr(["add", "account", "name=fs-even-a", "fairshare=1"])
+        c.sacctmgr(["add", "account", "name=fs-even-b", "fairshare=1"])
+        c.sacctmgr(["add", "user", f"name={user}", "account=fs-even-a"])
+        c.sacctmgr(["add", "user", f"name={user}", "account=fs-even-b"])
+
+        c.sacctmgr(["add", "qos", "name=fs-even-team", "priority=10000", "preemptmode=cancel"])
+        c.sacctmgr(["add", "qos", "name=fs-even-burst", "priority=100", "preemptmode=cancel"])
+
+        _seed_usage(c, user, "fs-even-a", 1_000_000)
+        _seed_usage(c, user, "fs-even-b", 1_000_000)
+        time.sleep(_FAIRSHARE_REFRESH_SECS)
+
+        victim_id = None
+        aggressor_id = None
+        try:
+            victim_script = c.write_file("fs-even-victim.sh", _SLEEP_SCRIPT)
+            victim_id = parse_job_id(
+                c.sbatch([
+                    "-N1", "--exclusive", f"--nodelist={node}",
+                    "-A", "fs-even-a", "-q", "fs-even-team", victim_script,
+                ])
+            )
+            assert victim_id is not None, "victim submit failed"
+            wait_job_state(c, victim_id, "R", timeout=30)
+            _assert_scontrol_state(c, victim_id, "RUNNING", "victim initial")
+
+            # Baseline before the aggressor exists, matching the inversion test:
+            # a later sample could absorb the very preemption being guarded
+            # against and turn this assertion into a no-op.
+            preempted_before = c.sdiag_jobs_preempted()
+
+            aggressor_script = c.write_file("fs-even-aggressor.sh", _SLEEP_SCRIPT)
+            aggressor_id = parse_job_id(
+                c.sbatch([
+                    "-N1", "--exclusive", f"--nodelist={node}",
+                    "-A", "fs-even-b", "-q", "fs-even-burst", aggressor_script,
+                ])
+            )
+            assert aggressor_id is not None, "aggressor submit failed"
+            wait_job_state(c, aggressor_id, "PD", timeout=30)
+
+            time.sleep(_GUARD_SECS)
+            sq = c.squeue_all()
+            assert job_state(sq, victim_id) == "R", (
+                "a QOS priority of 100 must not evict a QOS priority of 10000 when "
+                "fair-share is neutral on both sides"
+            )
+            _assert_scontrol_state(c, victim_id, "RUNNING", "victim after guard")
+            assert job_state(sq, aggressor_id) == "PD", (
+                "the low-QOS job must wait rather than displace the high-QOS job"
+            )
+            _assert_scontrol_state(c, aggressor_id, "PENDING", "aggressor after guard")
+            assert c.sdiag_jobs_preempted() == preempted_before, (
+                "no preemption may be recorded while fair-share is neutral"
+            )
+        finally:
+            for jid in (victim_id, aggressor_id):
+                if jid is not None:
+                    c.cli_allow_fail(["scancel", str(jid)])

--- a/tests/native_host/e2e/test_preemption_fairshare.py
+++ b/tests/native_host/e2e/test_preemption_fairshare.py
@@ -71,16 +71,24 @@ def _assert_scontrol_state(cluster, job_id: int, expected: str, label: str = "")
     )
 
 
+def _sql_str(value: str) -> str:
+    """Escape a value for embedding as a single-quoted SQL string literal."""
+    return value.replace("'", "''")
+
+
 def _seed_usage(cluster, user: str, account: str, cpu_seconds: int) -> None:
     """Plant a decayed-usage row so fair-share has history to divide by.
 
-    period_start is NOW() so exponential decay is negligible, keeping the
-    resulting factor predictable rather than a function of test runtime.
+    period_start is truncated to today (not NOW()) so exponential decay stays
+    negligible while repeated calls for the same user/account still collide on
+    the table's (user_name, account, period_start) primary key and update in
+    place instead of inserting duplicate rows.
     """
     cluster.psql(
         "INSERT INTO usage "
         "(user_name, account, period_start, period_end, cpu_seconds, gpu_seconds, job_count) "
-        f"VALUES ('{user}', '{account}', NOW(), NOW(), {cpu_seconds}, 0, 1) "
+        f"VALUES ('{_sql_str(user)}', '{_sql_str(account)}', "
+        f"date_trunc('day', NOW()), NOW(), {cpu_seconds}, 0, 1) "
         "ON CONFLICT (user_name, account, period_start) "
         "DO UPDATE SET cpu_seconds = EXCLUDED.cpu_seconds"
     )

--- a/tests/native_host/e2e/test_preemption_same_qos.py
+++ b/tests/native_host/e2e/test_preemption_same_qos.py
@@ -76,8 +76,10 @@ def _start_pair(cluster, qos: str, node: str, prefix: str):
     """Run a victim under *qos*, then queue an aggressor in the same QOS behind
     it and boost the aggressor past the 2x preemption threshold.
 
-    Returns (victim_id, aggressor_id) with the victim RUNNING and the aggressor
-    PENDING, both asserted.
+    Returns (victim_id, aggressor_id, preempted_before) with the victim RUNNING
+    and the aggressor PENDING, both asserted. preempted_before is the `Jobs
+    preempted` counter sampled just before the boost, so callers can assert
+    whether the scheduler actually acted on the allow-list gate.
     """
     victim_script = cluster.write_file(f"{prefix}-victim.sh", _SLEEP_SCRIPT)
     victim_id = parse_job_id(
@@ -99,11 +101,13 @@ def _start_pair(cluster, qos: str, node: str, prefix: str):
     wait_job_state(cluster, aggressor_id, "PD", timeout=30)
     _assert_scontrol_state(cluster, aggressor_id, "PENDING", "aggressor before boost")
 
+    preempted_before = cluster.sdiag_jobs_preempted()
+
     # Both jobs share a QOS, so their base priorities are identical and no gap
     # exists until the aggressor is boosted. Boosting isolates the allow-list as
     # the only remaining variable between this test and its counterpart.
     cluster.scontrol("update", f"JobId={aggressor_id}", f"Priority={_AGGRESSOR_PRIORITY}")
-    return victim_id, aggressor_id
+    return victim_id, aggressor_id, preempted_before
 
 
 class TestSameQosBlockedWithoutSelfListing:
@@ -125,7 +129,9 @@ class TestSameQosBlockedWithoutSelfListing:
         victim_id = None
         aggressor_id = None
         try:
-            victim_id, aggressor_id = _start_pair(c, "solo-burst", node, "same-qos-block")
+            victim_id, aggressor_id, preempted_before = _start_pair(
+                c, "solo-burst", node, "same-qos-block"
+            )
 
             # The priority gap is satisfied; only the allow-list stands in the
             # way. Nothing must change over several scheduler cycles.
@@ -140,6 +146,9 @@ class TestSameQosBlockedWithoutSelfListing:
                 "the boosted aggressor must keep waiting while the allow-list blocks it"
             )
             _assert_scontrol_state(c, aggressor_id, "PENDING", "aggressor after guard")
+            assert c.sdiag_jobs_preempted() == preempted_before, (
+                "no preemption decision should have been made while the allow-list blocks it"
+            )
         finally:
             for jid in (victim_id, aggressor_id):
                 if jid is not None:
@@ -173,14 +182,21 @@ class TestSameQosAllowedWhenSelfListed:
         time.sleep(_CACHE_WARMUP_SECS)
 
         listed = c.sacctmgr(["show", "qos", "format=Name,Preempt", "-P"])
-        assert "solo-burst-open" in listed, (
-            f"self-referential preempt allow-list was not stored:\n{listed}"
+        preempt_field = next(
+            (line.split("|", 1)[1] for line in listed.splitlines()
+             if line.startswith("solo-burst-open|")),
+            None,
+        )
+        assert preempt_field is not None and "solo-burst-open" in preempt_field, (
+            f"self-referential preempt allow-list was not stored in the Preempt field:\n{listed}"
         )
 
         victim_id = None
         aggressor_id = None
         try:
-            victim_id, aggressor_id = _start_pair(c, "solo-burst-open", node, "same-qos-allow")
+            victim_id, aggressor_id, preempted_before = _start_pair(
+                c, "solo-burst-open", node, "same-qos-allow"
+            )
 
             terminal = wait_job(c, victim_id, timeout=_WAIT_PREEMPT)
             assert terminal in ("CA", "GONE"), (
@@ -192,6 +208,9 @@ class TestSameQosAllowedWhenSelfListed:
 
             wait_job_state(c, aggressor_id, "R", timeout=30)
             _assert_scontrol_state(c, aggressor_id, "RUNNING", "aggressor after preemption")
+            assert c.sdiag_jobs_preempted() > preempted_before, (
+                "a QOS listing itself must trigger a scheduler preemption decision"
+            )
         finally:
             for jid in (victim_id, aggressor_id):
                 if jid is not None:
@@ -245,6 +264,8 @@ class TestEmptyAllowListsDisablePreemptionClusterWide:
             assert aggressor_id is not None, "aggressor submit failed"
             wait_job_state(c, aggressor_id, "PD", timeout=30)
 
+            preempted_before = c.sdiag_jobs_preempted()
+
             # Boost on top of the QOS gap so the priority threshold is
             # unambiguously cleared and only the allow-list can be responsible.
             c.scontrol("update", f"JobId={aggressor_id}", f"Priority={_AGGRESSOR_PRIORITY}")
@@ -258,6 +279,9 @@ class TestEmptyAllowListsDisablePreemptionClusterWide:
             _assert_scontrol_state(c, victim_id, "RUNNING", "victim after guard")
             assert job_state(sq, aggressor_id) == "PD", (
                 "the boosted high-QOS job must wait when no allow-list permits it"
+            )
+            assert c.sdiag_jobs_preempted() == preempted_before, (
+                "no preemption decision should have been made with all allow-lists empty"
             )
         finally:
             for jid in (victim_id, aggressor_id):

--- a/tests/native_host/e2e/test_preemption_same_qos.py
+++ b/tests/native_host/e2e/test_preemption_same_qos.py
@@ -1,0 +1,265 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Black-box end-to-end tests for preemption between two jobs in the *same* QOS.
+
+Under preempt_type=qos_priority a pending job may only evict a running job when
+the pending job's QOS lists the running job's QOS in its `preempt` allow-list.
+Spur applies that check uniformly, with no special case for the two QOS being
+identical — so a QOS naming *itself* is what enables same-QOS preemption.
+
+This differs from Slurm, where the allow-list is consulted only on the
+different-QOS branch and same-QOS preemption is gated by a dedicated
+PreemptMode=WITHIN flag; there, self-listing is a no-op.
+
+Every test here holds the priority gap constant and varies only the allow-list,
+so a passing result cannot be explained by the priority threshold instead. That
+matters: an existing test in test_burst_qos.py exercises two *different* burst
+QOS with equal priority, where either gate alone would produce the same outcome.
+
+Requires:
+  - preempt_type=qos_priority (scheduler config) so allow-list gating applies
+  - Postgres on node 0 (accounting_cluster fixture, skips when Docker is absent)
+"""
+
+import time
+
+import pytest
+
+from cluster import job_state, parse_job_id, wait_job, wait_job_state
+
+_SLEEP_SCRIPT = "#!/bin/bash\nsleep 600\n"
+_QUICK_SCRIPT = "#!/bin/bash\nsleep 5\n"
+
+_WAIT_PREEMPT = 60
+_GUARD_SECS = 12
+
+# QOS cache is refreshed on the same interval as the other accounting caches;
+# a freshly added or modified QOS needs a cycle before the scheduler sees it.
+_CACHE_WARMUP_SECS = 15
+
+# Large enough to clear the 2x effective-priority threshold against a job left
+# at the default base priority, matching how test_preemption_modes.py boosts.
+_AGGRESSOR_PRIORITY = 1_000_000
+
+_BASE_CONFIG = {
+    "partitions": [
+        {
+            "name": "default",
+            "state": "UP",
+            "default": True,
+            "nodes": "ALL",
+            "max_time": "24:00:00",
+            "default_time": "10:00",
+            "preempt_mode": "cancel",
+        }
+    ],
+    "scheduler": {
+        "preempt_type": "qos_priority",
+    },
+    # Required when the test runner SSHes in as root: spurd refuses to execute
+    # jobs as uid 0 unless this is explicitly enabled.
+    "auth": {"plugin": "none", "allow_root_jobs": True},
+}
+
+
+def _assert_scontrol_state(cluster, job_id: int, expected: str, label: str = "") -> None:
+    """Assert JobState=<expected> appears in scontrol show job output."""
+    show = cluster.scontrol("show", "job", str(job_id))
+    assert f"JobState={expected}" in show, (
+        f"{label or 'job'} {job_id}: expected JobState={expected} in scontrol output:\n{show}"
+    )
+
+
+def _start_pair(cluster, qos: str, node: str, prefix: str):
+    """Run a victim under *qos*, then queue an aggressor in the same QOS behind
+    it and boost the aggressor past the 2x preemption threshold.
+
+    Returns (victim_id, aggressor_id) with the victim RUNNING and the aggressor
+    PENDING, both asserted.
+    """
+    victim_script = cluster.write_file(f"{prefix}-victim.sh", _SLEEP_SCRIPT)
+    victim_id = parse_job_id(
+        cluster.sbatch([
+            "-N1", "--exclusive", f"--nodelist={node}", "-q", qos, victim_script,
+        ])
+    )
+    assert victim_id is not None, "victim submit failed"
+    wait_job_state(cluster, victim_id, "R", timeout=30)
+    _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim initial")
+
+    aggressor_script = cluster.write_file(f"{prefix}-aggressor.sh", _QUICK_SCRIPT)
+    aggressor_id = parse_job_id(
+        cluster.sbatch([
+            "-N1", "--exclusive", f"--nodelist={node}", "-q", qos, aggressor_script,
+        ])
+    )
+    assert aggressor_id is not None, "aggressor submit failed"
+    wait_job_state(cluster, aggressor_id, "PD", timeout=30)
+    _assert_scontrol_state(cluster, aggressor_id, "PENDING", "aggressor before boost")
+
+    # Both jobs share a QOS, so their base priorities are identical and no gap
+    # exists until the aggressor is boosted. Boosting isolates the allow-list as
+    # the only remaining variable between this test and its counterpart.
+    cluster.scontrol("update", f"JobId={aggressor_id}", f"Priority={_AGGRESSOR_PRIORITY}")
+    return victim_id, aggressor_id
+
+
+class TestSameQosBlockedWithoutSelfListing:
+    """A QOS that does not list itself must not preempt its own jobs, even when
+    the pending job's priority is far above the 2x threshold."""
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return _BASE_CONFIG
+
+    def test_same_qos_cannot_preempt_without_self_listing(self, accounting_cluster):
+        c = accounting_cluster
+        node = c.node_names[0]
+
+        # Empty allow-list: this QOS may preempt nothing, including itself.
+        c.sacctmgr(["add", "qos", "name=solo-burst", "priority=100", "preemptmode=cancel"])
+        time.sleep(_CACHE_WARMUP_SECS)
+
+        victim_id = None
+        aggressor_id = None
+        try:
+            victim_id, aggressor_id = _start_pair(c, "solo-burst", node, "same-qos-block")
+
+            # The priority gap is satisfied; only the allow-list stands in the
+            # way. Nothing must change over several scheduler cycles.
+            time.sleep(_GUARD_SECS)
+            sq = c.squeue_all()
+            assert job_state(sq, victim_id) == "R", (
+                "a QOS with an empty preempt allow-list must not evict its own job, "
+                "even with a priority gap well past the 2x threshold"
+            )
+            _assert_scontrol_state(c, victim_id, "RUNNING", "victim after guard")
+            assert job_state(sq, aggressor_id) == "PD", (
+                "the boosted aggressor must keep waiting while the allow-list blocks it"
+            )
+            _assert_scontrol_state(c, aggressor_id, "PENDING", "aggressor after guard")
+        finally:
+            for jid in (victim_id, aggressor_id):
+                if jid is not None:
+                    c.cli_allow_fail(["scancel", str(jid)])
+
+
+class TestSameQosAllowedWhenSelfListed:
+    """A QOS that names itself in its own preempt allow-list may evict its own
+    jobs, given the usual priority gap.
+
+    Same cluster config, same priority boost, same QOS priority as the blocked
+    case above — the single difference is `preempt=solo-burst-open`.
+    """
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return _BASE_CONFIG
+
+    def test_same_qos_preempts_when_self_listed(self, accounting_cluster):
+        c = accounting_cluster
+        node = c.node_names[0]
+
+        # Two steps, not one: CreateQos validates every allow-list name against
+        # the QOS table before inserting the new row, so a QOS cannot name
+        # itself at creation time ("QOS 'x' does not exist (in preempt
+        # allow-list)"). It has to exist first, then be modified.
+        c.sacctmgr(["add", "qos", "name=solo-burst-open", "priority=100",
+                    "preemptmode=cancel"])
+        c.sacctmgr(["modify", "qos", "name=solo-burst-open", "set",
+                    "preempt=solo-burst-open"])
+        time.sleep(_CACHE_WARMUP_SECS)
+
+        listed = c.sacctmgr(["show", "qos", "format=Name,Preempt", "-P"])
+        assert "solo-burst-open" in listed, (
+            f"self-referential preempt allow-list was not stored:\n{listed}"
+        )
+
+        victim_id = None
+        aggressor_id = None
+        try:
+            victim_id, aggressor_id = _start_pair(c, "solo-burst-open", node, "same-qos-allow")
+
+            terminal = wait_job(c, victim_id, timeout=_WAIT_PREEMPT)
+            assert terminal in ("CA", "GONE"), (
+                "a QOS listing itself must be able to preempt its own jobs; "
+                f"got {terminal!r}"
+            )
+            if terminal != "GONE":
+                _assert_scontrol_state(c, victim_id, "CANCELLED", "victim after preemption")
+
+            wait_job_state(c, aggressor_id, "R", timeout=30)
+            _assert_scontrol_state(c, aggressor_id, "RUNNING", "aggressor after preemption")
+        finally:
+            for jid in (victim_id, aggressor_id):
+                if jid is not None:
+                    c.cli_allow_fail(["scancel", str(jid)])
+
+
+class TestEmptyAllowListsDisablePreemptionClusterWide:
+    """With preempt_type=qos_priority and every allow-list left empty, no job may
+    preempt any other regardless of priority or QOS.
+
+    This is the recommended stop-the-bleeding configuration for a cluster whose
+    preemption is misbehaving, so it is worth an explicit test: flipping one
+    config field turns already-blank allow-lists into an effective kill switch.
+    """
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return _BASE_CONFIG
+
+    def test_empty_allow_lists_block_all_preemption(self, accounting_cluster):
+        c = accounting_cluster
+        node = c.node_names[0]
+
+        # A 100x QOS priority gap across two distinct QOS, neither listing the
+        # other. Under preempt_type=none this pairing preempts readily.
+        c.sacctmgr(["add", "qos", "name=killswitch-low", "priority=100", "preemptmode=cancel"])
+        c.sacctmgr(["add", "qos", "name=killswitch-high", "priority=10000", "preemptmode=cancel"])
+        time.sleep(_CACHE_WARMUP_SECS)
+
+        victim_id = None
+        aggressor_id = None
+        try:
+            victim_script = c.write_file("killswitch-victim.sh", _SLEEP_SCRIPT)
+            victim_id = parse_job_id(
+                c.sbatch([
+                    "-N1", "--exclusive", f"--nodelist={node}",
+                    "-q", "killswitch-low", victim_script,
+                ])
+            )
+            assert victim_id is not None, "victim submit failed"
+            wait_job_state(c, victim_id, "R", timeout=30)
+            _assert_scontrol_state(c, victim_id, "RUNNING", "victim initial")
+
+            aggressor_script = c.write_file("killswitch-aggressor.sh", _SLEEP_SCRIPT)
+            aggressor_id = parse_job_id(
+                c.sbatch([
+                    "-N1", "--exclusive", f"--nodelist={node}",
+                    "-q", "killswitch-high", aggressor_script,
+                ])
+            )
+            assert aggressor_id is not None, "aggressor submit failed"
+            wait_job_state(c, aggressor_id, "PD", timeout=30)
+
+            # Boost on top of the QOS gap so the priority threshold is
+            # unambiguously cleared and only the allow-list can be responsible.
+            c.scontrol("update", f"JobId={aggressor_id}", f"Priority={_AGGRESSOR_PRIORITY}")
+
+            time.sleep(_GUARD_SECS)
+            sq = c.squeue_all()
+            assert job_state(sq, victim_id) == "R", (
+                "preempt_type=qos_priority with empty allow-lists must disable "
+                "preemption entirely; the running job was evicted anyway"
+            )
+            _assert_scontrol_state(c, victim_id, "RUNNING", "victim after guard")
+            assert job_state(sq, aggressor_id) == "PD", (
+                "the boosted high-QOS job must wait when no allow-list permits it"
+            )
+        finally:
+            for jid in (victim_id, aggressor_id):
+                if jid is not None:
+                    c.cli_allow_fail(["scancel", str(jid)])


### PR DESCRIPTION
## What this adds

E2E coverage for two preemption behaviours that were untested, one of which is actively biting a production cluster.

**Fair-share can overturn QOS priority.** Preemption eligibility is a gap in *effective* priority, and effective priority multiplies fair-share in:

```
effective = base x min(fair_share, 10.0) x age_factor x max(partition_tier, 1)
base      = explicit --priority, else 1000 + qos.priority
```

Fair-share spans roughly 33x in practice (capped at 10.0 above, sinking toward the account's target share below) while a QOS priority of 10000 against 100 spans only 10x (base 11000 vs 1100). The wider range wins. On a production cluster this showed up as burst-QOS jobs (priority 100) repeatedly cancelling team-QOS jobs (priority 10000) whose owners had drifted over their fair-share target.

**Same-QOS preemption is gated purely by the allow-list.** Spur applies the `preempt` allow-list check uniformly with no special case for the two QOS being identical, so a QOS naming *itself* is what enables same-QOS preemption. This differs from Slurm, where the allow-list is only consulted on the different-QOS branch and same-QOS preemption needs a dedicated `PreemptMode=WITHIN` flag (self-listing there is a no-op).

## Approach

`test_preemption_fairshare.py` reproduces the inversion by planting `usage` rows so two accounts land far apart on fair-share, then asserts a QOS priority of 100 evicts a QOS priority of 10000. It ships with a control at neutral fair-share asserting the low-QOS job *cannot* preempt — without that, the inversion test would also pass under a hypothetical bug where anything can preempt anything.

`test_preemption_same_qos.py` covers two jobs sharing one QOS. The existing case in `test_burst_qos.py` uses two *different* burst QOS at equal priority, where either the allow-list or the priority threshold alone produces the same outcome; these hold the priority gap constant (via `scontrol update Priority=`) and vary only the allow-list, so the allow-list is the sole variable. It also covers `preempt_type=qos_priority` with empty allow-lists disabling preemption cluster-wide.

Both suites assert the scheduler's own `Jobs preempted` counter rather than only the terminal job state — `preempt_mode=cancel` lands a victim in `CANCELLED`, which is also where an ordinary `scancel` leaves it, so the end state alone does not prove a preemption happened.

Adds `SpurCluster.psql()` so a test can plant accounting rows that would otherwise take real workload hours to accumulate.

## Design choices

- **Unequal `fairshare` weights (1 vs 10) rather than three accounts.** With two equally-weighted accounts, `target_share` is 0.5 each and `actual_share` cannot exceed 1.0, so the heavy account's factor floors at ~0.5 — just short of the ~0.5 needed to cross the threshold. Skewing the weights gives a 5.5x margin so the assertion does not sit on the boundary.
- **`period_start = NOW()`** in the seeded rows keeps exponential decay negligible, so the resulting factor is predictable rather than a function of how long the test took to reach the assertion.
- **Counter baseline sampled before the aggressor is submitted.** The scheduler preempts in well under a second, so a baseline taken after waiting for the aggressor to reach PENDING already includes the preemption under test.

## Testing

Verified against **v0.10.0 (`91458403`)** on a 2-node cluster: **5 passed**.

The inversion test was mutation-checked — equalising the seeded usage makes it stop reproducing, confirming fair-share is what drives it rather than something incidental.

## Note for reviewers: a bug found while writing this

`sacctmgr add qos name=X ... preempt=X` fails with `QOS 'X' does not exist (in preempt allow-list)`. `CreateQos` validates every allow-list name against the QOS table before inserting the new row, so a QOS cannot reference itself at creation time — it must be added first, then modified. The test works around this with add-then-modify; the underlying behaviour is left as a separate issue.

## Follow-ups not in this PR

Coverage for same-pass duplicate victim selection (multiple pending jobs each independently claiming the same victim in one scheduler pass) is not included — under `cancel` the victim can only die once, so the observable damage is over-preemption of *other* jobs, which needs a different assertion strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)