### PR TITLE
feat(spurd): run containerized srun steps and cancel them on scancel

### DIFF
--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -104,6 +104,7 @@ async fn stream_output_only(
             job_id,
             stream: stream_name.to_string(),
             user: user.to_string(),
+            ..Default::default()
         })
         .await
         .context("failed to start output stream")?

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -10,7 +10,8 @@ use spur_core::config::HooksConfig;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
     CancelJobRequest, CompleteJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest,
-    JobSpec, JobState, RunStepRequest, StreamJobOutputRequest, SubmitJobRequest,
+    JobSpec, JobState, RunStepRequest, StreamJobOutputChunk, StreamJobOutputRequest,
+    SubmitJobRequest,
 };
 use std::collections::HashMap;
 use std::io::Write as _;
@@ -774,6 +775,22 @@ async fn dispatch_step(
     {
         anyhow::bail!("{err}");
     }
+    // Live-stream the step's output when it lands on a single node and the user
+    // has not redirected to a file. The tail runs concurrently with the blocking
+    // RunStep and ends when the step leaves the agent's active_steps (#781).
+    let live_node = if io.stdout.is_empty() && io.stderr.is_empty() {
+        single_step_node(client, job_id).await
+    } else {
+        None
+    };
+    let mut stream_handle = live_node.map(|node| {
+        let mut ctrl = client.clone();
+        let user = params.user.to_string();
+        tokio::spawn(async move {
+            stream_step_output_live(&mut ctrl, &node, job_id, step_id, &user).await
+        })
+    });
+
     let resp = client
         .run_step(RunStepRequest {
             job_id,
@@ -795,7 +812,24 @@ async fn dispatch_step(
         eprintln!("srun: dispatched to node {}", resp.node);
     }
 
-    emit_step_output(io, job_id, work_dir, &resp.stdout, &resp.stderr).await;
+    // The step has left active_steps, so a live tail eofs promptly; bound the
+    // join so a tail that never resolved (step failed to start) can't hang, and
+    // fall back to the buffered output whenever streaming didn't cover it.
+    let streamed = if let Some(handle) = stream_handle.as_mut() {
+        match tokio::time::timeout(std::time::Duration::from_secs(3), &mut *handle).await {
+            Ok(joined) => joined.unwrap_or(false),
+            Err(_) => {
+                handle.abort();
+                false
+            }
+        }
+    } else {
+        false
+    };
+
+    if !streamed {
+        emit_step_output(io, job_id, work_dir, &resp.stdout, &resp.stderr).await;
+    }
 
     Ok(StepDispatchResult {
         exit_code: resp.exit_code,
@@ -1060,6 +1094,7 @@ async fn try_stream_output(
             job_id,
             stream: "stdout".into(),
             user: user.to_string(),
+            ..Default::default()
         })
         .await
     {
@@ -1081,6 +1116,101 @@ async fn try_stream_output(
             Ok(None) => return true,
             Err(_) => return false,
         }
+    }
+}
+
+/// Write a step output stream's chunks to this process's stdout/stderr as they
+/// arrive, returning true on a clean eof. The lock is held only across each
+/// synchronous write, never an await.
+async fn drain_step_stream(
+    mut stream: tonic::Streaming<StreamJobOutputChunk>,
+    to_stderr: bool,
+) -> bool {
+    loop {
+        match stream.message().await {
+            Ok(Some(chunk)) => {
+                if chunk.eof {
+                    return true;
+                }
+                if to_stderr {
+                    let mut h = std::io::stderr().lock();
+                    let _ = h.write_all(&chunk.data);
+                    let _ = h.flush();
+                } else {
+                    let mut h = std::io::stdout().lock();
+                    let _ = h.write_all(&chunk.data);
+                    let _ = h.flush();
+                }
+            }
+            Ok(None) => return true,
+            Err(_) => return false,
+        }
+    }
+}
+
+/// Tail a step's stdout and stderr live from the agent on `node`, writing chunks
+/// to this process's stdout/stderr as they arrive. Returns true only if it
+/// connected and both streams reached a clean eof, so the caller can suppress
+/// the buffered response; any failure returns false and the caller falls back to
+/// printing the buffered output. Runs concurrently with the blocking RunStep and
+/// ends when the step leaves the agent's active_steps.
+async fn stream_step_output_live(
+    controller: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
+    node: &str,
+    job_id: u32,
+    step_id: u32,
+    user: &str,
+) -> bool {
+    if controller
+        .get_node(GetNodeRequest {
+            name: node.to_string(),
+        })
+        .await
+        .is_err()
+    {
+        return false;
+    }
+    let agent_addr = format!("http://{node}:6818");
+    let req = |stream: &str| StreamJobOutputRequest {
+        job_id,
+        step_id,
+        stream: stream.to_string(),
+        user: user.to_string(),
+    };
+    let Ok(mut agent_out) = crate::interactive::connect_agent(&agent_addr).await else {
+        return false;
+    };
+    let Ok(mut agent_err) = crate::interactive::connect_agent(&agent_addr).await else {
+        return false;
+    };
+    let out = match agent_out.stream_job_output(req("stdout")).await {
+        Ok(r) => r.into_inner(),
+        Err(_) => return false,
+    };
+    let err = match agent_err.stream_job_output(req("stderr")).await {
+        Ok(r) => r.into_inner(),
+        Err(_) => return false,
+    };
+    let (out_ok, err_ok) =
+        tokio::join!(drain_step_stream(out, false), drain_step_stream(err, true));
+    out_ok && err_ok
+}
+
+/// The single node a step will run on, or None when live streaming should be
+/// skipped: a multi-node step (its output is aggregated in the response) or an
+/// allocation whose nodelist cannot be read.
+async fn single_step_node(
+    controller: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
+    job_id: u32,
+) -> Option<String> {
+    let job = controller
+        .get_job(GetJobRequest { job_id })
+        .await
+        .ok()?
+        .into_inner();
+    match spur_core::hostlist::expand(&job.nodelist).ok()?.as_slice() {
+        [only] => Some(only.clone()),
+        _ => None,
     }
 }
 

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -737,7 +737,7 @@ struct StepDispatchParams<'a> {
 }
 
 /// Build the step's container spec from the srun args, or None when no image was
-/// requested (the step runs on the host, the pre-#777 behavior). Mirrors the
+/// requested (the step runs on the host, the pre-container behavior). Mirrors the
 /// container options srun exposes; the CLI does not surface name/readonly/
 /// entrypoint, so those stay unset.
 fn container_spec_from_args(args: &SrunArgs) -> Option<ContainerSpec> {
@@ -803,7 +803,7 @@ async fn dispatch_step(
     }
     // Live-stream the step's output when it lands on a single node and the user
     // has not redirected to a file. The tail runs concurrently with the blocking
-    // RunStep and ends when the step leaves the agent's active_steps (#781).
+    // RunStep and ends when the step leaves the agent's active_steps.
     let live_node = if io.stdout.is_empty() && io.stderr.is_empty() {
         single_step_node(client, job_id).await
     } else {

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -10,7 +10,7 @@ use spur_core::config::HooksConfig;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
     CancelJobRequest, CompleteJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest,
-    JobSpec, JobState, RunStepRequest, StreamJobOutputChunk, StreamJobOutputRequest,
+    ContainerSpec, JobSpec, JobState, RunStepRequest, StreamJobOutputChunk, StreamJobOutputRequest,
     SubmitJobRequest,
 };
 use std::collections::HashMap;
@@ -736,6 +736,29 @@ struct StepDispatchParams<'a> {
     user: &'a str,
 }
 
+/// Build the step's container spec from the srun args, or None when no image was
+/// requested (the step runs on the host, the pre-#777 behavior). Mirrors the
+/// container options srun exposes; the CLI does not surface name/readonly/
+/// entrypoint, so those stay unset.
+fn container_spec_from_args(args: &SrunArgs) -> Option<ContainerSpec> {
+    let image = args.container_image.clone().filter(|s| !s.is_empty())?;
+    Some(ContainerSpec {
+        image,
+        mounts: args.container_mounts.clone(),
+        workdir: args.container_workdir.clone().unwrap_or_default(),
+        name: String::new(),
+        readonly: false,
+        mount_home: args.container_mount_home,
+        env: args
+            .container_env
+            .iter()
+            .filter_map(|s| s.split_once('=').map(|(k, v)| (k.to_string(), v.to_string())))
+            .collect(),
+        entrypoint: String::new(),
+        remap_root: args.container_remap_root,
+    })
+}
+
 async fn dispatch_step(
     client: &mut SlurmControllerClient<crate::authclient::AuthChannel>,
     job_id: u32,
@@ -803,6 +826,7 @@ async fn dispatch_step(
             label: args.label,
             mpi: step_mpi.to_string(),
             user: params.user.to_string(),
+            container: container_spec_from_args(args),
         })
         .await
         .context("RunStep dispatch failed")?

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -9,9 +9,9 @@ use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
 use spur_core::config::HooksConfig;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
-    CancelJobRequest, CompleteJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest,
-    ContainerSpec, JobSpec, JobState, RunStepRequest, StreamJobOutputChunk, StreamJobOutputRequest,
-    SubmitJobRequest,
+    CancelJobRequest, CompleteJobRequest, ContainerSpec, CreateJobStepRequest, GetJobRequest,
+    GetNodeRequest, JobSpec, JobState, RunStepRequest, StreamJobOutputChunk,
+    StreamJobOutputRequest, SubmitJobRequest,
 };
 use std::collections::HashMap;
 use std::io::Write as _;
@@ -752,7 +752,10 @@ fn container_spec_from_args(args: &SrunArgs) -> Option<ContainerSpec> {
         env: args
             .container_env
             .iter()
-            .filter_map(|s| s.split_once('=').map(|(k, v)| (k.to_string(), v.to_string())))
+            .filter_map(|s| {
+                s.split_once('=')
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+            })
             .collect(),
         entrypoint: String::new(),
         remap_root: args.container_remap_root,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2764,6 +2764,7 @@ impl SlurmController for ControllerService {
         let environment = req.environment.clone();
         let uid = req.uid;
         let gid = req.gid;
+        let container = req.container.clone();
         let step_id = req.step_id;
         let label = req.label;
         let job_mpi = job.spec.mpi.as_deref().unwrap_or(spur_core::mpi::MPI_NONE);
@@ -2937,6 +2938,7 @@ impl SlurmController for ControllerService {
             let work_dir = work_dir.clone();
             let environment = environment.clone();
             let step_mpi = mpi.clone();
+            let container = container.clone();
             set.spawn(async move {
                 let mut agent = crate::agent_client::connect(agent_addr.clone())
                     .await
@@ -2962,6 +2964,7 @@ impl SlurmController for ControllerService {
                         pmix_plan,
                         mpi: step_mpi.clone(),
                         pmix_prepared: needs_pmix_prepare,
+                        container: container.clone(),
                     })
                     .await
                     .map_err(|e| {

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2408,10 +2408,16 @@ impl SlurmAgent for AgentService {
         }
 
         let read_back = |path: String| async move {
-            tokio::fs::read(&path)
-                .await
-                .map(|b| String::from_utf8_lossy(&b).into_owned())
-                .unwrap_or_default()
+            match tokio::fs::read(&path).await {
+                Ok(b) => String::from_utf8_lossy(&b).into_owned(),
+                Err(e) => {
+                    // Don't fail the step over a read-back error, but log it so a
+                    // missing response body can be correlated with a filesystem
+                    // fault rather than looking like the step produced no output.
+                    warn!(path = %path, error = %e, "failed to read back step output");
+                    String::new()
+                }
+            }
         };
 
         // Containerized step (spur#777): run the command inside the requested
@@ -2619,42 +2625,64 @@ impl SlurmAgent for AgentService {
                     tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
                 }
                 if file_path.is_empty() {
+                    // Could not resolve the step's spool file (the step failed to
+                    // start, or the step_id is wrong). Signal an error rather than
+                    // a clean EOF, so the client falls back to the buffered RunStep
+                    // output instead of treating an empty stream as success.
                     let _ = tx
-                        .send(Ok(StreamJobOutputChunk {
-                            data: Vec::new(),
-                            eof: true,
-                        }))
+                        .send(Err(Status::not_found(format!(
+                            "no output stream for job {job_id} step {step_id}"
+                        ))))
                         .await;
                     return;
                 }
-                let mut offset = 0u64;
+                use tokio::io::{AsyncReadExt, AsyncSeekExt};
+                let mut file = match tokio::fs::File::open(&file_path).await {
+                    Ok(f) => f,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(Status::internal(format!("open step output file: {e}"))))
+                            .await;
+                        return;
+                    }
+                };
+                // Tail incrementally: seek to the last offset and read only the
+                // newly appended bytes each poll, instead of re-reading the whole
+                // file (which is O(n^2) for high-volume steps).
+                let mut offset: u64 = 0;
                 loop {
-                    if let Ok(data) = tokio::fs::read(&file_path).await {
-                        if data.len() as u64 > offset {
-                            let new_data = data[offset as usize..].to_vec();
-                            offset = data.len() as u64;
-                            if tx
-                                .send(Ok(StreamJobOutputChunk {
-                                    data: new_data,
-                                    eof: false,
-                                }))
-                                .await
-                                .is_err()
-                            {
-                                break; // client disconnected
+                    if file.seek(std::io::SeekFrom::Start(offset)).await.is_ok() {
+                        let mut buf = Vec::new();
+                        if let Ok(n) = file.read_to_end(&mut buf).await {
+                            if n > 0 {
+                                offset += n as u64;
+                                if tx
+                                    .send(Ok(StreamJobOutputChunk {
+                                        data: buf,
+                                        eof: false,
+                                    }))
+                                    .await
+                                    .is_err()
+                                {
+                                    break; // client disconnected
+                                }
                             }
                         }
                     }
                     let still_running = active_steps.lock().await.contains_key(&step_key);
                     if !still_running {
-                        if let Ok(data) = tokio::fs::read(&file_path).await {
-                            if data.len() as u64 > offset {
-                                let _ = tx
-                                    .send(Ok(StreamJobOutputChunk {
-                                        data: data[offset as usize..].to_vec(),
-                                        eof: false,
-                                    }))
-                                    .await;
+                        // Final read to drain anything written after the last poll.
+                        if file.seek(std::io::SeekFrom::Start(offset)).await.is_ok() {
+                            let mut buf = Vec::new();
+                            if let Ok(n) = file.read_to_end(&mut buf).await {
+                                if n > 0 {
+                                    let _ = tx
+                                        .send(Ok(StreamJobOutputChunk {
+                                            data: buf,
+                                            eof: false,
+                                        }))
+                                        .await;
+                                }
                             }
                         }
                         let _ = tx

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -847,6 +847,79 @@ async fn reap_killed_job(mut job: executor::RunningJob) {
 }
 
 /// Build a bash script that execs a command vector without shell interpretation.
+/// Set up a per-step container rootfs and run the step inside it, returning the
+/// exit code. Builds the `ContainerConfig` from the wire spec (spur#777),
+/// reusing the same primitives as the batch container path. The rootfs is named
+/// per step so concurrent `srun --overlap` steps in one allocation don't share a
+/// tree; it is removed when the step finishes.
+#[allow(clippy::too_many_arguments)]
+async fn run_containerized_step(
+    spec: &ContainerSpec,
+    job_id: u32,
+    step_id: u32,
+    command: &[String],
+    user: &str,
+    uid: u32,
+    gid: u32,
+    gpu_devices: &[u32],
+    env: HashMap<String, String>,
+    memlock: spur_core::config::MemlockLimit,
+    stdout: std::fs::File,
+    stderr: std::fs::File,
+) -> anyhow::Result<i32> {
+    let mounts: Vec<crate::container::BindMount> = spec
+        .mounts
+        .iter()
+        .filter_map(|m| crate::container::parse_mount(m).ok())
+        .collect();
+    let username = if user.is_empty() {
+        "spur".to_string()
+    } else {
+        user.to_string()
+    };
+    let home_dir = std::env::var("HOME").unwrap_or_else(|_| format!("/home/{username}"));
+
+    let config = crate::container::ContainerConfig {
+        image: spec.image.clone(),
+        mounts,
+        workdir: (!spec.workdir.is_empty()).then(|| spec.workdir.clone()),
+        name: None, // per-step rootfs below; srun does not expose named containers
+        readonly: spec.readonly,
+        mount_home: spec.mount_home,
+        remap_root: spec.remap_root,
+        gpu_devices: gpu_devices.to_vec(),
+        environment: env.clone(),
+        container_env: spec.env.clone(),
+        entrypoint: (!spec.entrypoint.is_empty()).then(|| spec.entrypoint.clone()),
+        uid,
+        gid,
+        username,
+        home_dir,
+        device_plan: None, // GPU device-node injection is spur#777 phase 3
+    };
+
+    let image_path = crate::container::resolve_image(&spec.image, Some(user), Some(uid))
+        .map_err(|e| anyhow::anyhow!("resolve image {}: {e}", spec.image))?;
+
+    // Per-step rootfs so concurrent steps in one allocation don't collide.
+    let rootfs_name = format!("job{job_id}_step{step_id}");
+    let (rootfs, rootfs_mode) =
+        crate::container::setup_rootfs(&image_path, job_id, Some(&rootfs_name))?;
+
+    crate::executor::run_container_step(
+        job_id,
+        &config,
+        &rootfs,
+        rootfs_mode,
+        command,
+        &env,
+        memlock,
+        stdout,
+        stderr,
+    )
+    .await
+}
+
 fn build_one_shot_command_script(command: &[String]) -> Result<String, Status> {
     let joined = shlex::try_join(command.iter().map(String::as_str))
         .map_err(|e| Status::invalid_argument(format!("command is not shell-safe: {e}")))?;
@@ -1991,14 +2064,6 @@ impl SlurmAgent for AgentService {
         if req.command.is_empty() {
             return Err(Status::invalid_argument("no command specified"));
         }
-        // A containerized step (spur#777) runs inside the requested image. The
-        // fields are plumbed through here; the container launch path lands in the
-        // next change. Until then, refuse rather than silently run on the host.
-        if req.container.as_ref().is_some_and(|c| !c.image.is_empty()) {
-            return Err(Status::unimplemented(
-                "containerized job steps are not yet supported on this node (spur#777)",
-            ));
-        }
         // Steps carry their own uid straight from the wire — gate them exactly like a batch launch.
         if let Err(msg) = crate::privdrop::check_root_execution_allowed(
             req.uid,
@@ -2043,7 +2108,7 @@ impl SlurmAgent for AgentService {
         // node already confirmed via LaunchJob (confirm_dispatch_on_nodes) — so a
         // miss is a wrong job/node pairing, not a launch race. The one uncovered
         // case is a spurd restart mid-job, which starts `running` empty.
-        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi) = {
+        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi, job_user) = {
             let jobs = self.running.lock().await;
             let tracked = jobs.get(&job_id).ok_or_else(|| {
                 Status::not_found(format!("job {} not running on this node", job_id))
@@ -2062,6 +2127,7 @@ impl SlurmAgent for AgentService {
                 tracked.memory_mb,
                 nodelist,
                 tracked.mpi.clone(),
+                tracked.user.clone(),
             )
         };
 
@@ -2267,6 +2333,57 @@ impl SlurmAgent for AgentService {
             return Ok(Response::new(cancelled_step_response()));
         }
 
+        // Redirect the step's stdout/stderr to per-step spool files rather than
+        // piping the whole output into memory: the child inherits the write fds,
+        // stream_job_output tails the files live, and output stays bounded on this
+        // node. Paths are recorded in active_steps so the tail can find them. Both
+        // the host and container paths below use these files.
+        let step_files =
+            crate::executor::open_step_output_files(job_id, step_id, req.uid, req.gid)
+                .map_err(|e| Status::internal(format!("step output files: {e}")))?;
+        let stdout_path = step_files.stdout_path.to_string_lossy().into_owned();
+        let stderr_path = step_files.stderr_path.to_string_lossy().into_owned();
+        {
+            let mut steps = self.active_steps.lock().await;
+            if let Some(step) = steps.get_mut(&step_key) {
+                step.stdout_path = stdout_path.clone();
+                step.stderr_path = stderr_path.clone();
+            }
+        }
+
+        let read_back = |path: String| async move {
+            tokio::fs::read(&path)
+                .await
+                .map(|b| String::from_utf8_lossy(&b).into_owned())
+                .unwrap_or_default()
+        };
+
+        // Containerized step (spur#777): run the command inside the requested
+        // image via the shared container primitives, output to the spool files.
+        if let Some(spec) = req.container.as_ref().filter(|c| !c.image.is_empty()) {
+            let exit_code = run_containerized_step(
+                spec,
+                job_id,
+                step_id,
+                &req.command,
+                &job_user,
+                req.uid,
+                req.gid,
+                &gpu_devices,
+                env,
+                self.limits.memlock,
+                step_files.stdout,
+                step_files.stderr,
+            )
+            .await
+            .map_err(|e| Status::internal(format!("containerized step failed: {e:#}")))?;
+            return Ok(Response::new(RunCommandResponse {
+                exit_code,
+                stdout: read_back(stdout_path).await,
+                stderr: read_back(stderr_path).await,
+            }));
+        }
+
         let mut cmd = tokio::process::Command::new(&program);
         cmd.args(&program_args)
             .current_dir(&work_dir)
@@ -2298,23 +2415,6 @@ impl SlurmAgent for AgentService {
         );
 
         use std::process::Stdio;
-
-        // Redirect the step's stdout/stderr to per-step spool files rather than
-        // piping the whole output into memory: the child inherits the write fds,
-        // stream_job_output tails the files live, and output stays bounded on this
-        // node. Paths are recorded in active_steps so the tail can find them.
-        let step_files =
-            crate::executor::open_step_output_files(job_id, step_id, req.uid, req.gid)
-                .map_err(|e| Status::internal(format!("step output files: {e}")))?;
-        let stdout_path = step_files.stdout_path.to_string_lossy().into_owned();
-        let stderr_path = step_files.stderr_path.to_string_lossy().into_owned();
-        {
-            let mut steps = self.active_steps.lock().await;
-            if let Some(step) = steps.get_mut(&step_key) {
-                step.stdout_path = stdout_path.clone();
-                step.stderr_path = stderr_path.clone();
-            }
-        }
 
         let mut child = cmd
             .stdout(Stdio::from(step_files.stdout))
@@ -2363,14 +2463,8 @@ impl SlurmAgent for AgentService {
         }
 
         // Backward-compatible: the response still carries the step's output by
-        // reading the spool files back. #781 replaces this with a client-side
-        // StreamJobOutput tail and drops the read-back, removing the memory bound.
-        let read_back = |path: String| async move {
-            tokio::fs::read(&path)
-                .await
-                .map(|b| String::from_utf8_lossy(&b).into_owned())
-                .unwrap_or_default()
-        };
+        // reading the spool files back (see `read_back` above). #781 replaces this
+        // with a client-side StreamJobOutput tail and drops the read-back.
         Ok(Response::new(RunCommandResponse {
             exit_code: spur_core::process::shell_exit_code(&status),
             stdout: read_back(stdout_path).await,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2395,9 +2395,8 @@ impl SlurmAgent for AgentService {
         // stream_job_output tails the files live, and output stays bounded on this
         // node. Paths are recorded in active_steps so the tail can find them. Both
         // the host and container paths below use these files.
-        let step_files =
-            crate::executor::open_step_output_files(job_id, step_id, req.uid, req.gid)
-                .map_err(|e| Status::internal(format!("step output files: {e}")))?;
+        let step_files = crate::executor::open_step_output_files(job_id, step_id, req.uid, req.gid)
+            .map_err(|e| Status::internal(format!("step output files: {e}")))?;
         let stdout_path = step_files.stdout_path.to_string_lossy().into_owned();
         let stderr_path = step_files.stderr_path.to_string_lossy().into_owned();
         {
@@ -4329,7 +4328,10 @@ mod tests {
         // More output appears, then the step finishes.
         {
             use std::io::Write;
-            let mut f = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap();
             f.write_all(b"part2\n").unwrap();
         }
         svc.active_steps.lock().await.remove(&(job_id, step_id));

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2381,6 +2381,107 @@ impl SlurmAgent for AgentService {
         self.check_job_access(job_id, identity.as_ref(), &req.user, "read output of")
             .await?;
 
+        // Step output: tail the per-step spool file recorded by run_command and
+        // finish when the step leaves active_steps (rather than the batch file,
+        // which ends only when the whole allocation does). This is what lets an
+        // srun step stream live and terminate at step exit (#781).
+        if req.step_id != 0 {
+            let active_steps = self.active_steps.clone();
+            let want_stderr = req.stream == "stderr";
+            let step_id = req.step_id;
+            let step_key = (job_id, step_id);
+            let (tx, rx) = tokio::sync::mpsc::channel(32);
+            tokio::spawn(async move {
+                // run_command records the step's output path right before it
+                // spawns the child (once the spool file exists). Wait for that,
+                // falling back to the deterministic spool path if the file is
+                // already on disk (a step that finished before we observed its
+                // active_steps entry), and giving up only if the step comes and
+                // goes without ever producing a file.
+                const START_POLLS: u32 = 150; // 150 * 200ms = 30s startup grace
+                let mut file_path = String::new();
+                let mut seen = false;
+                for _ in 0..START_POLLS {
+                    {
+                        let steps = active_steps.lock().await;
+                        if let Some(step) = steps.get(&step_key) {
+                            seen = true;
+                            let path = if want_stderr {
+                                &step.stderr_path
+                            } else {
+                                &step.stdout_path
+                            };
+                            if !path.is_empty() {
+                                file_path = path.clone();
+                                break;
+                            }
+                        }
+                    }
+                    if let Some(existing) =
+                        crate::executor::existing_step_output_path(job_id, step_id, want_stderr)
+                    {
+                        file_path = existing;
+                        break;
+                    }
+                    // Present then gone without a file: the step failed to spawn.
+                    if seen && !active_steps.lock().await.contains_key(&step_key) {
+                        break;
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+                }
+                if file_path.is_empty() {
+                    let _ = tx
+                        .send(Ok(StreamJobOutputChunk {
+                            data: Vec::new(),
+                            eof: true,
+                        }))
+                        .await;
+                    return;
+                }
+                let mut offset = 0u64;
+                loop {
+                    if let Ok(data) = tokio::fs::read(&file_path).await {
+                        if data.len() as u64 > offset {
+                            let new_data = data[offset as usize..].to_vec();
+                            offset = data.len() as u64;
+                            if tx
+                                .send(Ok(StreamJobOutputChunk {
+                                    data: new_data,
+                                    eof: false,
+                                }))
+                                .await
+                                .is_err()
+                            {
+                                break; // client disconnected
+                            }
+                        }
+                    }
+                    let still_running = active_steps.lock().await.contains_key(&step_key);
+                    if !still_running {
+                        if let Ok(data) = tokio::fs::read(&file_path).await {
+                            if data.len() as u64 > offset {
+                                let _ = tx
+                                    .send(Ok(StreamJobOutputChunk {
+                                        data: data[offset as usize..].to_vec(),
+                                        eof: false,
+                                    }))
+                                    .await;
+                            }
+                        }
+                        let _ = tx
+                            .send(Ok(StreamJobOutputChunk {
+                                data: Vec::new(),
+                                eof: true,
+                            }))
+                            .await;
+                        break;
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+                }
+            });
+            return Ok(Response::new(ReceiverStream::new(rx)));
+        }
+
         // No retry on a miss, same as run_command: a Running job has been
         // confirmed on every node (confirm_dispatch_on_nodes). Callers here
         // (srun --attach, sattach) hit the agent directly with no controller
@@ -3988,6 +4089,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stream_job_output_tails_step_spool_file() {
+        use tokio_stream::StreamExt as _;
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let job_id = 77;
+        svc.insert_test_job(job_id, TrackedJob::dummy(std::process::id()))
+            .await;
+
+        // A step whose spool file already holds some output, recorded as an
+        // active step (as run_command would).
+        let step_id = 5;
+        let dir = std::env::temp_dir().join(format!("spur-stream-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("step5.out");
+        std::fs::write(&path, b"part1\n").unwrap();
+        svc.active_steps.lock().await.insert(
+            (job_id, step_id),
+            ActiveStep {
+                stdout_path: path.to_string_lossy().into_owned(),
+                ..Default::default()
+            },
+        );
+
+        let mut stream = svc
+            .stream_job_output(Request::new(StreamJobOutputRequest {
+                job_id,
+                step_id,
+                stream: "stdout".into(),
+                user: "testuser".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        // The already-written bytes stream out before the step ends.
+        let first = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+            .await
+            .expect("a chunk should arrive")
+            .expect("stream still open")
+            .unwrap();
+        assert_eq!(first.data, b"part1\n");
+        assert!(!first.eof);
+
+        // More output appears, then the step finishes.
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+            f.write_all(b"part2\n").unwrap();
+        }
+        svc.active_steps.lock().await.remove(&(job_id, step_id));
+
+        let mut rest = Vec::new();
+        loop {
+            let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+                .await
+                .expect("a chunk should arrive")
+                .expect("stream still open")
+                .unwrap();
+            if chunk.eof {
+                break;
+            }
+            rest.extend_from_slice(&chunk.data);
+        }
+        assert_eq!(rest, b"part2\n");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
     async fn stream_job_output_rejects_non_owner() {
         let svc = AgentService::new(
             test_reporter(),
@@ -4003,6 +4177,7 @@ mod tests {
                 job_id: 44,
                 stream: "stdout".into(),
                 user: "intruder".into(),
+                ..Default::default()
             }))
             .await
             .expect_err("a non-owner must not read another user's job output");

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1991,6 +1991,14 @@ impl SlurmAgent for AgentService {
         if req.command.is_empty() {
             return Err(Status::invalid_argument("no command specified"));
         }
+        // A containerized step (spur#777) runs inside the requested image. The
+        // fields are plumbed through here; the container launch path lands in the
+        // next change. Until then, refuse rather than silently run on the host.
+        if req.container.as_ref().is_some_and(|c| !c.image.is_empty()) {
+            return Err(Status::unimplemented(
+                "containerized job steps are not yet supported on this node (spur#777)",
+            ));
+        }
         // Steps carry their own uid straight from the wire — gate them exactly like a batch launch.
         if let Err(msg) = crate::privdrop::check_root_execution_allowed(
             req.uid,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -856,7 +856,7 @@ async fn reap_killed_job(mut job: executor::RunningJob) {
 
 /// Build a bash script that execs a command vector without shell interpretation.
 /// Set up a per-step container rootfs and run the step inside it, returning the
-/// exit code. Builds the `ContainerConfig` from the wire spec (spur#777),
+/// exit code. Builds the `ContainerConfig` from the wire spec,
 /// reusing the same primitives as the batch container path. The rootfs is named
 /// per step so concurrent `srun --overlap` steps in one allocation don't share a
 /// tree; it is removed when the step finishes.
@@ -905,7 +905,7 @@ async fn run_containerized_step(
         gid,
         username,
         home_dir,
-        device_plan, // GPU device-node injection into the container (spur#777)
+        device_plan, // GPU device-node injection into the container
     };
 
     let image_path = crate::container::resolve_image(&spec.image, Some(user), Some(uid))
@@ -2420,7 +2420,7 @@ impl SlurmAgent for AgentService {
             }
         };
 
-        // Containerized step (spur#777): run the command inside the requested
+        // Containerized step: run the command inside the requested
         // image via the shared container primitives, output to the spool files.
         if let Some(spec) = req.container.as_ref().filter(|c| !c.image.is_empty()) {
             // Inject the step's allocated GPUs into the container (device nodes +
@@ -2556,7 +2556,7 @@ impl SlurmAgent for AgentService {
         }
 
         // Backward-compatible: the response still carries the step's output by
-        // reading the spool files back (see `read_back` above). #781 replaces this
+        // reading the spool files back (see `read_back` above); a later change replaces this
         // with a client-side StreamJobOutput tail and drops the read-back.
         Ok(Response::new(RunCommandResponse {
             exit_code: spur_core::process::shell_exit_code(&status),
@@ -2579,7 +2579,7 @@ impl SlurmAgent for AgentService {
         // Step output: tail the per-step spool file recorded by run_command and
         // finish when the step leaves active_steps (rather than the batch file,
         // which ends only when the whole allocation does). This is what lets an
-        // srun step stream live and terminate at step exit (#781).
+        // srun step stream live and terminate at step exit.
         if req.step_id != 0 {
             let active_steps = self.active_steps.clone();
             let want_stderr = req.stream == "stderr";
@@ -4773,7 +4773,7 @@ mod tests {
         assert_eq!(resp.exit_code, 0);
         // The step's stdout must live in a spool file the agent can tail, not
         // only in the RPC response — this file is what StreamJobOutput follows
-        // (#781). step_id defaults to 0 here, so the file is step0.out.
+        //. step_id defaults to 0 here, so the file is step0.out.
         let contents = [
             std::path::PathBuf::from("/var/spool/spur"),
             std::env::temp_dir().join("spur"),

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -230,6 +230,14 @@ fn cancelled_step_response() -> RunCommandResponse {
 fn signal_step_process_group(pid: u32, signal: i32) {
     let sig =
         nix::sys::signal::Signal::try_from(signal).unwrap_or(nix::sys::signal::Signal::SIGTERM);
+    // Walk the process tree FIRST (leaf-first), then signal the group. A
+    // containerized step's workload runs as a grandchild inside a PID namespace,
+    // so it is in a different host process group that killpg misses; the tree
+    // walk reaches it the way batch container jobs are killed. Order matters:
+    // signalling the group first would kill the intermediate parent, emptying
+    // /proc/<pid>/children before the walk can find the grandchild. Harmless for a
+    // host step (the tree is just the step process).
+    crate::executor::kill_process_tree(pid as i32, sig);
     let leader = nix::unistd::Pid::from_raw(pid as i32);
     if let Err(e) = nix::sys::signal::killpg(leader, sig) {
         if let Err(kill_err) = nix::sys::signal::kill(leader, Some(sig)) {
@@ -1824,6 +1832,52 @@ impl SlurmAgent for AgentService {
             self.send_explicit_signal(job_id, req.signal).await;
         } else {
             self.graceful_cancel(job_id).await;
+        }
+
+        // The signal paths above act on the tracked batch process only. An srun
+        // allocation's running steps live in active_steps (a transient
+        // run_command child, host or containerized), so cancel them too — set
+        // cancel_requested to catch a step that has not spawned yet, and signal
+        // the process group of one already running. Without this, `scancel` of an
+        // allocation leaves its running step alive.
+        let step_signal = if req.signal > 0 {
+            req.signal
+        } else {
+            nix::sys::signal::Signal::SIGTERM as i32
+        };
+        let step_pids: Vec<u32> = {
+            let mut steps = self.active_steps.lock().await;
+            steps
+                .iter_mut()
+                .filter(|(&(jid, _), _)| jid == job_id)
+                .filter_map(|(_, step)| {
+                    step.cancel_requested = true;
+                    step.pid
+                })
+                .collect()
+        };
+        info!(
+            job_id,
+            signal = step_signal,
+            step_pids = ?step_pids,
+            "cancel_job: signalling running steps"
+        );
+        for pid in &step_pids {
+            signal_step_process_group(*pid, step_signal);
+        }
+        // A containerized step's workload is PID 1 of its own PID namespace and
+        // ignores SIGTERM unless it installed a handler, so a graceful cancel
+        // leaves it running. Escalate to SIGKILL after a grace period (matching
+        // the job's SIGTERM → 5s → SIGKILL), which PID 1 cannot ignore from the
+        // parent namespace. Skipped when the caller already asked for SIGKILL.
+        let sigkill = nix::sys::signal::Signal::SIGKILL as i32;
+        if step_signal != sigkill && !step_pids.is_empty() {
+            tokio::spawn(async move {
+                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                for pid in step_pids {
+                    signal_step_process_group(pid, sigkill);
+                }
+            });
         }
 
         // The signal paths only act on a running job; release a still-launching

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -200,6 +200,10 @@ fn start_pmix_launch(
 struct ActiveStep {
     cancel_requested: bool,
     pid: Option<u32>,
+    /// Spool files the step's stdout/stderr are redirected to, so
+    /// `stream_job_output` can tail them live keyed on (job_id, step_id).
+    stdout_path: String,
+    stderr_path: String,
 }
 
 struct ActiveStepGuard {
@@ -2287,9 +2291,26 @@ impl SlurmAgent for AgentService {
 
         use std::process::Stdio;
 
+        // Redirect the step's stdout/stderr to per-step spool files rather than
+        // piping the whole output into memory: the child inherits the write fds,
+        // stream_job_output tails the files live, and output stays bounded on this
+        // node. Paths are recorded in active_steps so the tail can find them.
+        let step_files =
+            crate::executor::open_step_output_files(job_id, step_id, req.uid, req.gid)
+                .map_err(|e| Status::internal(format!("step output files: {e}")))?;
+        let stdout_path = step_files.stdout_path.to_string_lossy().into_owned();
+        let stderr_path = step_files.stderr_path.to_string_lossy().into_owned();
+        {
+            let mut steps = self.active_steps.lock().await;
+            if let Some(step) = steps.get_mut(&step_key) {
+                step.stdout_path = stdout_path.clone();
+                step.stderr_path = stderr_path.clone();
+            }
+        }
+
         let mut child = cmd
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stdout(Stdio::from(step_files.stdout))
+            .stderr(Stdio::from(step_files.stderr))
             .spawn()
             .map_err(|e| Status::internal(format!("command failed: {}", e)))?;
         if let Some(pid) = child.id() {
@@ -2305,13 +2326,13 @@ impl SlurmAgent for AgentService {
             if cancel_now {
                 signal_step_process_group(pid, nix::sys::signal::Signal::SIGTERM as i32);
                 let _ = child.kill().await;
-                let _ = child.wait_with_output().await;
+                let _ = child.wait().await;
                 return Ok(Response::new(cancelled_step_response()));
             }
         }
 
-        let output = match child.wait_with_output().await {
-            Ok(output) => output,
+        let status = match child.wait().await {
+            Ok(status) => status,
             Err(e) => return Err(Status::internal(format!("command failed: {}", e))),
         };
 
@@ -2333,10 +2354,19 @@ impl SlurmAgent for AgentService {
             }
         }
 
+        // Backward-compatible: the response still carries the step's output by
+        // reading the spool files back. #781 replaces this with a client-side
+        // StreamJobOutput tail and drops the read-back, removing the memory bound.
+        let read_back = |path: String| async move {
+            tokio::fs::read(&path)
+                .await
+                .map(|b| String::from_utf8_lossy(&b).into_owned())
+                .unwrap_or_default()
+        };
         Ok(Response::new(RunCommandResponse {
-            exit_code: spur_core::process::shell_exit_code(&output.status),
-            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            exit_code: spur_core::process::shell_exit_code(&status),
+            stdout: read_back(stdout_path).await,
+            stderr: read_back(stderr_path).await,
         }))
     }
 
@@ -3380,6 +3410,7 @@ impl AgentService {
             ActiveStep {
                 cancel_requested: false,
                 pid,
+                ..Default::default()
             },
         );
     }
@@ -3662,7 +3693,12 @@ mod tests {
             Arc::new(Mutex::new(DeviceRegistry::new())),
             spur_core::config::MemlockLimit::Unlimited,
         );
-        let job_id = 100;
+        // A unique job_id per test so each gets its own step spool dir
+        // (temp/spur/job<id>/step0.out) and parallel tests do not clobber one
+        // another's step output. Production step_ids are unique per job via
+        // create_job_step; only these fixed-id tests would otherwise collide.
+        static NEXT_JOB_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(100);
+        let job_id = NEXT_JOB_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         svc.insert_test_job(job_id, TrackedJob::dummy(0)).await;
         (svc, job_id)
     }
@@ -4326,6 +4362,33 @@ mod tests {
         assert_eq!(resp.exit_code, 0);
         let observed_canonical = std::fs::canonicalize(resp.stdout.trim()).unwrap();
         assert_eq!(observed_canonical, tmp_canonical);
+    }
+
+    #[tokio::test]
+    async fn run_command_writes_step_output_to_spool_file() {
+        let (svc, job_id) = run_command_test_setup().await;
+        let req = Request::new(RunCommandRequest {
+            command: vec!["echo".into(), "spooled-marker".into()],
+            uid: 0,
+            gid: 0,
+            job_id,
+            ..Default::default()
+        });
+        let resp = svc.run_command(req).await.unwrap().into_inner();
+        assert_eq!(resp.exit_code, 0);
+        // The step's stdout must live in a spool file the agent can tail, not
+        // only in the RPC response — this file is what StreamJobOutput follows
+        // (#781). step_id defaults to 0 here, so the file is step0.out.
+        let contents = [
+            std::path::PathBuf::from("/var/spool/spur"),
+            std::env::temp_dir().join("spur"),
+        ]
+        .iter()
+        .find_map(|base| {
+            std::fs::read_to_string(base.join(format!("job{job_id}")).join("step0.out")).ok()
+        })
+        .expect("step stdout spool file should exist on disk");
+        assert_eq!(contents.trim(), "spooled-marker");
     }
 
     #[tokio::test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -862,10 +862,12 @@ async fn run_containerized_step(
     uid: u32,
     gid: u32,
     gpu_devices: &[u32],
+    device_plan: Option<spur_devices::inject::ContainerInjectionPlan>,
     env: HashMap<String, String>,
     memlock: spur_core::config::MemlockLimit,
     stdout: std::fs::File,
     stderr: std::fs::File,
+    pid_tx: tokio::sync::oneshot::Sender<i32>,
 ) -> anyhow::Result<i32> {
     let mounts: Vec<crate::container::BindMount> = spec
         .mounts
@@ -895,7 +897,7 @@ async fn run_containerized_step(
         gid,
         username,
         home_dir,
-        device_plan: None, // GPU device-node injection is spur#777 phase 3
+        device_plan, // GPU device-node injection into the container (spur#777)
     };
 
     let image_path = crate::container::resolve_image(&spec.image, Some(user), Some(uid))
@@ -916,6 +918,7 @@ async fn run_containerized_step(
         memlock,
         stdout,
         stderr,
+        pid_tx,
     )
     .await
 }
@@ -2361,6 +2364,34 @@ impl SlurmAgent for AgentService {
         // Containerized step (spur#777): run the command inside the requested
         // image via the shared container primitives, output to the spool files.
         if let Some(spec) = req.container.as_ref().filter(|c| !c.image.is_empty()) {
+            // Inject the step's allocated GPUs into the container (device nodes +
+            // env), the same plan the batch container path uses.
+            let device_plan = if gpu_devices.is_empty() {
+                None
+            } else {
+                Some(
+                    self.device_registry
+                        .lock()
+                        .await
+                        .build_job_injection_plans("gpu", &gpu_devices, req.uid, req.gid)
+                        .map_err(|e| {
+                            Status::failed_precondition(format!("GPU injection plan failed: {e}"))
+                        })?
+                        .1,
+                )
+            };
+            // Record the container step's pid (its process-group leader) in
+            // active_steps as soon as it forks, so cancel_step can signal it.
+            let (pid_tx, pid_rx) = tokio::sync::oneshot::channel::<i32>();
+            let steps_for_pid = self.active_steps.clone();
+            let pid_recorder = tokio::spawn(async move {
+                if let Ok(pid) = pid_rx.await {
+                    let mut steps = steps_for_pid.lock().await;
+                    if let Some(step) = steps.get_mut(&step_key) {
+                        step.pid = Some(pid as u32);
+                    }
+                }
+            });
             let exit_code = run_containerized_step(
                 spec,
                 job_id,
@@ -2370,13 +2401,16 @@ impl SlurmAgent for AgentService {
                 req.uid,
                 req.gid,
                 &gpu_devices,
+                device_plan,
                 env,
                 self.limits.memlock,
                 step_files.stdout,
                 step_files.stderr,
+                pid_tx,
             )
             .await
             .map_err(|e| Status::internal(format!("containerized step failed: {e:#}")))?;
+            pid_recorder.abort();
             return Ok(Response::new(RunCommandResponse {
                 exit_code,
                 stdout: read_back(stdout_path).await,

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1212,7 +1212,7 @@ pub fn cleanup_cgroup(cgroup_path: &Path) {
 }
 
 /// Recursively signal a process and all its descendants (children first).
-fn kill_process_tree(pid: i32, sig: Signal) {
+pub(crate) fn kill_process_tree(pid: i32, sig: Signal) {
     let children = get_child_pids(pid);
     for child in &children {
         kill_process_tree(*child, sig);

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1275,7 +1275,11 @@ pub(crate) struct StepOutputFiles {
 /// roots [`open_step_output_files`] (via [`create_job_spool_dir`]) chooses
 /// between. A reader that did not open the file cannot see which root the writer
 /// picked, so it checks both. Kept in sync with `open_step_output_files`' names.
-pub(crate) fn step_output_path_candidates(job_id: JobId, step_id: u32, stderr: bool) -> Vec<PathBuf> {
+pub(crate) fn step_output_path_candidates(
+    job_id: JobId,
+    step_id: u32,
+    stderr: bool,
+) -> Vec<PathBuf> {
     let name = format!("step{step_id}.{}", if stderr { "err" } else { "out" });
     [PathBuf::from(SPOOL_ROOT), std::env::temp_dir().join("spur")]
         .into_iter()
@@ -1285,7 +1289,11 @@ pub(crate) fn step_output_path_candidates(job_id: JobId, step_id: u32, stderr: b
 
 /// The step's spool file if it already exists on disk, so a reader can tail a
 /// step that finished before it observed the step's active_steps entry.
-pub(crate) fn existing_step_output_path(job_id: JobId, step_id: u32, stderr: bool) -> Option<String> {
+pub(crate) fn existing_step_output_path(
+    job_id: JobId,
+    step_id: u32,
+    stderr: bool,
+) -> Option<String> {
     step_output_path_candidates(job_id, step_id, stderr)
         .into_iter()
         .find(|p| p.exists())
@@ -1877,8 +1885,8 @@ async fn launch_container_job(
 /// Wrap a step's argv in a one-shot bash script that execs it, shell-escaped so
 /// metacharacters stay literal (matching `srun`'s no-shell argv semantics).
 fn build_container_step_script(command: &[String]) -> anyhow::Result<String> {
-    let joined = shlex::try_join(command.iter().map(String::as_str))
-        .context("command is not shell-safe")?;
+    let joined =
+        shlex::try_join(command.iter().map(String::as_str)).context("command is not shell-safe")?;
     Ok(format!("#!/bin/bash\nexec {joined}\n"))
 }
 
@@ -2027,15 +2035,14 @@ pub async fn run_container_step(
 
             // Wait for the step to finish in a blocking task so the async runtime
             // is not stalled.
-            let exit = tokio::task::spawn_blocking(move || {
-                match nix::sys::wait::waitpid(child, None) {
+            let exit =
+                tokio::task::spawn_blocking(move || match nix::sys::wait::waitpid(child, None) {
                     Ok(nix::sys::wait::WaitStatus::Exited(_, code)) => code,
                     Ok(nix::sys::wait::WaitStatus::Signaled(_, sig, _)) => 128 + sig as i32,
                     _ => 1,
-                }
-            })
-            .await
-            .unwrap_or(1);
+                })
+                .await
+                .unwrap_or(1);
 
             crate::container::cleanup_rootfs(job_id, &rootfs_mode);
             let _ = std::fs::remove_dir_all(&rootfs_buf);

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1315,11 +1315,27 @@ pub(crate) fn open_step_output_files(
     let stdout_path = spool_dir.join(format!("step{step_id}.out"));
     let stderr_path = spool_dir.join(format!("step{step_id}.err"));
     let open = |path: &Path| -> Result<std::fs::File, LaunchError> {
-        open_output_file(&path.to_string_lossy(), false).map_err(|e| {
+        let file = open_output_file(&path.to_string_lossy(), false).map_err(|e| {
             LaunchError::NodeFault(
                 anyhow::Error::new(e).context(format!("open step output file {}", path.display())),
             )
-        })
+        })?;
+        // These files hold arbitrary user output, so keep them private (0600) —
+        // they can otherwise become world-readable under a typical umask. The
+        // child inherits the write fd, so it writes regardless of ownership; hand
+        // ownership to the job user when spurd is root so only they (and root)
+        // can read it, matching write_job_scratch.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+            if should_run_as_user(uid) {
+                use nix::unistd::{Gid, Uid};
+                let _ =
+                    nix::unistd::chown(path, Some(Uid::from_raw(uid)), Some(Gid::from_raw(gid)));
+            }
+        }
+        Ok(file)
     };
     let stdout = open(&stdout_path)?;
     let stderr = open(&stderr_path)?;

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -103,7 +103,7 @@ fn classify_spool_error(dir: &Path, err: anyhow::Error) -> LaunchError {
     }
 }
 
-use crate::container::ContainerConfig;
+use crate::container::{ContainerConfig, RootfsMode};
 
 /// Cgroup root for slurmd-managed jobs.
 const CGROUP_ROOT: &str = "/sys/fs/cgroup/spur";
@@ -1870,6 +1870,168 @@ async fn launch_container_job(
                 },
                 pty_master,
             ))
+        }
+    }
+}
+
+/// Wrap a step's argv in a one-shot bash script that execs it, shell-escaped so
+/// metacharacters stay literal (matching `srun`'s no-shell argv semantics).
+fn build_container_step_script(command: &[String]) -> anyhow::Result<String> {
+    let joined = shlex::try_join(command.iter().map(String::as_str))
+        .context("command is not shell-safe")?;
+    Ok(format!("#!/bin/bash\nexec {joined}\n"))
+}
+
+/// Run a single job step inside a container to completion, returning its exit
+/// code.
+///
+/// Unlike [`launch_container_job`] — which yields a tracked, long-running
+/// `RunningJob` for a batch job — this forks, runs `container_init` (namespaces,
+/// mounts, `pivot_root`, priv drop) and the step command, and waits
+/// synchronously: a step's transient run-to-completion lifecycle. The child's
+/// stdout/stderr are the step's spool files (the child inherits the write fds via
+/// `dup2`), so the existing StreamJobOutput tail streams a containerized step's
+/// output the same way. The per-step `rootfs` is removed on return.
+///
+/// Reuses the same container primitives as the batch path rather than
+/// duplicating the fork/namespace logic.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_container_step(
+    job_id: JobId,
+    config: &ContainerConfig,
+    rootfs: &Path,
+    rootfs_mode: RootfsMode,
+    command: &[String],
+    env: &HashMap<String, String>,
+    memlock: MemlockLimit,
+    stdout: std::fs::File,
+    stderr: std::fs::File,
+) -> anyhow::Result<i32> {
+    use std::os::fd::AsRawFd;
+
+    // Step script inside the container's /tmp (visible after pivot_root). The
+    // rootfs is per-step, so this fixed name does not collide across steps.
+    let script = build_container_step_script(command)?;
+    let tmp_dir = rootfs.join("tmp");
+    std::fs::create_dir_all(&tmp_dir).ok();
+    let script_path = tmp_dir.join("spur_step.sh");
+    std::fs::write(&script_path, &script)
+        .with_context(|| format!("write step script {}", script_path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755));
+    }
+
+    // Sync pipe: child reports container_init status.
+    let (pipe_r, pipe_w) = nix::unistd::pipe().context("create sync pipe")?;
+    nix::fcntl::fcntl(
+        &pipe_r,
+        nix::fcntl::FcntlArg::F_SETFD(nix::fcntl::FdFlag::FD_CLOEXEC),
+    )
+    .ok();
+    let ready_r = pipe_r.as_raw_fd();
+    let ready_w = pipe_w.as_raw_fd();
+
+    let stdout_fd = stdout.as_raw_fd();
+    let stderr_fd = stderr.as_raw_fd();
+    // The parent frame stays alive across the fork (it awaits the child below),
+    // so the child reads `config`/`rootfs` through the parent's memory (COW). The
+    // owned env copy is what the child mutates and execs with.
+    let rootfs_buf = rootfs.to_path_buf();
+    let env_snapshot = env.clone();
+    let container_env = config.container_env.clone();
+
+    match unsafe { nix::unistd::fork().context("fork for container step")? } {
+        nix::unistd::ForkResult::Child => {
+            // === CHILD === synchronous only; the tokio runtime is broken here.
+            drop(pipe_r);
+            unsafe {
+                libc::signal(libc::SIGCHLD, libc::SIG_DFL);
+                libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+                // Wire the step's spool files to stdout/stderr.
+                if libc::dup2(stdout_fd, libc::STDOUT_FILENO) < 0
+                    || libc::dup2(stderr_fd, libc::STDERR_FILENO) < 0
+                {
+                    libc::_exit(1);
+                }
+            }
+            crate::container::close_inherited_fds(ready_w);
+            apply_memlock(memlock);
+
+            let hook_env = match crate::container::container_init(config, &rootfs_buf) {
+                Ok(env) => env,
+                Err(e) => {
+                    let msg = format!("E:{:#}", e);
+                    unsafe {
+                        libc::write(ready_w, msg.as_ptr() as *const _, msg.len());
+                    }
+                    std::process::exit(1);
+                }
+            };
+            unsafe {
+                libc::write(ready_w, b"OK".as_ptr() as *const _, 2);
+            }
+            drop(pipe_w);
+
+            let mut final_env = env_snapshot;
+            for (k, v) in &container_env {
+                final_env.insert(k.clone(), v.clone());
+            }
+            for (k, v) in hook_env {
+                final_env.insert(k, v);
+            }
+            let c_env: Vec<CString> = final_env
+                .iter()
+                .filter_map(|(k, v)| CString::new(format!("{}={}", k, v)).ok())
+                .collect();
+            let c_env_refs: Vec<&std::ffi::CStr> = c_env.iter().map(|s| s.as_c_str()).collect();
+
+            let shell = if Path::new("/bin/bash").exists() {
+                "/bin/bash"
+            } else {
+                "/bin/sh"
+            };
+            let c_shell = CString::new(shell).unwrap();
+            let exec_args = [c_shell.clone(), CString::new("/tmp/spur_step.sh").unwrap()];
+            let exec_refs: Vec<&std::ffi::CStr> = exec_args.iter().map(|s| s.as_c_str()).collect();
+            let _ = nix::unistd::execve(&c_shell, &exec_refs, &c_env_refs);
+            eprintln!("spur: execve failed: {}", std::io::Error::last_os_error());
+            std::process::exit(1);
+        }
+        nix::unistd::ForkResult::Parent { child } => {
+            drop(pipe_w);
+            // The child holds the dup'd write fds now; release the parent copies.
+            drop(stdout);
+            drop(stderr);
+
+            let mut buf = [0u8; 512];
+            let n = unsafe { libc::read(ready_r, buf.as_mut_ptr() as *mut _, buf.len()) };
+            let n = n.max(0) as usize;
+            drop(pipe_r);
+            if n < 2 || &buf[..2] != b"OK" {
+                let msg = String::from_utf8_lossy(&buf[..n]).to_string();
+                let _ = nix::sys::wait::waitpid(child, None);
+                crate::container::cleanup_rootfs(job_id, &rootfs_mode);
+                let _ = std::fs::remove_dir_all(&rootfs_buf);
+                bail!("container step init failed for job {}: {}", job_id, msg);
+            }
+
+            // Wait for the step to finish in a blocking task so the async runtime
+            // is not stalled.
+            let exit = tokio::task::spawn_blocking(move || {
+                match nix::sys::wait::waitpid(child, None) {
+                    Ok(nix::sys::wait::WaitStatus::Exited(_, code)) => code,
+                    Ok(nix::sys::wait::WaitStatus::Signaled(_, sig, _)) => 128 + sig as i32,
+                    _ => 1,
+                }
+            })
+            .await
+            .unwrap_or(1);
+
+            crate::container::cleanup_rootfs(job_id, &rootfs_mode);
+            let _ = std::fs::remove_dir_all(&rootfs_buf);
+            Ok(exit)
         }
     }
 }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1271,6 +1271,27 @@ pub(crate) struct StepOutputFiles {
     pub stderr_path: PathBuf,
 }
 
+/// The candidate spool paths for a step's stdout or stderr, mirroring the spool
+/// roots [`open_step_output_files`] (via [`create_job_spool_dir`]) chooses
+/// between. A reader that did not open the file cannot see which root the writer
+/// picked, so it checks both. Kept in sync with `open_step_output_files`' names.
+pub(crate) fn step_output_path_candidates(job_id: JobId, step_id: u32, stderr: bool) -> Vec<PathBuf> {
+    let name = format!("step{step_id}.{}", if stderr { "err" } else { "out" });
+    [PathBuf::from(SPOOL_ROOT), std::env::temp_dir().join("spur")]
+        .into_iter()
+        .map(|base| base.join(format!("job{job_id}")).join(&name))
+        .collect()
+}
+
+/// The step's spool file if it already exists on disk, so a reader can tail a
+/// step that finished before it observed the step's active_steps entry.
+pub(crate) fn existing_step_output_path(job_id: JobId, step_id: u32, stderr: bool) -> Option<String> {
+    step_output_path_candidates(job_id, step_id, stderr)
+        .into_iter()
+        .find(|p| p.exists())
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
 /// Open a step's stdout/stderr spool files under the job spool dir, creating the
 /// dir if needed. The agent (root) opens the files and hands the write fds to the
 /// child via stdio redirection, so the child writes even after dropping to its

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1259,6 +1259,49 @@ fn open_output_file(path: &str, use_append: bool) -> std::io::Result<std::fs::Fi
     opts.open(path)
 }
 
+/// A step's stdout/stderr spool files, open for the child to inherit and their
+/// paths for the agent to tail. Steps stream through these files (StreamJobOutput
+/// follows the growing file) instead of buffering their whole output in the RPC
+/// response, so a step's output is bounded on the compute node and visible before
+/// the step exits.
+pub(crate) struct StepOutputFiles {
+    pub stdout: std::fs::File,
+    pub stderr: std::fs::File,
+    pub stdout_path: PathBuf,
+    pub stderr_path: PathBuf,
+}
+
+/// Open a step's stdout/stderr spool files under the job spool dir, creating the
+/// dir if needed. The agent (root) opens the files and hands the write fds to the
+/// child via stdio redirection, so the child writes even after dropping to its
+/// uid; the files stay agent-readable so `stream_job_output` can tail them.
+/// Lives under the job spool tree so `cleanup_job_spool` reclaims it at job end.
+pub(crate) fn open_step_output_files(
+    job_id: JobId,
+    step_id: u32,
+    uid: u32,
+    gid: u32,
+) -> Result<StepOutputFiles, LaunchError> {
+    let spool_dir = create_job_spool_dir(job_id, uid, gid)?;
+    let stdout_path = spool_dir.join(format!("step{step_id}.out"));
+    let stderr_path = spool_dir.join(format!("step{step_id}.err"));
+    let open = |path: &Path| -> Result<std::fs::File, LaunchError> {
+        open_output_file(&path.to_string_lossy(), false).map_err(|e| {
+            LaunchError::NodeFault(
+                anyhow::Error::new(e).context(format!("open step output file {}", path.display())),
+            )
+        })
+    };
+    let stdout = open(&stdout_path)?;
+    let stderr = open(&stderr_path)?;
+    Ok(StepOutputFiles {
+        stdout,
+        stderr,
+        stdout_path,
+        stderr_path,
+    })
+}
+
 /// Send file descriptors to a peer over a Unix socket via SCM_RIGHTS.
 fn send_fds(sock: RawFd, fds: &[RawFd]) -> nix::Result<()> {
     use nix::sys::socket::{sendmsg, ControlMessage, MsgFlags};

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1906,6 +1906,7 @@ pub async fn run_container_step(
     memlock: MemlockLimit,
     stdout: std::fs::File,
     stderr: std::fs::File,
+    pid_tx: tokio::sync::oneshot::Sender<i32>,
 ) -> anyhow::Result<i32> {
     use std::os::fd::AsRawFd;
 
@@ -1949,6 +1950,9 @@ pub async fn run_container_step(
             unsafe {
                 libc::signal(libc::SIGCHLD, libc::SIG_DFL);
                 libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+                // Own process group so cancel_step's killpg reaches every process
+                // the container spawns, not just the step's entry process.
+                libc::setpgid(0, 0);
                 // Wire the step's spool files to stdout/stderr.
                 if libc::dup2(stdout_fd, libc::STDOUT_FILENO) < 0
                     || libc::dup2(stderr_fd, libc::STDERR_FILENO) < 0
@@ -2004,6 +2008,10 @@ pub async fn run_container_step(
             // The child holds the dup'd write fds now; release the parent copies.
             drop(stdout);
             drop(stderr);
+
+            // Publish the child pid (its own process group leader) so cancel_step
+            // can signal the step's whole process group.
+            let _ = pid_tx.send(child.as_raw());
 
             let mut buf = [0u8; 512];
             let n = unsafe { libc::read(ready_r, buf.as_mut_ptr() as *mut _, buf.len()) };

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -995,6 +995,21 @@ message ExecInJobResponse {
 // Controller-side request: run a step inside an allocation. The controller
 // fans out tasks across the allocation's nodes via each agent's RunCommand
 // RPC. Used by srun inside sbatch/salloc and standalone srun.
+// Container options for a job step run on a bare-metal node (spur#777). Absent =
+// run the step on the host (the pre-#777 behavior). The field set mirrors the
+// container options `srun` exposes and JobSpec carries for batch jobs.
+message ContainerSpec {
+  string image = 1;                 // OCI image ref or squashfs path; empty = no container
+  repeated string mounts = 2;       // "/src:/dst:ro" bind mounts
+  string workdir = 3;               // Workdir inside the container
+  string name = 4;                  // Named container (persists across jobs)
+  bool readonly = 5;                // Read-only rootfs
+  bool mount_home = 6;              // Bind-mount the user's home directory
+  map<string, string> env = 7;      // Extra env vars inside the container
+  string entrypoint = 8;            // Override entrypoint
+  bool remap_root = 9;              // Remap the user to root inside the container
+}
+
 message RunStepRequest {
   uint32 job_id = 1;
   repeated string command = 2;
@@ -1006,6 +1021,7 @@ message RunStepRequest {
   bool label = 8;      // Prefix output lines with [rank] (srun -l)
   string mpi = 9;      // Step MPI type; when empty, inherit job.spec.mpi
   string user = 10;    // Requesting user; verified identity must own the job; the controller/admin credential overrides
+  ContainerSpec container = 11;  // Run the step inside this container; absent = on the host (spur#777)
 }
 
 message RunStepResponse {
@@ -1229,6 +1245,7 @@ message RunCommandRequest {
   string mpi = 13;             // Resolved step MPI type: "none" or "pmix"
   // When true, PMIx was prepared via PreparePmix on the controller before RunCommand.
   bool pmix_prepared = 14;
+  ContainerSpec container = 15;  // Run the step inside this container; absent = on the host (spur#777)
 }
 
 // Register a srun-only allocation on an agent without starting a batch process.

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -995,8 +995,8 @@ message ExecInJobResponse {
 // Controller-side request: run a step inside an allocation. The controller
 // fans out tasks across the allocation's nodes via each agent's RunCommand
 // RPC. Used by srun inside sbatch/salloc and standalone srun.
-// Container options for a job step run on a bare-metal node (spur#777). Absent =
-// run the step on the host (the pre-#777 behavior). The field set mirrors the
+// Container options for a job step run on a bare-metal node. Absent =
+// run the step on the host (the pre-container behavior). The field set mirrors the
 // container options `srun` exposes and JobSpec carries for batch jobs.
 message ContainerSpec {
   string image = 1;                 // OCI image ref or squashfs path; empty = no container
@@ -1021,7 +1021,7 @@ message RunStepRequest {
   bool label = 8;      // Prefix output lines with [rank] (srun -l)
   string mpi = 9;      // Step MPI type; when empty, inherit job.spec.mpi
   string user = 10;    // Requesting user; verified identity must own the job; the controller/admin credential overrides
-  ContainerSpec container = 11;  // Run the step inside this container; absent = on the host (spur#777)
+  ContainerSpec container = 11;  // Run the step inside this container; absent = on the host
 }
 
 message RunStepResponse {
@@ -1245,7 +1245,7 @@ message RunCommandRequest {
   string mpi = 13;             // Resolved step MPI type: "none" or "pmix"
   // When true, PMIx was prepared via PreparePmix on the controller before RunCommand.
   bool pmix_prepared = 14;
-  ContainerSpec container = 15;  // Run the step inside this container; absent = on the host (spur#777)
+  ContainerSpec container = 15;  // Run the step inside this container; absent = on the host
 }
 
 // Register a srun-only allocation on an agent without starting a batch process.

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1265,6 +1265,7 @@ message StreamJobOutputRequest {
   uint32 job_id = 1;
   string stream = 2;  // "stdout" or "stderr"
   string user = 3;    // Requesting user; verified identity must own the job; the controller/admin credential overrides
+  uint32 step_id = 4; // 0 = the batch job's own output; >0 = tail that step's per-step spool file
 }
 
 message StreamJobOutputChunk {

--- a/tests/native_host/e2e/test_srun_container_gpu.py
+++ b/tests/native_host/e2e/test_srun_container_gpu.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""E2E test: GPU device injection into a containerized job step (spur#777).
+"""E2E test: GPU device injection into a containerized job step.
 
 A containerized `srun` step must receive the allocation's GPU device nodes
 (injected into the container) the same way a batch container job does.
@@ -9,7 +9,7 @@ A containerized `srun` step must receive the allocation's GPU device nodes
 The node's GPU is registered via a config `[[devices.gres]]` entry mapping the
 gres to the render node, so the test does not depend on the node having KFD
 compute topology (auto-detect) — it exercises the injection path, which is what
-spur#777 phase 3 added for steps. Needs a root agent (namespaces + device
+this change added for steps. Needs a root agent (namespaces + device
 injection).
 """
 

--- a/tests/native_host/e2e/test_srun_container_gpu.py
+++ b/tests/native_host/e2e/test_srun_container_gpu.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E test: GPU device injection into a containerized job step (spur#777).
+
+A containerized `srun` step must receive the allocation's GPU device nodes
+(injected into the container) the same way a batch container job does.
+
+The node's GPU is registered via a config `[[devices.gres]]` entry mapping the
+gres to the render node, so the test does not depend on the node having KFD
+compute topology (auto-detect) — it exercises the injection path, which is what
+spur#777 phase 3 added for steps. Needs a root agent (namespaces + device
+injection).
+"""
+
+import pytest
+
+from conftest import _deploy_cluster
+
+pytestmark = pytest.mark.rootful
+
+# The render node present on the test host; the gres maps to it so the scheduler
+# has a GPU to allocate and the agent has a device node to inject.
+RENDER_NODE = "/dev/dri/renderD128"
+
+GRES_CONFIG = {
+    "devices": {
+        "auto_detect": False,
+        "gres": [
+            {
+                "name": "gpu",
+                "type": "test",
+                "file": RENDER_NODE,
+                "flags": ["amd_gpu_env"],
+            }
+        ],
+    }
+}
+
+
+@pytest.fixture
+def gpu_container_cluster(ssh_nodes, remote_bin_dir, tmp_path):
+    if not ssh_nodes[0].exec_allow_fail(f"test -e {RENDER_NODE} && echo yes || true").strip():
+        pytest.skip(f"{RENDER_NODE} not present on the test host")
+    c = _deploy_cluster(ssh_nodes, remote_bin_dir, agent_as_root=True, config_overrides=GRES_CONFIG)
+    try:
+        c.container_preflight()
+        c.container_image = c.build_container_image(tmp_path)
+        yield c
+    finally:
+        c.teardown()
+
+
+class TestSrunContainerGpu:
+    def test_step_gets_gpu_device_injected(self, gpu_container_cluster):
+        cluster = gpu_container_cluster
+        img = cluster.container_image
+        code, out = cluster.salloc_run(
+            f'srun --container-image={img} '
+            f'sh -c "if [ -e {RENDER_NODE} ]; then echo GPU-IN-CONTAINER; '
+            f'else echo NO-GPU; fi"\n',
+            salloc_args=["-N", "1", "--gres=gpu:1", "-t", "0:05"],
+        )
+        assert code == 0, out
+        assert "GPU-IN-CONTAINER" in out, f"render node not injected into the container:\n{out}"
+        assert "NO-GPU" not in out, out

--- a/tests/native_host/e2e/test_srun_container_step.py
+++ b/tests/native_host/e2e/test_srun_container_step.py
@@ -9,6 +9,9 @@ so the presence of a host-only directory cleanly distinguishes the host from the
 container filesystem.
 """
 
+import threading
+import time
+
 import pytest
 
 from conftest import _deploy_cluster
@@ -71,3 +74,48 @@ class TestSrunContainerStep:
         assert code == 0, out
         assert "MOUNT-MARKER-XYZ" in out, out
 
+    def test_scancel_kills_a_running_container_step(self, container_cluster):
+        cluster = container_cluster
+        img = cluster.container_image
+        job_name = "ctn-cancel"
+
+        def run():
+            cluster.salloc_run(
+                f"srun --container-image={img} sleep 120\n",
+                salloc_args=["-N", "1", "-J", job_name, "-t", "0:05"],
+            )
+
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        try:
+            deadline = time.time() + 40
+            job_id = None
+            while time.time() < deadline:
+                ids = cluster.running_job_ids_by_name(job_name)
+                if ids:
+                    job_id = ids[0]
+                    break
+                time.sleep(1)
+            assert job_id is not None, "container step allocation never reached running"
+            # Let the container's `sleep` actually start before cancelling. Match
+            # the process by exact name (pgrep -x) so the `srun ... sleep 120`
+            # client command line does not count as the workload.
+            time.sleep(5)
+            assert cluster.nodes[0].exec_allow_fail("pgrep -x sleep || true").strip()
+
+            cluster.scancel(str(job_id))
+
+            # scancel must terminate the running step: salloc returns and the
+            # container's `sleep` is gone (after the SIGTERM → SIGKILL escalation).
+            t.join(timeout=40)
+            assert not t.is_alive(), "salloc did not return after scancel — step not cancelled"
+            deadline = time.time() + 20
+            leftover = "x"
+            while time.time() < deadline:
+                leftover = cluster.nodes[0].exec_allow_fail("pgrep -x sleep || true").strip()
+                if not leftover:
+                    break
+                time.sleep(1)
+            assert not leftover, f"cancelled step left a sleep process:\n{leftover}"
+        finally:
+            t.join(timeout=5)

--- a/tests/native_host/e2e/test_srun_container_step.py
+++ b/tests/native_host/e2e/test_srun_container_step.py
@@ -56,3 +56,18 @@ class TestSrunContainerStep:
         )
         assert code == 0, out
         assert "ctn-exit=13" in out, out
+
+    def test_step_container_bind_mount(self, container_cluster):
+        cluster = container_cluster
+        img = cluster.container_image
+        # A host file bind-mounted into the container must be readable inside.
+        marker = cluster.write_file("mount-marker.txt", "MOUNT-MARKER-XYZ\n")
+        src_dir = marker.rsplit("/", 1)[0]
+        code, out = cluster.salloc_run(
+            f"srun --container-image={img} "
+            f"--container-mounts={src_dir}:/mnt:ro "
+            f"cat /mnt/mount-marker.txt\n"
+        )
+        assert code == 0, out
+        assert "MOUNT-MARKER-XYZ" in out, out
+

--- a/tests/native_host/e2e/test_srun_container_step.py
+++ b/tests/native_host/e2e/test_srun_container_step.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""E2E tests for `srun --container-image` on bare-metal job steps (spur#777).
+"""E2E tests for `srun --container-image` on bare-metal job steps.
 
 Inside an allocation, `srun --container-image=IMG cmd` must run cmd *inside* the
 image, not on the host. The test image is a minimal rootfs (no /var, /opt, ...),

--- a/tests/native_host/e2e/test_srun_container_step.py
+++ b/tests/native_host/e2e/test_srun_container_step.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for `srun --container-image` on bare-metal job steps (spur#777).
+
+Inside an allocation, `srun --container-image=IMG cmd` must run cmd *inside* the
+image, not on the host. The test image is a minimal rootfs (no /var, /opt, ...),
+so the presence of a host-only directory cleanly distinguishes the host from the
+container filesystem.
+"""
+
+import pytest
+
+from conftest import _deploy_cluster
+
+
+@pytest.fixture
+def container_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides, tmp_path):
+    """A rootful single-node cluster with the minimal test image built and
+    shipped. Containerized steps enter mount/PID/user namespaces and pivot_root,
+    which need a root agent; an unprivileged agent cannot set them up."""
+    c = _deploy_cluster(
+        ssh_nodes,
+        remote_bin_dir,
+        agent_as_root=True,
+        config_overrides=cluster_config_overrides,
+    )
+    try:
+        c.container_preflight()
+        agent_user = c.spurd_agent_user(0)
+        assert agent_user == "root", f"containerized steps need a root agent, got {agent_user!r}"
+        c.container_image = c.build_container_image(tmp_path)
+        yield c
+    finally:
+        c.teardown()
+
+
+class TestSrunContainerStep:
+    def test_step_runs_inside_the_image(self, container_cluster):
+        cluster = container_cluster
+        img = cluster.container_image
+        # /var exists on the host but not in the minimal test image.
+        code, out = cluster.salloc_run(
+            f"srun --container-image={img} "
+            f'sh -c "if [ -d /var ]; then echo HOST-FS; else echo CONTAINER-FS; fi"\n'
+        )
+        assert code == 0, out
+        assert "CONTAINER-FS" in out, out
+        assert "HOST-FS" not in out, out
+
+    def test_step_exit_code_from_container(self, container_cluster):
+        cluster = container_cluster
+        img = cluster.container_image
+        code, out = cluster.salloc_run(
+            f'srun --container-image={img} sh -c "exit 13" || echo "ctn-exit=$?"\n'
+        )
+        assert code == 0, out
+        assert "ctn-exit=13" in out, out

--- a/tests/native_host/e2e/test_srun_step_output.py
+++ b/tests/native_host/e2e/test_srun_step_output.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for srun step output delivery (spur#781).
+
+A command run as an srun step inside an allocation has its stdout/stderr
+redirected to per-step spool files on the node; the client tails those files
+live via StreamJobOutput while the RunStep dispatch is in flight. These tests
+drive real steps through an allocation shell and assert their output reaches
+the client intact.
+"""
+
+
+class TestSrunStepOutput:
+    def test_step_stdout_reaches_client(self, cluster):
+        code, out = cluster.salloc_run(
+            'srun echo STEP-MARKER-ALPHA\n'
+            'srun bash -c "echo line1; echo line2; echo line3"\n'
+        )
+        assert code == 0, out
+        assert "STEP-MARKER-ALPHA" in out, out
+        for line in ("line1", "line2", "line3"):
+            assert line in out, out
+
+    def test_step_stderr_reaches_client(self, cluster):
+        code, out = cluster.salloc_run(
+            'srun bash -c "echo to-stderr 1>&2"\n'
+        )
+        assert code == 0, out
+        assert "to-stderr" in out, out
+
+    def test_step_exit_code_and_output_both_delivered(self, cluster):
+        # srun exits with the step's exit code; the output before the failure
+        # must still reach the client through the streaming path.
+        code, out = cluster.salloc_run(
+            'srun bash -c "echo before-fail; exit 7" || echo "step-exit=$?"\n'
+        )
+        assert code == 0, out
+        assert "before-fail" in out, out
+        assert "step-exit=7" in out, out


### PR DESCRIPTION
## Summary
Run a bare-metal `srun` **step** inside its `--container-image` (instead of silently on the host), and make a running step cancelable by `scancel`. Largest part of the step-dispatch convergence (#777/#780/#781).

> **Stacked on #819** (base branch `users/powderluv/step-output-streaming`). Review/merge #819 first; this PR shows only the container + cancel delta. The containerized step's output flows through the per-step spool files from #819.

### Containerized steps (#777)
- **proto** — `ContainerSpec` on `RunStepRequest`/`RunCommandRequest`; `srun` fills it, `spurctld` forwards it per node. The step's spec travels on the step RPC, so `scheduler_loop`'s `dispatch_spec=None` needs no change for the explicit `srun --container-image` case.
- **launch** — a dedicated one-shot `executor::run_container_step` reuses the *safe primitives* (`resolve_image`/`setup_rootfs`/`container_init`) with step lifecycle: fork, wire stdio to the spool files, `container_init` (namespaces/mounts/pivot_root/priv-drop), exec a step script, `waitpid` for the exit code, `cleanup_rootfs`. It does **not** reuse batch `launch_job` (which keys a cgroup on `job_id`, runs prolog/burst-buffer/PTY, and yields a tracked long-running job). The rootfs is named per step (`job<id>_step<step>`) so concurrent `srun --overlap` steps don't collide.
- **GPU injection** — the step gets the allocation's GPUs via the same `build_job_injection_plans(...).1` → `ContainerConfig.device_plan` the batch path uses.

### scancel cancels a running step (host and container)
The agent's `cancel_job` now cascades to `active_steps` (previously it signalled only the tracked batch process, so `scancel` orphaned a running step). Two container subtleties: the workload is a grandchild in a PID namespace / different host process group, so we **walk the process tree first** (before signalling the group, which would empty `/proc/<pid>/children`); and it's PID 1 of its namespace and ignores SIGTERM, so we **escalate to SIGKILL after a 5s grace**. Benefits plain steps too.

## Testing (rootful E2E on shark-a + unit + clippy)
`test_srun_container_step.py`: runs inside the image, exit code, bind mount, and `scancel` kills a running container step. `test_srun_container_gpu.py`: the GPU device node is injected into the container. Cancel/signal unit tests still pass.

## Notes / follow-ups
- The GPU E2E registers the render node as a synthetic gpu gres via config (`[[devices.gres]] file=… flags=[amd_gpu_env]`) because the test host lacks KFD compute topology; it verifies the *injection* path (real ROCm-compute allocation needs a KFD-capable node).
- cgroup membership for steps is not added here (native-host steps don't get a cgroup today — a separate change).
- The `--container-image` step-mode warning added in #820 becomes obsolete once this lands.

Closes #777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
