### PR TITLE
feat(spurd): file-back and live-stream srun step output

### DIFF
--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -104,6 +104,7 @@ async fn stream_output_only(
             job_id,
             stream: stream_name.to_string(),
             user: user.to_string(),
+            ..Default::default()
         })
         .await
         .context("failed to start output stream")?

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -10,7 +10,8 @@ use spur_core::config::HooksConfig;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
     CancelJobRequest, CompleteJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest,
-    JobSpec, JobState, RunStepRequest, StreamJobOutputRequest, SubmitJobRequest,
+    JobSpec, JobState, RunStepRequest, StreamJobOutputChunk, StreamJobOutputRequest,
+    SubmitJobRequest,
 };
 use std::collections::HashMap;
 use std::io::Write as _;
@@ -774,6 +775,22 @@ async fn dispatch_step(
     {
         anyhow::bail!("{err}");
     }
+    // Live-stream the step's output when it lands on a single node and the user
+    // has not redirected to a file. The tail runs concurrently with the blocking
+    // RunStep and ends when the step leaves the agent's active_steps (#781).
+    let live_node = if io.stdout.is_empty() && io.stderr.is_empty() {
+        single_step_node(client, job_id).await
+    } else {
+        None
+    };
+    let mut stream_handle = live_node.map(|node| {
+        let mut ctrl = client.clone();
+        let user = params.user.to_string();
+        tokio::spawn(async move {
+            stream_step_output_live(&mut ctrl, &node, job_id, step_id, &user).await
+        })
+    });
+
     let resp = client
         .run_step(RunStepRequest {
             job_id,
@@ -795,7 +812,24 @@ async fn dispatch_step(
         eprintln!("srun: dispatched to node {}", resp.node);
     }
 
-    emit_step_output(io, job_id, work_dir, &resp.stdout, &resp.stderr).await;
+    // The step has left active_steps, so a live tail eofs promptly; bound the
+    // join so a tail that never resolved (step failed to start) can't hang, and
+    // fall back to the buffered output whenever streaming didn't cover it.
+    let streamed = if let Some(handle) = stream_handle.as_mut() {
+        match tokio::time::timeout(std::time::Duration::from_secs(3), &mut *handle).await {
+            Ok(joined) => joined.unwrap_or(false),
+            Err(_) => {
+                handle.abort();
+                false
+            }
+        }
+    } else {
+        false
+    };
+
+    if !streamed {
+        emit_step_output(io, job_id, work_dir, &resp.stdout, &resp.stderr).await;
+    }
 
     Ok(StepDispatchResult {
         exit_code: resp.exit_code,
@@ -1060,6 +1094,7 @@ async fn try_stream_output(
             job_id,
             stream: "stdout".into(),
             user: user.to_string(),
+            ..Default::default()
         })
         .await
     {
@@ -1081,6 +1116,101 @@ async fn try_stream_output(
             Ok(None) => return true,
             Err(_) => return false,
         }
+    }
+}
+
+/// Write a step output stream's chunks to this process's stdout/stderr as they
+/// arrive, returning true on a clean eof. The lock is held only across each
+/// synchronous write, never an await.
+async fn drain_step_stream(
+    mut stream: tonic::Streaming<StreamJobOutputChunk>,
+    to_stderr: bool,
+) -> bool {
+    loop {
+        match stream.message().await {
+            Ok(Some(chunk)) => {
+                if chunk.eof {
+                    return true;
+                }
+                if to_stderr {
+                    let mut h = std::io::stderr().lock();
+                    let _ = h.write_all(&chunk.data);
+                    let _ = h.flush();
+                } else {
+                    let mut h = std::io::stdout().lock();
+                    let _ = h.write_all(&chunk.data);
+                    let _ = h.flush();
+                }
+            }
+            Ok(None) => return true,
+            Err(_) => return false,
+        }
+    }
+}
+
+/// Tail a step's stdout and stderr live from the agent on `node`, writing chunks
+/// to this process's stdout/stderr as they arrive. Returns true only if it
+/// connected and both streams reached a clean eof, so the caller can suppress
+/// the buffered response; any failure returns false and the caller falls back to
+/// printing the buffered output. Runs concurrently with the blocking RunStep and
+/// ends when the step leaves the agent's active_steps.
+async fn stream_step_output_live(
+    controller: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
+    node: &str,
+    job_id: u32,
+    step_id: u32,
+    user: &str,
+) -> bool {
+    if controller
+        .get_node(GetNodeRequest {
+            name: node.to_string(),
+        })
+        .await
+        .is_err()
+    {
+        return false;
+    }
+    let agent_addr = format!("http://{node}:6818");
+    let req = |stream: &str| StreamJobOutputRequest {
+        job_id,
+        step_id,
+        stream: stream.to_string(),
+        user: user.to_string(),
+    };
+    let Ok(mut agent_out) = crate::interactive::connect_agent(&agent_addr).await else {
+        return false;
+    };
+    let Ok(mut agent_err) = crate::interactive::connect_agent(&agent_addr).await else {
+        return false;
+    };
+    let out = match agent_out.stream_job_output(req("stdout")).await {
+        Ok(r) => r.into_inner(),
+        Err(_) => return false,
+    };
+    let err = match agent_err.stream_job_output(req("stderr")).await {
+        Ok(r) => r.into_inner(),
+        Err(_) => return false,
+    };
+    let (out_ok, err_ok) =
+        tokio::join!(drain_step_stream(out, false), drain_step_stream(err, true));
+    out_ok && err_ok
+}
+
+/// The single node a step will run on, or None when live streaming should be
+/// skipped: a multi-node step (its output is aggregated in the response) or an
+/// allocation whose nodelist cannot be read.
+async fn single_step_node(
+    controller: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
+    job_id: u32,
+) -> Option<String> {
+    let job = controller
+        .get_job(GetJobRequest { job_id })
+        .await
+        .ok()?
+        .into_inner();
+    match spur_core::hostlist::expand(&job.nodelist).ok()?.as_slice() {
+        [only] => Some(only.clone()),
+        _ => None,
     }
 }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2357,10 +2357,16 @@ impl SlurmAgent for AgentService {
         // reading the spool files back. #781 replaces this with a client-side
         // StreamJobOutput tail and drops the read-back, removing the memory bound.
         let read_back = |path: String| async move {
-            tokio::fs::read(&path)
-                .await
-                .map(|b| String::from_utf8_lossy(&b).into_owned())
-                .unwrap_or_default()
+            match tokio::fs::read(&path).await {
+                Ok(b) => String::from_utf8_lossy(&b).into_owned(),
+                Err(e) => {
+                    // Don't fail the step over a read-back error, but log it so a
+                    // missing response body can be correlated with a filesystem
+                    // fault rather than looking like the step produced no output.
+                    warn!(path = %path, error = %e, "failed to read back step output");
+                    String::new()
+                }
+            }
         };
         Ok(Response::new(RunCommandResponse {
             exit_code: spur_core::process::shell_exit_code(&status),
@@ -2429,42 +2435,64 @@ impl SlurmAgent for AgentService {
                     tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
                 }
                 if file_path.is_empty() {
+                    // Could not resolve the step's spool file (the step failed to
+                    // start, or the step_id is wrong). Signal an error rather than
+                    // a clean EOF, so the client falls back to the buffered RunStep
+                    // output instead of treating an empty stream as success.
                     let _ = tx
-                        .send(Ok(StreamJobOutputChunk {
-                            data: Vec::new(),
-                            eof: true,
-                        }))
+                        .send(Err(Status::not_found(format!(
+                            "no output stream for job {job_id} step {step_id}"
+                        ))))
                         .await;
                     return;
                 }
-                let mut offset = 0u64;
+                use tokio::io::{AsyncReadExt, AsyncSeekExt};
+                let mut file = match tokio::fs::File::open(&file_path).await {
+                    Ok(f) => f,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(Status::internal(format!("open step output file: {e}"))))
+                            .await;
+                        return;
+                    }
+                };
+                // Tail incrementally: seek to the last offset and read only the
+                // newly appended bytes each poll, instead of re-reading the whole
+                // file (which is O(n^2) for high-volume steps).
+                let mut offset: u64 = 0;
                 loop {
-                    if let Ok(data) = tokio::fs::read(&file_path).await {
-                        if data.len() as u64 > offset {
-                            let new_data = data[offset as usize..].to_vec();
-                            offset = data.len() as u64;
-                            if tx
-                                .send(Ok(StreamJobOutputChunk {
-                                    data: new_data,
-                                    eof: false,
-                                }))
-                                .await
-                                .is_err()
-                            {
-                                break; // client disconnected
+                    if file.seek(std::io::SeekFrom::Start(offset)).await.is_ok() {
+                        let mut buf = Vec::new();
+                        if let Ok(n) = file.read_to_end(&mut buf).await {
+                            if n > 0 {
+                                offset += n as u64;
+                                if tx
+                                    .send(Ok(StreamJobOutputChunk {
+                                        data: buf,
+                                        eof: false,
+                                    }))
+                                    .await
+                                    .is_err()
+                                {
+                                    break; // client disconnected
+                                }
                             }
                         }
                     }
                     let still_running = active_steps.lock().await.contains_key(&step_key);
                     if !still_running {
-                        if let Ok(data) = tokio::fs::read(&file_path).await {
-                            if data.len() as u64 > offset {
-                                let _ = tx
-                                    .send(Ok(StreamJobOutputChunk {
-                                        data: data[offset as usize..].to_vec(),
-                                        eof: false,
-                                    }))
-                                    .await;
+                        // Final read to drain anything written after the last poll.
+                        if file.seek(std::io::SeekFrom::Start(offset)).await.is_ok() {
+                            let mut buf = Vec::new();
+                            if let Ok(n) = file.read_to_end(&mut buf).await {
+                                if n > 0 {
+                                    let _ = tx
+                                        .send(Ok(StreamJobOutputChunk {
+                                            data: buf,
+                                            eof: false,
+                                        }))
+                                        .await;
+                                }
                             }
                         }
                         let _ = tx

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2381,6 +2381,107 @@ impl SlurmAgent for AgentService {
         self.check_job_access(job_id, identity.as_ref(), &req.user, "read output of")
             .await?;
 
+        // Step output: tail the per-step spool file recorded by run_command and
+        // finish when the step leaves active_steps (rather than the batch file,
+        // which ends only when the whole allocation does). This is what lets an
+        // srun step stream live and terminate at step exit (#781).
+        if req.step_id != 0 {
+            let active_steps = self.active_steps.clone();
+            let want_stderr = req.stream == "stderr";
+            let step_id = req.step_id;
+            let step_key = (job_id, step_id);
+            let (tx, rx) = tokio::sync::mpsc::channel(32);
+            tokio::spawn(async move {
+                // run_command records the step's output path right before it
+                // spawns the child (once the spool file exists). Wait for that,
+                // falling back to the deterministic spool path if the file is
+                // already on disk (a step that finished before we observed its
+                // active_steps entry), and giving up only if the step comes and
+                // goes without ever producing a file.
+                const START_POLLS: u32 = 150; // 150 * 200ms = 30s startup grace
+                let mut file_path = String::new();
+                let mut seen = false;
+                for _ in 0..START_POLLS {
+                    {
+                        let steps = active_steps.lock().await;
+                        if let Some(step) = steps.get(&step_key) {
+                            seen = true;
+                            let path = if want_stderr {
+                                &step.stderr_path
+                            } else {
+                                &step.stdout_path
+                            };
+                            if !path.is_empty() {
+                                file_path = path.clone();
+                                break;
+                            }
+                        }
+                    }
+                    if let Some(existing) =
+                        crate::executor::existing_step_output_path(job_id, step_id, want_stderr)
+                    {
+                        file_path = existing;
+                        break;
+                    }
+                    // Present then gone without a file: the step failed to spawn.
+                    if seen && !active_steps.lock().await.contains_key(&step_key) {
+                        break;
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+                }
+                if file_path.is_empty() {
+                    let _ = tx
+                        .send(Ok(StreamJobOutputChunk {
+                            data: Vec::new(),
+                            eof: true,
+                        }))
+                        .await;
+                    return;
+                }
+                let mut offset = 0u64;
+                loop {
+                    if let Ok(data) = tokio::fs::read(&file_path).await {
+                        if data.len() as u64 > offset {
+                            let new_data = data[offset as usize..].to_vec();
+                            offset = data.len() as u64;
+                            if tx
+                                .send(Ok(StreamJobOutputChunk {
+                                    data: new_data,
+                                    eof: false,
+                                }))
+                                .await
+                                .is_err()
+                            {
+                                break; // client disconnected
+                            }
+                        }
+                    }
+                    let still_running = active_steps.lock().await.contains_key(&step_key);
+                    if !still_running {
+                        if let Ok(data) = tokio::fs::read(&file_path).await {
+                            if data.len() as u64 > offset {
+                                let _ = tx
+                                    .send(Ok(StreamJobOutputChunk {
+                                        data: data[offset as usize..].to_vec(),
+                                        eof: false,
+                                    }))
+                                    .await;
+                            }
+                        }
+                        let _ = tx
+                            .send(Ok(StreamJobOutputChunk {
+                                data: Vec::new(),
+                                eof: true,
+                            }))
+                            .await;
+                        break;
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+                }
+            });
+            return Ok(Response::new(ReceiverStream::new(rx)));
+        }
+
         // No retry on a miss, same as run_command: a Running job has been
         // confirmed on every node (confirm_dispatch_on_nodes). Callers here
         // (srun --attach, sattach) hit the agent directly with no controller
@@ -3988,6 +4089,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stream_job_output_tails_step_spool_file() {
+        use tokio_stream::StreamExt as _;
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let job_id = 77;
+        svc.insert_test_job(job_id, TrackedJob::dummy(std::process::id()))
+            .await;
+
+        // A step whose spool file already holds some output, recorded as an
+        // active step (as run_command would).
+        let step_id = 5;
+        let dir = std::env::temp_dir().join(format!("spur-stream-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("step5.out");
+        std::fs::write(&path, b"part1\n").unwrap();
+        svc.active_steps.lock().await.insert(
+            (job_id, step_id),
+            ActiveStep {
+                stdout_path: path.to_string_lossy().into_owned(),
+                ..Default::default()
+            },
+        );
+
+        let mut stream = svc
+            .stream_job_output(Request::new(StreamJobOutputRequest {
+                job_id,
+                step_id,
+                stream: "stdout".into(),
+                user: "testuser".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        // The already-written bytes stream out before the step ends.
+        let first = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+            .await
+            .expect("a chunk should arrive")
+            .expect("stream still open")
+            .unwrap();
+        assert_eq!(first.data, b"part1\n");
+        assert!(!first.eof);
+
+        // More output appears, then the step finishes.
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+            f.write_all(b"part2\n").unwrap();
+        }
+        svc.active_steps.lock().await.remove(&(job_id, step_id));
+
+        let mut rest = Vec::new();
+        loop {
+            let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+                .await
+                .expect("a chunk should arrive")
+                .expect("stream still open")
+                .unwrap();
+            if chunk.eof {
+                break;
+            }
+            rest.extend_from_slice(&chunk.data);
+        }
+        assert_eq!(rest, b"part2\n");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
     async fn stream_job_output_rejects_non_owner() {
         let svc = AgentService::new(
             test_reporter(),
@@ -4003,6 +4177,7 @@ mod tests {
                 job_id: 44,
                 stream: "stdout".into(),
                 user: "intruder".into(),
+                ..Default::default()
             }))
             .await
             .expect_err("a non-owner must not read another user's job output");

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2295,9 +2295,8 @@ impl SlurmAgent for AgentService {
         // piping the whole output into memory: the child inherits the write fds,
         // stream_job_output tails the files live, and output stays bounded on this
         // node. Paths are recorded in active_steps so the tail can find them.
-        let step_files =
-            crate::executor::open_step_output_files(job_id, step_id, req.uid, req.gid)
-                .map_err(|e| Status::internal(format!("step output files: {e}")))?;
+        let step_files = crate::executor::open_step_output_files(job_id, step_id, req.uid, req.gid)
+            .map_err(|e| Status::internal(format!("step output files: {e}")))?;
         let stdout_path = step_files.stdout_path.to_string_lossy().into_owned();
         let stderr_path = step_files.stderr_path.to_string_lossy().into_owned();
         {
@@ -4139,7 +4138,10 @@ mod tests {
         // More output appears, then the step finishes.
         {
             use std::io::Write;
-            let mut f = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap();
             f.write_all(b"part2\n").unwrap();
         }
         svc.active_steps.lock().await.remove(&(job_id, step_id));

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -200,6 +200,10 @@ fn start_pmix_launch(
 struct ActiveStep {
     cancel_requested: bool,
     pid: Option<u32>,
+    /// Spool files the step's stdout/stderr are redirected to, so
+    /// `stream_job_output` can tail them live keyed on (job_id, step_id).
+    stdout_path: String,
+    stderr_path: String,
 }
 
 struct ActiveStepGuard {
@@ -2287,9 +2291,26 @@ impl SlurmAgent for AgentService {
 
         use std::process::Stdio;
 
+        // Redirect the step's stdout/stderr to per-step spool files rather than
+        // piping the whole output into memory: the child inherits the write fds,
+        // stream_job_output tails the files live, and output stays bounded on this
+        // node. Paths are recorded in active_steps so the tail can find them.
+        let step_files =
+            crate::executor::open_step_output_files(job_id, step_id, req.uid, req.gid)
+                .map_err(|e| Status::internal(format!("step output files: {e}")))?;
+        let stdout_path = step_files.stdout_path.to_string_lossy().into_owned();
+        let stderr_path = step_files.stderr_path.to_string_lossy().into_owned();
+        {
+            let mut steps = self.active_steps.lock().await;
+            if let Some(step) = steps.get_mut(&step_key) {
+                step.stdout_path = stdout_path.clone();
+                step.stderr_path = stderr_path.clone();
+            }
+        }
+
         let mut child = cmd
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stdout(Stdio::from(step_files.stdout))
+            .stderr(Stdio::from(step_files.stderr))
             .spawn()
             .map_err(|e| Status::internal(format!("command failed: {}", e)))?;
         if let Some(pid) = child.id() {
@@ -2305,13 +2326,13 @@ impl SlurmAgent for AgentService {
             if cancel_now {
                 signal_step_process_group(pid, nix::sys::signal::Signal::SIGTERM as i32);
                 let _ = child.kill().await;
-                let _ = child.wait_with_output().await;
+                let _ = child.wait().await;
                 return Ok(Response::new(cancelled_step_response()));
             }
         }
 
-        let output = match child.wait_with_output().await {
-            Ok(output) => output,
+        let status = match child.wait().await {
+            Ok(status) => status,
             Err(e) => return Err(Status::internal(format!("command failed: {}", e))),
         };
 
@@ -2333,10 +2354,19 @@ impl SlurmAgent for AgentService {
             }
         }
 
+        // Backward-compatible: the response still carries the step's output by
+        // reading the spool files back. #781 replaces this with a client-side
+        // StreamJobOutput tail and drops the read-back, removing the memory bound.
+        let read_back = |path: String| async move {
+            tokio::fs::read(&path)
+                .await
+                .map(|b| String::from_utf8_lossy(&b).into_owned())
+                .unwrap_or_default()
+        };
         Ok(Response::new(RunCommandResponse {
-            exit_code: spur_core::process::shell_exit_code(&output.status),
-            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            exit_code: spur_core::process::shell_exit_code(&status),
+            stdout: read_back(stdout_path).await,
+            stderr: read_back(stderr_path).await,
         }))
     }
 
@@ -3380,6 +3410,7 @@ impl AgentService {
             ActiveStep {
                 cancel_requested: false,
                 pid,
+                ..Default::default()
             },
         );
     }
@@ -3662,7 +3693,12 @@ mod tests {
             Arc::new(Mutex::new(DeviceRegistry::new())),
             spur_core::config::MemlockLimit::Unlimited,
         );
-        let job_id = 100;
+        // A unique job_id per test so each gets its own step spool dir
+        // (temp/spur/job<id>/step0.out) and parallel tests do not clobber one
+        // another's step output. Production step_ids are unique per job via
+        // create_job_step; only these fixed-id tests would otherwise collide.
+        static NEXT_JOB_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(100);
+        let job_id = NEXT_JOB_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         svc.insert_test_job(job_id, TrackedJob::dummy(0)).await;
         (svc, job_id)
     }
@@ -4326,6 +4362,33 @@ mod tests {
         assert_eq!(resp.exit_code, 0);
         let observed_canonical = std::fs::canonicalize(resp.stdout.trim()).unwrap();
         assert_eq!(observed_canonical, tmp_canonical);
+    }
+
+    #[tokio::test]
+    async fn run_command_writes_step_output_to_spool_file() {
+        let (svc, job_id) = run_command_test_setup().await;
+        let req = Request::new(RunCommandRequest {
+            command: vec!["echo".into(), "spooled-marker".into()],
+            uid: 0,
+            gid: 0,
+            job_id,
+            ..Default::default()
+        });
+        let resp = svc.run_command(req).await.unwrap().into_inner();
+        assert_eq!(resp.exit_code, 0);
+        // The step's stdout must live in a spool file the agent can tail, not
+        // only in the RPC response — this file is what StreamJobOutput follows
+        // (#781). step_id defaults to 0 here, so the file is step0.out.
+        let contents = [
+            std::path::PathBuf::from("/var/spool/spur"),
+            std::env::temp_dir().join("spur"),
+        ]
+        .iter()
+        .find_map(|base| {
+            std::fs::read_to_string(base.join(format!("job{job_id}")).join("step0.out")).ok()
+        })
+        .expect("step stdout spool file should exist on disk");
+        assert_eq!(contents.trim(), "spooled-marker");
     }
 
     #[tokio::test]

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1315,11 +1315,26 @@ pub(crate) fn open_step_output_files(
     let stdout_path = spool_dir.join(format!("step{step_id}.out"));
     let stderr_path = spool_dir.join(format!("step{step_id}.err"));
     let open = |path: &Path| -> Result<std::fs::File, LaunchError> {
-        open_output_file(&path.to_string_lossy(), false).map_err(|e| {
+        let file = open_output_file(&path.to_string_lossy(), false).map_err(|e| {
             LaunchError::NodeFault(
                 anyhow::Error::new(e).context(format!("open step output file {}", path.display())),
             )
-        })
+        })?;
+        // These files hold arbitrary user output, so keep them private (0600) —
+        // they can otherwise become world-readable under a typical umask. The
+        // child inherits the write fd, so it writes regardless of ownership; hand
+        // ownership to the job user when spurd is root so only they (and root)
+        // can read it, matching write_job_scratch.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+            if should_run_as_user(uid) {
+                use nix::unistd::{Gid, Uid};
+                let _ = nix::unistd::chown(path, Some(Uid::from_raw(uid)), Some(Gid::from_raw(gid)));
+            }
+        }
+        Ok(file)
     };
     let stdout = open(&stdout_path)?;
     let stderr = open(&stderr_path)?;

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1275,7 +1275,11 @@ pub(crate) struct StepOutputFiles {
 /// roots [`open_step_output_files`] (via [`create_job_spool_dir`]) chooses
 /// between. A reader that did not open the file cannot see which root the writer
 /// picked, so it checks both. Kept in sync with `open_step_output_files`' names.
-pub(crate) fn step_output_path_candidates(job_id: JobId, step_id: u32, stderr: bool) -> Vec<PathBuf> {
+pub(crate) fn step_output_path_candidates(
+    job_id: JobId,
+    step_id: u32,
+    stderr: bool,
+) -> Vec<PathBuf> {
     let name = format!("step{step_id}.{}", if stderr { "err" } else { "out" });
     [PathBuf::from(SPOOL_ROOT), std::env::temp_dir().join("spur")]
         .into_iter()
@@ -1285,7 +1289,11 @@ pub(crate) fn step_output_path_candidates(job_id: JobId, step_id: u32, stderr: b
 
 /// The step's spool file if it already exists on disk, so a reader can tail a
 /// step that finished before it observed the step's active_steps entry.
-pub(crate) fn existing_step_output_path(job_id: JobId, step_id: u32, stderr: bool) -> Option<String> {
+pub(crate) fn existing_step_output_path(
+    job_id: JobId,
+    step_id: u32,
+    stderr: bool,
+) -> Option<String> {
     step_output_path_candidates(job_id, step_id, stderr)
         .into_iter()
         .find(|p| p.exists())

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1271,6 +1271,27 @@ pub(crate) struct StepOutputFiles {
     pub stderr_path: PathBuf,
 }
 
+/// The candidate spool paths for a step's stdout or stderr, mirroring the spool
+/// roots [`open_step_output_files`] (via [`create_job_spool_dir`]) chooses
+/// between. A reader that did not open the file cannot see which root the writer
+/// picked, so it checks both. Kept in sync with `open_step_output_files`' names.
+pub(crate) fn step_output_path_candidates(job_id: JobId, step_id: u32, stderr: bool) -> Vec<PathBuf> {
+    let name = format!("step{step_id}.{}", if stderr { "err" } else { "out" });
+    [PathBuf::from(SPOOL_ROOT), std::env::temp_dir().join("spur")]
+        .into_iter()
+        .map(|base| base.join(format!("job{job_id}")).join(&name))
+        .collect()
+}
+
+/// The step's spool file if it already exists on disk, so a reader can tail a
+/// step that finished before it observed the step's active_steps entry.
+pub(crate) fn existing_step_output_path(job_id: JobId, step_id: u32, stderr: bool) -> Option<String> {
+    step_output_path_candidates(job_id, step_id, stderr)
+        .into_iter()
+        .find(|p| p.exists())
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
 /// Open a step's stdout/stderr spool files under the job spool dir, creating the
 /// dir if needed. The agent (root) opens the files and hands the write fds to the
 /// child via stdio redirection, so the child writes even after dropping to its

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1259,6 +1259,49 @@ fn open_output_file(path: &str, use_append: bool) -> std::io::Result<std::fs::Fi
     opts.open(path)
 }
 
+/// A step's stdout/stderr spool files, open for the child to inherit and their
+/// paths for the agent to tail. Steps stream through these files (StreamJobOutput
+/// follows the growing file) instead of buffering their whole output in the RPC
+/// response, so a step's output is bounded on the compute node and visible before
+/// the step exits.
+pub(crate) struct StepOutputFiles {
+    pub stdout: std::fs::File,
+    pub stderr: std::fs::File,
+    pub stdout_path: PathBuf,
+    pub stderr_path: PathBuf,
+}
+
+/// Open a step's stdout/stderr spool files under the job spool dir, creating the
+/// dir if needed. The agent (root) opens the files and hands the write fds to the
+/// child via stdio redirection, so the child writes even after dropping to its
+/// uid; the files stay agent-readable so `stream_job_output` can tail them.
+/// Lives under the job spool tree so `cleanup_job_spool` reclaims it at job end.
+pub(crate) fn open_step_output_files(
+    job_id: JobId,
+    step_id: u32,
+    uid: u32,
+    gid: u32,
+) -> Result<StepOutputFiles, LaunchError> {
+    let spool_dir = create_job_spool_dir(job_id, uid, gid)?;
+    let stdout_path = spool_dir.join(format!("step{step_id}.out"));
+    let stderr_path = spool_dir.join(format!("step{step_id}.err"));
+    let open = |path: &Path| -> Result<std::fs::File, LaunchError> {
+        open_output_file(&path.to_string_lossy(), false).map_err(|e| {
+            LaunchError::NodeFault(
+                anyhow::Error::new(e).context(format!("open step output file {}", path.display())),
+            )
+        })
+    };
+    let stdout = open(&stdout_path)?;
+    let stderr = open(&stderr_path)?;
+    Ok(StepOutputFiles {
+        stdout,
+        stderr,
+        stdout_path,
+        stderr_path,
+    })
+}
+
 /// Send file descriptors to a peer over a Unix socket via SCM_RIGHTS.
 fn send_fds(sock: RawFd, fds: &[RawFd]) -> nix::Result<()> {
     use nix::sys::socket::{sendmsg, ControlMessage, MsgFlags};

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1331,7 +1331,8 @@ pub(crate) fn open_step_output_files(
             let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
             if should_run_as_user(uid) {
                 use nix::unistd::{Gid, Uid};
-                let _ = nix::unistd::chown(path, Some(Uid::from_raw(uid)), Some(Gid::from_raw(gid)));
+                let _ =
+                    nix::unistd::chown(path, Some(Uid::from_raw(uid)), Some(Gid::from_raw(gid)));
             }
         }
         Ok(file)

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1265,6 +1265,7 @@ message StreamJobOutputRequest {
   uint32 job_id = 1;
   string stream = 2;  // "stdout" or "stderr"
   string user = 3;    // Requesting user; verified identity must own the job; the controller/admin credential overrides
+  uint32 step_id = 4; // 0 = the batch job's own output; >0 = tail that step's per-step spool file
 }
 
 message StreamJobOutputChunk {

--- a/tests/native_host/e2e/test_srun_step_output.py
+++ b/tests/native_host/e2e/test_srun_step_output.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for srun step output delivery (spur#781).
+
+A command run as an srun step inside an allocation has its stdout/stderr
+redirected to per-step spool files on the node; the client tails those files
+live via StreamJobOutput while the RunStep dispatch is in flight. These tests
+drive real steps through an allocation shell and assert their output reaches
+the client intact.
+"""
+
+
+class TestSrunStepOutput:
+    def test_step_stdout_reaches_client(self, cluster):
+        code, out = cluster.salloc_run(
+            'srun echo STEP-MARKER-ALPHA\n'
+            'srun bash -c "echo line1; echo line2; echo line3"\n'
+        )
+        assert code == 0, out
+        assert "STEP-MARKER-ALPHA" in out, out
+        for line in ("line1", "line2", "line3"):
+            assert line in out, out
+
+    def test_step_stderr_reaches_client(self, cluster):
+        code, out = cluster.salloc_run(
+            'srun bash -c "echo to-stderr 1>&2"\n'
+        )
+        assert code == 0, out
+        assert "to-stderr" in out, out
+
+    def test_step_exit_code_and_output_both_delivered(self, cluster):
+        # srun exits with the step's exit code; the output before the failure
+        # must still reach the client through the streaming path.
+        code, out = cluster.salloc_run(
+            'srun bash -c "echo before-fail; exit 7" || echo "step-exit=$?"\n'
+        )
+        assert code == 0, out
+        assert "before-fail" in out, out
+        assert "step-exit=7" in out, out


### PR DESCRIPTION
## Summary
Back srun **step** output with per-step spool files and stream it to the client live, instead of buffering the whole thing in the `RunStep` response until the step exits. Part of the bare-metal step-dispatch convergence (#777/#780/#781).

Two commits:
- **file-backed step output** — `spurd::run_command` now redirects each step's stdout/stderr to per-step spool files under the job spool dir (keyed on `(job_id, step_id)`) instead of `Stdio::piped()` + `wait_with_output()`. The child inherits the write fds (writes fine after privilege-drop); paths are recorded in `active_steps`. Response stays backward-compatible via a read-back for now.
- **live streaming** — `StreamJobOutputRequest` gains `step_id`; `stream_job_output` tails the step's spool file and ends when the step leaves `active_steps` (with a deterministic-path fallback for a step that finished before it was observed). The client `dispatch_step` runs a concurrent tail of the step's stdout+stderr while `RunStep` is in flight (single-node), suppressing the buffered print when streaming covered it. A client disconnect does not kill the step.

## Scope
Delivers **live delivery for single-node steps** — output appears before the step exits. It does not yet remove the response read-back for the multi-node / `-o`-file / streaming-failure fallbacks; that needs multi-node stream muxing and streaming into a client `-o` file (follow-ups).

## Testing
- `cargo test -p spurd` / `-p spur-cli` (new unit tests: on-disk spool file, step tail)
- clippy clean
- E2E on a single-node cluster: `test_srun_step_output.py` (stdout, stderr, exit-code + output) — green on shark-a

Closes #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
