### PR TITLE
fix(spurd): sweep the allocation cgroup on cancel

### DIFF
--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2904,8 +2904,9 @@ impl AgentService {
                 warn!(job_id, error = %e, "PMIx stop failed on job drop");
             }
             // Reclaim the allocation cgroup a step/interactive session may have
-            // created (best-effort; only removes once it is empty).
-            crate::executor::remove_job_cgroup(job_id);
+            // created: kill any residual members and remove it. This is the
+            // default node-side teardown, independent of any site epilog.
+            crate::executor::reclaim_job_cgroup(job_id);
         }
     }
 

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1116,9 +1116,16 @@ pub(crate) fn setup_step_cgroup(
 
 /// Remove a job's cgroup directory once its allocation ends (best-effort). The
 /// directory removes only when empty, so this is a no-op while processes remain.
-pub(crate) fn remove_job_cgroup(job_id: JobId) {
+/// Reclaim a job's cgroup when its allocation ends: SIGKILL any process still in
+/// it, then remove the directory. This is the default node-side teardown for
+/// residual processes of a released allocation (an interactive/step child, or —
+/// once sessions are adopted — a debug SSH session), independent of any
+/// site-configured epilog. A no-op when the cgroup was never created.
+pub(crate) fn reclaim_job_cgroup(job_id: JobId) {
     let path = PathBuf::from(CGROUP_ROOT).join(format!("job_{}", job_id));
-    let _ = std::fs::remove_dir(&path);
+    if path.exists() {
+        cleanup_cgroup(&path);
+    }
 }
 
 /// Join the calling process to a cgroup (its pid → `cgroup.procs`). Runs post-fork

--- a/tests/native_host/e2e/test_cancel_sweep.py
+++ b/tests/native_host/e2e/test_cancel_sweep.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E test: cancelling an allocation sweeps its job cgroup (issue #799).
+
+A process left running inside the allocation's cgroup (a step that backgrounds
+work, or an adopted session) must be killed when the allocation ends, without
+depending on a site-configured epilog.
+"""
+
+import time
+
+import pytest
+
+from conftest import _deploy_cluster
+
+pytestmark = pytest.mark.rootful
+
+
+@pytest.fixture
+def rootful_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
+    fstype = ssh_nodes[0].exec_allow_fail("stat -fc %T /sys/fs/cgroup").strip()
+    if "cgroup2fs" not in fstype:
+        pytest.skip("node 0 is not cgroup v2")
+    c = _deploy_cluster(ssh_nodes, remote_bin_dir, agent_as_root=True,
+                        config_overrides=cluster_config_overrides)
+    try:
+        yield c
+    finally:
+        c.teardown()
+
+
+class TestCancelSweep:
+    def test_cancel_kills_residual_cgroup_process(self, rootful_cluster):
+        c = rootful_cluster
+        # A step backgrounds a process that outlives it; it stays in the
+        # allocation cgroup. When salloc exits the allocation is cancelled.
+        c.nodes[0].exec_allow_fail("pkill -x sleep")
+        c.salloc_run(
+            'srun bash -c "setsid sleep 300 </dev/null >/dev/null 2>&1 &"\n'
+        )
+        deadline = time.time() + 15
+        leftover = "x"
+        while time.time() < deadline:
+            leftover = c.nodes[0].exec_allow_fail("pgrep -x sleep || true").strip()
+            if not leftover:
+                break
+            time.sleep(1)
+        assert not leftover, f"cancel left a residual cgroup process:\n{leftover}"


### PR DESCRIPTION
## Summary
Job teardown only signalled processes spurd created (the launched process group / container subtree), so a process left running inside the allocation's cgroup survived cancellation and kept its device access on a node already back in the schedulable pool (issue #799). `hooks.epilog` defaults to `None`, so a site without a custom epilog got **no** sweep at all.

> **Stacked on #830** (base branch `users/powderluv/fix-802-step-cgroup`). #802 creates the cgroup on the interactive/step path; this PR makes teardown sweep it.

## Fix
Make the allocation teardown **reclaim the job cgroup**: SIGKILL every process still in it, then remove the directory — a default, config-free node-side sweep, reusing the same `cleanup_cgroup` the batch path already uses.

Note: an SSH session that was never *adopted* into the cgroup (the exact repro) is only fully covered once #782 places sessions into it; this PR is the default sweep the issue asks for, and it kills adopted sessions and any residual step/interactive descendants.

## Testing
E2E (rootful): a process backgrounded inside a step's cgroup is gone after the allocation is cancelled.

Closes #799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
