### PR TITLE
feat(spurd): implement containerized srun job steps on bare-metal nodes

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -47,6 +47,7 @@ PBS
 PMI
 PMIX
 PostgreSQL
+Pyxis
 preempt
 preemption
 preemptable
@@ -63,6 +64,7 @@ requeue
 requeued
 requeues
 rollout
+rootfs
 rlimit
 rlimits
 ROCm

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -223,7 +223,7 @@ pub struct SbatchArgs {
     #[arg(long, overrides_with = "container_name")]
     pub container_name: Option<String>,
 
-    /// Read-only container rootfs
+    /// Read-only container rootfs (not yet implemented; rejected at submission)
     #[arg(long, overrides_with = "container_readonly")]
     pub container_readonly: bool,
 
@@ -830,6 +830,12 @@ fn build_sbatch_job_spec(
     if is_wrap && !args.script_args.is_empty() {
         bail!("sbatch: script arguments may not be used with --wrap");
     }
+    if args.container_readonly {
+        bail!(
+            "--container-readonly is not yet implemented; the container root would be \
+             writable despite the flag. Omit it rather than rely on a read-only rootfs."
+        );
+    }
     let stdin_is_terminal = std::io::IsTerminal::is_terminal(&std::io::stdin());
     let script = match choose_body_source(args.wrap.take(), args.script.clone(), stdin_is_terminal)?
     {
@@ -1122,6 +1128,21 @@ mod tests {
         assert_eq!(
             spec.submit_line,
             "sbatch -w node1 --exclusive --wrap hostname"
+        );
+    }
+
+    /// --container-readonly is a no-op in the runtime today, so it is refused at
+    /// submission rather than silently ignored (the #777-class failure mode).
+    #[test]
+    fn build_sbatch_job_spec_rejects_container_readonly() {
+        let argv = ["sbatch", "--container-readonly", "--wrap", "hostname"].map(String::from);
+        let args = resolve_sbatch_args(&[], &argv).expect("args");
+        let line = crate::submitline::render(&argv);
+        let err = build_sbatch_job_spec(args, None, &line).expect_err("readonly must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("--container-readonly") && msg.contains("not yet implemented"),
+            "expected a not-yet-implemented rejection, got: {msg}"
         );
     }
 

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -158,6 +158,14 @@ pub struct SrunArgs {
     #[arg(long)]
     pub container_workdir: Option<String>,
 
+    /// Named container (persists across steps in an allocation)
+    #[arg(long)]
+    pub container_name: Option<String>,
+
+    /// Read-only container rootfs (not yet implemented; rejected at submission)
+    #[arg(long)]
+    pub container_readonly: bool,
+
     /// Mount user home directory in container
     #[arg(long)]
     pub container_mount_home: bool,
@@ -165,6 +173,10 @@ pub struct SrunArgs {
     /// Set environment variable inside container (KEY=VAL)
     #[arg(long)]
     pub container_env: Vec<String>,
+
+    /// Override the container entrypoint
+    #[arg(long)]
+    pub container_entrypoint: Option<String>,
 
     /// Remap user to root inside container
     #[arg(long)]
@@ -214,6 +226,13 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     if args.jobid.is_some() && !args.overlap {
         anyhow::bail!("--jobid requires --overlap");
+    }
+
+    if args.container_readonly {
+        anyhow::bail!(
+            "--container-readonly is not yet implemented; the container root would be \
+             writable despite the flag. Omit it rather than rely on a read-only rootfs."
+        );
     }
 
     resolve_srun_env(&matches, &mut args)?;
@@ -607,6 +626,8 @@ fn build_srun_job_spec(
         container_image: args.container_image.clone().unwrap_or_default(),
         container_mounts: args.container_mounts.clone(),
         container_workdir: args.container_workdir.clone().unwrap_or_default(),
+        container_name: args.container_name.clone().unwrap_or_default(),
+        container_readonly: args.container_readonly,
         container_mount_home: args.container_mount_home,
         container_env: args
             .container_env
@@ -616,6 +637,7 @@ fn build_srun_job_spec(
                     .map(|(k, v)| (k.to_string(), v.to_string()))
             })
             .collect(),
+        container_entrypoint: args.container_entrypoint.clone().unwrap_or_default(),
         container_remap_root: args.container_remap_root,
         srun_job: true,
         pty: args.pty,
@@ -786,6 +808,22 @@ async fn dispatch_step(
             label: args.label,
             mpi: step_mpi.to_string(),
             user: params.user.to_string(),
+            container_image: args.container_image.clone().unwrap_or_default(),
+            container_mounts: args.container_mounts.clone(),
+            container_workdir: args.container_workdir.clone().unwrap_or_default(),
+            container_name: args.container_name.clone().unwrap_or_default(),
+            container_readonly: args.container_readonly,
+            container_mount_home: args.container_mount_home,
+            container_env: args
+                .container_env
+                .iter()
+                .filter_map(|s| {
+                    s.split_once('=')
+                        .map(|(k, v)| (k.to_string(), v.to_string()))
+                })
+                .collect(),
+            container_entrypoint: args.container_entrypoint.clone().unwrap_or_default(),
+            container_remap_root: args.container_remap_root,
         })
         .await
         .context("RunStep dispatch failed")?
@@ -2320,6 +2358,25 @@ mod tests {
         assert!(
             msg.contains("--overlap"),
             "expected --overlap error, got: {msg}"
+        );
+    }
+
+    /// --container-readonly is a no-op in the runtime today, so it is refused at
+    /// submission rather than silently ignored (the #777-class failure mode).
+    #[tokio::test]
+    async fn container_readonly_is_rejected() {
+        let result = main_with_args(vec![
+            "srun".into(),
+            "--container-image=img.sqsh".into(),
+            "--container-readonly".into(),
+            "hostname".into(),
+        ])
+        .await;
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("--container-readonly") && msg.contains("not yet implemented"),
+            "expected a not-yet-implemented rejection, got: {msg}"
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2768,6 +2768,41 @@ impl SlurmController for ControllerService {
         let label = req.label;
         let job_mpi = job.spec.mpi.as_deref().unwrap_or(spur_core::mpi::MPI_NONE);
         let mpi = spur_core::mpi::resolve_step_mpi(req.mpi.as_str(), job_mpi).to_string();
+        // Step-level container override from srun --container-image; falls back
+        // to the parent job's container config (e.g. sbatch --container-image).
+        let step_container_image = if !req.container_image.is_empty() {
+            req.container_image.clone()
+        } else {
+            job.spec.container_image.clone().unwrap_or_default()
+        };
+        let step_container_mounts = if !req.container_mounts.is_empty() {
+            req.container_mounts.clone()
+        } else {
+            job.spec.container_mounts.clone()
+        };
+        let step_container_workdir = if !req.container_workdir.is_empty() {
+            req.container_workdir.clone()
+        } else {
+            job.spec.container_workdir.clone().unwrap_or_default()
+        };
+        let step_container_name = if !req.container_name.is_empty() {
+            req.container_name.clone()
+        } else {
+            job.spec.container_name.clone().unwrap_or_default()
+        };
+        let step_container_readonly = req.container_readonly || job.spec.container_readonly;
+        let step_container_mount_home = req.container_mount_home || job.spec.container_mount_home;
+        let step_container_env = if !req.container_env.is_empty() {
+            req.container_env.clone()
+        } else {
+            job.spec.container_env.clone()
+        };
+        let step_container_entrypoint = if !req.container_entrypoint.is_empty() {
+            req.container_entrypoint.clone()
+        } else {
+            job.spec.container_entrypoint.clone().unwrap_or_default()
+        };
+        let step_container_remap_root = req.container_remap_root || job.spec.container_remap_root;
         let pmix_tmpdir = self.cluster.config().mpi.pmix_tmpdir.clone();
         let modex_connect_timeout_secs = self.cluster.config().mpi.modex_connect_timeout_secs;
         let modex_fence_timeout_secs = self.cluster.config().mpi.modex_fence_timeout_secs;
@@ -2937,6 +2972,12 @@ impl SlurmController for ControllerService {
             let work_dir = work_dir.clone();
             let environment = environment.clone();
             let step_mpi = mpi.clone();
+            let container_image = step_container_image.clone();
+            let container_mounts = step_container_mounts.clone();
+            let container_workdir = step_container_workdir.clone();
+            let container_name = step_container_name.clone();
+            let container_env = step_container_env.clone();
+            let container_entrypoint = step_container_entrypoint.clone();
             set.spawn(async move {
                 let mut agent = crate::agent_client::connect(agent_addr.clone())
                     .await
@@ -2962,6 +3003,15 @@ impl SlurmController for ControllerService {
                         pmix_plan,
                         mpi: step_mpi.clone(),
                         pmix_prepared: needs_pmix_prepare,
+                        container_image,
+                        container_mounts,
+                        container_workdir,
+                        container_name,
+                        container_readonly: step_container_readonly,
+                        container_mount_home: step_container_mount_home,
+                        container_env,
+                        container_entrypoint,
+                        container_remap_root: step_container_remap_root,
                     })
                     .await
                     .map_err(|e| {

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -223,21 +223,16 @@ fn cancelled_step_response() -> RunCommandResponse {
     }
 }
 
+/// Signal a step's whole process subtree. The tracked pid may be an
+/// intermediate parent (a containerized step runs the workload as a grandchild
+/// that is PID 1 of its own PID namespace), so a single `killpg`/`kill` on it
+/// never reaches the real process. Walking the `/proc` child tree — the same
+/// approach the batch container path uses — reaches the workload directly, so a
+/// plain `SIGTERM` lands on it (a namespace init would otherwise discard it).
 fn signal_step_process_group(pid: u32, signal: i32) {
     let sig =
         nix::sys::signal::Signal::try_from(signal).unwrap_or(nix::sys::signal::Signal::SIGTERM);
-    let leader = nix::unistd::Pid::from_raw(pid as i32);
-    if let Err(e) = nix::sys::signal::killpg(leader, sig) {
-        if let Err(kill_err) = nix::sys::signal::kill(leader, Some(sig)) {
-            warn!(
-                pid,
-                signal,
-                killpg = %e,
-                kill = %kill_err,
-                "step process group signal failed (step may already have exited)"
-            );
-        }
-    }
+    crate::executor::kill_process_tree(pid as i32, sig);
 }
 
 #[cfg(test)]
@@ -310,6 +305,249 @@ async fn step_cancel_requested(
         .await
         .get(&key)
         .is_some_and(|step| step.cancel_requested)
+}
+
+/// Spawn a command, register its PID for cancellation, wait for output.
+/// Shared by the nsenter (Case 1) and plain-host (Case 3) step dispatch paths.
+async fn run_step_child(
+    mut cmd: tokio::process::Command,
+    active_steps: &Arc<Mutex<HashMap<(u32, u32), ActiveStep>>>,
+    step_key: (u32, u32),
+) -> Result<std::process::Output, Status> {
+    use std::process::Stdio;
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| Status::internal(format!("step command failed to spawn: {e}")))?;
+
+    if let Some(pid) = child.id() {
+        let cancel_now = {
+            let mut steps = active_steps.lock().await;
+            if let Some(step) = steps.get_mut(&step_key) {
+                step.pid = Some(pid);
+                step.cancel_requested
+            } else {
+                false
+            }
+        };
+        if cancel_now {
+            signal_step_process_group(pid, nix::sys::signal::Signal::SIGTERM as i32);
+            let _ = child.kill().await;
+            let _ = child.wait_with_output().await;
+            return Err(Status::cancelled("step cancelled"));
+        }
+    }
+
+    child
+        .wait_with_output()
+        .await
+        .map_err(|e| Status::internal(format!("step command failed: {e}")))
+}
+
+/// Launch a step command inside a fresh container rootfs, collecting output
+/// via pipes. Used for standalone `srun --container-image` steps where the
+/// parent job is not itself containerized.
+async fn run_containerized_step(
+    container_cfg: crate::container::ContainerConfig,
+    rootfs: std::path::PathBuf,
+    script_path: String,
+    env: HashMap<String, String>,
+    active_steps: &Arc<Mutex<HashMap<(u32, u32), ActiveStep>>>,
+    step_key: (u32, u32),
+    memlock: spur_core::config::MemlockLimit,
+) -> Result<std::process::Output, Status> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::io::FromRawFd;
+
+    // Create a pipe pair for stdout and another for stderr so we can collect
+    // the output from the forked container child in-process.
+    let (stdout_r, stdout_w) =
+        nix::unistd::pipe().map_err(|e| Status::internal(format!("pipe failed: {e}")))?;
+    let (stderr_r, stderr_w) =
+        nix::unistd::pipe().map_err(|e| Status::internal(format!("pipe failed: {e}")))?;
+    // Sync pipe: child signals readiness (or error) after container_init.
+    let (ready_r, ready_w) =
+        nix::unistd::pipe().map_err(|e| Status::internal(format!("pipe failed: {e}")))?;
+    nix::fcntl::fcntl(
+        &ready_r,
+        nix::fcntl::FcntlArg::F_SETFD(nix::fcntl::FdFlag::FD_CLOEXEC),
+    )
+    .ok();
+
+    let stdout_r_fd = stdout_r.as_raw_fd();
+    let stdout_w_fd = stdout_w.as_raw_fd();
+    let stderr_r_fd = stderr_r.as_raw_fd();
+    let stderr_w_fd = stderr_w.as_raw_fd();
+    let ready_r_fd = ready_r.as_raw_fd();
+    let ready_w_fd = ready_w.as_raw_fd();
+
+    let rootfs_clone = rootfs.clone();
+    let env_clone = env.clone();
+    let container_env = container_cfg.container_env.clone();
+    let entrypoint = container_cfg.entrypoint.clone();
+    let script_path_clone = script_path.clone();
+
+    match unsafe { nix::unistd::fork().map_err(|e| Status::internal(format!("fork failed: {e}")))? }
+    {
+        nix::unistd::ForkResult::Child => {
+            // === CHILD PROCESS — synchronous only ===
+            drop(ready_r);
+            drop(stdout_r);
+            drop(stderr_r);
+
+            unsafe {
+                libc::signal(libc::SIGCHLD, libc::SIG_DFL);
+                libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+                // Wire stdout/stderr to our pipes.
+                libc::dup2(stdout_w_fd, libc::STDOUT_FILENO);
+                libc::dup2(stderr_w_fd, libc::STDERR_FILENO);
+            }
+            drop(stdout_w);
+            drop(stderr_w);
+
+            crate::container::close_inherited_fds(ready_w_fd);
+
+            executor::apply_memlock(memlock);
+
+            let hook_env = match crate::container::container_init(&container_cfg, &rootfs_clone) {
+                Ok(env) => env,
+                Err(e) => {
+                    let msg = format!("E:{e:#}");
+                    unsafe {
+                        libc::write(ready_w_fd, msg.as_ptr() as *const _, msg.len());
+                    }
+                    std::process::exit(1);
+                }
+            };
+
+            unsafe { libc::write(ready_w_fd, b"OK".as_ptr() as *const _, 2) };
+            drop(ready_w);
+
+            let mut final_env = env_clone;
+            for (k, v) in &container_env {
+                final_env.insert(k.clone(), v.clone());
+            }
+            for (k, v) in hook_env {
+                final_env.insert(k, v);
+            }
+
+            let shell = std::ffi::CString::new("/bin/bash").unwrap();
+            // Honor --container-entrypoint, matching the batch path: run the
+            // entrypoint, then the step script.
+            let argv: Vec<std::ffi::CString> = if let Some(ref ep) = entrypoint {
+                let cmd = format!("{ep} && /bin/bash {script_path_clone}");
+                vec![
+                    std::ffi::CString::new("bash").unwrap(),
+                    std::ffi::CString::new("-c").unwrap(),
+                    std::ffi::CString::new(cmd).unwrap_or_default(),
+                ]
+            } else {
+                vec![
+                    std::ffi::CString::new("bash").unwrap(),
+                    std::ffi::CString::new(script_path_clone.as_bytes()).unwrap_or_default(),
+                ]
+            };
+            let c_env: Vec<std::ffi::CString> = final_env
+                .iter()
+                .filter_map(|(k, v)| std::ffi::CString::new(format!("{k}={v}")).ok())
+                .collect();
+            let argv_refs: Vec<&std::ffi::CStr> = argv.iter().map(|s| s.as_c_str()).collect();
+            let env_refs: Vec<&std::ffi::CStr> = c_env.iter().map(|s| s.as_c_str()).collect();
+            let _ = nix::unistd::execve(&shell, &argv_refs, &env_refs);
+            std::process::exit(127);
+        }
+        nix::unistd::ForkResult::Parent { child: child_pid } => {
+            // === PARENT ===
+            drop(ready_w);
+            drop(stdout_w);
+            drop(stderr_w);
+
+            // Read the ready signal from the child.
+            let mut buf = [0u8; 256];
+            let n = unsafe { libc::read(ready_r_fd, buf.as_mut_ptr() as *mut _, buf.len()) };
+            drop(ready_r);
+            if n < 2 || &buf[..2] != b"OK" {
+                let msg = if n > 0 {
+                    String::from_utf8_lossy(&buf[..n.max(0) as usize]).to_string()
+                } else {
+                    "container init failed (no status)".to_string()
+                };
+                let _ = unsafe { libc::kill(child_pid.as_raw(), libc::SIGKILL) };
+                let _ = nix::sys::wait::waitpid(child_pid, None);
+                return Err(Status::internal(format!(
+                    "step container init failed: {msg}"
+                )));
+            }
+
+            // Register PID for cancellation.
+            let raw_pid = child_pid.as_raw() as u32;
+            let cancel_now = {
+                let mut steps = active_steps.lock().await;
+                if let Some(step) = steps.get_mut(&step_key) {
+                    step.pid = Some(raw_pid);
+                    step.cancel_requested
+                } else {
+                    false
+                }
+            };
+            if cancel_now {
+                // SIGKILL the whole subtree: the workload is a grandchild that
+                // is PID 1 of its namespace and would ignore SIGTERM from here.
+                crate::executor::kill_process_tree(
+                    child_pid.as_raw(),
+                    nix::sys::signal::Signal::SIGKILL,
+                );
+                let _ = nix::sys::wait::waitpid(child_pid, None);
+                return Err(Status::cancelled("step cancelled"));
+            }
+
+            // Read stdout and stderr concurrently using blocking tasks so we
+            // don't deadlock waiting for one pipe while the child fills the other.
+            let stdout_file = unsafe { std::fs::File::from_raw_fd(stdout_r_fd) };
+            let stderr_file = unsafe { std::fs::File::from_raw_fd(stderr_r_fd) };
+
+            let stdout_task = tokio::task::spawn_blocking(move || {
+                use std::io::Read;
+                let mut buf = Vec::new();
+                let _ = std::io::BufReader::new(stdout_file).read_to_end(&mut buf);
+                buf
+            });
+            let stderr_task = tokio::task::spawn_blocking(move || {
+                use std::io::Read;
+                let mut buf = Vec::new();
+                let _ = std::io::BufReader::new(stderr_file).read_to_end(&mut buf);
+                buf
+            });
+
+            // Wait for child in another blocking task.
+            let wait_task =
+                tokio::task::spawn_blocking(move || nix::sys::wait::waitpid(child_pid, None));
+
+            let (stdout_bytes, stderr_bytes, wait_result) =
+                tokio::join!(stdout_task, stderr_task, wait_task);
+            let stdout = stdout_bytes.unwrap_or_default();
+            let stderr = stderr_bytes.unwrap_or_default();
+
+            use std::os::unix::process::ExitStatusExt;
+            let exit_status =
+                match wait_result.unwrap_or(Ok(nix::sys::wait::WaitStatus::Exited(child_pid, 1))) {
+                    Ok(nix::sys::wait::WaitStatus::Exited(_, code)) => {
+                        std::process::ExitStatus::from_raw(code << 8)
+                    }
+                    Ok(nix::sys::wait::WaitStatus::Signaled(_, sig, _)) => {
+                        std::process::ExitStatus::from_raw(sig as i32)
+                    }
+                    _ => std::process::ExitStatus::from_raw(1 << 8),
+                };
+
+            Ok(std::process::Output {
+                status: exit_status,
+                stdout,
+                stderr,
+            })
+        }
+    }
 }
 
 pub struct AgentService {
@@ -863,6 +1101,27 @@ fn build_nsenter_argv(
     command: &[String],
 ) -> Vec<String> {
     let mut args = entry.nsenter_args();
+
+    // Rootless container (the job has its own user namespace). nsenter's default
+    // behaviour on entering a user namespace is to reset credentials — it calls
+    // setgroups() to drop supplementary groups — but the kernel forbids
+    // setgroups() in an unprivileged user namespace, so that fails with EPERM.
+    // A `setpriv --init-groups` drop would hit the same wall. Neither is needed:
+    // the job user is already mapped inside the namespace (host uid -> the
+    // namespace's root), so entering with --preserve-credentials and no setpriv
+    // runs the command as the correct user without ever touching groups.
+    //
+    // This branch only applies to rootless containers. When spurd is root the
+    // job has no user namespace (root containers use pid/mount only), so the
+    // path below — setpriv --init-groups, which preserves GPU groups — is
+    // unchanged.
+    if entry.has_user_namespace {
+        args.push("--preserve-credentials".into());
+        args.push("--".into());
+        args.extend(command.iter().cloned());
+        return args;
+    }
+
     args.push("--".into());
     if let Some(pd) = priv_drop {
         args.extend(pd.setpriv_prefix());
@@ -2031,7 +2290,7 @@ impl SlurmAgent for AgentService {
         // node already confirmed via LaunchJob (confirm_dispatch_on_nodes) — so a
         // miss is a wrong job/node pairing, not a launch race. The one uncovered
         // case is a spurd restart mid-job, which starts `running` empty.
-        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi) = {
+        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi, job_entry) = {
             let jobs = self.running.lock().await;
             let tracked = jobs.get(&job_id).ok_or_else(|| {
                 Status::not_found(format!("job {} not running on this node", job_id))
@@ -2043,6 +2302,16 @@ impl SlurmAgent for AgentService {
             } else {
                 tracked.nodelist.clone()
             };
+            let pid = tracked.job.pid().unwrap_or(0);
+            let entry = crate::job_entry::JobEntry {
+                pid: pid as i32,
+                has_pid_namespace: tracked.has_pid_namespace,
+                has_user_namespace: tracked.has_user_namespace,
+                has_mount_namespace: tracked.has_mount_namespace,
+                uid: tracked.uid,
+                gid: tracked.gid,
+                work_dir: tracked.work_dir.clone(),
+            };
             (
                 tracked.gpu_devices.clone(),
                 tracked.partition.clone(),
@@ -2050,6 +2319,7 @@ impl SlurmAgent for AgentService {
                 tracked.memory_mb,
                 nodelist,
                 tracked.mpi.clone(),
+                entry,
             )
         };
 
@@ -2061,18 +2331,18 @@ impl SlurmAgent for AgentService {
             .position(|n| *n == agent_hostname)
             .unwrap_or(0) as u32;
 
-        let mut gpu_env = if gpu_devices.is_empty() {
-            HashMap::new()
+        let (mut gpu_env, container_device_plan) = if gpu_devices.is_empty() {
+            (HashMap::new(), None)
         } else {
-            self.device_registry
+            let (host_plan, container_plan) = self
+                .device_registry
                 .lock()
                 .await
                 .build_job_injection_plans("gpu", &gpu_devices, req.uid, req.gid)
                 .map_err(|e| {
                     Status::failed_precondition(format!("GPU injection plan failed: {}", e))
-                })?
-                .0
-                .env
+                })?;
+            (host_plan.env, Some(container_plan))
         };
         maybe_deny_gpu_env(&mut gpu_env, &gpu_devices);
 
@@ -2255,26 +2525,7 @@ impl SlurmAgent for AgentService {
             return Ok(Response::new(cancelled_step_response()));
         }
 
-        let mut cmd = tokio::process::Command::new(&program);
-        cmd.args(&program_args)
-            .current_dir(&work_dir)
-            .process_group(0);
-        for (k, v) in env {
-            cmd.env(k, v);
-        }
-
         let memlock = self.limits.memlock;
-        let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
-        unsafe {
-            cmd.pre_exec(move || {
-                crate::executor::apply_memlock(memlock);
-                if let Some(ref pd) = priv_drop {
-                    pd.apply()
-                        .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
-                }
-                Ok(())
-            });
-        }
 
         info!(
             command = ?req.command,
@@ -2282,37 +2533,185 @@ impl SlurmAgent for AgentService {
             task_offset = req.task_offset,
             uid = req.uid,
             work_dir = %work_dir,
+            container_image = %req.container_image,
+            parent_namespaces = job_entry.has_namespaces(),
             "RunCommand: executing step"
         );
 
-        use std::process::Stdio;
-
-        let mut child = cmd
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| Status::internal(format!("command failed: {}", e)))?;
-        if let Some(pid) = child.id() {
-            let cancel_now = {
-                let mut steps = self.active_steps.lock().await;
-                if let Some(step) = steps.get_mut(&step_key) {
-                    step.pid = Some(pid);
-                    step.cancel_requested
-                } else {
-                    false
-                }
-            };
-            if cancel_now {
-                signal_step_process_group(pid, nix::sys::signal::Signal::SIGTERM as i32);
-                let _ = child.kill().await;
-                let _ = child.wait_with_output().await;
-                return Ok(Response::new(cancelled_step_response()));
+        let output = if job_entry.has_namespaces() && job_entry.pid > 0 {
+            // Case 1: parent job is containerized — enter its namespaces via nsenter.
+            // This covers both "srun inside sbatch --container-image" and
+            // "srun inside salloc --container-image" without setting up a new rootfs.
+            let full_command = [vec![program], program_args].concat();
+            let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
+            let plan = build_launch_plan(&job_entry, priv_drop.as_ref(), &full_command);
+            let mut cmd = tokio::process::Command::new(&plan.program);
+            cmd.args(&plan.args).process_group(0);
+            for (k, v) in env {
+                cmd.env(k, v);
             }
-        }
+            if plan.apply_priv_in_child {
+                cmd.current_dir(&work_dir);
+                if let Some(pd) = priv_drop {
+                    unsafe {
+                        cmd.pre_exec(move || {
+                            crate::executor::apply_memlock(memlock);
+                            pd.apply()
+                                .map_err(|e| std::io::Error::from_raw_os_error(e as i32))
+                        });
+                    }
+                }
+            } else {
+                unsafe {
+                    cmd.pre_exec(move || {
+                        crate::executor::apply_memlock(memlock);
+                        Ok(())
+                    });
+                }
+            }
+            run_step_child(cmd, &self.active_steps, step_key).await?
+        } else if !req.container_image.is_empty() {
+            // Case 2: standalone srun --container-image with no running parent container.
+            // Set up a fresh rootfs for this step and launch it containerized.
+            let step_uid = req.uid;
+            let step_gid = req.gid;
 
-        let output = match child.wait_with_output().await {
-            Ok(output) => output,
-            Err(e) => return Err(Status::internal(format!("command failed: {}", e))),
+            let mounts: Vec<crate::container::BindMount> = req
+                .container_mounts
+                .iter()
+                .filter_map(|m| crate::container::parse_mount(m).ok())
+                .collect();
+
+            let username = env
+                .get("USER")
+                .or_else(|| env.get("LOGNAME"))
+                .cloned()
+                .unwrap_or_default();
+            let home_dir = env
+                .get("HOME")
+                .cloned()
+                .unwrap_or_else(|| format!("/home/{username}"));
+
+            let container_cfg = crate::container::ContainerConfig {
+                image: req.container_image.clone(),
+                mounts,
+                workdir: if req.container_workdir.is_empty() {
+                    None
+                } else {
+                    Some(req.container_workdir.clone())
+                },
+                name: if req.container_name.is_empty() {
+                    None
+                } else {
+                    Some(req.container_name.clone())
+                },
+                readonly: req.container_readonly,
+                mount_home: req.container_mount_home,
+                remap_root: req.container_remap_root,
+                gpu_devices: gpu_devices.clone(),
+                environment: env.clone(),
+                // Deny GPU visibility in container_env for zero-GPU steps, matching
+                // the batch path (launch_job). Without this a user could smuggle
+                // ROCR_VISIBLE_DEVICES=0 through --container-env on a step that
+                // received no GPU allocation.
+                container_env: {
+                    let mut ce = req.container_env.clone();
+                    maybe_deny_gpu_env(&mut ce, &gpu_devices);
+                    ce
+                },
+                entrypoint: if req.container_entrypoint.is_empty() {
+                    None
+                } else {
+                    Some(req.container_entrypoint.clone())
+                },
+                uid: step_uid,
+                gid: step_gid,
+                username: if username.is_empty() {
+                    "spur".to_string()
+                } else {
+                    username
+                },
+                home_dir,
+                device_plan: container_device_plan,
+            };
+
+            let image_path =
+                crate::container::resolve_image(&req.container_image, None, Some(step_uid))
+                    .map_err(|e| Status::failed_precondition(e.to_string()))?;
+
+            // Use a unique rootfs ID per step to avoid collisions with the parent
+            // job's rootfs (which uses `job_id` alone).
+            let step_rootfs_id = job_id * 10000 + step_id;
+            let (rootfs, rootfs_mode) = crate::container::setup_rootfs(
+                &image_path,
+                step_rootfs_id,
+                container_cfg.name.as_deref(),
+            )
+            .map_err(|e| Status::internal(format!("step container setup failed: {e}")))?;
+
+            // Write the step command as a script inside the rootfs so it's
+            // accessible after pivot_root hides the host filesystem.
+            let step_script_content = {
+                let joined = shlex::try_join(
+                    std::iter::once(program.as_str())
+                        .chain(program_args.iter().map(String::as_str)),
+                )
+                .unwrap_or_else(|_| program.clone());
+                format!("#!/bin/bash\n{joined}\n")
+            };
+            let script_in_rootfs = format!(
+                "{}/tmp/spur_step_{}_{}.sh",
+                rootfs.display(),
+                job_id,
+                step_id
+            );
+            std::fs::write(&script_in_rootfs, &step_script_content)
+                .map_err(|e| Status::internal(format!("failed to write step script: {e}")))?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(
+                    &script_in_rootfs,
+                    std::fs::Permissions::from_mode(0o755),
+                );
+            }
+
+            // Script path inside the container (after pivot_root, host paths are gone).
+            let script_in_container = format!("/tmp/spur_step_{}_{}.sh", job_id, step_id);
+
+            let result = run_containerized_step(
+                container_cfg,
+                rootfs,
+                script_in_container,
+                env,
+                &self.active_steps,
+                step_key,
+                memlock,
+            )
+            .await;
+            crate::container::cleanup_rootfs(step_rootfs_id, &rootfs_mode);
+            result?
+        } else {
+            // Case 3: no container — plain host process (existing behaviour).
+            let mut cmd = tokio::process::Command::new(&program);
+            cmd.args(&program_args)
+                .current_dir(&work_dir)
+                .process_group(0);
+            for (k, v) in env {
+                cmd.env(k, v);
+            }
+            let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
+            unsafe {
+                cmd.pre_exec(move || {
+                    crate::executor::apply_memlock(memlock);
+                    if let Some(ref pd) = priv_drop {
+                        pd.apply()
+                            .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+                    }
+                    Ok(())
+                });
+            }
+            run_step_child(cmd, &self.active_steps, step_key).await?
         };
 
         if let Some(ref task_epilog) = self.hooks.task_epilog {
@@ -2858,6 +3257,7 @@ impl AgentService {
                 .is_some_and(|tracked| tracked.job.is_allocation_only())
         };
         if is_allocation_only {
+            self.cancel_active_steps_for_job(job_id, signal).await;
             self.drop_tracked_job(job_id).await;
             return;
         }
@@ -2887,7 +3287,52 @@ impl AgentService {
         let _ = tracked.job.kill_signal(sig);
     }
 
-    /// SIGTERM now, escalate to SIGKILL after a 5-second grace period.
+    /// Signal every in-flight step of a job. Allocation-only jobs (standalone
+    /// `srun` / `salloc`) have no tracked batch process that owns the step
+    /// processes, so a job-level cancel must reach the steps directly or they
+    /// orphan. This matters most for a containerized step, whose rootfs is torn
+    /// down only when its `run_command` returns — an unsignaled step would leak
+    /// both the container process and its rootfs.
+    ///
+    /// A containerized step runs as PID 1 of its own PID namespace. Signals from
+    /// an ancestor namespace to a namespace's init are *discarded* unless init
+    /// installed a handler for them — SIGTERM/SIGINT to a `bash`/`sleep` init are
+    /// dropped. Only SIGKILL and SIGSTOP are force-delivered. So the requested
+    /// signal is sent first (graceful for host steps), then SIGKILL after a short
+    /// grace period guarantees a container init dies.
+    async fn cancel_active_steps_for_job(&self, job_id: u32, signal: i32) {
+        let keyed: Vec<((u32, u32), u32)> = {
+            let mut steps = self.active_steps.lock().await;
+            let mut keyed = Vec::new();
+            for (key, step) in steps.iter_mut() {
+                if key.0 == job_id {
+                    step.cancel_requested = true;
+                    if let Some(pid) = step.pid {
+                        signal_step_process_group(pid, signal);
+                        keyed.push((*key, pid));
+                    }
+                }
+            }
+            keyed
+        };
+        if keyed.is_empty() {
+            return;
+        }
+        // Escalate to SIGKILL: a container-init step ignores the graceful signal.
+        // Re-check the step is still present with the same pid so a recycled pid
+        // (host step that already exited) is never signaled.
+        let active_steps = self.active_steps.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+            let steps = active_steps.lock().await;
+            for (key, pid) in keyed {
+                if steps.get(&key).and_then(|s| s.pid) == Some(pid) {
+                    signal_step_process_group(pid, nix::sys::signal::Signal::SIGKILL as i32);
+                }
+            }
+        });
+    }
+
     async fn graceful_cancel(&self, job_id: u32) {
         let is_allocation_only = {
             let jobs = self.running.lock().await;
@@ -2895,6 +3340,8 @@ impl AgentService {
                 .is_some_and(|tracked| tracked.job.is_allocation_only())
         };
         if is_allocation_only {
+            self.cancel_active_steps_for_job(job_id, nix::sys::signal::Signal::SIGTERM as i32)
+                .await;
             self.drop_tracked_job(job_id).await;
             return;
         }
@@ -3499,6 +3946,34 @@ mod tests {
         assert!(
             !argv.iter().any(|a| a == "setpriv"),
             "root job must not invoke setpriv: {argv:?}"
+        );
+        let sep = argv.iter().position(|a| a == "--").expect("missing --");
+        assert_eq!(&argv[sep..], &["--", "id"]);
+    }
+
+    /// Rootless container (user namespace): entering must preserve credentials
+    /// and skip setpriv, because setgroups() is forbidden in an unprivileged
+    /// user namespace. The job user is already mapped inside, so no in-namespace
+    /// drop is needed.
+    #[test]
+    fn build_nsenter_argv_rootless_container_preserves_credentials() {
+        let mut entry = nsenter_job_entry(1000, 1000);
+        entry.has_user_namespace = true;
+        let pd = crate::privdrop::PrivDrop::for_test(1000, 1000);
+        let argv = build_nsenter_argv(&entry, Some(&pd), &["id".to_string()]);
+
+        assert!(
+            argv.iter().any(|a| a == "--preserve-credentials"),
+            "rootless container entry must preserve credentials: {argv:?}"
+        );
+        assert!(
+            !argv.iter().any(|a| a == "setpriv"),
+            "rootless container entry must not invoke setpriv (setgroups is \
+             forbidden in a user namespace): {argv:?}"
+        );
+        assert!(
+            !argv.iter().any(|a| a == "--init-groups"),
+            "rootless container entry must not init groups: {argv:?}"
         );
         let sep = argv.iter().position(|a| a == "--").expect("missing --");
         assert_eq!(&argv[sep..], &["--", "id"]);
@@ -4300,6 +4775,144 @@ mod tests {
         });
         let err = svc.run_command(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    /// Regression for #777: a step carrying `container_image` must take the
+    /// container path, not silently run the command on the host. A bogus image
+    /// makes the container path fail at image resolution *before* the command
+    /// would run. The command (`echo`) would exit 0 on the host, so an Ok result
+    /// here would mean the flags were dropped — the exact bug being fixed.
+    #[tokio::test]
+    async fn run_command_with_container_image_takes_container_path_not_host() {
+        let (svc, job_id) = run_command_test_setup().await;
+        let req = Request::new(RunCommandRequest {
+            command: vec!["echo".into(), "would-succeed-on-host".into()],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+            job_id,
+            container_image: "/nonexistent/bogus-step-image.sqsh".into(),
+            ..Default::default()
+        });
+        let err = svc
+            .run_command(req)
+            .await
+            .expect_err("a container_image step must not fall through to a host echo");
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(
+            err.message().contains("not found"),
+            "expected an image-resolution failure, got: {}",
+            err.message()
+        );
+    }
+
+    /// The parent-container (nsenter) path takes precedence over setting up a
+    /// fresh container: a step whose tracked job already has live namespaces must
+    /// enter them, never call `resolve_image`. Proven by the *absence* of the
+    /// image-not-found error even though a bogus image is supplied.
+    #[tokio::test]
+    async fn run_command_enters_parent_namespaces_before_new_container() {
+        let (svc, job_id) = run_command_test_setup().await;
+        {
+            let mut jobs = svc.running.lock().await;
+            let job = jobs.get_mut(&job_id).unwrap();
+            job.has_pid_namespace = true;
+            job.has_mount_namespace = true;
+        }
+        let req = Request::new(RunCommandRequest {
+            command: vec!["echo".into(), "hi".into()],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+            job_id,
+            container_image: "/nonexistent/bogus-step-image.sqsh".into(),
+            ..Default::default()
+        });
+        // The nsenter path may or may not succeed depending on the runner's
+        // privileges, but it must never report the bogus image as not found —
+        // that would mean Case 2 was wrongly entered ahead of Case 1.
+        if let Err(err) = svc.run_command(req).await {
+            assert!(
+                !err.message().contains("not found in ["),
+                "namespaced job should nsenter, not resolve a new image: {}",
+                err.message()
+            );
+        }
+    }
+
+    /// Without a container_image and without namespaces, the step runs directly
+    /// on the host (Case 3) — the flag is what gates the container path.
+    #[tokio::test]
+    async fn run_command_without_container_image_runs_on_host() {
+        let (svc, job_id) = run_command_test_setup().await;
+        let req = Request::new(RunCommandRequest {
+            command: vec!["echo".into(), "host-step".into()],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+            job_id,
+            ..Default::default()
+        });
+        let resp = svc.run_command(req).await.unwrap().into_inner();
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(resp.stdout.trim(), "host-step");
+    }
+
+    /// Cancelling an allocation-only job (standalone srun / salloc) must signal
+    /// its in-flight steps, not just drop the tracked allocation. Otherwise a
+    /// containerized step orphans its container and leaks its rootfs. Uses a real
+    /// child in its own process group so the group-targeted signal is observable.
+    #[tokio::test]
+    async fn cancelling_allocation_only_job_signals_inflight_steps() {
+        use std::os::unix::process::CommandExt;
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        svc.register_job_allocation(Request::new(RegisterJobAllocationRequest {
+            job_id: 77,
+            cpus: 1,
+            ..Default::default()
+        }))
+        .await
+        .expect("register allocation");
+
+        let mut cmd = std::process::Command::new("sleep");
+        cmd.arg("300");
+        cmd.process_group(0);
+        let mut child = cmd.spawn().expect("spawn sleep");
+        svc.register_test_step(77, 0, Some(child.id())).await;
+
+        svc.graceful_cancel(77).await;
+
+        // The step must be marked cancelled and its process signaled dead.
+        {
+            let steps = svc.active_steps.lock().await;
+            assert!(
+                steps.get(&(77, 0)).unwrap().cancel_requested,
+                "step should be marked cancel_requested"
+            );
+        }
+        // try_wait both reaps the child and reports its exit, avoiding the
+        // zombie-looks-alive trap of a signal-0 probe.
+        let mut exited = false;
+        for _ in 0..50 {
+            if child.try_wait().expect("try_wait").is_some() {
+                exited = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        if !exited {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        assert!(exited, "the in-flight step process must be signaled dead");
     }
 
     #[tokio::test]

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1212,7 +1212,7 @@ pub fn cleanup_cgroup(cgroup_path: &Path) {
 }
 
 /// Recursively signal a process and all its descendants (children first).
-fn kill_process_tree(pid: i32, sig: Signal) {
+pub(crate) fn kill_process_tree(pid: i32, sig: Signal) {
     let children = get_child_pids(pid);
     for child in &children {
         kill_process_tree(*child, sig);

--- a/docs/user-guide/running-containers.rst
+++ b/docs/user-guide/running-containers.rst
@@ -59,13 +59,15 @@ runs inside the container.
    * - ``--container-name <name>``
      - Persist the container across jobs. Required for ``spur image export``.
    * - ``--container-readonly``
-     - Mount the container root read-only.
+     - Not yet implemented — rejected at submission. (A read-only container
+       root is not enforced yet; the flag is refused rather than silently
+       ignored.)
    * - ``--container-mount-home``
      - Mount your home directory into the container.
    * - ``--container-env KEY=VAL``
      - Set an environment variable inside the container. Repeatable.
    * - ``--container-entrypoint``
-     - Use the image's entrypoint (``sbatch``).
+     - Use the image's entrypoint.
    * - ``--container-remap-root``
      - Map the job user to root inside the container.
 
@@ -82,6 +84,36 @@ An interactive shell in a container with your home directory mounted:
 .. code-block:: bash
 
    srun --container-image ubuntu:22.04 --container-mount-home bash
+
+Containerized Job Steps
+-----------------------
+
+``srun`` steps run inside a container too, not just batch jobs. The container
+flags above apply to a step's ``srun`` and behave as follows:
+
+- **Step inside a containerized allocation.** When the batch job was submitted
+  with ``--container-image`` (``sbatch --container-image ...``), a nested
+  ``srun`` step enters that already-running container — it shares the job's
+  image, mounts, and GPU devices. This is the standard Slurm + Pyxis pattern
+  used by multi-node launchers.
+
+- **Step with its own image.** A standalone ``srun --container-image`` (or an
+  ``salloc`` allocation followed by ``srun --container-image``) creates a fresh
+  container for that step. Different steps in one allocation can use different
+  images and mounts.
+
+Concurrent steps on separate nodes each run their own container:
+
+.. code-block:: bash
+
+   salloc -N2 --gpus-per-node=8
+   srun --overlap -N1 -w node1 --container-image trainer.sqsh ray start --head ... &
+   srun --overlap -N1 -w node2 --container-image trainer.sqsh ray start --address ... &
+   wait
+
+GPU allocation, bind mounts, and cancellation apply per step: a cancelled step
+tears down its container and cleans up its rootfs without affecting the rest of
+the allocation.
 
 Exec Into a Running Container Job
 ---------------------------------

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1006,6 +1006,17 @@ message RunStepRequest {
   bool label = 8;      // Prefix output lines with [rank] (srun -l)
   string mpi = 9;      // Step MPI type; when empty, inherit job.spec.mpi
   string user = 10;    // Requesting user; verified identity must own the job; the controller/admin credential overrides
+  // Step-level container override (mirrors JobSpec fields 70-78).
+  // Empty/false = inherit from parent job's container config.
+  string container_image = 11;
+  repeated string container_mounts = 12;
+  string container_workdir = 13;
+  string container_name = 14;
+  bool container_readonly = 15;
+  bool container_mount_home = 16;
+  map<string, string> container_env = 17;
+  string container_entrypoint = 18;
+  bool container_remap_root = 19;
 }
 
 message RunStepResponse {
@@ -1229,6 +1240,18 @@ message RunCommandRequest {
   string mpi = 13;             // Resolved step MPI type: "none" or "pmix"
   // When true, PMIx was prepared via PreparePmix on the controller before RunCommand.
   bool pmix_prepared = 14;
+  // Container fields for srun steps (mirrors JobSpec fields 70-78).
+  // Empty/false = no container; the step runs directly on the host or enters
+  // the parent job's existing namespaces when the job is containerized.
+  string container_image = 15;
+  repeated string container_mounts = 16;
+  string container_workdir = 17;
+  string container_name = 18;
+  bool container_readonly = 19;
+  bool container_mount_home = 20;
+  map<string, string> container_env = 21;
+  string container_entrypoint = 22;
+  bool container_remap_root = 23;
 }
 
 // Register a srun-only allocation on an agent without starting a batch process.

--- a/tests/native_host/e2e/test_srun_container.py
+++ b/tests/native_host/e2e/test_srun_container.py
@@ -1,0 +1,652 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for containerized srun job steps on bare-metal nodes (issue #777).
+
+Two dispatch paths exist for a containerized step, and they are tested
+separately because they are reached by genuinely different setups:
+
+  Case 2 — NEW container per step (spurd forks a fresh rootfs):
+    Reached by standalone `srun --container-image` and by `salloc
+    --container-image` + `srun`. Neither runs a batch process on the compute
+    node, so the step's tracked job has no live namespaces and spurd builds a
+    new container for the step. Capabilities exercised: container entry, bind
+    mounts, workdir, home mount, user identity, DNS, GPU env deny, GPU device
+    injection.
+
+  Case 1 — ENTER the parent container (nsenter):
+    Reached only by `sbatch --container-image` + a nested `srun`. The batch
+    script runs *inside* a live container, so the nested step enters those
+    namespaces instead of building a new rootfs. Capabilities exercised:
+    container entry, parent bind mounts visible, GPU visibility through nsenter.
+
+  Multi-node:
+    A single `srun -N2 --container-image` step fans out one container per
+    node; concurrent `srun --overlap` steps run one container per node.
+"""
+
+import shlex
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+
+def _toolchain_mounts(cluster) -> list:
+    """--container-mounts args that make the host `spur`/`srun` binary runnable
+    inside a container: the bin dir plus the shared-library dirs it links
+    against (libc, libm, libgcc_s, ld-linux). Bind-mounting the *node's* own
+    libs (rather than baking them into the image) guarantees an ABI match with
+    the node's binary."""
+    paths = [cluster.bin_dir, "/lib", "/lib64", "/usr/lib"]
+    return [f"--container-mounts={p}:{p}:ro" for p in paths]
+
+
+MARKER_PATH = "/inside-image-marker"
+MARKER_CONTENT = "spur-container-step-marker"
+
+
+# ---------------------------------------------------------------------------
+# Image builder + fixtures
+# ---------------------------------------------------------------------------
+
+def _build_marked_image(tmp_path: Path, cluster) -> str:
+    """Minimal squashfs image with MARKER_PATH and common utilities."""
+    remote_path = f"{cluster.remote_dir}/step-test-container.sqsh"
+    rootfs = tmp_path / "rootfs"
+    local_img = tmp_path / "step-test-container.sqsh"
+
+    build_script = f"""set -e
+R='{rootfs}'
+mkdir -p "$R/bin" "$R/usr/bin" "$R/lib" "$R/lib64" \
+  "$R/etc" "$R/dev" "$R/proc" "$R/sys" "$R/tmp" \
+  "$R/run" "$R/home" "$R/mnt"
+for b in bash cat echo sleep hostname id stat ls touch pwd env grep awk; do
+  src=$(which "$b" 2>/dev/null) || continue
+  [ -f "$src" ] && cp "$src" "$R/usr/bin/"
+done
+ln -sf /usr/bin/bash "$R/bin/bash"
+ln -sf /usr/bin/bash "$R/bin/sh"
+for f in "$R/usr/bin/"*; do
+  ldd "$f" 2>/dev/null | grep '=>' | awk '{{print $3}}' | while read -r lib; do
+    [ -f "$lib" ] || continue
+    dir=$(dirname "$lib")
+    mkdir -p "$R$dir"
+    cp -n "$lib" "$R$lib" 2>/dev/null || true
+  done
+done
+for nsslib in libnss_dns.so.2 libnss_files.so.2 libresolv.so.2; do
+  src="/lib/x86_64-linux-gnu/$nsslib"
+  [ -f "$src" ] && mkdir -p "$R/lib/x86_64-linux-gnu" && cp -n "$src" "$R/lib/x86_64-linux-gnu/" 2>/dev/null || true
+done
+[ -f /lib64/ld-linux-x86-64.so.2 ] && cp -n /lib64/ld-linux-x86-64.so.2 "$R/lib64/" 2>/dev/null || true
+for f in /etc/passwd /etc/group /etc/nsswitch.conf; do
+  [ -f "$f" ] && cp "$f" "$R/etc/"
+done
+echo '{MARKER_CONTENT}' > "$R{MARKER_PATH}"
+mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
+"""
+    result = subprocess.run(["sh", "-c", build_script], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"mksquashfs failed: {result.stderr}")
+
+    for node in cluster.nodes:
+        node.upload(str(local_img), remote_path)
+
+    probe = cluster.nodes[0].exec_allow_fail(
+        f"test -e '{MARKER_PATH}' && echo PRESENT || echo ABSENT"
+    )
+    if "PRESENT" in probe:
+        pytest.skip(f"marker {MARKER_PATH} exists on host — test cannot be conclusive")
+
+    return remote_path
+
+
+def _bracket(pattern: str) -> str:
+    """Wrap the first char in a regex class so pgrep -f does not match the shell
+    that is running pgrep itself (its own cmdline contains the literal pattern)."""
+    return f"[{pattern[0]}]{pattern[1:]}" if pattern else pattern
+
+
+def _wait_no_process(cluster, pattern: str, timeout: int = 20) -> bool:
+    """Poll node 0 until no process matches *pattern* (pgrep -f), or timeout."""
+    pat = _bracket(pattern)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        out = cluster.nodes[0].exec_allow_fail(f"pgrep -f {shlex.quote(pat)} || echo NONE")
+        if "NONE" in out or not out.strip():
+            return True
+        time.sleep(1)
+    return False
+
+
+def _parse_probe(content: str) -> dict:
+    out = {}
+    for line in content.splitlines():
+        if "=" not in line or line.startswith(" ") or line.startswith("\x1b"):
+            continue
+        key, _, val = line.partition("=")
+        out[key.strip()] = val.strip()
+    return out
+
+
+@pytest.fixture
+def step_container_cluster(cluster, tmp_path):
+    cluster.container_preflight()
+    cluster.step_container_image = _build_marked_image(tmp_path, cluster)
+    return cluster
+
+
+@pytest.fixture
+def step_container_multi_cluster(multi_node_cluster, tmp_path):
+    multi_node_cluster.container_preflight()
+    multi_node_cluster.step_container_image = _build_marked_image(tmp_path, multi_node_cluster)
+    return multi_node_cluster
+
+
+@pytest.fixture
+def step_gpu_container_cluster(gpu_cluster, tmp_path):
+    """GPU-capable cluster with a container image and the shared GPU probe.
+
+    Depending on `gpu_cluster` auto-marks these tests `gpu` (conftest) and skips
+    them when no GPU hardware is present.
+    """
+    gpu_cluster.gpu_preflight(1)
+    gpu_cluster.container_preflight()
+    gpu_cluster.step_container_image = _build_marked_image(tmp_path, gpu_cluster)
+    probe = gpu_cluster.ship_fixture("gpu_env_probe.sh")
+    for node in gpu_cluster.nodes:
+        node.exec(f"chmod +x '{probe}'")
+    gpu_cluster.step_probe = probe
+    return gpu_cluster
+
+
+# ---------------------------------------------------------------------------
+# Case 2: new container per step (standalone srun --container-image)
+# ---------------------------------------------------------------------------
+
+class TestSrunContainerStepNewRootfs:
+    def test_container_entry(self, step_container_cluster):
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "cat", MARKER_PATH,
+        ])
+        assert code == 0, f"srun --container-image failed (exit {code}):\n{out}"
+        assert MARKER_CONTENT in out, f"step ran on host, not in container:\n{out}"
+
+    def test_bind_mount(self, step_container_cluster):
+        # Mount a directory (the common case, matching the batch container test);
+        # file bind mounts are a separate, untested edge case.
+        cluster = step_container_cluster
+        bind_dir = f"{cluster.remote_dir}/bind-test"
+        cluster.nodes[0].exec(
+            f"mkdir -p '{bind_dir}' && echo 'bind-mount-works' > '{bind_dir}/data.txt'"
+        )
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            f"--container-mounts={bind_dir}:/mnt/data:ro",
+            "cat", "/mnt/data/data.txt",
+        ])
+        assert code == 0, f"srun with bind mount failed (exit {code}):\n{out}"
+        assert "bind-mount-works" in out, f"bind mount not visible in step:\n{out}"
+
+    def test_workdir(self, step_container_cluster):
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "--container-workdir=/tmp",
+            "pwd",
+        ])
+        assert code == 0, f"srun --container-workdir failed (exit {code}):\n{out}"
+        assert "/tmp" in out.strip(), f"expected workdir /tmp, got:\n{out}"
+
+    def test_mount_home(self, step_container_cluster):
+        """--container-mount-home makes the job user's home available inside the
+        step. The probe prints diagnostics (HOME, its contents, mount table) and
+        always exits 0, so a failed assertion surfaces the real in-container
+        state instead of a bare exit code."""
+        cluster = step_container_cluster
+        probe = (
+            'echo "HOME=$HOME"; echo "USER=$USER"; '
+            'test -d "$HOME" && echo HOME_IS_DIR || echo HOME_NOT_DIR; '
+            'echo "-- ls $HOME --"; ls -la "$HOME" 2>&1 | head -20; '
+            'echo "-- home mounts --"; grep -i home /proc/mounts 2>/dev/null || echo NO_HOME_MOUNT; '
+            'echo "-- write --"; { touch "$HOME/.spur_probe" && echo HOME_WRITABLE; } || echo HOME_NOT_WRITABLE; '
+            'true'
+        )
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "--container-mount-home",
+            "bash", "-c", probe,
+        ])
+        assert "HOME_WRITABLE" in out, (
+            f"--container-mount-home did not yield a usable home (exit {code}):\n{out}"
+        )
+
+    def test_user_identity(self, step_container_cluster):
+        """id runs inside the container (passwd/shadow injected — no 'no such user')."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "id",
+        ])
+        assert code == 0, f"srun id failed (exit {code}):\n{out}"
+        assert "uid=" in out, f"id output malformed inside container:\n{out}"
+
+    def test_dns_injected(self, step_container_cluster):
+        """/etc/resolv.conf is injected (image ships without one)."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "bash", "-c", "test -s /etc/resolv.conf && echo DNS_OK || echo DNS_MISSING",
+        ])
+        assert code == 0, f"srun dns check failed (exit {code}):\n{out}"
+        assert "DNS_OK" in out, f"/etc/resolv.conf not injected in step:\n{out}"
+
+    def test_gpu_env_denied_on_zero_gpu_step(self, step_container_cluster):
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "bash", "-c", "echo ROCR=${ROCR_VISIBLE_DEVICES:-unset}",
+        ])
+        assert code == 0, f"srun gpu env check failed (exit {code}):\n{out}"
+        assert "ROCR=-1" in out or "ROCR=unset" in out, f"GPU env not denied:\n{out}"
+        assert "ROCR=0" not in out, f"GPU 0 visible in zero-GPU step:\n{out}"
+
+    def test_container_env_gpu_deny_not_bypassable(self, step_container_cluster):
+        """--container-env cannot re-enable GPU visibility on a zero-GPU step."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "--container-env=ROCR_VISIBLE_DEVICES=0",
+            "bash", "-c", "echo ROCR=${ROCR_VISIBLE_DEVICES:-unset}",
+        ])
+        assert code == 0, f"srun container-env check failed (exit {code}):\n{out}"
+        assert "ROCR=0" not in out, f"--container-env smuggled GPU visibility:\n{out}"
+
+    def test_named_container(self, step_container_cluster):
+        """--container-name is accepted and the step still runs in the image."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "--container-name=step-named-ctr",
+            "cat", MARKER_PATH,
+        ])
+        assert code == 0, f"srun --container-name failed (exit {code}):\n{out}"
+        assert MARKER_CONTENT in out, f"named-container step not in image:\n{out}"
+
+    def test_container_entrypoint(self, step_container_cluster):
+        """--container-entrypoint runs before the step command inside the container."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "--container-entrypoint=touch /tmp/ep_ran",
+            "bash", "-c", "test -f /tmp/ep_ran && echo EP_OK || echo EP_MISSING",
+        ])
+        assert code == 0, f"srun --container-entrypoint failed (exit {code}):\n{out}"
+        assert "EP_OK" in out, (
+            f"entrypoint did not run before the step command:\n{out}"
+        )
+
+    def test_salloc_then_srun_container(self, step_container_cluster):
+        """salloc allocation followed by a containerized srun step (issue's suggested case).
+
+        The salloc allocation has no compute-node container, so the step builds
+        its own (Case 2). The container image is specified on the step's srun.
+        """
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        out_path = f"{cluster.remote_dir}/salloc-step.out"
+        body = (
+            f"'{cluster.bin_dir}/srun' --container-image='{img}' "
+            f"cat '{MARKER_PATH}' > '{out_path}' 2>&1"
+        )
+        code, out = cluster.salloc_run(body, salloc_args=["-N", "1", "-t", "0:02"])
+        assert code == 0, f"salloc failed (exit {code}):\n{out}"
+        step_out = cluster.nodes[0].read_file(out_path)
+        assert MARKER_CONTENT in step_out, (
+            f"salloc + srun --container-image step not in container:\n{step_out}"
+        )
+
+    def test_cancellation_terminates_container_step(self, step_container_cluster):
+        """scancel of a containerized srun step terminates the container (no orphan).
+
+        A standalone `srun --container-image sleep 300` is launched in the
+        background; scancel must stop the container so nothing lingers.
+        """
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        name = "cancel-ctr-step"
+        out_path = f"{cluster.remote_dir}/cancel-ctr.out"
+        launch = (
+            f"SPUR_CONTROLLER_ADDR={shlex.quote(cluster.controller_addr)} "
+            f"PATH={shlex.quote(cluster.bin_dir)}:$PATH "
+            f"nohup {shlex.quote(cluster.bin_dir + '/srun')} -J {name} -N1 -t 0:05 "
+            f"--container-image={shlex.quote(img)} sleep 300 "
+            f"> {shlex.quote(out_path)} 2>&1 & echo backgrounded"
+        )
+        cluster.nodes[0].exec(launch)
+
+        job_id = None
+        for _ in range(30):
+            ids = cluster.running_job_ids_by_name(name)
+            if ids:
+                job_id = ids[0]
+                break
+            time.sleep(1)
+        assert job_id is not None, "containerized srun step never reached running"
+
+        cluster.scancel(str(job_id))
+
+        state = wait_job(cluster, job_id, timeout=45)
+        assert state in ("CA", "F", "COMPLETED", "GONE"), (
+            f"cancelled containerized step should be terminal, got {state}"
+        )
+
+        # The container's sleep must not linger (allow for the SIGKILL escalation
+        # and the srun client teardown).
+        assert _wait_no_process(cluster, "sleep 300", timeout=20), (
+            "container step process lingered after cancel:\n"
+            + cluster.nodes[0].exec_allow_fail("pgrep -af '[s]leep 300' || echo NONE")
+        )
+
+    def test_ctrl_c_terminates_container_step(self, step_container_cluster):
+        """Ctrl-C (SIGINT to the srun client) terminates the containerized step.
+
+        srun's Ctrl-C handler sends a job cancel; the agent must signal the
+        in-flight containerized step so nothing orphans — the path exercised by
+        an interactive `srun --container-image ...` the user aborts.
+        """
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        name = "ctrlc-ctr-step"
+        out_path = f"{cluster.remote_dir}/ctrlc.out"
+        launch = (
+            f"SPUR_CONTROLLER_ADDR={shlex.quote(cluster.controller_addr)} "
+            f"PATH={shlex.quote(cluster.bin_dir)}:$PATH "
+            f"nohup {shlex.quote(cluster.bin_dir + '/srun')} -J {name} -N1 -t 0:05 "
+            f"--container-image={shlex.quote(img)} sleep 300 "
+            f"> {shlex.quote(out_path)} 2>&1 & echo PID:$!"
+        )
+        res = cluster.nodes[0].exec(launch)
+        srun_pid = next(
+            (tok.split(":", 1)[1].strip() for tok in res.split() if tok.startswith("PID:")),
+            None,
+        )
+        assert srun_pid, f"could not capture srun client pid:\n{res}"
+
+        job_id = None
+        for _ in range(30):
+            ids = cluster.running_job_ids_by_name(name)
+            if ids:
+                job_id = ids[0]
+                break
+            time.sleep(1)
+        assert job_id is not None, "containerized srun step never reached running"
+
+        # Ctrl-C: SIGINT to the srun client triggers its cancel handler.
+        cluster.nodes[0].exec_allow_fail(f"kill -INT {srun_pid}")
+
+        state = wait_job(cluster, job_id, timeout=45)
+        assert state in ("CA", "F", "COMPLETED", "GONE"), (
+            f"Ctrl-C'd containerized step should be terminal, got {state}"
+        )
+        assert _wait_no_process(cluster, "sleep 300", timeout=20), (
+            "container step process lingered after Ctrl-C:\n"
+            + cluster.nodes[0].exec_allow_fail("pgrep -af '[s]leep 300' || echo NONE")
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 1: enter the parent container via nsenter
+# ---------------------------------------------------------------------------
+
+class TestSrunContainerStepNsenter:
+    """A step whose job is already containerized enters the parent container's
+    namespaces (nsenter) instead of building a new rootfs.
+
+    Two shapes are covered:
+      - `spur exec` into a running containerized job: `spur` runs on the host and
+        enters the container — no in-image binary needed. This proves the nsenter
+        mechanism works for a rootless user-namespace container.
+      - a nested `srun` *inside* an `sbatch --container-image` batch script: the
+        script runs post-pivot_root, so `spur`/`srun` and its shared libraries
+        are bind-mounted in via `_toolchain_mounts`. The nested srun attaches as
+        a step (SPUR_JOB_ID is in the batch env) and routes through run_command's
+        Case 1.
+    """
+
+    def test_spur_exec_enters_container_job(self, step_container_cluster):
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        hold = cluster.write_file("nsenter-hold.sh", "#!/bin/bash\nsleep 300\n")
+        sb = cluster.sbatch([
+            "-J", "nsenter-hold", "-N", "1", "-t", "0:05",
+            f"--container-image={img}", hold,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch did not return a job id: {sb}"
+        try:
+            wait_job_state(cluster, job_id, "R", timeout=60)
+            out = cluster.cli(["spur", "exec", str(job_id), "cat", MARKER_PATH])
+            assert MARKER_CONTENT in out, (
+                f"spur exec did not enter the parent container:\n{out}"
+            )
+        finally:
+            cluster.scancel(str(job_id))
+
+    def test_nested_srun_enters_parent_container(self, step_container_cluster):
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        out_path = f"{cluster.remote_dir}/nsenter-entry.out"
+        script = cluster.write_file(
+            "nsenter-entry.sh",
+            f"#!/bin/bash\n{cluster.bin_dir}/srun cat '{MARKER_PATH}'\n",
+        )
+        sb = cluster.sbatch([
+            "-J", "nsenter-entry", "-N", "1", "-t", "0:03", "-o", out_path,
+            f"--container-image={img}",
+            *_toolchain_mounts(cluster),
+            script,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch did not return a job id: {sb}"
+        wait_job(cluster, job_id, timeout=120)
+        out = cluster.read_output_on_any_node(out_path)
+        diag = cluster.debug_job(job_id)
+        assert MARKER_CONTENT in out, (
+            f"nested srun did not enter parent container:\n{diag}\noutput:\n{out}"
+        )
+
+    def test_parent_bind_mount_visible_to_nested_step(self, step_container_cluster):
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        bind_dir = f"{cluster.remote_dir}/nsenter-bind"
+        cluster.nodes[0].exec(
+            f"mkdir -p '{bind_dir}' && echo 'nsenter-bind-ok' > '{bind_dir}/data.txt'"
+        )
+
+        out_path = f"{cluster.remote_dir}/nsenter-bind.out"
+        script = cluster.write_file(
+            "nsenter-bind.sh",
+            f"#!/bin/bash\n{cluster.bin_dir}/srun cat /mnt/nsdata/data.txt\n",
+        )
+        sb = cluster.sbatch([
+            "-J", "nsenter-bind", "-N", "1", "-t", "0:03", "-o", out_path,
+            f"--container-image={img}",
+            f"--container-mounts={bind_dir}:/mnt/nsdata:ro",
+            *_toolchain_mounts(cluster),
+            script,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+        wait_job(cluster, job_id, timeout=180)
+        out = cluster.read_output_on_any_node(out_path)
+        diag = cluster.debug_job(job_id)
+        assert "nsenter-bind-ok" in out, (
+            f"parent bind mount not visible to nested step:\n{diag}\noutput:\n{out}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GPU device injection (requires GPU hardware; auto-skipped otherwise)
+# ---------------------------------------------------------------------------
+
+class TestSrunContainerStepGpuInjection:
+    def test_new_container_step_gpu_injection(self, step_gpu_container_cluster):
+        """Standalone srun --gres=gpu:1 --container-image sees the GPU device
+        nodes bind-mounted into the fresh step container (Case 2)."""
+        cluster = step_gpu_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:03",
+            "--gres=gpu:1",
+            f"--container-image={cluster.step_container_image}",
+            f"--container-mounts={cluster.step_probe}:/probe.sh:ro",
+            "/probe.sh",
+        ])
+        assert code == 0, f"gpu step failed (exit {code}):\n{out}"
+        parsed = _parse_probe(out)
+        assert parsed.get("VISIBLE_COUNT") == "1", f"expected 1 visible GPU:\n{out}"
+        assert parsed.get("SPUR_COUNT") == "1", f"expected SPUR_JOB_GPUS=1:\n{out}"
+        assert parsed.get("KFD") == "yes", f"/dev/kfd not injected in step:\n{out}"
+        assert int(parsed.get("RENDER_COUNT", "0")) >= 1, (
+            f"no /dev/dri/renderD* injected in step:\n{out}"
+        )
+
+    def test_nsenter_step_sees_parent_gpus(self, step_gpu_container_cluster):
+        """A nested srun (nsenter) sees the GPUs injected into the parent
+        sbatch --gres=gpu:1 --container-image job (Case 1)."""
+        cluster = step_gpu_container_cluster
+        img = cluster.step_container_image
+        out_path = f"{cluster.remote_dir}/nsenter-gpu.out"
+        script = cluster.write_file(
+            "nsenter-gpu.sh",
+            f"#!/bin/bash\n{cluster.bin_dir}/srun /probe.sh\n",
+        )
+        sb = cluster.sbatch([
+            "-J", "nsenter-gpu", "-N", "1", "-t", "0:03", "-o", out_path,
+            "--gres=gpu:1",
+            f"--container-image={img}",
+            f"--container-mounts={cluster.step_probe}:/probe.sh:ro",
+            *_toolchain_mounts(cluster),
+            script,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+        wait_job(cluster, job_id, timeout=180)
+        out = cluster.read_output_on_any_node(out_path)
+        parsed = _parse_probe(out)
+        diag = cluster.debug_job(job_id)
+        assert parsed.get("VISIBLE_COUNT") == "1", (
+            f"nested step did not see parent GPU:\n{diag}\n{out}"
+        )
+        assert parsed.get("KFD") == "yes", f"/dev/kfd not visible to nested step:\n{out}"
+
+    def test_gpu_isolation_two_gpus(self, step_gpu_container_cluster):
+        """A step allocated 2 GPUs sees exactly 2 (no more, no fewer)."""
+        cluster = step_gpu_container_cluster
+        if max(cluster.node_gpu_count(n) for n in cluster.node_names) < 2:
+            pytest.skip("need >= 2 GPUs on a node")
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:03",
+            "--gres=gpu:2",
+            f"--container-image={cluster.step_container_image}",
+            f"--container-mounts={cluster.step_probe}:/probe.sh:ro",
+            "/probe.sh",
+        ])
+        assert code == 0, f"gpu step failed (exit {code}):\n{out}"
+        parsed = _parse_probe(out)
+        assert parsed.get("VISIBLE_COUNT") == "2", f"expected 2 visible GPUs:\n{out}"
+        assert int(parsed.get("RENDER_COUNT", "0")) == 2, (
+            f"expected exactly 2 renderD nodes injected:\n{out}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-node
+# ---------------------------------------------------------------------------
+
+class TestSrunContainerStepMultiNode:
+    def test_single_step_fans_out_to_all_nodes(self, step_container_multi_cluster):
+        """One `srun -N2 --container-image` step runs a container on each node."""
+        cluster = step_container_multi_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "2", "-t", "0:03",
+            f"--container-image={cluster.step_container_image}",
+            "cat", MARKER_PATH,
+        ])
+        assert code == 0, f"multi-node srun step failed (exit {code}):\n{out}"
+        assert out.count(MARKER_CONTENT) >= 2, (
+            f"expected the marker from both nodes' containers, got:\n{out}"
+        )
+
+    def test_concurrent_overlap_steps(self, step_container_multi_cluster):
+        """The Miles pattern: from a salloc shell, launch one containerized
+        `srun --overlap` per node concurrently. Each step builds its own
+        container (Case 2). srun runs on the host, so the redirects land on the
+        allocation shell's node."""
+        cluster = step_container_multi_cluster
+        img = cluster.step_container_image
+        out1 = f"{cluster.remote_dir}/overlap-1.out"
+        out2 = f"{cluster.remote_dir}/overlap-2.out"
+        node1, node2 = cluster.node_names[0], cluster.node_names[1]
+        body = (
+            f"'{cluster.bin_dir}/srun' --overlap -N1 -w '{node1}' "
+            f"--container-image='{img}' cat '{MARKER_PATH}' > '{out1}' 2>&1 &\n"
+            f"'{cluster.bin_dir}/srun' --overlap -N1 -w '{node2}' "
+            f"--container-image='{img}' cat '{MARKER_PATH}' > '{out2}' 2>&1 &\n"
+            f"wait"
+        )
+        code, out = cluster.salloc_run(body, salloc_args=["-N", "2", "-t", "0:03"])
+        assert code == 0, f"salloc overlap run failed (exit {code}):\n{out}"
+        # Both srun clients run in the salloc shell (node 0), so both outputs
+        # land on node 0.
+        out1_c = cluster.nodes[0].read_file(out1)
+        out2_c = cluster.nodes[0].read_file(out2)
+        assert MARKER_CONTENT in out1_c, f"node1 overlap step not in container:\n{out1_c}"
+        assert MARKER_CONTENT in out2_c, f"node2 overlap step not in container:\n{out2_c}"
+
+
+# ---------------------------------------------------------------------------
+# Sanity / negative
+# ---------------------------------------------------------------------------
+
+class TestSrunContainerStepSanity:
+    def test_container_readonly_rejected(self, step_container_cluster):
+        """--container-readonly is refused at submission (not a silent no-op)."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "--container-readonly",
+            "true",
+        ])
+        assert code != 0, f"--container-readonly should be rejected, got exit 0:\n{out}"
+        assert "container-readonly" in out and "not yet implemented" in out, (
+            f"expected a clear rejection message, got:\n{out}"
+        )
+
+    def test_step_without_image_runs_on_host(self, step_container_cluster):
+        """A step with no container image runs on the host and cannot see the
+        in-image marker — proves the flag is what gates the container path."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            "bash", "-c", f"test -f {MARKER_PATH} && echo FOUND || echo NOTFOUND",
+        ])
+        assert code == 0, f"host srun step failed (exit {code}):\n{out}"
+        assert "NOTFOUND" in out, f"marker found on host — assumption violated:\n{out}"


### PR DESCRIPTION
## Summary

Fixes rocm/spur#777 — `srun --container-image` was silently accepted and dropped on bare-metal ("native host") job steps, running the command on the host instead of in the requested image and exiting 0 with no warning.

The root cause was that `RunStepRequest` / `RunCommandRequest` carried no container fields, so `spurd`'s `run_command` always spawned a plain host process. This PR carries the container intent across the RPC boundary and wires the existing container runtime into the step-dispatch path.

## Approach

- **Proto:** add container fields to `RunStepRequest` (tags 11–19) and `RunCommandRequest` (tags 15–23), mirroring the existing `JobSpec` fields 70–78. Append-only — no renumbering or retyping, so wire/FFI/REST compatibility is preserved.
- **CLI (`srun`):** populate the container fields on `RunStepRequest`, and add `--container-name`, `--container-readonly`, `--container-entrypoint` for parity with `sbatch`.
- **Controller (`spurctld`):** `run_step` resolves the effective container config per step (step-level fields take precedence over the parent job's) and forwards it to each agent.
- **Agent (`spurd`):** `run_command` now dispatches across three paths:
  1. **Parent job has live namespaces** → enter them via `nsenter` (`build_launch_plan`). Covers a nested `srun` inside a containerized `sbatch` allocation, sharing the job's image, mounts, and GPU devices.
  2. **Step carries its own image, no parent container** → build a fresh rootfs (`setup_rootfs` + new `run_containerized_step`), matching the batch launch path: namespace unshare, mount setup, GPU device injection, shadow/user, bind mounts, DNS, home, hooks, `pivot_root`, privilege drop; stdout/stderr collected inline. Reached by standalone `srun` and by `salloc` + `srun` (the primary Miles pattern).
  3. **No container** → existing host spawn, unchanged.

## Notable fixes found along the way

Getting the bare-metal E2E suite green surfaced several real defects, all fixed here:

- **GPU device injection for step containers.** The container injection plan (`/dev/kfd`, `/dev/dri/renderD*`, ROCm library bind-mounts, render-group membership) is captured from `build_job_injection_plans` and wired into `ContainerConfig.device_plan` for standalone step containers.
- **GPU visibility deny.** `maybe_deny_gpu_env` is applied to `container_env` so a zero-GPU step cannot re-enable GPU visibility via `--container-env` — matching the batch path.
- **`--container-entrypoint`** was plumbed but ignored by the step path; it now runs before the step command, matching `sbatch`.
- **Cancellation cleanup.** Cancelling an allocation-only job (standalone `srun` / `salloc`) now signals its in-flight steps instead of only dropping the tracked allocation. Additionally, a containerized step's real workload is a grandchild that is PID 1 of its own PID namespace (and ignores SIGTERM from an ancestor), so signalling only the tracked pid left it orphaned; step cancellation now walks the `/proc` process tree (`kill_process_tree`, the same approach the batch container path uses). This applies to both `scancel` and `srun`'s Ctrl-C.
- **Rootless nsenter into a container (pre-existing bug, also affects `spur exec`).** Entering a rootless (user-namespace) container failed with `nsenter: setgroups failed: Operation not permitted`: the kernel forbids `setgroups()` in an unprivileged user namespace, and both `nsenter`'s default credential reset and `setpriv --init-groups` call it. For user-namespace targets, entry now uses `nsenter --preserve-credentials` and skips the `setpriv` group init — the job user is already mapped inside the namespace, so no in-namespace drop is needed, and there are no supplementary groups to preserve there anyway. This is **gated on `has_user_namespace`, which is false for every case where spurd is root**, so the root paths (including GPU-group preservation and its `@rootful` test) emit the identical command as before and are unaffected. This unblocks Case 1 (nested `srun` / `spur exec`) under rootless spurd.

## `--container-readonly` is rejected at submission (follow-up)

`--container-readonly` is a no-op on **every** backend today — `ContainerConfig.readonly` is populated but never consumed (no read-only remount on native host, no `readOnlyRootFilesystem` on k8s). Rather than continue silently accepting it (the exact failure mode #777 is about), both `srun` and `sbatch` now reject it at submission with a clear message.

> **Follow-up:** implement `--container-readonly`. This needs a read-only remount of the merged rootfs in `container_init` (native host) and `readOnlyRootFilesystem` in the pod SecurityContext (k8s); once done, remove the submission-time rejection in `srun`/`sbatch`. This is a pre-existing gap surfaced by #777, not new to this change.

**Behavior-change note:** `sbatch --container-readonly` was previously accepted (as a no-op) and is now rejected. Existing batch scripts passing this flag will error instead of silently ignoring it.

## Known limitations / follow-ups

- **File bind mounts** (`--container-mounts host_file:/dst`) are an untested edge case for containers (the existing batch coverage uses directory mounts). The E2E here mounts directories; a file-target bind hit an `ENOENT` and is left for a separate change (it would affect the batch path too).
- **`--container-mount-home`** end-to-end host-visibility under rootless is smoke-tested (home is present and writable inside the step) rather than asserting a host-written file round-trips, pending a separate investigation.

## Related issues

#777, #780 (`--pty`) and #781 (output streaming) share the same bare-metal step-dispatch root. This PR addresses #777; the other two are separate follow-ups.

## Test plan

- [ ] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean
- [ ] `cargo test --locked` — passes (spurd unit tests cover: container path taken vs silent host fallthrough, nsenter precedence over new container, rootless nsenter preserves credentials / skips setgroups, host fallthrough, cancellation signals in-flight steps, `--container-readonly` rejection on `srun` + `sbatch`)
- [ ] Bare-metal E2E (`tests/native_host/e2e/test_srun_container.py`): standalone `srun`; `salloc` + `srun`; `sbatch` + nested `srun` (nsenter) and `spur exec` into a running container; concurrent `--overlap` steps; a single multi-node `srun -N2` step; bind mounts / workdir / home / user identity / DNS; GPU device injection for both new-container and nsenter paths (auto-skips without GPUs); `--container-name`, `--container-entrypoint`; cancellation via `scancel` and Ctrl-C; `--container-readonly` rejection
