### PR TITLE
fix(spurd): confine step and interactive jobs to the job cgroup

### DIFF
--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -98,6 +98,16 @@ impl NodeAllocation {
             .collect()
     }
 
+    /// The cores allocated to `job_id` (empty if it holds no allocation here).
+    /// Steps/interactive sessions use this to pin their cgroup's `cpuset.cpus` to
+    /// the same cores the job was granted.
+    pub fn job_cpu_ids(&self, job_id: u32) -> Vec<u32> {
+        self.owners
+            .get(&job_id)
+            .map(|a| a.cpu_ids.clone())
+            .unwrap_or_default()
+    }
+
     /// Available GPU count (optionally filtered by type).
     pub fn free_gpus(&self, gpu_type: Option<&str>) -> u32 {
         self.gpu_allocated

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2269,8 +2269,16 @@ impl SlurmAgent for AgentService {
 
         let memlock = self.limits.memlock;
         let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
+        // Confine the step to the allocation's cgroup (create-or-join). Without
+        // this a step runs in spurd's own cgroup with no per-job limits. Join
+        // while still root, before the privilege drop.
+        let cgroup_procs =
+            crate::executor::setup_step_cgroup(job_id, &self.cgroup, cpus, memory_mb);
         unsafe {
             cmd.pre_exec(move || {
+                if let Some(ref procs) = cgroup_procs {
+                    crate::executor::join_cgroup_self(procs, -1);
+                }
                 crate::executor::apply_memlock(memlock);
                 if let Some(ref pd) = priv_drop {
                     pd.apply()
@@ -2644,8 +2652,17 @@ impl SlurmAgent for AgentService {
             return Err(Status::permission_denied(msg));
         }
 
+        // Confine the interactive session to the allocation's cgroup (create-or-
+        // join) so it obeys the same per-job limits as a batch job.
+        let cgroup_procs = {
+            let jobs = self.running.lock().await;
+            jobs.get(&init.job_id).and_then(|t| {
+                crate::executor::setup_step_cgroup(init.job_id, &self.cgroup, t.cpus, t.memory_mb)
+            })
+        };
+
         let (master_fd, child, child_pid) =
-            Self::spawn_pty_in_job(&entry, &argv, init.job_id, winsize.as_ref())?;
+            Self::spawn_pty_in_job(&entry, &argv, init.job_id, winsize.as_ref(), cgroup_procs)?;
 
         info!(
             job_id = init.job_id,
@@ -2886,6 +2903,9 @@ impl AgentService {
             if let Err(e) = self.mpi_host.stop_pmix_server(job_id) {
                 warn!(job_id, error = %e, "PMIx stop failed on job drop");
             }
+            // Reclaim the allocation cgroup a step/interactive session may have
+            // created (best-effort; only removes once it is empty).
+            crate::executor::remove_job_cgroup(job_id);
         }
     }
 
@@ -3363,6 +3383,7 @@ impl AgentService {
         argv: &[String],
         job_id: u32,
         winsize: Option<&crate::pty::WindowSize>,
+        cgroup_procs: Option<std::ffi::CString>,
     ) -> Result<(std::os::fd::OwnedFd, tokio::process::Child, i32), Status> {
         use std::os::fd::AsRawFd;
         use std::process::Stdio;
@@ -3432,6 +3453,11 @@ impl AgentService {
         unsafe {
             cmd.pre_exec(move || {
                 raw.wire()?;
+                // Confine the interactive session to the allocation's cgroup,
+                // while still root, before the privilege drop.
+                if let Some(ref procs) = cgroup_procs {
+                    crate::executor::join_cgroup_self(procs, -1);
+                }
                 if let Some(ref pd) = priv_drop_for_child {
                     pd.apply()
                         .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
@@ -3715,7 +3741,7 @@ mod tests {
             work_dir: "/tmp".into(),
         };
         let (master, mut child, pid) =
-            AgentService::spawn_pty_in_job(&entry, &["true".to_string()], 7, None)
+            AgentService::spawn_pty_in_job(&entry, &["true".to_string()], 7, None, None)
                 .expect("spawn_pty_in_job should succeed for a direct /usr/bin/true");
         assert!(pid > 0);
         let status = child.wait().await.expect("child should be reapable");

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2271,13 +2271,17 @@ impl SlurmAgent for AgentService {
         let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
         // Confine the step to the allocation's cgroup (create-or-join). Without
         // this a step runs in spurd's own cgroup with no per-job limits. Join
-        // while still root, before the privilege drop.
+        // while still root, before the privilege drop. Pin to the job's cores so
+        // `constrain_cores` applies to the step too.
+        let cpu_ids = self.allocation.lock().await.job_cpu_ids(job_id);
         let cgroup_procs =
-            crate::executor::setup_step_cgroup(job_id, &self.cgroup, cpus, memory_mb);
+            crate::executor::setup_step_cgroup(job_id, &self.cgroup, cpus, memory_mb, &cpu_ids);
         unsafe {
             cmd.pre_exec(move || {
                 if let Some(ref procs) = cgroup_procs {
-                    crate::executor::join_cgroup_self(procs, -1);
+                    // The step's stderr is already wired to its spool file here,
+                    // so report a join failure there rather than dropping it.
+                    crate::executor::join_cgroup_self(procs, libc::STDERR_FILENO);
                 }
                 crate::executor::apply_memlock(memlock);
                 if let Some(ref pd) = priv_drop {
@@ -2653,12 +2657,25 @@ impl SlurmAgent for AgentService {
         }
 
         // Confine the interactive session to the allocation's cgroup (create-or-
-        // join) so it obeys the same per-job limits as a batch job.
-        let cgroup_procs = {
+        // join) so it obeys the same per-job limits as a batch job. Read the
+        // job's sizing under the lock, then do the (synchronous) cgroup I/O
+        // outside it so the async runtime is not blocked.
+        let sizing = {
             let jobs = self.running.lock().await;
-            jobs.get(&init.job_id).and_then(|t| {
-                crate::executor::setup_step_cgroup(init.job_id, &self.cgroup, t.cpus, t.memory_mb)
-            })
+            jobs.get(&init.job_id).map(|t| (t.cpus, t.memory_mb))
+        };
+        let cgroup_procs = match sizing {
+            Some((cpus, memory_mb)) => {
+                let cpu_ids = self.allocation.lock().await.job_cpu_ids(init.job_id);
+                crate::executor::setup_step_cgroup(
+                    init.job_id,
+                    &self.cgroup,
+                    cpus,
+                    memory_mb,
+                    &cpu_ids,
+                )
+            }
+            None => None,
         };
 
         let (master_fd, child, child_pid) =

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1100,9 +1100,30 @@ fn permitted_cores(requested: &[u32], parent_effective: &str) -> Vec<u32> {
         .collect()
 }
 
+/// Create-or-join the job's cgroup for a transient step or interactive session
+/// and return its `cgroup.procs` path for [`join_cgroup_self`] in a pre-exec hook.
+/// Idempotent: the batch launch or an earlier step in the same allocation may
+/// have created it already, in which case the process joins the existing one.
+pub(crate) fn setup_step_cgroup(
+    job_id: JobId,
+    cgroup: &CgroupConfig,
+    cpus: u32,
+    memory_mb: u64,
+) -> Option<std::ffi::CString> {
+    let path = setup_cgroup(job_id, cgroup, cpus, memory_mb, &[]).ok()??;
+    std::ffi::CString::new(path.join("cgroup.procs").as_os_str().as_bytes()).ok()
+}
+
+/// Remove a job's cgroup directory once its allocation ends (best-effort). The
+/// directory removes only when empty, so this is a no-op while processes remain.
+pub(crate) fn remove_job_cgroup(job_id: JobId) {
+    let path = PathBuf::from(CGROUP_ROOT).join(format!("job_{}", job_id));
+    let _ = std::fs::remove_dir(&path);
+}
+
 /// Join the calling process to a cgroup (its pid → `cgroup.procs`). Runs post-fork
 /// pre-exec so it's async-signal-safe (raw syscalls only); best-effort, warns to `log_fd`.
-fn join_cgroup_self(procs_path: &std::ffi::CStr, log_fd: RawFd) {
+pub(crate) fn join_cgroup_self(procs_path: &std::ffi::CStr, log_fd: RawFd) {
     let pid = unsafe { libc::getpid() };
 
     let mut buf = [0u8; 24];

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1109,8 +1109,12 @@ pub(crate) fn setup_step_cgroup(
     cgroup: &CgroupConfig,
     cpus: u32,
     memory_mb: u64,
+    cpu_ids: &[u32],
 ) -> Option<std::ffi::CString> {
-    let path = setup_cgroup(job_id, cgroup, cpus, memory_mb, &[]).ok()??;
+    // Pass the job's allocated cores so `constrain_cores` pins cpuset.cpus, the
+    // same as the batch path — otherwise a step that creates the cgroup (an
+    // srun-only allocation) would run core-unconfined.
+    let path = setup_cgroup(job_id, cgroup, cpus, memory_mb, cpu_ids).ok()??;
     std::ffi::CString::new(path.join("cgroup.procs").as_os_str().as_bytes()).ok()
 }
 

--- a/tests/native_host/e2e/test_step_cgroup.py
+++ b/tests/native_host/e2e/test_step_cgroup.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E test: srun steps and interactive sessions are confined to the job cgroup.
+
+Previously the step/interactive dispatch path spawned directly with no cgroup, so
+those jobs ran in spurd's own service cgroup with no per-job limits (issue #802).
+"""
+
+import pytest
+
+from conftest import _deploy_cluster
+
+pytestmark = pytest.mark.rootful
+
+
+@pytest.fixture
+def rootful_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
+    fstype = ssh_nodes[0].exec_allow_fail("stat -fc %T /sys/fs/cgroup").strip()
+    if "cgroup2fs" not in fstype:
+        pytest.skip("node 0 is not cgroup v2")
+    c = _deploy_cluster(ssh_nodes, remote_bin_dir, agent_as_root=True,
+                        config_overrides=cluster_config_overrides)
+    try:
+        yield c
+    finally:
+        c.teardown()
+
+
+class TestStepCgroup:
+    def test_step_runs_in_job_cgroup(self, rootful_cluster):
+        code, out = rootful_cluster.salloc_run(
+            'srun bash -c "cat /proc/self/cgroup"\n'
+        )
+        assert code == 0, out
+        # The step must be under /spur/job_<id>, not spurd's own service cgroup.
+        assert "/spur/job_" in out, f"step not in a job cgroup:\n{out}"
+        assert "spurd.service" not in out, f"step still in spurd's cgroup:\n{out}"

--- a/tests/native_host/e2e/test_step_cgroup.py
+++ b/tests/native_host/e2e/test_step_cgroup.py
@@ -4,7 +4,7 @@
 """E2E test: srun steps and interactive sessions are confined to the job cgroup.
 
 Previously the step/interactive dispatch path spawned directly with no cgroup, so
-those jobs ran in spurd's own service cgroup with no per-job limits (issue #802).
+those jobs ran in spurd's own service cgroup with no per-job limits.
 """
 
 import pytest


### PR DESCRIPTION
## Summary
The step (`run_command`) and interactive (`spawn_pty_in_job`) dispatch paths spawned directly with a privilege drop but never created or joined a cgroup, so those jobs ran in **spurd's own service cgroup** — no per-job limits, shared with the daemon and every other user's interactive session on the node (issue #802). Only the batch launch path called `setup_cgroup`.

```
user@node-a:~$ cat /proc/self/cgroup        # interactive job, before
0::/system.slice/spurd.service
```

## Fix
Create-or-join the allocation's cgroup on both paths:
- `setup_step_cgroup()` runs the idempotent `setup_cgroup` (the batch launch, or an earlier step in the same allocation, may have created it — the process then joins the existing one) and returns its `cgroup.procs` path.
- the child joins via `join_cgroup_self` in its pre-exec hook, while still root, before the privilege drop.
- the cgroup is reclaimed (best-effort, empty-only) when the allocation is dropped.

## Testing
E2E (rootful): a step reports a `/spur/job_<id>` cgroup, not `spurd.service`.

Note: this is also the enabler for session adoption (#782) and for killing residual processes on cancel (#799), which need a real per-job cgroup to exist.

Closes #802.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
