### PR TITLE
feat: adopt compute-node SSH sessions into the allocation (pam_exec)

### DIFF
--- a/crates/spur-cli/src/adopt.rs
+++ b/crates/spur-cli/src/adopt.rs
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `spur adopt` — pam_exec helper that adopts a compute-node SSH session into
+//! the allocation its user holds on the node.
+//!
+//! Wire it into sshd's PAM stack, e.g.:
+//!
+//! ```text
+//! account  optional  pam_exec.so          /usr/bin/spur adopt
+//! session  optional  pam_exec.so seteuid  /usr/bin/spur adopt
+//! ```
+//!
+//! pam_exec runs this once per phase and passes `PAM_USER` / `PAM_TYPE` in the
+//! environment. Behaviour by phase:
+//!
+//! - `account` — admission. When `SPUR_REQUIRE_ALLOCATION=1` is set on the
+//!   pam line, refuse (exit non-zero) a user who holds no allocation on this
+//!   node; otherwise always permit. Off by default so unadopted sessions keep
+//!   working where site policy allows them.
+//! - `open_session` — adoption. Join the session's process to the allocation's
+//!   cgroup so it is under the job's resource control and is swept when the
+//!   allocation ends (#799). The job environment is written to stdout as
+//!   `export` lines for a wrapper to apply (pam_exec cannot set session env
+//!   itself).
+//!
+//! Answered by the local agent's `AdoptSession` RPC. Best-effort: any error in
+//! the session phase is logged and ignored so a transient fault never locks a
+//! user out of a node.
+
+use anyhow::{Context, Result};
+use spur_proto::proto::AdoptSessionRequest;
+
+/// Where the local node agent listens; override for testing.
+fn agent_addr() -> String {
+    std::env::var("SPUR_AGENT_ADDR").unwrap_or_else(|_| "http://127.0.0.1:6818".to_string())
+}
+
+fn uid_for_user(user: &str) -> Option<u32> {
+    // Numeric PAM_USER, or resolve the name via NSS.
+    if let Ok(uid) = user.parse::<u32>() {
+        return Some(uid);
+    }
+    let cuser = std::ffi::CString::new(user).ok()?;
+    let pw = unsafe { libc::getpwnam(cuser.as_ptr()) };
+    if pw.is_null() {
+        None
+    } else {
+        Some(unsafe { (*pw).pw_uid })
+    }
+}
+
+pub async fn main_with_args(_args: Vec<String>) -> Result<()> {
+    let pam_type = std::env::var("PAM_TYPE").unwrap_or_default();
+    let pam_user = std::env::var("PAM_USER").unwrap_or_default();
+
+    // Only the account (admission) and open_session (adoption) phases act.
+    if pam_type != "account" && pam_type != "open_session" {
+        return Ok(());
+    }
+
+    let Some(uid) = uid_for_user(&pam_user) else {
+        // Cannot resolve the user: deny admission (fail closed), no-op adoption.
+        if pam_type == "account" && require_allocation() {
+            std::process::exit(1);
+        }
+        return Ok(());
+    };
+
+    let resp = match query_allocation(uid).await {
+        Ok(r) => r,
+        Err(e) => {
+            // Fail open on adoption; fail closed on admission only if required.
+            eprintln!("spur adopt: agent query failed: {e:#}");
+            if pam_type == "account" && require_allocation() {
+                std::process::exit(1);
+            }
+            return Ok(());
+        }
+    };
+
+    match pam_type.as_str() {
+        "account" if require_allocation() && !resp.has_allocation => {
+            eprintln!("spur adopt: {pam_user} holds no allocation on this node; access refused");
+            std::process::exit(1);
+        }
+        "open_session" if resp.has_allocation => adopt_into(&resp),
+        _ => {}
+    }
+    Ok(())
+}
+
+fn require_allocation() -> bool {
+    matches!(
+        std::env::var("SPUR_REQUIRE_ALLOCATION").ok().as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
+}
+
+async fn query_allocation(uid: u32) -> Result<spur_proto::proto::AdoptSessionResponse> {
+    let mut agent = crate::interactive::connect_agent(&agent_addr())
+        .await
+        .context("connect to local agent")?;
+    let resp = agent
+        .adopt_session(AdoptSessionRequest { uid })
+        .await
+        .context("AdoptSession RPC")?
+        .into_inner();
+    Ok(resp)
+}
+
+/// Join the session into the job cgroup and emit the job environment.
+fn adopt_into(resp: &spur_proto::proto::AdoptSessionResponse) {
+    // Move the session's process (pam_exec's parent — the sshd session leader)
+    // into the job cgroup; its shell inherits the membership.
+    if !resp.cgroup_path.is_empty() {
+        let procs = std::path::Path::new(&resp.cgroup_path).join("cgroup.procs");
+        let ppid = unsafe { libc::getppid() };
+        if let Err(e) = std::fs::write(&procs, ppid.to_string()) {
+            eprintln!("spur adopt: could not join cgroup {}: {e}", procs.display());
+        }
+    }
+
+    // pam_exec does not propagate our environment to the session, so emit the
+    // job env as shell `export` lines for a wrapper (or a sourced rc) to apply.
+    let mut keys: Vec<&String> = resp.environment.keys().collect();
+    keys.sort();
+    for k in keys {
+        if let Some(v) = resp.environment.get(k) {
+            println!("export {}={}", k, shell_quote(v));
+        }
+    }
+}
+
+fn shell_quote(v: &str) -> String {
+    if v.is_empty() {
+        return "''".to_string();
+    }
+    if v.bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.' | b'/' | b':' | b','))
+    {
+        v.to_string()
+    } else {
+        format!("'{}'", v.replace('\'', r"'\''"))
+    }
+}

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod adopt;
 mod authclient;
 mod env_defaults;
 mod exec;
@@ -184,7 +185,7 @@ fn main() -> anyhow::Result<()> {
         "sbatch" | "srun" | "squeue" | "scancel" | "sinfo" | "sacct" | "sacctmgr" | "scontrol"
         | "sprio" | "sshare" | "sstat" | "sdiag" | "sreport" | "strigger" | "sattach"
         | "scrontab" | "smd" => Some(args[1].as_str()),
-        "net" | "node" | "k8s" | "image" | "exec" | "token" => Some(args[1].as_str()),
+        "net" | "node" | "k8s" | "image" | "exec" | "token" | "adopt" => Some(args[1].as_str()),
         _ => None,
     };
 
@@ -238,6 +239,7 @@ fn main() -> anyhow::Result<()> {
             "image" => runtime.block_on(image::main_with_args(rewritten)),
             "exec" => runtime.block_on(exec::main_with_args(rewritten)),
             "token" => runtime.block_on(token::main_with_args(rewritten)),
+            "adopt" => runtime.block_on(adopt::main_with_args(rewritten)),
             _ => unreachable!(),
         };
         return result;

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2602,6 +2602,81 @@ impl SlurmAgent for AgentService {
         Ok(Response::new(ReceiverStream::new(rx)))
     }
 
+    async fn adopt_session(
+        &self,
+        request: Request<AdoptSessionRequest>,
+    ) -> Result<Response<AdoptSessionResponse>, Status> {
+        Self::require_controller(&request)?;
+        let uid = request.into_inner().uid;
+
+        // The allocation this uid holds on this node. Deterministic when several
+        // exist: the lowest job_id (an explicit override can come later).
+        let alloc = {
+            let jobs = self.running.lock().await;
+            jobs.iter()
+                .filter(|(_, t)| t.uid == uid)
+                .min_by_key(|(id, _)| **id)
+                .map(|(id, t)| {
+                    (
+                        *id,
+                        t.gid,
+                        t.gpu_devices.clone(),
+                        t.partition.clone(),
+                        t.nodelist.clone(),
+                        t.cpus,
+                        t.memory_mb,
+                    )
+                })
+        };
+
+        let Some((job_id, gid, gpu_devices, partition, nodelist, cpus, memory_mb)) = alloc else {
+            return Ok(Response::new(AdoptSessionResponse {
+                has_allocation: false,
+                ..Default::default()
+            }));
+        };
+
+        // GPU visibility + job env the adopted session should carry, matching
+        // what a step in the allocation sees.
+        let mut gpu_env = if gpu_devices.is_empty() {
+            HashMap::new()
+        } else {
+            self.device_registry
+                .lock()
+                .await
+                .build_job_injection_plans("gpu", &gpu_devices, uid, gid)
+                .map(|(host, _)| host.env)
+                .unwrap_or_default()
+        };
+        maybe_deny_gpu_env(&mut gpu_env, &gpu_devices);
+
+        let mut senv = SpurEnv::new();
+        senv.extend(&gpu_env);
+        senv.set_with_slurm_twin("SPUR_JOB_ID", job_id);
+        senv.set_with_slurm_twin("SPUR_JOBID", job_id);
+        senv.set_with_slurm_twin("SPUR_JOB_PARTITION", &partition);
+        senv.set_with_slurm_twin("SPUR_NODELIST", &nodelist);
+        senv.set_with_slurm_twin("SPUR_JOB_NODELIST", &nodelist);
+        senv.set_with_slurm_twin("SPUR_CPUS_ON_NODE", cpus);
+
+        // Ensure the allocation cgroup exists (a bare salloc may have run no step
+        // yet) so the session has a target to join. Empty when enforcement is off.
+        let cgroup_path = crate::executor::setup_step_cgroup(job_id, &self.cgroup, cpus, memory_mb)
+            .map(|_| {
+                crate::executor::job_cgroup_dir(job_id)
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .unwrap_or_default();
+
+        Ok(Response::new(AdoptSessionResponse {
+            has_allocation: true,
+            job_id,
+            cgroup_path,
+            environment: senv.into_map(),
+        }))
+    }
+
     async fn interactive_session(
         &self,
         request: Request<tonic::Streaming<InteractiveInput>>,
@@ -4140,6 +4215,40 @@ mod tests {
             .expect_err("a non-owner must not exec inside another user's job");
 
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn adopt_session_resolves_the_uids_allocation() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let job_id = 88;
+        svc.insert_test_job(job_id, TrackedJob::dummy(std::process::id()))
+            .await;
+
+        // The owner's uid (TrackedJob::dummy uses uid 0) finds the allocation.
+        let resp = svc
+            .adopt_session(Request::new(AdoptSessionRequest { uid: 0 }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp.has_allocation);
+        assert_eq!(resp.job_id, job_id);
+        assert_eq!(
+            resp.environment.get("SPUR_JOB_ID").map(String::as_str),
+            Some("88")
+        );
+
+        // A uid with no allocation on this node gets nothing to adopt into.
+        let none = svc
+            .adopt_session(Request::new(AdoptSessionRequest { uid: 4242 }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(!none.has_allocation);
     }
 
     #[tokio::test]

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1116,13 +1116,18 @@ pub(crate) fn setup_step_cgroup(
 
 /// Remove a job's cgroup directory once its allocation ends (best-effort). The
 /// directory removes only when empty, so this is a no-op while processes remain.
+/// The job's cgroup directory (whether or not it currently exists).
+pub(crate) fn job_cgroup_dir(job_id: JobId) -> PathBuf {
+    PathBuf::from(CGROUP_ROOT).join(format!("job_{}", job_id))
+}
+
 /// Reclaim a job's cgroup when its allocation ends: SIGKILL any process still in
 /// it, then remove the directory. This is the default node-side teardown for
 /// residual processes of a released allocation (an interactive/step child, or —
 /// once sessions are adopted — a debug SSH session), independent of any
 /// site-configured epilog. A no-op when the cgroup was never created.
 pub(crate) fn reclaim_job_cgroup(job_id: JobId) {
-    let path = PathBuf::from(CGROUP_ROOT).join(format!("job_{}", job_id));
+    let path = job_cgroup_dir(job_id);
     if path.exists() {
         cleanup_cgroup(&path);
     }

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -477,6 +477,9 @@ service SlurmAgent {
   rpc StreamJobOutput(StreamJobOutputRequest) returns (stream StreamJobOutputChunk);
   // PTY-backed interactive session (srun --pty, sattach, srun --overlap --pty)
   rpc InteractiveSession(stream InteractiveInput) returns (stream InteractiveOutput);
+  // Whether a uid holds an allocation on this node, and how to adopt an SSH
+  // session into it (pam session adoption / admission). Answered locally.
+  rpc AdoptSession(AdoptSessionRequest) returns (AdoptSessionResponse);
 
   // -- Native cluster component control: the controller drives each node's
   //    spurd-owned k0s systemd unit through these. --
@@ -1248,6 +1251,18 @@ message RegisterJobAllocationRequest {
 }
 
 message RegisterJobAllocationResponse {}
+
+// Adopt an SSH session on this node into the allocation its user holds.
+message AdoptSessionRequest {
+  uint32 uid = 1;  // the local user whose session should be adopted
+}
+
+message AdoptSessionResponse {
+  bool has_allocation = 1;  // whether the uid holds an allocation on this node
+  uint32 job_id = 2;        // the chosen allocation (deterministic across calls)
+  string cgroup_path = 3;   // /sys/fs/cgroup/spur/job_<id> to join; empty if not confined
+  map<string, string> environment = 4;  // GPU visibility + SPUR_*/SLURM_* to export
+}
 
 message RunCommandResponse {
   int32 exit_code = 1;

--- a/tests/native_host/e2e/test_session_adoption.py
+++ b/tests/native_host/e2e/test_session_adoption.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E test: `spur adopt` pam_exec helper (issue #782).
+
+Adoption places a session belonging to a user who holds an allocation into the
+job cgroup and emits the job environment; admission (opt-in) refuses a user who
+holds none.
+"""
+
+import threading
+import time
+
+import pytest
+
+from conftest import _deploy_cluster
+
+pytestmark = pytest.mark.rootful
+
+
+@pytest.fixture
+def rootful_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
+    fstype = ssh_nodes[0].exec_allow_fail("stat -fc %T /sys/fs/cgroup").strip()
+    if "cgroup2fs" not in fstype:
+        pytest.skip("node 0 is not cgroup v2")
+    c = _deploy_cluster(ssh_nodes, remote_bin_dir, agent_as_root=True,
+                        config_overrides=cluster_config_overrides)
+    try:
+        yield c
+    finally:
+        c.teardown()
+
+
+class TestSessionAdoption:
+    def test_adopt_admission_and_environment(self, rootful_cluster):
+        c = rootful_cluster
+        node = c.nodes[0]
+        owner_uid = node.exec_allow_fail("id -u").strip()
+        spur = f"{c.bin_dir}/spur"
+        job_name = "adopt-test"
+
+        def hold():
+            c.salloc_run("sleep 30\n",
+                         salloc_args=["-N", "1", "-J", job_name, "-t", "0:05"])
+
+        t = threading.Thread(target=hold, daemon=True)
+        t.start()
+        try:
+            jid = None
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                ids = c.running_job_ids_by_name(job_name)
+                if ids:
+                    jid = ids[0]
+                    break
+                time.sleep(1)
+            assert jid is not None, "allocation never reached running"
+
+            # Admission: the owner holds an allocation -> permitted (exit 0).
+            rc = node.exec_allow_fail(
+                f"PAM_TYPE=account PAM_USER={owner_uid} SPUR_REQUIRE_ALLOCATION=1 "
+                f"{spur} adopt; echo RC=$?"
+            )
+            assert "RC=0" in rc, rc
+
+            # Admission: a uid with no allocation -> refused (exit 1).
+            rc = node.exec_allow_fail(
+                f"PAM_TYPE=account PAM_USER=99991 SPUR_REQUIRE_ALLOCATION=1 "
+                f"{spur} adopt; echo RC=$?"
+            )
+            assert "RC=1" in rc, rc
+
+            # Adoption: open_session emits the job env.
+            env_out = node.exec_allow_fail(
+                f"PAM_TYPE=open_session PAM_USER={owner_uid} {spur} adopt 2>/dev/null"
+            )
+            assert f"SPUR_JOB_ID={jid}" in env_out, env_out
+
+            # Adoption: the session process joins the job cgroup. pam_exec's
+            # session hook runs as root, so simulate that with sudo; the sudo
+            # shell is the helper's parent and must land in /spur/job_<id>.
+            cg_out = node.exec_allow_fail(
+                f"sudo bash -c 'PAM_TYPE=open_session PAM_USER={owner_uid} "
+                f"{spur} adopt >/dev/null 2>&1; cat /proc/$$/cgroup'"
+            )
+            assert f"/spur/job_{jid}" in cg_out, cg_out
+        finally:
+            if jid is not None:
+                c.scancel(str(jid))
+            t.join(timeout=10)


### PR DESCRIPTION
## Summary
A compute-node SSH session had no relationship to the jobs its user held there — no resource control, no job environment, no teardown, and admission decided by per-node sshd config rather than by holding an allocation (issue #782). There was also no node RPC that could answer the question an adoption module must ask.

> **Stacked on #831 → #830 (#799 → #802).** Adoption needs a per-job cgroup (#802) and is swept at allocation end (#799).

## What's added
- **`AdoptSession` RPC (agent)** — given a uid: whether it holds an allocation on this node, the job cgroup to join (ensured to exist), and the GPU/job environment. Deterministic when several allocations exist (lowest job id).
- **`spur adopt` pam_exec helper**, wired into sshd's PAM stack:
  ```
  account  optional  pam_exec.so          /usr/bin/spur adopt
  session  optional  pam_exec.so seteuid  /usr/bin/spur adopt
  ```
  - **account = admission**: with `SPUR_REQUIRE_ALLOCATION=1` on the pam line, refuse a user who holds no allocation (**opt-in**, off by default — unadopted sessions keep working where site policy allows).
  - **open_session = adoption**: join the session's process to the job cgroup (resource control + swept at allocation end via #799) and emit the job env.

## Mechanism/scope decisions (per the issue)
- **pam_exec helper** (not a C PAM module or a `spur ssh` wrapper): portable, no cdylib, works with stock sshd, covers scp/rsync/sftp/forwarding.
- **Adoption + admission together**, admission opt-in.

## Testing
- Unit test for the RPC resolution.
- E2E (rootful): admission (owner permitted, non-owner refused), env emission, and cgroup join.

## Known limitation
pam_exec cannot set the session's environment itself, so the job env is emitted as `export` lines for a wrapper/sourced rc to apply; the cgroup confinement and admission (the security-relevant parts) work directly. A native PAM module would be needed to inject env into the session in-process — a possible follow-up.

Closes #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
