### PR TITLE
feat(spurd): containerized srun steps on bare-metal nodes

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -47,6 +47,7 @@ PBS
 PMI
 PMIX
 PostgreSQL
+Pyxis
 preempt
 preemption
 preemptable
@@ -63,6 +64,7 @@ requeue
 requeued
 requeues
 rollout
+rootfs
 rlimit
 rlimits
 ROCm

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -223,7 +223,7 @@ pub struct SbatchArgs {
     #[arg(long, overrides_with = "container_name")]
     pub container_name: Option<String>,
 
-    /// Read-only container rootfs
+    /// Read-only container rootfs (not yet implemented; rejected at submission)
     #[arg(long, overrides_with = "container_readonly")]
     pub container_readonly: bool,
 
@@ -235,7 +235,7 @@ pub struct SbatchArgs {
     #[arg(long)]
     pub container_env: Vec<String>,
 
-    /// Override container entrypoint
+    /// Shell command run inside the container before the job script
     #[arg(long, overrides_with = "container_entrypoint")]
     pub container_entrypoint: Option<String>,
 
@@ -830,6 +830,12 @@ fn build_sbatch_job_spec(
     if is_wrap && !args.script_args.is_empty() {
         bail!("sbatch: script arguments may not be used with --wrap");
     }
+    if args.container_readonly {
+        bail!(
+            "--container-readonly is not yet implemented; the container root would be \
+             writable despite the flag. Omit it rather than rely on a read-only rootfs."
+        );
+    }
     let stdin_is_terminal = std::io::IsTerminal::is_terminal(&std::io::stdin());
     let script = match choose_body_source(args.wrap.take(), args.script.clone(), stdin_is_terminal)?
     {
@@ -1122,6 +1128,21 @@ mod tests {
         assert_eq!(
             spec.submit_line,
             "sbatch -w node1 --exclusive --wrap hostname"
+        );
+    }
+
+    /// --container-readonly is a no-op in the runtime today, so it is refused at
+    /// submission rather than silently ignored (the #777-class failure mode).
+    #[test]
+    fn build_sbatch_job_spec_rejects_container_readonly() {
+        let argv = ["sbatch", "--container-readonly", "--wrap", "hostname"].map(String::from);
+        let args = resolve_sbatch_args(&[], &argv).expect("args");
+        let line = crate::submitline::render(&argv);
+        let err = build_sbatch_job_spec(args, None, &line).expect_err("readonly must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("--container-readonly") && msg.contains("not yet implemented"),
+            "expected a not-yet-implemented rejection, got: {msg}"
         );
     }
 

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -9,9 +9,9 @@ use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
 use spur_core::config::HooksConfig;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
-    CancelJobRequest, CompleteJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest,
-    JobSpec, JobState, RunStepRequest, StreamJobOutputChunk, StreamJobOutputRequest,
-    SubmitJobRequest,
+    CancelJobRequest, CompleteJobRequest, ContainerSpec, CreateJobStepRequest, GetJobRequest,
+    GetNodeRequest, JobSpec, JobState, RunStepRequest, StreamJobOutputChunk,
+    StreamJobOutputRequest, SubmitJobRequest,
 };
 use std::collections::HashMap;
 use std::io::Write as _;
@@ -159,6 +159,14 @@ pub struct SrunArgs {
     #[arg(long)]
     pub container_workdir: Option<String>,
 
+    /// Named container (persists across steps in an allocation)
+    #[arg(long)]
+    pub container_name: Option<String>,
+
+    /// Read-only container rootfs (not yet implemented; rejected at submission)
+    #[arg(long)]
+    pub container_readonly: bool,
+
     /// Mount user home directory in container
     #[arg(long)]
     pub container_mount_home: bool,
@@ -166,6 +174,10 @@ pub struct SrunArgs {
     /// Set environment variable inside container (KEY=VAL)
     #[arg(long)]
     pub container_env: Vec<String>,
+
+    /// Shell command run inside the container before the job script
+    #[arg(long)]
+    pub container_entrypoint: Option<String>,
 
     /// Remap user to root inside container
     #[arg(long)]
@@ -215,6 +227,13 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     if args.jobid.is_some() && !args.overlap {
         anyhow::bail!("--jobid requires --overlap");
+    }
+
+    if args.container_readonly {
+        anyhow::bail!(
+            "--container-readonly is not yet implemented; the container root would be \
+             writable despite the flag. Omit it rather than rely on a read-only rootfs."
+        );
     }
 
     resolve_srun_env(&matches, &mut args)?;
@@ -608,6 +627,8 @@ fn build_srun_job_spec(
         container_image: args.container_image.clone().unwrap_or_default(),
         container_mounts: args.container_mounts.clone(),
         container_workdir: args.container_workdir.clone().unwrap_or_default(),
+        container_name: args.container_name.clone().unwrap_or_default(),
+        container_readonly: args.container_readonly,
         container_mount_home: args.container_mount_home,
         container_env: args
             .container_env
@@ -617,10 +638,41 @@ fn build_srun_job_spec(
                     .map(|(k, v)| (k.to_string(), v.to_string()))
             })
             .collect(),
+        container_entrypoint: args.container_entrypoint.clone().unwrap_or_default(),
         container_remap_root: args.container_remap_root,
         srun_job: true,
         pty: args.pty,
         ..Default::default()
+    })
+}
+
+/// Build the step's `ContainerSpec` from srun's container flags. Returns `None`
+/// when no image is requested, so the step inherits the parent job's container
+/// config (or runs on the host). srun does not surface name/readonly/entrypoint.
+fn container_spec_from_srun_args(args: &SrunArgs) -> Option<ContainerSpec> {
+    let image = args.container_image.clone()?;
+    if image.is_empty() {
+        return None;
+    }
+    Some(ContainerSpec {
+        image,
+        mounts: args.container_mounts.clone(),
+        workdir: args.container_workdir.clone().unwrap_or_default(),
+        name: args.container_name.clone().unwrap_or_default(),
+        // --container-readonly is rejected at submission (a no-op today), so it
+        // never reaches here as true.
+        readonly: false,
+        mount_home: args.container_mount_home,
+        env: args
+            .container_env
+            .iter()
+            .filter_map(|s| {
+                s.split_once('=')
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+            })
+            .collect(),
+        entrypoint: args.container_entrypoint.clone().unwrap_or_default(),
+        remap_root: args.container_remap_root,
     })
 }
 
@@ -803,6 +855,7 @@ async fn dispatch_step(
             label: args.label,
             mpi: step_mpi.to_string(),
             user: params.user.to_string(),
+            container: container_spec_from_srun_args(args),
         })
         .await
         .context("RunStep dispatch failed")?
@@ -2450,6 +2503,25 @@ mod tests {
         assert!(
             msg.contains("--overlap"),
             "expected --overlap error, got: {msg}"
+        );
+    }
+
+    /// --container-readonly is a no-op in the runtime today, so it is refused at
+    /// submission rather than silently ignored (the #777-class failure mode).
+    #[tokio::test]
+    async fn container_readonly_is_rejected() {
+        let result = main_with_args(vec![
+            "srun".into(),
+            "--container-image=img.sqsh".into(),
+            "--container-readonly".into(),
+            "hostname".into(),
+        ])
+        .await;
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("--container-readonly") && msg.contains("not yet implemented"),
+            "expected a not-yet-implemented rejection, got: {msg}"
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2768,6 +2768,22 @@ impl SlurmController for ControllerService {
         let label = req.label;
         let job_mpi = job.spec.mpi.as_deref().unwrap_or(spur_core::mpi::MPI_NONE);
         let mpi = spur_core::mpi::resolve_step_mpi(req.mpi.as_str(), job_mpi).to_string();
+        // Effective container for the step: the step's own ContainerSpec when it
+        // set one (srun --container-image), otherwise inherit the parent job's
+        // container config (sbatch --container-image). When the step overrides,
+        // its env is merged over the job's container env (step-wins) so setting
+        // one step variable doesn't silently drop the job's container env.
+        let step_container = match req.container.clone().filter(|c| !c.image.is_empty()) {
+            Some(mut step) => {
+                if let Some(parent) = container_spec_from_job_spec(&job.spec) {
+                    let mut env = parent.env;
+                    env.extend(step.env);
+                    step.env = env;
+                }
+                Some(step)
+            }
+            None => container_spec_from_job_spec(&job.spec),
+        };
         let pmix_tmpdir = self.cluster.config().mpi.pmix_tmpdir.clone();
         let modex_connect_timeout_secs = self.cluster.config().mpi.modex_connect_timeout_secs;
         let modex_fence_timeout_secs = self.cluster.config().mpi.modex_fence_timeout_secs;
@@ -2937,6 +2953,7 @@ impl SlurmController for ControllerService {
             let work_dir = work_dir.clone();
             let environment = environment.clone();
             let step_mpi = mpi.clone();
+            let container = step_container.clone();
             set.spawn(async move {
                 let mut agent = crate::agent_client::connect(agent_addr.clone())
                     .await
@@ -2962,6 +2979,7 @@ impl SlurmController for ControllerService {
                         pmix_plan,
                         mpi: step_mpi.clone(),
                         pmix_prepared: needs_pmix_prepare,
+                        container,
                     })
                     .await
                     .map_err(|e| {
@@ -3606,6 +3624,24 @@ pub async fn serve(
 
 /// Resolve the target node for a job step. Empty = first allocated (legacy
 /// default); a named node must be one the job holds, else it targets outside it.
+/// Build a step `ContainerSpec` from a parent job's container config, so a
+/// nested `srun` (or one that omits `--container-image`) inherits the job's
+/// container. Returns `None` when the job has no container image.
+fn container_spec_from_job_spec(spec: &spur_core::job::JobSpec) -> Option<ContainerSpec> {
+    let image = spec.container_image.clone().filter(|s| !s.is_empty())?;
+    Some(ContainerSpec {
+        image,
+        mounts: spec.container_mounts.clone(),
+        workdir: spec.container_workdir.clone().unwrap_or_default(),
+        name: spec.container_name.clone().unwrap_or_default(),
+        readonly: spec.container_readonly,
+        mount_home: spec.container_mount_home,
+        env: spec.container_env.clone(),
+        entrypoint: spec.container_entrypoint.clone().unwrap_or_default(),
+        remap_root: spec.container_remap_root,
+    })
+}
+
 fn select_step_node<'a>(allocated: &'a [String], requested: &str) -> Result<&'a str, String> {
     if requested.is_empty() {
         return allocated

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -196,10 +196,20 @@ fn start_pmix_launch(
     Ok((guard, plan, per_local_rank_env))
 }
 
+/// Monotonic, never-reused id stamped on each `ActiveStep`. The delayed SIGKILL
+/// escalation compares epochs (not pids) so it can never signal a recycled pid
+/// belonging to a different step that reused the same (job_id, step_id) key.
+static STEP_EPOCH: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+fn next_step_epoch() -> u64 {
+    STEP_EPOCH.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
 #[derive(Debug, Default)]
 struct ActiveStep {
     cancel_requested: bool,
     pid: Option<u32>,
+    epoch: u64,
     /// Spool files the step's stdout/stderr are redirected to, so
     /// `stream_job_output` can tail them live keyed on (job_id, step_id).
     stdout_path: String,
@@ -227,19 +237,32 @@ fn cancelled_step_response() -> RunCommandResponse {
     }
 }
 
-fn signal_step_process_group(pid: u32, signal: i32) {
+/// Signal a step's whole workload. The tracked pid may be an intermediate
+/// parent (a containerized step runs the workload as a grandchild that is PID 1
+/// of its own PID namespace), so a single `kill` on it never reaches the real
+/// process. It walks the `/proc` descendant tree first (before the group signal
+/// can reparent/reap children and empty `/proc/<pid>/children`), then signals
+/// the process group (host steps are group leaders, so this also covers a
+/// double-forked descendant that reparented out of the `/proc` tree).
+/// Best-effort; warns only when the tracked pid cannot be signalled at all.
+fn signal_step_tree(pid: u32, signal: i32) {
     let sig =
         nix::sys::signal::Signal::try_from(signal).unwrap_or(nix::sys::signal::Signal::SIGTERM);
-    let leader = nix::unistd::Pid::from_raw(pid as i32);
-    if let Err(e) = nix::sys::signal::killpg(leader, sig) {
-        if let Err(kill_err) = nix::sys::signal::kill(leader, Some(sig)) {
-            warn!(
-                pid,
-                signal,
-                killpg = %e,
-                kill = %kill_err,
-                "step process group signal failed (step may already have exited)"
-            );
+    let target = nix::unistd::Pid::from_raw(pid as i32);
+    crate::executor::kill_process_tree(pid as i32, sig);
+    if let Err(pg_err) = nix::sys::signal::killpg(target, sig) {
+        // Not a group leader (a container fork), or already gone. Fall back to
+        // the tracked pid so an unsignalable step still surfaces a warning.
+        if let Err(e) = nix::sys::signal::kill(target, Some(sig)) {
+            if e != nix::errno::Errno::ESRCH {
+                warn!(
+                    pid,
+                    signal,
+                    killpg = %pg_err,
+                    kill = %e,
+                    "failed to signal step (it may already have exited)"
+                );
+            }
         }
     }
 }
@@ -314,6 +337,253 @@ async fn step_cancel_requested(
         .await
         .get(&key)
         .is_some_and(|step| step.cancel_requested)
+}
+
+/// Spawn a command, register its PID for cancellation, wait for output.
+/// Shared by the nsenter (Case 1) and plain-host (Case 3) step dispatch paths.
+/// Spawn a tokio step command with stdout/stderr redirected to the per-step
+/// spool files (so `stream_job_output` can tail them live), register its pid for
+/// cancellation, and wait. Returns `Ok(None)` if the step was cancelled before
+/// it could run. Shared by the nsenter (Case 1) and plain-host (Case 3) paths.
+async fn run_tokio_step_to_spool(
+    mut cmd: tokio::process::Command,
+    step_files: crate::executor::StepOutputFiles,
+    active_steps: &Arc<Mutex<HashMap<(u32, u32), ActiveStep>>>,
+    step_key: (u32, u32),
+) -> Result<Option<std::process::ExitStatus>, Status> {
+    use std::process::Stdio;
+    let mut child = cmd
+        .stdout(Stdio::from(step_files.stdout))
+        .stderr(Stdio::from(step_files.stderr))
+        .spawn()
+        .map_err(|e| Status::internal(format!("step command failed to spawn: {e}")))?;
+
+    if let Some(pid) = child.id() {
+        let cancel_now = {
+            let mut steps = active_steps.lock().await;
+            if let Some(step) = steps.get_mut(&step_key) {
+                step.pid = Some(pid);
+                step.cancel_requested
+            } else {
+                false
+            }
+        };
+        if cancel_now {
+            signal_step_tree(pid, nix::sys::signal::Signal::SIGTERM as i32);
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Ok(None);
+        }
+    }
+
+    match child.wait().await {
+        Ok(status) => Ok(Some(status)),
+        Err(e) => Err(Status::internal(format!("step command failed: {e}"))),
+    }
+}
+
+/// Launch a step command inside a fresh container rootfs, wiring the step's
+/// stdout/stderr to the per-step spool files (so `stream_job_output` can tail
+/// them live), matching the non-container step path. Used for standalone
+/// `srun --container-image` steps where the parent job is not itself
+/// containerized. Returns `Ok(None)` if the step was cancelled before it ran.
+// A fork/exec helper — each input is a distinct piece of the child's context.
+#[allow(clippy::too_many_arguments)]
+async fn run_containerized_step(
+    container_cfg: crate::container::ContainerConfig,
+    rootfs: std::path::PathBuf,
+    script_path: String,
+    env: HashMap<String, String>,
+    step_files: crate::executor::StepOutputFiles,
+    active_steps: &Arc<Mutex<HashMap<(u32, u32), ActiveStep>>>,
+    step_key: (u32, u32),
+    memlock: spur_core::config::MemlockLimit,
+) -> Result<Option<std::process::ExitStatus>, Status> {
+    use std::os::fd::AsRawFd;
+
+    // Sync pipe: child signals readiness (or error) after container_init.
+    let (ready_r, ready_w) =
+        nix::unistd::pipe().map_err(|e| Status::internal(format!("pipe failed: {e}")))?;
+    nix::fcntl::fcntl(
+        &ready_r,
+        nix::fcntl::FcntlArg::F_SETFD(nix::fcntl::FdFlag::FD_CLOEXEC),
+    )
+    .ok();
+
+    let ready_r_fd = ready_r.as_raw_fd();
+    let ready_w_fd = ready_w.as_raw_fd();
+    // Raw fds of the spool files the step's stdout/stderr are redirected to.
+    let stdout_fd = step_files.stdout.as_raw_fd();
+    let stderr_fd = step_files.stderr.as_raw_fd();
+
+    let rootfs_clone = rootfs.clone();
+    // Start from the image's own config.Env (as `docker run` does and as the
+    // batch container path does), with the job environment layered on top; read
+    // from the rootfs before the fork. Keeps a containerized step consistent with
+    // a containerized batch job (e.g. tools on the image's PATH resolve).
+    let env_clone = spur_net::oci::container_base_env(&rootfs, env);
+    let container_env = container_cfg.container_env.clone();
+    let entrypoint = container_cfg.entrypoint.clone();
+    let script_path_clone = script_path.clone();
+
+    // Reject NUL bytes before forking: a NUL would otherwise degrade the child's
+    // exec to `bash -c ""`, which exits 0 and reports a step that never ran as a
+    // success.
+    for s in [Some(script_path_clone.as_str()), entrypoint.as_deref()]
+        .into_iter()
+        .flatten()
+    {
+        if s.as_bytes().contains(&0) {
+            return Err(Status::invalid_argument(
+                "container entrypoint or step command contains a NUL byte",
+            ));
+        }
+    }
+
+    match unsafe { nix::unistd::fork().map_err(|e| Status::internal(format!("fork failed: {e}")))? }
+    {
+        nix::unistd::ForkResult::Child => {
+            // === CHILD PROCESS — synchronous only ===
+            drop(ready_r);
+
+            unsafe {
+                libc::signal(libc::SIGCHLD, libc::SIG_DFL);
+                libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+                // Wire stdout/stderr to the per-step spool files.
+                libc::dup2(stdout_fd, libc::STDOUT_FILENO);
+                libc::dup2(stderr_fd, libc::STDERR_FILENO);
+            }
+
+            crate::container::close_inherited_fds(ready_w_fd);
+
+            executor::apply_memlock(memlock);
+
+            let hook_env = match crate::container::container_init(&container_cfg, &rootfs_clone) {
+                Ok(env) => env,
+                Err(e) => {
+                    let msg = format!("E:{e:#}");
+                    unsafe {
+                        libc::write(ready_w_fd, msg.as_ptr() as *const _, msg.len());
+                    }
+                    std::process::exit(1);
+                }
+            };
+
+            unsafe { libc::write(ready_w_fd, b"OK".as_ptr() as *const _, 2) };
+            drop(ready_w);
+
+            let mut final_env = env_clone;
+            for (k, v) in &container_env {
+                final_env.insert(k.clone(), v.clone());
+            }
+            for (k, v) in hook_env {
+                final_env.insert(k, v);
+            }
+
+            // Probe for a shell in the image (busybox/alpine has no /bin/bash),
+            // matching the batch path in executor.rs.
+            let shell = if std::path::Path::new("/bin/bash").exists() {
+                "/bin/bash"
+            } else {
+                "/bin/sh"
+            };
+            let c_shell = std::ffi::CString::new(shell)
+                .unwrap_or_else(|_| std::ffi::CString::new("/bin/sh").unwrap());
+            // Honor --container-entrypoint, matching the batch path: run the
+            // entrypoint, then the step script, with the same shell. NUL bytes in
+            // these strings were rejected before fork, so CString::new cannot fail
+            // here in practice.
+            let argv: Vec<std::ffi::CString> = if let Some(ref ep) = entrypoint {
+                let cmd = format!("{ep} && {shell} {script_path_clone}");
+                vec![
+                    c_shell.clone(),
+                    std::ffi::CString::new("-c").unwrap_or_default(),
+                    std::ffi::CString::new(cmd).unwrap_or_default(),
+                ]
+            } else {
+                vec![
+                    c_shell.clone(),
+                    std::ffi::CString::new(script_path_clone.as_bytes()).unwrap_or_default(),
+                ]
+            };
+            let c_env: Vec<std::ffi::CString> = final_env
+                .iter()
+                .filter_map(|(k, v)| std::ffi::CString::new(format!("{k}={v}")).ok())
+                .collect();
+            let argv_refs: Vec<&std::ffi::CStr> = argv.iter().map(|s| s.as_c_str()).collect();
+            let env_refs: Vec<&std::ffi::CStr> = c_env.iter().map(|s| s.as_c_str()).collect();
+            let _ = nix::unistd::execve(&c_shell, &argv_refs, &env_refs);
+            // stderr is the step's spool file here; surface the failure like the
+            // batch path rather than exiting silently.
+            eprintln!(
+                "spur: execve {shell} failed: {}",
+                std::io::Error::last_os_error()
+            );
+            std::process::exit(127);
+        }
+        nix::unistd::ForkResult::Parent { child: child_pid } => {
+            // === PARENT ===
+            drop(ready_w);
+            // The spool-file fds belong to the child now; close our copies.
+            drop(step_files);
+
+            // Read the ready signal from the child.
+            let mut buf = [0u8; 256];
+            let n = unsafe { libc::read(ready_r_fd, buf.as_mut_ptr() as *mut _, buf.len()) };
+            drop(ready_r);
+            if n < 2 || &buf[..2] != b"OK" {
+                let msg = if n > 0 {
+                    String::from_utf8_lossy(&buf[..n.max(0) as usize]).to_string()
+                } else {
+                    "container init failed (no status)".to_string()
+                };
+                let _ = unsafe { libc::kill(child_pid.as_raw(), libc::SIGKILL) };
+                let _ = nix::sys::wait::waitpid(child_pid, None);
+                return Err(Status::internal(format!(
+                    "step container init failed: {msg}"
+                )));
+            }
+
+            // Register PID for cancellation.
+            let raw_pid = child_pid.as_raw() as u32;
+            let cancel_now = {
+                let mut steps = active_steps.lock().await;
+                if let Some(step) = steps.get_mut(&step_key) {
+                    step.pid = Some(raw_pid);
+                    step.cancel_requested
+                } else {
+                    false
+                }
+            };
+            if cancel_now {
+                // SIGKILL the whole subtree: the workload is a grandchild that
+                // is PID 1 of its namespace and would ignore SIGTERM from here.
+                crate::executor::kill_process_tree(
+                    child_pid.as_raw(),
+                    nix::sys::signal::Signal::SIGKILL,
+                );
+                let _ = nix::sys::wait::waitpid(child_pid, None);
+                return Ok(None);
+            }
+
+            let wait_result =
+                tokio::task::spawn_blocking(move || nix::sys::wait::waitpid(child_pid, None)).await;
+
+            use std::os::unix::process::ExitStatusExt;
+            let exit_status =
+                match wait_result.unwrap_or(Ok(nix::sys::wait::WaitStatus::Exited(child_pid, 1))) {
+                    Ok(nix::sys::wait::WaitStatus::Exited(_, code)) => {
+                        std::process::ExitStatus::from_raw(code << 8)
+                    }
+                    Ok(nix::sys::wait::WaitStatus::Signaled(_, sig, _)) => {
+                        std::process::ExitStatus::from_raw(sig as i32)
+                    }
+                    _ => std::process::ExitStatus::from_raw(1 << 8),
+                };
+
+            Ok(Some(exit_status))
+        }
+    }
 }
 
 pub struct AgentService {
@@ -516,7 +786,10 @@ impl AgentService {
 
                 for c in &completed {
                     jobs.remove(&c.job_id);
-                    crate::container::cleanup_rootfs(c.job_id, &c.rootfs_mode);
+                    crate::container::cleanup_rootfs(
+                        &crate::container::job_rootfs_base(c.job_id),
+                        &c.rootfs_mode,
+                    );
                     crate::executor::cleanup_job_spool(c.job_id);
                     if let Some(ref cgroup) = c.cgroup {
                         crate::executor::cleanup_cgroup(cgroup);
@@ -867,6 +1140,27 @@ fn build_nsenter_argv(
     command: &[String],
 ) -> Vec<String> {
     let mut args = entry.nsenter_args();
+
+    // Rootless container (the job has its own user namespace). nsenter's default
+    // behaviour on entering a user namespace is to reset credentials — it calls
+    // setgroups() to drop supplementary groups — but the kernel forbids
+    // setgroups() in an unprivileged user namespace, so that fails with EPERM.
+    // A `setpriv --init-groups` drop would hit the same wall. Neither is needed:
+    // the job user is already mapped inside the namespace (host uid -> the
+    // namespace's root), so entering with --preserve-credentials and no setpriv
+    // runs the command as the correct user without ever touching groups.
+    //
+    // This branch only applies to rootless containers. When spurd is root the
+    // job has no user namespace (root containers use pid/mount only), so the
+    // path below — setpriv --init-groups, which preserves GPU groups — is
+    // unchanged.
+    if entry.has_user_namespace {
+        args.push("--preserve-credentials".into());
+        args.push("--".into());
+        args.extend(command.iter().cloned());
+        return args;
+    }
+
     args.push("--".into());
     if let Some(pd) = priv_drop {
         args.extend(pd.setpriv_prefix());
@@ -931,6 +1225,21 @@ impl Drop for StepScriptCleanup {
         let path_refs: Vec<&std::path::Path> =
             self.paths.iter().map(std::path::PathBuf::as_path).collect();
         cleanup_step_scripts(&self.dir, &path_refs);
+    }
+}
+
+/// Removes a step's container rootfs on drop, so a rootfs is torn down even when
+/// the `run_command` future is dropped mid-flight (srun Ctrl-C, client
+/// disconnect, controller RPC timeout) between `setup_rootfs` and the normal
+/// cleanup — otherwise every such attempt leaks an extracted/mounted rootfs.
+struct StepRootfsGuard {
+    base: String,
+    mode: crate::container::RootfsMode,
+}
+
+impl Drop for StepRootfsGuard {
+    fn drop(&mut self) {
+        crate::container::cleanup_rootfs(&self.base, &self.mode);
     }
 }
 
@@ -1347,9 +1656,12 @@ impl SlurmAgent for AgentService {
             )
             .map_err(|e| Status::failed_precondition(e.to_string()))?;
 
-            let (rootfs, rootfs_mode) =
-                crate::container::setup_rootfs(&image_path, job_id, cfg.name.as_deref())
-                    .map_err(|e| Status::internal(format!("container setup failed: {}", e)))?;
+            let (rootfs, rootfs_mode) = crate::container::setup_rootfs(
+                &image_path,
+                &crate::container::job_rootfs_base(job_id),
+                cfg.name.as_deref(),
+            )
+            .map_err(|e| Status::internal(format!("container setup failed: {}", e)))?;
 
             // Copy user script into rootfs/tmp/ so it's accessible after pivot_root
             let container_script = format!("{}/tmp/spur_job_{}.sh", rootfs.display(), job_id);
@@ -1604,7 +1916,10 @@ impl SlurmAgent for AgentService {
                         // The cgroup handle is this launch's own, so it is always
                         // safe to release.
                         if !running.lock().await.contains_key(&job_id) {
-                            crate::container::cleanup_rootfs(job_id, &rootfs_mode);
+                            crate::container::cleanup_rootfs(
+                                &crate::container::job_rootfs_base(job_id),
+                                &rootfs_mode,
+                            );
                             crate::executor::cleanup_job_spool(job_id);
                         }
                         if let Some(ref cg) = cgroup {
@@ -1790,7 +2105,7 @@ impl SlurmAgent for AgentService {
             }
         };
         if let Some(pid) = pid {
-            signal_step_process_group(pid, signal);
+            signal_step_tree(pid, signal);
         }
         Ok(Response::new(()))
     }
@@ -2021,10 +2336,13 @@ impl SlurmAgent for AgentService {
         let step_id = req.step_id;
         let step_key = (job_id, step_id);
         {
-            self.active_steps
-                .lock()
-                .await
-                .insert(step_key, ActiveStep::default());
+            self.active_steps.lock().await.insert(
+                step_key,
+                ActiveStep {
+                    epoch: next_step_epoch(),
+                    ..Default::default()
+                },
+            );
         }
         let _active_step_guard = ActiveStepGuard {
             steps: self.active_steps.clone(),
@@ -2035,7 +2353,7 @@ impl SlurmAgent for AgentService {
         // node already confirmed via LaunchJob (confirm_dispatch_on_nodes) — so a
         // miss is a wrong job/node pairing, not a launch race. The one uncovered
         // case is a spurd restart mid-job, which starts `running` empty.
-        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi) = {
+        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi, job_entry) = {
             let jobs = self.running.lock().await;
             let tracked = jobs.get(&job_id).ok_or_else(|| {
                 Status::not_found(format!("job {} not running on this node", job_id))
@@ -2047,6 +2365,16 @@ impl SlurmAgent for AgentService {
             } else {
                 tracked.nodelist.clone()
             };
+            let pid = tracked.job.pid().unwrap_or(0);
+            let entry = crate::job_entry::JobEntry {
+                pid: pid as i32,
+                has_pid_namespace: tracked.has_pid_namespace,
+                has_user_namespace: tracked.has_user_namespace,
+                has_mount_namespace: tracked.has_mount_namespace,
+                uid: tracked.uid,
+                gid: tracked.gid,
+                work_dir: tracked.work_dir.clone(),
+            };
             (
                 tracked.gpu_devices.clone(),
                 tracked.partition.clone(),
@@ -2054,6 +2382,7 @@ impl SlurmAgent for AgentService {
                 tracked.memory_mb,
                 nodelist,
                 tracked.mpi.clone(),
+                entry,
             )
         };
 
@@ -2065,18 +2394,18 @@ impl SlurmAgent for AgentService {
             .position(|n| *n == agent_hostname)
             .unwrap_or(0) as u32;
 
-        let mut gpu_env = if gpu_devices.is_empty() {
-            HashMap::new()
+        let (mut gpu_env, container_device_plan) = if gpu_devices.is_empty() {
+            (HashMap::new(), None)
         } else {
-            self.device_registry
+            let (host_plan, container_plan) = self
+                .device_registry
                 .lock()
                 .await
                 .build_job_injection_plans("gpu", &gpu_devices, req.uid, req.gid)
                 .map_err(|e| {
                     Status::failed_precondition(format!("GPU injection plan failed: {}", e))
-                })?
-                .0
-                .env
+                })?;
+            (host_plan.env, Some(container_plan))
         };
         maybe_deny_gpu_env(&mut gpu_env, &gpu_devices);
 
@@ -2259,26 +2588,7 @@ impl SlurmAgent for AgentService {
             return Ok(Response::new(cancelled_step_response()));
         }
 
-        let mut cmd = tokio::process::Command::new(&program);
-        cmd.args(&program_args)
-            .current_dir(&work_dir)
-            .process_group(0);
-        for (k, v) in env {
-            cmd.env(k, v);
-        }
-
         let memlock = self.limits.memlock;
-        let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
-        unsafe {
-            cmd.pre_exec(move || {
-                crate::executor::apply_memlock(memlock);
-                if let Some(ref pd) = priv_drop {
-                    pd.apply()
-                        .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
-                }
-                Ok(())
-            });
-        }
 
         info!(
             command = ?req.command,
@@ -2286,14 +2596,13 @@ impl SlurmAgent for AgentService {
             task_offset = req.task_offset,
             uid = req.uid,
             work_dir = %work_dir,
+            container_image = req.container.as_ref().map(|c| c.image.as_str()).unwrap_or(""),
+            parent_namespaces = job_entry.has_namespaces(),
             "RunCommand: executing step"
         );
 
-        use std::process::Stdio;
-
-        // Redirect the step's stdout/stderr to per-step spool files rather than
-        // piping the whole output into memory: the child inherits the write fds,
-        // stream_job_output tails the files live, and output stays bounded on this
+        // Redirect the step's stdout/stderr to per-step spool files so
+        // stream_job_output can tail them live and output stays bounded on this
         // node. Paths are recorded in active_steps so the tail can find them.
         let step_files = crate::executor::open_step_output_files(job_id, step_id, req.uid, req.gid)
             .map_err(|e| Status::internal(format!("step output files: {e}")))?;
@@ -2307,32 +2616,238 @@ impl SlurmAgent for AgentService {
             }
         }
 
-        let mut child = cmd
-            .stdout(Stdio::from(step_files.stdout))
-            .stderr(Stdio::from(step_files.stderr))
-            .spawn()
-            .map_err(|e| Status::internal(format!("command failed: {}", e)))?;
-        if let Some(pid) = child.id() {
-            let cancel_now = {
-                let mut steps = self.active_steps.lock().await;
-                if let Some(step) = steps.get_mut(&step_key) {
-                    step.pid = Some(pid);
-                    step.cancel_requested
-                } else {
-                    false
+        // Three dispatch paths, each wiring the step's stdio to the spool files
+        // above. `None` means the step was cancelled before it ran.
+        let maybe_status: Option<std::process::ExitStatus> = if job_entry.has_namespaces()
+            && job_entry.pid > 0
+        {
+            // Case 1: parent job is containerized — enter its namespaces via nsenter
+            // (srun inside sbatch/salloc --container-image).
+            //
+            // If the step asked for its own image, it is not honored here: the
+            // step joins the parent's live container. Leave a trace rather than
+            // silently dropping it (the #777 anti-pattern).
+            if let Some(c) = req.container.as_ref() {
+                if !c.image.is_empty() {
+                    warn!(
+                        job_id,
+                        step_id,
+                        image = %c.image,
+                        "step --container-image ignored: joining the parent job's \
+                         running container instead of building a new one"
+                    );
                 }
-            };
-            if cancel_now {
-                signal_step_process_group(pid, nix::sys::signal::Signal::SIGTERM as i32);
-                let _ = child.kill().await;
-                let _ = child.wait().await;
-                return Ok(Response::new(cancelled_step_response()));
             }
-        }
+            // Enter the step's work_dir *inside* the container by cd-ing in a
+            // shell that runs after nsenter — a host-side chdir does not
+            // survive entering the container's pivoted mount namespace, and
+            // nsenter --wd is unreliable under a rootless user namespace. The
+            // cd is best-effort (`;`, not `&&`) so a work_dir absent inside
+            // the container still runs the command rather than failing it.
+            let inner = shlex::try_join(
+                std::iter::once(program.as_str()).chain(program_args.iter().map(String::as_str)),
+            )
+            .map_err(|e| {
+                Status::invalid_argument(format!("step command is not shell-safe: {e}"))
+            })?;
+            let wd = shlex::try_quote(&work_dir)
+                .map(|s| s.into_owned())
+                .unwrap_or_else(|_| work_dir.clone());
+            let full_command = vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                format!("cd {wd} 2>/dev/null; exec {inner}"),
+            ];
+            let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
+            let plan = build_launch_plan(&job_entry, priv_drop.as_ref(), &full_command);
+            let mut cmd = tokio::process::Command::new(&plan.program);
+            // Restore the pre-change unconditional cwd (a plain host or
+            // rootful-namespaced step honours it). Entering a rootless
+            // container's pivoted mount namespace does not preserve it — that
+            // remains best-effort.
+            cmd.args(&plan.args).current_dir(&work_dir).process_group(0);
+            for (k, v) in env {
+                cmd.env(k, v);
+            }
+            if plan.apply_priv_in_child {
+                if let Some(pd) = priv_drop {
+                    unsafe {
+                        cmd.pre_exec(move || {
+                            crate::executor::apply_memlock(memlock);
+                            pd.apply()
+                                .map_err(|e| std::io::Error::from_raw_os_error(e as i32))
+                        });
+                    }
+                }
+            } else {
+                unsafe {
+                    cmd.pre_exec(move || {
+                        crate::executor::apply_memlock(memlock);
+                        Ok(())
+                    });
+                }
+            }
+            run_tokio_step_to_spool(cmd, step_files, &self.active_steps, step_key).await?
+        } else if req.container.as_ref().is_some_and(|c| !c.image.is_empty()) {
+            // Case 2: standalone srun --container-image with no running parent
+            // container — set up a fresh rootfs for this step.
+            let c = req
+                .container
+                .as_ref()
+                .expect("container present in this arm");
+            let step_uid = req.uid;
+            let step_gid = req.gid;
 
-        let status = match child.wait().await {
-            Ok(status) => status,
-            Err(e) => return Err(Status::internal(format!("command failed: {}", e))),
+            let mounts: Vec<crate::container::BindMount> = c
+                .mounts
+                .iter()
+                .filter_map(|m| crate::container::parse_mount(m).ok())
+                .collect();
+
+            let username = env
+                .get("USER")
+                .or_else(|| env.get("LOGNAME"))
+                .cloned()
+                .unwrap_or_default();
+            let home_dir = env
+                .get("HOME")
+                .cloned()
+                .unwrap_or_else(|| format!("/home/{username}"));
+
+            let container_cfg = crate::container::ContainerConfig {
+                image: c.image.clone(),
+                mounts,
+                workdir: if c.workdir.is_empty() {
+                    None
+                } else {
+                    Some(c.workdir.clone())
+                },
+                name: if c.name.is_empty() {
+                    None
+                } else {
+                    Some(c.name.clone())
+                },
+                readonly: c.readonly,
+                mount_home: c.mount_home,
+                remap_root: c.remap_root,
+                gpu_devices: gpu_devices.clone(),
+                environment: env.clone(),
+                // Deny GPU visibility in container_env for zero-GPU steps, matching
+                // the batch path (launch_job). Without this a user could smuggle
+                // ROCR_VISIBLE_DEVICES=0 through --container-env on a step that
+                // received no GPU allocation.
+                container_env: {
+                    let mut ce = c.env.clone();
+                    maybe_deny_gpu_env(&mut ce, &gpu_devices);
+                    ce
+                },
+                entrypoint: if c.entrypoint.is_empty() {
+                    None
+                } else {
+                    Some(c.entrypoint.clone())
+                },
+                uid: step_uid,
+                gid: step_gid,
+                username: if username.is_empty() {
+                    "spur".to_string()
+                } else {
+                    username
+                },
+                home_dir,
+                device_plan: container_device_plan,
+            };
+
+            let image_path = crate::container::resolve_image(&c.image, None, Some(step_uid))
+                .map_err(|e| Status::failed_precondition(e.to_string()))?;
+
+            // Per-step rootfs namespace, disjoint from the batch job's
+            // (`job_<id>`), so a step can never resolve to or delete a batch
+            // rootfs, and with no id arithmetic that could overflow.
+            let step_base = crate::container::step_rootfs_base(job_id, step_id);
+            let (rootfs, rootfs_mode) = crate::container::setup_rootfs(
+                &image_path,
+                &step_base,
+                container_cfg.name.as_deref(),
+            )
+            .map_err(|e| Status::internal(format!("step container setup failed: {e}")))?;
+            // Tear the rootfs down on any exit from here on, including a
+            // dropped future — not just the normal return below.
+            let _rootfs_guard = StepRootfsGuard {
+                base: step_base.clone(),
+                mode: rootfs_mode.clone(),
+            };
+
+            // Write the step command as a script inside the rootfs so it's
+            // accessible after pivot_root hides the host filesystem.
+            let step_script_content = {
+                let joined = shlex::try_join(
+                    std::iter::once(program.as_str())
+                        .chain(program_args.iter().map(String::as_str)),
+                )
+                .map_err(|e| {
+                    Status::invalid_argument(format!("step command is not shell-safe: {e}"))
+                })?;
+                format!("#!/bin/bash\n{joined}\n")
+            };
+            let script_in_rootfs = format!(
+                "{}/tmp/spur_step_{}_{}.sh",
+                rootfs.display(),
+                job_id,
+                step_id
+            );
+            std::fs::write(&script_in_rootfs, &step_script_content)
+                .map_err(|e| Status::internal(format!("failed to write step script: {e}")))?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(
+                    &script_in_rootfs,
+                    std::fs::Permissions::from_mode(0o755),
+                );
+            }
+
+            // Script path inside the container (after pivot_root, host paths are gone).
+            let script_in_container = format!("/tmp/spur_step_{}_{}.sh", job_id, step_id);
+
+            // The rootfs is cleaned up by `_rootfs_guard` on scope exit
+            // (normal return or dropped future).
+            run_containerized_step(
+                container_cfg,
+                rootfs,
+                script_in_container,
+                env,
+                step_files,
+                &self.active_steps,
+                step_key,
+                memlock,
+            )
+            .await?
+        } else {
+            // Case 3: no container — plain host process.
+            let mut cmd = tokio::process::Command::new(&program);
+            cmd.args(&program_args)
+                .current_dir(&work_dir)
+                .process_group(0);
+            for (k, v) in env {
+                cmd.env(k, v);
+            }
+            let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
+            unsafe {
+                cmd.pre_exec(move || {
+                    crate::executor::apply_memlock(memlock);
+                    if let Some(ref pd) = priv_drop {
+                        pd.apply()
+                            .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+                    }
+                    Ok(())
+                });
+            }
+            run_tokio_step_to_spool(cmd, step_files, &self.active_steps, step_key).await?
+        };
+
+        let status = match maybe_status {
+            Some(s) => s,
+            None => return Ok(Response::new(cancelled_step_response())),
         };
 
         if let Some(ref task_epilog) = self.hooks.task_epilog {
@@ -3016,6 +3531,7 @@ impl AgentService {
                 .is_some_and(|tracked| tracked.job.is_allocation_only())
         };
         if is_allocation_only {
+            self.cancel_active_steps_for_job(job_id, signal).await;
             self.drop_tracked_job(job_id).await;
             return;
         }
@@ -3045,7 +3561,63 @@ impl AgentService {
         let _ = tracked.job.kill_signal(sig);
     }
 
-    /// SIGTERM now, escalate to SIGKILL after a 5-second grace period.
+    /// Signal every in-flight step of a job. Allocation-only jobs (standalone
+    /// `srun` / `salloc`) have no tracked batch process that owns the step
+    /// processes, so a job-level cancel must reach the steps directly or they
+    /// orphan. This matters most for a containerized step, whose rootfs is torn
+    /// down only when its `run_command` returns — an unsignaled step would leak
+    /// both the container process and its rootfs.
+    ///
+    /// A containerized step runs as PID 1 of its own PID namespace. Signals from
+    /// an ancestor namespace to a namespace's init are *discarded* unless init
+    /// installed a handler for them — SIGTERM/SIGINT to a `bash`/`sleep` init are
+    /// dropped. Only SIGKILL and SIGSTOP are force-delivered. So the requested
+    /// signal is sent first (graceful for host steps), then SIGKILL after a short
+    /// grace period guarantees a container init dies.
+    async fn cancel_active_steps_for_job(&self, job_id: u32, signal: i32) {
+        // Snapshot (key, pid, epoch) under the lock, then signal *outside* it:
+        // signal_step_tree walks /proc, so holding active_steps across it would
+        // block every concurrent run_command (and the ActiveStepGuard's try_lock
+        // cleanup, which silently skips on contention).
+        let targets: Vec<((u32, u32), u32, u64)> = {
+            let mut steps = self.active_steps.lock().await;
+            let mut targets = Vec::new();
+            for (key, step) in steps.iter_mut() {
+                if key.0 == job_id {
+                    step.cancel_requested = true;
+                    if let Some(pid) = step.pid {
+                        targets.push((*key, pid, step.epoch));
+                    }
+                }
+            }
+            targets
+        };
+        if targets.is_empty() {
+            return;
+        }
+        for (_key, pid, _epoch) in &targets {
+            signal_step_tree(*pid, signal);
+        }
+        // Escalate to SIGKILL: a container-init step ignores the graceful signal.
+        // Compare epochs (not pids) so a step that reused the (job, step) key
+        // with a recycled pid is never signalled.
+        let active_steps = self.active_steps.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+            let still: Vec<u32> = {
+                let steps = active_steps.lock().await;
+                targets
+                    .iter()
+                    .filter(|(key, _pid, epoch)| steps.get(key).map(|s| s.epoch) == Some(*epoch))
+                    .map(|(_key, pid, _epoch)| *pid)
+                    .collect()
+            };
+            for pid in still {
+                signal_step_tree(pid, nix::sys::signal::Signal::SIGKILL as i32);
+            }
+        });
+    }
+
     async fn graceful_cancel(&self, job_id: u32) {
         let is_allocation_only = {
             let jobs = self.running.lock().await;
@@ -3053,6 +3625,8 @@ impl AgentService {
                 .is_some_and(|tracked| tracked.job.is_allocation_only())
         };
         if is_allocation_only {
+            self.cancel_active_steps_for_job(job_id, nix::sys::signal::Signal::SIGTERM as i32)
+                .await;
             self.drop_tracked_job(job_id).await;
             return;
         }
@@ -3658,6 +4232,34 @@ mod tests {
         assert!(
             !argv.iter().any(|a| a == "setpriv"),
             "root job must not invoke setpriv: {argv:?}"
+        );
+        let sep = argv.iter().position(|a| a == "--").expect("missing --");
+        assert_eq!(&argv[sep..], &["--", "id"]);
+    }
+
+    /// Rootless container (user namespace): entering must preserve credentials
+    /// and skip setpriv, because setgroups() is forbidden in an unprivileged
+    /// user namespace. The job user is already mapped inside, so no in-namespace
+    /// drop is needed.
+    #[test]
+    fn build_nsenter_argv_rootless_container_preserves_credentials() {
+        let mut entry = nsenter_job_entry(1000, 1000);
+        entry.has_user_namespace = true;
+        let pd = crate::privdrop::PrivDrop::for_test(1000, 1000);
+        let argv = build_nsenter_argv(&entry, Some(&pd), &["id".to_string()]);
+
+        assert!(
+            argv.iter().any(|a| a == "--preserve-credentials"),
+            "rootless container entry must preserve credentials: {argv:?}"
+        );
+        assert!(
+            !argv.iter().any(|a| a == "setpriv"),
+            "rootless container entry must not invoke setpriv (setgroups is \
+             forbidden in a user namespace): {argv:?}"
+        );
+        assert!(
+            !argv.iter().any(|a| a == "--init-groups"),
+            "rootless container entry must not init groups: {argv:?}"
         );
         let sep = argv.iter().position(|a| a == "--").expect("missing --");
         assert_eq!(&argv[sep..], &["--", "id"]);
@@ -4543,6 +5145,170 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::NotFound);
     }
 
+    /// Regression for #777: a step carrying `container_image` must take the
+    /// container path, not silently run the command on the host. A bogus image
+    /// makes the container path fail at image resolution *before* the command
+    /// would run. The command (`echo`) would exit 0 on the host, so an Ok result
+    /// here would mean the flags were dropped — the exact bug being fixed.
+    #[tokio::test]
+    async fn run_command_with_container_image_takes_container_path_not_host() {
+        let (svc, job_id) = run_command_test_setup().await;
+        let req = Request::new(RunCommandRequest {
+            command: vec!["echo".into(), "would-succeed-on-host".into()],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+            job_id,
+            container: Some(spur_proto::proto::ContainerSpec {
+                image: "/nonexistent/bogus-step-image.sqsh".into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        let err = svc
+            .run_command(req)
+            .await
+            .expect_err("a container_image step must not fall through to a host echo");
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(
+            err.message().contains("not found"),
+            "expected an image-resolution failure, got: {}",
+            err.message()
+        );
+    }
+
+    /// The parent-container (nsenter) path takes precedence over setting up a
+    /// fresh container: a step whose tracked job already has live namespaces must
+    /// enter them, never call `resolve_image`. Proven by the *absence* of the
+    /// image-not-found error even though a bogus image is supplied.
+    #[tokio::test]
+    async fn run_command_enters_parent_namespaces_before_new_container() {
+        let (svc, job_id) = run_command_test_setup().await;
+        {
+            let mut jobs = svc.running.lock().await;
+            let job = jobs.get_mut(&job_id).unwrap();
+            job.has_pid_namespace = true;
+            job.has_mount_namespace = true;
+        }
+        let req = Request::new(RunCommandRequest {
+            command: vec!["echo".into(), "hi".into()],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+            job_id,
+            container: Some(spur_proto::proto::ContainerSpec {
+                image: "/nonexistent/bogus-step-image.sqsh".into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        // The nsenter path was taken, not Case 2: the bogus image is never
+        // resolved. On a typical (unprivileged) test runner setns is denied, so
+        // the step comes back as a run with an nsenter trace on stderr — the
+        // observable branch — rather than the "image not found" resolution error.
+        match svc.run_command(req).await {
+            Ok(resp) => {
+                let r = resp.into_inner();
+                assert!(
+                    !r.stdout.contains("not found in [") && !r.stderr.contains("not found in ["),
+                    "namespaced job must nsenter, not resolve a new image: {r:?}"
+                );
+                assert!(
+                    r.exit_code == 0
+                        || r.stderr.to_lowercase().contains("nsenter")
+                        || r.stderr.contains("Operation not permitted")
+                        || !r.stderr.is_empty(),
+                    "expected the nsenter path (success, or an nsenter/permission \
+                     failure on an unprivileged runner), got: {r:?}"
+                );
+            }
+            Err(err) => {
+                // A spawn error (e.g. no nsenter binary) is acceptable, as long as
+                // it is not image resolution — that would mean Case 2 was entered.
+                assert!(
+                    !err.message().contains("not found in ["),
+                    "namespaced job should nsenter, not resolve a new image: {}",
+                    err.message()
+                );
+            }
+        }
+    }
+
+    /// Without a container_image and without namespaces, the step runs directly
+    /// on the host (Case 3) — the flag is what gates the container path.
+    #[tokio::test]
+    async fn run_command_without_container_image_runs_on_host() {
+        let (svc, job_id) = run_command_test_setup().await;
+        let req = Request::new(RunCommandRequest {
+            command: vec!["echo".into(), "host-step".into()],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+            job_id,
+            ..Default::default()
+        });
+        let resp = svc.run_command(req).await.unwrap().into_inner();
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(resp.stdout.trim(), "host-step");
+    }
+
+    /// Cancelling an allocation-only job (standalone srun / salloc) must signal
+    /// its in-flight steps, not just drop the tracked allocation. Otherwise a
+    /// containerized step orphans its container and leaks its rootfs. Uses a real
+    /// child in its own process group so the group-targeted signal is observable.
+    #[tokio::test]
+    async fn cancelling_allocation_only_job_signals_inflight_steps() {
+        use std::os::unix::process::CommandExt;
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        svc.register_job_allocation(Request::new(RegisterJobAllocationRequest {
+            job_id: 77,
+            cpus: 1,
+            ..Default::default()
+        }))
+        .await
+        .expect("register allocation");
+
+        let mut cmd = std::process::Command::new("sleep");
+        cmd.arg("300");
+        cmd.process_group(0);
+        let mut child = cmd.spawn().expect("spawn sleep");
+        svc.register_test_step(77, 0, Some(child.id())).await;
+
+        svc.graceful_cancel(77).await;
+
+        // The step must be marked cancelled and its process signaled dead.
+        {
+            let steps = svc.active_steps.lock().await;
+            assert!(
+                steps.get(&(77, 0)).unwrap().cancel_requested,
+                "step should be marked cancel_requested"
+            );
+        }
+        // try_wait both reaps the child and reports its exit, avoiding the
+        // zombie-looks-alive trap of a signal-0 probe.
+        let mut exited = false;
+        for _ in 0..50 {
+            if child.try_wait().expect("try_wait").is_some() {
+                exited = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        if !exited {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        assert!(exited, "the in-flight step process must be signaled dead");
+    }
+
     #[tokio::test]
     async fn run_command_uses_provided_work_dir() {
         // The bug repro: the user's workflow is `salloc; srun hostname`.
@@ -4701,7 +5467,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn signal_step_process_group_terminates_child_processes() {
+    async fn signal_step_tree_terminates_child_processes() {
         use std::time::Duration;
 
         let mut child = tokio::process::Command::new("bash")
@@ -4713,7 +5479,7 @@ mod tests {
         let pid = child.id().expect("spawned child should have pid");
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        signal_step_process_group(pid, nix::sys::signal::Signal::SIGTERM as i32);
+        signal_step_tree(pid, nix::sys::signal::Signal::SIGTERM as i32);
 
         let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
             .await

--- a/crates/spurd/src/container.rs
+++ b/crates/spurd/src/container.rs
@@ -230,16 +230,28 @@ pub enum RootfsMode {
 /// unsquashfs extraction if not root or mount fails.
 ///
 /// Named containers always use extraction (they persist across jobs).
+/// Rootfs directory base name for a batch job's container.
+pub fn job_rootfs_base(job_id: u32) -> String {
+    format!("job_{job_id}")
+}
+
+/// Rootfs directory base name for a per-step container. Kept in a separate
+/// namespace from `job_rootfs_base` so a step can never resolve to (and later
+/// delete) a batch job's live rootfs, and to avoid any id arithmetic.
+pub fn step_rootfs_base(job_id: u32, step_id: u32) -> String {
+    format!("step_{job_id}_{step_id}")
+}
+
 pub fn setup_rootfs(
     image_path: &Path,
-    job_id: u32,
+    base: &str,
     name: Option<&str>,
 ) -> anyhow::Result<(PathBuf, RootfsMode)> {
     let cdir = container_dir();
     let base_dir = if let Some(name) = name {
         cdir.join(sanitize_name(name))
     } else {
-        cdir.join(format!("job_{}", job_id))
+        cdir.join(base)
     };
 
     // If named container already exists, reuse it
@@ -400,8 +412,8 @@ pub fn parse_mount(spec: &str) -> anyhow::Result<BindMount> {
 /// Clean up an unnamed container rootfs.
 ///
 /// Handles both overlay (unmount) and extracted (rm -rf) modes.
-pub fn cleanup_rootfs(job_id: u32, mode: &RootfsMode) {
-    let base_dir = container_dir().join(format!("job_{}", job_id));
+pub fn cleanup_rootfs(base: &str, mode: &RootfsMode) {
+    let base_dir = container_dir().join(base);
     if !base_dir.exists() {
         return;
     }
@@ -1748,8 +1760,24 @@ mod tests {
     #[test]
     fn test_cleanup_rootfs_nonexistent() {
         // Should not panic when cleaning up a rootfs that doesn't exist
-        cleanup_rootfs(999999, &RootfsMode::Extracted);
-        cleanup_rootfs(999998, &RootfsMode::Overlay);
+        cleanup_rootfs(&job_rootfs_base(999999), &RootfsMode::Extracted);
+        cleanup_rootfs(&job_rootfs_base(999998), &RootfsMode::Overlay);
+    }
+
+    #[test]
+    fn step_and_job_rootfs_bases_never_overlap() {
+        // A step must never resolve to a batch job's rootfs dir, and the naming
+        // must not depend on id arithmetic that could overflow or alias.
+        assert_ne!(job_rootfs_base(1), step_rootfs_base(1, 0));
+        assert_ne!(job_rootfs_base(10000), step_rootfs_base(1, 0));
+        // Distinct steps of a job never collide, including large step ids that a
+        // `job_id * 10000 + step_id` scheme would have wrapped or aliased.
+        assert_ne!(step_rootfs_base(1, 0), step_rootfs_base(1, 10000));
+        assert_ne!(step_rootfs_base(1, 2), step_rootfs_base(2, 1));
+        // No batch job id maps onto a step base regardless of magnitude.
+        for job in [0u32, 1, 42, 429_500, u32::MAX] {
+            assert!(!job_rootfs_base(job).starts_with("step_"));
+        }
     }
 
     // --- run_hooks ---

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1212,7 +1212,7 @@ pub fn cleanup_cgroup(cgroup_path: &Path) {
 }
 
 /// Recursively signal a process and all its descendants (children first).
-fn kill_process_tree(pid: i32, sig: Signal) {
+pub(crate) fn kill_process_tree(pid: i32, sig: Signal) {
     let children = get_child_pids(pid);
     for child in &children {
         kill_process_tree(*child, sig);

--- a/docs/user-guide/running-containers.rst
+++ b/docs/user-guide/running-containers.rst
@@ -59,13 +59,16 @@ runs inside the container.
    * - ``--container-name <name>``
      - Persist the container across jobs. Required for ``spur image export``.
    * - ``--container-readonly``
-     - Mount the container root read-only.
+     - Not yet implemented — rejected at submission. (A read-only container
+       root is not enforced yet; the flag is refused rather than silently
+       ignored.)
    * - ``--container-mount-home``
      - Mount your home directory into the container.
    * - ``--container-env KEY=VAL``
      - Set an environment variable inside the container. Repeatable.
-   * - ``--container-entrypoint``
-     - Use the image's entrypoint (``sbatch``).
+   * - ``--container-entrypoint <cmd>``
+     - Shell command run inside the container immediately before the job script
+       (``<cmd> && <script>``). It does not replace the image's ENTRYPOINT.
    * - ``--container-remap-root``
      - Map the job user to root inside the container.
 
@@ -111,6 +114,44 @@ This is what lets an image's own tooling run without spelling out its paths:
 
    # torchrun lives on the image's PATH (/opt/venv/bin), not the host's
    sbatch --container-image registry.example.com/pytorch:latest train.sh
+
+Containerized Job Steps
+-----------------------
+
+``srun`` steps run inside a container too, not just batch jobs. The container
+flags above apply to a step's ``srun`` and behave as follows:
+
+- **Step inside a containerized allocation.** When the batch job was submitted
+  with ``--container-image`` (``sbatch --container-image ...``), a nested
+  ``srun`` step enters that already-running container — it shares the job's
+  image, mounts, and GPU devices. This is the standard Slurm + Pyxis pattern
+  used by multi-node launchers.
+
+- **Step with its own image.** A standalone ``srun --container-image`` (or an
+  ``salloc`` allocation followed by ``srun --container-image``) creates a fresh
+  container for that step. Different steps in one allocation can use different
+  images and mounts.
+
+Allocate first, then run steps from inside the allocation shell. A single step
+fans out one container per allocated node:
+
+.. code-block:: bash
+
+   salloc -N2 --gpus-per-node=8
+   # ...now inside the allocation shell:
+   srun --container-image trainer.sqsh <command>   # one container per node
+
+.. note::
+
+   A step is dispatched to every node in the allocation; per-node targeting of
+   an individual step (``-w``/``--nodelist``) is not yet honored for steps, and
+   ``--overlap`` only applies within an allocation (it keys off
+   ``SPUR_JOB_ID``). For per-node roles (e.g. a Ray head vs. workers), branch on
+   ``$SPUR_NODE_RANK`` inside the step command.
+
+GPU allocation, bind mounts, and cancellation apply per step: a cancelled step
+tears down its container and cleans up its rootfs without affecting the rest of
+the allocation.
 
 Exec Into a Running Container Job
 ---------------------------------

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1006,6 +1006,23 @@ message RunStepRequest {
   bool label = 8;      // Prefix output lines with [rank] (srun -l)
   string mpi = 9;      // Step MPI type; when empty, inherit job.spec.mpi
   string user = 10;    // Requesting user; verified identity must own the job; the controller/admin credential overrides
+  // Step-level container override. Absent = inherit from the parent job's
+  // container config (empty image = run on the host / enter the parent).
+  ContainerSpec container = 11;
+}
+
+// Container settings carried on a step RPC, mirroring the JobSpec container
+// fields. An empty `image` means no container.
+message ContainerSpec {
+  string image = 1;                 // OCI image ref or squashfs path
+  repeated string mounts = 2;       // "/src:/dst:ro" bind mounts
+  string workdir = 3;               // Working directory inside the container
+  string name = 4;                  // Named container (persists across jobs)
+  bool readonly = 5;                // Read-only rootfs
+  bool mount_home = 6;              // Bind-mount the user's home directory
+  map<string, string> env = 7;      // Extra env vars inside the container
+  string entrypoint = 8;            // Override the container entrypoint
+  bool remap_root = 9;              // Remap the user to root inside the container
 }
 
 message RunStepResponse {
@@ -1229,6 +1246,9 @@ message RunCommandRequest {
   string mpi = 13;             // Resolved step MPI type: "none" or "pmix"
   // When true, PMIx was prepared via PreparePmix on the controller before RunCommand.
   bool pmix_prepared = 14;
+  // Container for this step. Absent/empty image = no container; the step runs
+  // on the host or enters the parent job's namespaces when it is containerized.
+  ContainerSpec container = 15;
 }
 
 // Register a srun-only allocation on an agent without starting a batch process.

--- a/tests/native_host/e2e/test_srun_container.py
+++ b/tests/native_host/e2e/test_srun_container.py
@@ -1,0 +1,683 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for containerized srun job steps on bare-metal nodes (issue #777).
+
+Two dispatch paths exist for a containerized step, and they are tested
+separately because they are reached by genuinely different setups:
+
+  Case 2 — NEW container per step (spurd forks a fresh rootfs):
+    Reached by standalone `srun --container-image` and by `salloc
+    --container-image` + `srun`. Neither runs a batch process on the compute
+    node, so the step's tracked job has no live namespaces and spurd builds a
+    new container for the step. Capabilities exercised: container entry, bind
+    mounts, workdir, home mount, user identity, DNS, GPU env deny, GPU device
+    injection.
+
+  Case 1 — ENTER the parent container (nsenter):
+    Reached only by `sbatch --container-image` + a nested `srun`. The batch
+    script runs *inside* a live container, so the nested step enters those
+    namespaces instead of building a new rootfs. Capabilities exercised:
+    container entry, parent bind mounts visible, GPU visibility through nsenter.
+
+  Multi-node:
+    A single `srun -N2 --container-image` step fans out one container per
+    node; concurrent `srun --overlap` steps run one container per node.
+"""
+
+import shlex
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+
+def _toolchain_mounts(cluster) -> list:
+    """--container-mounts args that make the host `spur`/`srun` binary runnable
+    inside a container: the bin dir plus the shared-library dirs it links
+    against (libc, libm, libgcc_s, ld-linux). Bind-mounting the *node's* own
+    libs (rather than baking them into the image) guarantees an ABI match with
+    the node's binary."""
+    paths = [cluster.bin_dir, "/lib", "/lib64", "/usr/lib"]
+    return [f"--container-mounts={p}:{p}:ro" for p in paths]
+
+
+MARKER_PATH = "/inside-image-marker"
+MARKER_CONTENT = "spur-container-step-marker"
+
+
+# ---------------------------------------------------------------------------
+# Image builder + fixtures
+# ---------------------------------------------------------------------------
+
+def _build_marked_image(tmp_path: Path, cluster) -> str:
+    """Minimal squashfs image with MARKER_PATH and common utilities."""
+    remote_path = f"{cluster.remote_dir}/step-test-container.sqsh"
+    rootfs = tmp_path / "rootfs"
+    local_img = tmp_path / "step-test-container.sqsh"
+
+    build_script = f"""set -e
+R='{rootfs}'
+mkdir -p "$R/bin" "$R/usr/bin" "$R/lib" "$R/lib64" \
+  "$R/etc" "$R/dev" "$R/proc" "$R/sys" "$R/tmp" \
+  "$R/run" "$R/home" "$R/mnt"
+for b in bash cat echo sleep hostname id stat ls touch pwd env grep awk; do
+  src=$(which "$b" 2>/dev/null) || continue
+  [ -f "$src" ] && cp "$src" "$R/usr/bin/"
+done
+ln -sf /usr/bin/bash "$R/bin/bash"
+ln -sf /usr/bin/bash "$R/bin/sh"
+for f in "$R/usr/bin/"*; do
+  ldd "$f" 2>/dev/null | grep '=>' | awk '{{print $3}}' | while read -r lib; do
+    [ -f "$lib" ] || continue
+    dir=$(dirname "$lib")
+    mkdir -p "$R$dir"
+    cp -n "$lib" "$R$lib" 2>/dev/null || true
+  done
+done
+for nsslib in libnss_dns.so.2 libnss_files.so.2 libresolv.so.2; do
+  src="/lib/x86_64-linux-gnu/$nsslib"
+  [ -f "$src" ] && mkdir -p "$R/lib/x86_64-linux-gnu" && cp -n "$src" "$R/lib/x86_64-linux-gnu/" 2>/dev/null || true
+done
+[ -f /lib64/ld-linux-x86-64.so.2 ] && cp -n /lib64/ld-linux-x86-64.so.2 "$R/lib64/" 2>/dev/null || true
+for f in /etc/passwd /etc/group /etc/nsswitch.conf; do
+  [ -f "$f" ] && cp "$f" "$R/etc/"
+done
+echo '{MARKER_CONTENT}' > "$R{MARKER_PATH}"
+mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
+"""
+    result = subprocess.run(["sh", "-c", build_script], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"mksquashfs failed: {result.stderr}")
+
+    for node in cluster.nodes:
+        node.upload(str(local_img), remote_path)
+
+    probe = cluster.nodes[0].exec_allow_fail(
+        f"test -e '{MARKER_PATH}' && echo PRESENT || echo ABSENT"
+    )
+    if "PRESENT" in probe:
+        pytest.skip(f"marker {MARKER_PATH} exists on host — test cannot be conclusive")
+
+    return remote_path
+
+
+def _bracket(pattern: str) -> str:
+    """Wrap the first char in a regex class so pgrep -f does not match the shell
+    that is running pgrep itself (its own cmdline contains the literal pattern)."""
+    return f"[{pattern[0]}]{pattern[1:]}" if pattern else pattern
+
+
+def _wait_no_process(cluster, pattern: str, timeout: int = 20) -> bool:
+    """Poll node 0 until no process matches *pattern* (pgrep -f), or timeout."""
+    pat = _bracket(pattern)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        out = cluster.nodes[0].exec_allow_fail(f"pgrep -f {shlex.quote(pat)} || echo NONE")
+        if "NONE" in out or not out.strip():
+            return True
+        time.sleep(1)
+    return False
+
+
+def _parse_probe(content: str) -> dict:
+    out = {}
+    for line in content.splitlines():
+        if "=" not in line or line.startswith(" ") or line.startswith("\x1b"):
+            continue
+        key, _, val = line.partition("=")
+        out[key.strip()] = val.strip()
+    return out
+
+
+@pytest.fixture
+def step_container_cluster(cluster, tmp_path):
+    cluster.container_preflight()
+    cluster.step_container_image = _build_marked_image(tmp_path, cluster)
+    return cluster
+
+
+@pytest.fixture
+def step_container_multi_cluster(multi_node_cluster, tmp_path):
+    multi_node_cluster.container_preflight()
+    multi_node_cluster.step_container_image = _build_marked_image(tmp_path, multi_node_cluster)
+    return multi_node_cluster
+
+
+@pytest.fixture
+def step_gpu_container_cluster(gpu_cluster, tmp_path):
+    """GPU-capable cluster with a container image and the shared GPU probe.
+
+    Depending on `gpu_cluster` auto-marks these tests `gpu` (conftest) and skips
+    them when no GPU hardware is present.
+    """
+    gpu_cluster.gpu_preflight(1)
+    gpu_cluster.container_preflight()
+    gpu_cluster.step_container_image = _build_marked_image(tmp_path, gpu_cluster)
+    probe = gpu_cluster.ship_fixture("gpu_env_probe.sh")
+    for node in gpu_cluster.nodes:
+        node.exec(f"chmod +x '{probe}'")
+    gpu_cluster.step_probe = probe
+    return gpu_cluster
+
+
+# ---------------------------------------------------------------------------
+# Case 2: new container per step (standalone srun --container-image)
+# ---------------------------------------------------------------------------
+
+class TestSrunContainerStepNewRootfs:
+    def test_container_entry(self, step_container_cluster):
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "cat", MARKER_PATH,
+        ])
+        assert code == 0, f"srun --container-image failed (exit {code}):\n{out}"
+        assert MARKER_CONTENT in out, f"step ran on host, not in container:\n{out}"
+
+    def test_bind_mount(self, step_container_cluster):
+        # Mount a directory (the common case, matching the batch container test);
+        # file bind mounts are a separate, untested edge case.
+        cluster = step_container_cluster
+        bind_dir = f"{cluster.remote_dir}/bind-test"
+        # Create the bind source on every node: spur does not distribute it, and
+        # the step may be scheduled on any node in the allocation.
+        for node in cluster.nodes:
+            node.exec(f"mkdir -p '{bind_dir}' && echo 'bind-mount-works' > '{bind_dir}/data.txt'")
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            f"--container-mounts={bind_dir}:/mnt/data:ro",
+            "cat", "/mnt/data/data.txt",
+        ])
+        assert code == 0, f"srun with bind mount failed (exit {code}):\n{out}"
+        assert "bind-mount-works" in out, f"bind mount not visible in step:\n{out}"
+
+    def test_workdir(self, step_container_cluster):
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "--container-workdir=/tmp",
+            "pwd",
+        ])
+        assert code == 0, f"srun --container-workdir failed (exit {code}):\n{out}"
+        assert "/tmp" in out.strip(), f"expected workdir /tmp, got:\n{out}"
+
+    def test_mount_home(self, step_container_cluster):
+        """--container-mount-home makes the job user's home available inside the
+        step. The probe prints diagnostics (HOME, its contents, mount table) and
+        always exits 0, so a failed assertion surfaces the real in-container
+        state instead of a bare exit code."""
+        cluster = step_container_cluster
+        probe = (
+            'echo "HOME=$HOME"; echo "USER=$USER"; '
+            'test -d "$HOME" && echo HOME_IS_DIR || echo HOME_NOT_DIR; '
+            'echo "-- ls $HOME --"; ls -la "$HOME" 2>&1 | head -20; '
+            'echo "-- home mounts --"; grep -i home /proc/mounts 2>/dev/null || echo NO_HOME_MOUNT; '
+            'echo "-- write --"; { touch "$HOME/.spur_probe" && echo HOME_WRITABLE; } || echo HOME_NOT_WRITABLE; '
+            'true'
+        )
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "--container-mount-home",
+            "bash", "-c", probe,
+        ])
+        assert "HOME_WRITABLE" in out, (
+            f"--container-mount-home did not yield a usable home (exit {code}):\n{out}"
+        )
+
+    def test_user_identity(self, step_container_cluster):
+        """id runs inside the container (passwd/shadow injected — no 'no such user')."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "id",
+        ])
+        assert code == 0, f"srun id failed (exit {code}):\n{out}"
+        assert "uid=" in out, f"id output malformed inside container:\n{out}"
+
+    def test_dns_injected(self, step_container_cluster):
+        """/etc/resolv.conf is injected (image ships without one)."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "bash", "-c", "test -s /etc/resolv.conf && echo DNS_OK || echo DNS_MISSING",
+        ])
+        assert code == 0, f"srun dns check failed (exit {code}):\n{out}"
+        assert "DNS_OK" in out, f"/etc/resolv.conf not injected in step:\n{out}"
+
+    def test_gpu_env_denied_on_zero_gpu_step(self, step_container_cluster):
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "bash", "-c", "echo ROCR=${ROCR_VISIBLE_DEVICES:-unset}",
+        ])
+        assert code == 0, f"srun gpu env check failed (exit {code}):\n{out}"
+        assert "ROCR=-1" in out or "ROCR=unset" in out, f"GPU env not denied:\n{out}"
+        assert "ROCR=0" not in out, f"GPU 0 visible in zero-GPU step:\n{out}"
+
+    def test_container_env_gpu_deny_not_bypassable(self, step_container_cluster):
+        """--container-env cannot re-enable GPU visibility on a zero-GPU step."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "--container-env=ROCR_VISIBLE_DEVICES=0",
+            "bash", "-c", "echo ROCR=${ROCR_VISIBLE_DEVICES:-unset}",
+        ])
+        assert code == 0, f"srun container-env check failed (exit {code}):\n{out}"
+        assert "ROCR=0" not in out, f"--container-env smuggled GPU visibility:\n{out}"
+
+    def test_named_container(self, step_container_cluster):
+        """--container-name is accepted and the step still runs in the image."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "--container-name=step-named-ctr",
+            "cat", MARKER_PATH,
+        ])
+        assert code == 0, f"srun --container-name failed (exit {code}):\n{out}"
+        assert MARKER_CONTENT in out, f"named-container step not in image:\n{out}"
+
+    def test_container_entrypoint(self, step_container_cluster):
+        """--container-entrypoint runs before the step command inside the container."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "--container-entrypoint=touch /tmp/ep_ran",
+            "bash", "-c", "test -f /tmp/ep_ran && echo EP_OK || echo EP_MISSING",
+        ])
+        assert code == 0, f"srun --container-entrypoint failed (exit {code}):\n{out}"
+        assert "EP_OK" in out, (
+            f"entrypoint did not run before the step command:\n{out}"
+        )
+
+    def test_salloc_then_srun_container(self, step_container_cluster):
+        """salloc allocation followed by a containerized srun step (issue's suggested case).
+
+        The salloc allocation has no compute-node container, so the step builds
+        its own (Case 2). The container image is specified on the step's srun.
+        """
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        out_path = f"{cluster.remote_dir}/salloc-step.out"
+        body = (
+            f"'{cluster.bin_dir}/srun' --container-image='{img}' "
+            f"cat '{MARKER_PATH}' > '{out_path}' 2>&1"
+        )
+        code, out = cluster.salloc_run(body, salloc_args=["-N", "1", "-t", "0:02"])
+        assert code == 0, f"salloc failed (exit {code}):\n{out}"
+        step_out = cluster.nodes[0].read_file(out_path)
+        assert MARKER_CONTENT in step_out, (
+            f"salloc + srun --container-image step not in container:\n{step_out}"
+        )
+
+    def test_cancellation_terminates_container_step(self, step_container_cluster):
+        """scancel of a containerized srun step terminates the container (no orphan).
+
+        A standalone `srun --container-image sleep 300` is launched in the
+        background; scancel must stop the container so nothing lingers.
+        """
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        name = "cancel-ctr-step"
+        out_path = f"{cluster.remote_dir}/cancel-ctr.out"
+        launch = (
+            f"SPUR_CONTROLLER_ADDR={shlex.quote(cluster.controller_addr)} "
+            f"PATH={shlex.quote(cluster.bin_dir)}:$PATH "
+            f"nohup {shlex.quote(cluster.bin_dir + '/srun')} -J {name} -N1 -t 0:05 "
+            f"--container-image={shlex.quote(img)} sleep 300 "
+            f"> {shlex.quote(out_path)} 2>&1 & echo backgrounded"
+        )
+        cluster.nodes[0].exec(launch)
+
+        job_id = None
+        for _ in range(30):
+            ids = cluster.running_job_ids_by_name(name)
+            if ids:
+                job_id = ids[0]
+                break
+            time.sleep(1)
+        assert job_id is not None, "containerized srun step never reached running"
+
+        cluster.scancel(str(job_id))
+
+        state = wait_job(cluster, job_id, timeout=45)
+        assert state in ("CA", "F", "COMPLETED", "GONE"), (
+            f"cancelled containerized step should be terminal, got {state}"
+        )
+
+        # The container's sleep must not linger (allow for the SIGKILL escalation
+        # and the srun client teardown).
+        assert _wait_no_process(cluster, "sleep 300", timeout=20), (
+            "container step process lingered after cancel:\n"
+            + cluster.nodes[0].exec_allow_fail("pgrep -af '[s]leep 300' || echo NONE")
+        )
+
+    def test_ctrl_c_terminates_container_step(self, step_container_cluster):
+        """Ctrl-C (SIGINT to the srun client) terminates the containerized step.
+
+        srun's Ctrl-C handler sends a job cancel; the agent must signal the
+        in-flight containerized step so nothing orphans — the path exercised by
+        an interactive `srun --container-image ...` the user aborts.
+        """
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        name = "ctrlc-ctr-step"
+        out_path = f"{cluster.remote_dir}/ctrlc.out"
+        launch = (
+            f"SPUR_CONTROLLER_ADDR={shlex.quote(cluster.controller_addr)} "
+            f"PATH={shlex.quote(cluster.bin_dir)}:$PATH "
+            f"nohup {shlex.quote(cluster.bin_dir + '/srun')} -J {name} -N1 -t 0:05 "
+            f"--container-image={shlex.quote(img)} sleep 300 "
+            f"> {shlex.quote(out_path)} 2>&1 & echo PID:$!"
+        )
+        res = cluster.nodes[0].exec(launch)
+        srun_pid = next(
+            (tok.split(":", 1)[1].strip() for tok in res.split() if tok.startswith("PID:")),
+            None,
+        )
+        assert srun_pid, f"could not capture srun client pid:\n{res}"
+
+        job_id = None
+        for _ in range(30):
+            ids = cluster.running_job_ids_by_name(name)
+            if ids:
+                job_id = ids[0]
+                break
+            time.sleep(1)
+        assert job_id is not None, "containerized srun step never reached running"
+
+        # Ctrl-C: SIGINT to the srun client triggers its cancel handler.
+        cluster.nodes[0].exec_allow_fail(f"kill -INT {srun_pid}")
+
+        state = wait_job(cluster, job_id, timeout=45)
+        assert state in ("CA", "F", "COMPLETED", "GONE"), (
+            f"Ctrl-C'd containerized step should be terminal, got {state}"
+        )
+        assert _wait_no_process(cluster, "sleep 300", timeout=20), (
+            "container step process lingered after Ctrl-C:\n"
+            + cluster.nodes[0].exec_allow_fail("pgrep -af '[s]leep 300' || echo NONE")
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 1: enter the parent container via nsenter
+# ---------------------------------------------------------------------------
+
+class TestSrunContainerStepNsenter:
+    """A step whose job is already containerized enters the parent container's
+    namespaces (nsenter) instead of building a new rootfs.
+
+    Two shapes are covered:
+      - `spur exec` into a running containerized job: `spur` runs on the host and
+        enters the container — no in-image binary needed. This proves the nsenter
+        mechanism works for a rootless user-namespace container.
+      - a nested `srun` *inside* an `sbatch --container-image` batch script: the
+        script runs post-pivot_root, so `spur`/`srun` and its shared libraries
+        are bind-mounted in via `_toolchain_mounts`. The nested srun attaches as
+        a step (SPUR_JOB_ID is in the batch env) and routes through run_command's
+        Case 1.
+    """
+
+    def test_spur_exec_enters_container_job(self, step_container_cluster):
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        hold = cluster.write_file("nsenter-hold.sh", "#!/bin/bash\nsleep 300\n")
+        sb = cluster.sbatch([
+            "-J", "nsenter-hold", "-N", "1", "-t", "0:05",
+            f"--container-image={img}", hold,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch did not return a job id: {sb}"
+        try:
+            wait_job_state(cluster, job_id, "R", timeout=60)
+            out = cluster.cli(["spur", "exec", str(job_id), "cat", MARKER_PATH])
+            assert MARKER_CONTENT in out, (
+                f"spur exec did not enter the parent container:\n{out}"
+            )
+        finally:
+            cluster.scancel(str(job_id))
+
+    def test_nested_srun_enters_parent_container(self, step_container_cluster):
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        out_path = f"{cluster.remote_dir}/nsenter-entry.out"
+        script = cluster.write_file(
+            "nsenter-entry.sh",
+            f"#!/bin/bash\n{cluster.bin_dir}/srun cat '{MARKER_PATH}'\n",
+        )
+        sb = cluster.sbatch([
+            "-J", "nsenter-entry", "-N", "1", "-t", "0:03", "-o", out_path,
+            f"--container-image={img}",
+            *_toolchain_mounts(cluster),
+            script,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch did not return a job id: {sb}"
+        wait_job(cluster, job_id, timeout=120)
+        out = cluster.read_output_on_any_node(out_path)
+        diag = cluster.debug_job(job_id)
+        assert MARKER_CONTENT in out, (
+            f"nested srun did not enter parent container:\n{diag}\noutput:\n{out}"
+        )
+
+    def test_nested_srun_inherits_workdir(self, step_container_cluster):
+        """A nested srun (nsenter) runs in the step's work_dir, not spurd's cwd.
+        Compares the batch script's own cwd to the step's cwd so the check has no
+        hardcoded path (an absolute-path command would not catch the regression)."""
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        out_path = f"{cluster.remote_dir}/nsenter-wd.out"
+        script = cluster.write_file(
+            "nsenter-wd.sh",
+            "#!/bin/bash\n"
+            'echo "BATCH_PWD=$(pwd)"\n'
+            f"{cluster.bin_dir}/srun bash -c 'echo STEP_PWD=$(pwd)'\n",
+        )
+        sb = cluster.sbatch([
+            "-J", "nsenter-wd", "-N", "1", "-t", "0:03", "-o", out_path,
+            f"--container-image={img}",
+            *_toolchain_mounts(cluster),
+            script,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+        wait_job(cluster, job_id, timeout=120)
+        out = cluster.read_output_on_any_node(out_path)
+        parsed = _parse_probe(out)
+        diag = cluster.debug_job(job_id)
+        assert parsed.get("STEP_PWD") and parsed.get("STEP_PWD") == parsed.get("BATCH_PWD"), (
+            f"nested step cwd should match the batch cwd:\n{diag}\noutput:\n{out}"
+        )
+
+    def test_parent_bind_mount_visible_to_nested_step(self, step_container_cluster):
+        cluster = step_container_cluster
+        img = cluster.step_container_image
+        bind_dir = f"{cluster.remote_dir}/nsenter-bind"
+        # Create the bind source on every node (the batch job may land on any
+        # node; spur does not distribute host paths).
+        for node in cluster.nodes:
+            node.exec(f"mkdir -p '{bind_dir}' && echo 'nsenter-bind-ok' > '{bind_dir}/data.txt'")
+
+        out_path = f"{cluster.remote_dir}/nsenter-bind.out"
+        script = cluster.write_file(
+            "nsenter-bind.sh",
+            f"#!/bin/bash\n{cluster.bin_dir}/srun cat /mnt/nsdata/data.txt\n",
+        )
+        sb = cluster.sbatch([
+            "-J", "nsenter-bind", "-N", "1", "-t", "0:03", "-o", out_path,
+            f"--container-image={img}",
+            f"--container-mounts={bind_dir}:/mnt/nsdata:ro",
+            *_toolchain_mounts(cluster),
+            script,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+        wait_job(cluster, job_id, timeout=180)
+        out = cluster.read_output_on_any_node(out_path)
+        diag = cluster.debug_job(job_id)
+        assert "nsenter-bind-ok" in out, (
+            f"parent bind mount not visible to nested step:\n{diag}\noutput:\n{out}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GPU device injection (requires GPU hardware; auto-skipped otherwise)
+# ---------------------------------------------------------------------------
+
+class TestSrunContainerStepGpuInjection:
+    def test_new_container_step_gpu_injection(self, step_gpu_container_cluster):
+        """Standalone srun --gres=gpu:1 --container-image sees the GPU device
+        nodes bind-mounted into the fresh step container (Case 2)."""
+        cluster = step_gpu_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:03",
+            "--gres=gpu:1",
+            f"--container-image={cluster.step_container_image}",
+            f"--container-mounts={cluster.step_probe}:/probe.sh:ro",
+            "/probe.sh",
+        ])
+        assert code == 0, f"gpu step failed (exit {code}):\n{out}"
+        parsed = _parse_probe(out)
+        assert parsed.get("VISIBLE_COUNT") == "1", f"expected 1 visible GPU:\n{out}"
+        assert parsed.get("SPUR_COUNT") == "1", f"expected SPUR_JOB_GPUS=1:\n{out}"
+        assert parsed.get("KFD") == "yes", f"/dev/kfd not injected in step:\n{out}"
+        assert int(parsed.get("RENDER_COUNT", "0")) >= 1, (
+            f"no /dev/dri/renderD* injected in step:\n{out}"
+        )
+
+    def test_nsenter_step_sees_parent_gpus(self, step_gpu_container_cluster):
+        """A nested srun (nsenter) sees the GPUs injected into the parent
+        sbatch --gres=gpu:1 --container-image job (Case 1)."""
+        cluster = step_gpu_container_cluster
+        img = cluster.step_container_image
+        out_path = f"{cluster.remote_dir}/nsenter-gpu.out"
+        script = cluster.write_file(
+            "nsenter-gpu.sh",
+            f"#!/bin/bash\n{cluster.bin_dir}/srun /probe.sh\n",
+        )
+        sb = cluster.sbatch([
+            "-J", "nsenter-gpu", "-N", "1", "-t", "0:03", "-o", out_path,
+            "--gres=gpu:1",
+            f"--container-image={img}",
+            f"--container-mounts={cluster.step_probe}:/probe.sh:ro",
+            *_toolchain_mounts(cluster),
+            script,
+        ])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+        wait_job(cluster, job_id, timeout=180)
+        out = cluster.read_output_on_any_node(out_path)
+        parsed = _parse_probe(out)
+        diag = cluster.debug_job(job_id)
+        assert parsed.get("VISIBLE_COUNT") == "1", (
+            f"nested step did not see parent GPU:\n{diag}\n{out}"
+        )
+        assert parsed.get("KFD") == "yes", f"/dev/kfd not visible to nested step:\n{out}"
+
+    def test_gpu_isolation_two_gpus(self, step_gpu_container_cluster):
+        """A step allocated 2 GPUs sees exactly 2 (no more, no fewer)."""
+        cluster = step_gpu_container_cluster
+        if max(cluster.node_gpu_count(n) for n in cluster.node_names) < 2:
+            pytest.skip("need >= 2 GPUs on a node")
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:03",
+            "--gres=gpu:2",
+            f"--container-image={cluster.step_container_image}",
+            f"--container-mounts={cluster.step_probe}:/probe.sh:ro",
+            "/probe.sh",
+        ])
+        assert code == 0, f"gpu step failed (exit {code}):\n{out}"
+        parsed = _parse_probe(out)
+        assert parsed.get("VISIBLE_COUNT") == "2", f"expected 2 visible GPUs:\n{out}"
+        assert int(parsed.get("RENDER_COUNT", "0")) == 2, (
+            f"expected exactly 2 renderD nodes injected:\n{out}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-node
+# ---------------------------------------------------------------------------
+
+class TestSrunContainerStepMultiNode:
+    def test_single_step_fans_out_to_all_nodes(self, step_container_multi_cluster):
+        """One `srun -N2 --container-image` step runs a container on each node."""
+        cluster = step_container_multi_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "2", "-t", "0:03",
+            f"--container-image={cluster.step_container_image}",
+            "cat", MARKER_PATH,
+        ])
+        assert code == 0, f"multi-node srun step failed (exit {code}):\n{out}"
+        assert out.count(MARKER_CONTENT) >= 2, (
+            f"expected the marker from both nodes' containers, got:\n{out}"
+        )
+
+    def test_concurrent_overlap_steps(self, step_container_multi_cluster):
+        """The Miles pattern: from a salloc shell, launch one containerized
+        `srun --overlap` per node concurrently. Each step builds its own
+        container (Case 2). srun runs on the host, so the redirects land on the
+        allocation shell's node."""
+        cluster = step_container_multi_cluster
+        img = cluster.step_container_image
+        out1 = f"{cluster.remote_dir}/overlap-1.out"
+        out2 = f"{cluster.remote_dir}/overlap-2.out"
+        node1, node2 = cluster.node_names[0], cluster.node_names[1]
+        body = (
+            f"'{cluster.bin_dir}/srun' --overlap -N1 -w '{node1}' "
+            f"--container-image='{img}' cat '{MARKER_PATH}' > '{out1}' 2>&1 &\n"
+            f"'{cluster.bin_dir}/srun' --overlap -N1 -w '{node2}' "
+            f"--container-image='{img}' cat '{MARKER_PATH}' > '{out2}' 2>&1 &\n"
+            f"wait"
+        )
+        code, out = cluster.salloc_run(body, salloc_args=["-N", "2", "-t", "0:03"])
+        assert code == 0, f"salloc overlap run failed (exit {code}):\n{out}"
+        # Both srun clients run in the salloc shell (node 0), so both outputs
+        # land on node 0.
+        out1_c = cluster.nodes[0].read_file(out1)
+        out2_c = cluster.nodes[0].read_file(out2)
+        assert MARKER_CONTENT in out1_c, f"node1 overlap step not in container:\n{out1_c}"
+        assert MARKER_CONTENT in out2_c, f"node2 overlap step not in container:\n{out2_c}"
+
+
+# ---------------------------------------------------------------------------
+# Sanity / negative
+# ---------------------------------------------------------------------------
+
+class TestSrunContainerStepSanity:
+    def test_container_readonly_rejected(self, step_container_cluster):
+        """--container-readonly is refused at submission (not a silent no-op)."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            f"--container-image={cluster.step_container_image}",
+            "--container-readonly",
+            "true",
+        ])
+        assert code != 0, f"--container-readonly should be rejected, got exit 0:\n{out}"
+        assert "container-readonly" in out and "not yet implemented" in out, (
+            f"expected a clear rejection message, got:\n{out}"
+        )
+
+    def test_step_without_image_runs_on_host(self, step_container_cluster):
+        """A step with no container image runs on the host and cannot see the
+        in-image marker — proves the flag is what gates the container path."""
+        cluster = step_container_cluster
+        code, out = cluster.srun_with_exit([
+            "-N", "1", "-t", "0:02",
+            "bash", "-c", f"test -f {MARKER_PATH} && echo FOUND || echo NOTFOUND",
+        ])
+        assert code == 0, f"host srun step failed (exit {code}):\n{out}"
+        assert "NOTFOUND" in out, f"marker found on host — assumption violated:\n{out}"


### PR DESCRIPTION
## Summary

Fixes rocm/spur#777 — `srun --container-image` was silently accepted and dropped on bare-metal ("native host") job steps, running the command on the host instead of in the requested image. This carries the container intent across the step RPC and wires the existing container runtime into the step-dispatch path.

**This supersedes #818.** It is #818 rebased onto the merged output-streaming work (#819) and reworked to adopt the two architectural wins from @powderluv's #821, plus every review comment from #818 addressed. See "Relationship to #818/#819/#821" below.

## Approach

- **Proto:** a single `ContainerSpec` message on `RunStepRequest` (tag 11) and `RunCommandRequest` (tag 15) — append-only, no renumber/retype. `JobSpec`'s existing container fields (70–78) are unchanged.
- **CLI (`srun`):** fills `ContainerSpec` from the container flags (parity with `sbatch`, incl. `--container-name/--container-readonly/--container-entrypoint`).
- **Controller (`spurctld`):** `run_step` resolves the effective container per step (step override, else inherit the parent job; the step's env is **merged over** the job's, step-wins) and forwards it to each agent.
- **Agent (`spurd`):** `run_command` dispatches across three paths, each wiring the step's stdout/stderr to the per-step spool files (so `stream_job_output` tails them live — the #819 model):
  1. **Parent job has live namespaces** → enter them via `nsenter` (nested `srun`/`spur exec` into a running container). Includes the rootless `setgroups` fix (see below).
  2. **Step carries its own image, no parent container** → build a fresh rootfs (`setup_rootfs` + `run_containerized_step`): namespaces, mounts, GPU device injection, shadow/user, DNS, home, hooks, `pivot_root`, priv-drop. Reached by standalone `srun` and by `salloc` + `srun` (the primary Miles pattern).
  3. **No container** → host spawn.

## Notable correctness work

- **Rootless nsenter into a container (pre-existing bug, also fixed `spur exec`).** Entering a rootless (user-namespace) container failed with `nsenter: setgroups failed: Operation not permitted` (the kernel forbids `setgroups()` in an unprivileged user namespace). For user-namespace targets, entry now uses `nsenter --preserve-credentials` and skips `setpriv --init-groups`. **Gated on `has_user_namespace`, which is false whenever spurd is root**, so the root paths (and their `@rootful` groups test) emit the identical command as before.
- **Cancellation.** A containerized step's real workload is a grandchild that is PID 1 of its own namespace (ignores SIGTERM from an ancestor). Cancellation walks the `/proc` tree **and** signals the process group, snapshots pids under the `active_steps` lock and signals outside it, and escalates to SIGKILL guarded by a monotonic epoch (never a recycled pid). Applies to `scancel` and `srun` Ctrl-C.
- **GPU:** device-plan injection for step containers; `maybe_deny_gpu_env` on `container_env` so a zero-GPU step can't re-enable GPU visibility via `--container-env`.
- **`--container-readonly`** is a no-op on every backend today, so it is **rejected at submission** (with a follow-up to implement it) rather than silently accepted.

## #818 review comments (from @yansun1996) — all addressed here

- rootfs id collision / `u32` overflow → `setup_rootfs`/`cleanup_rootfs` take an explicit base; steps use a `step_<job>_<step>` namespace disjoint from `job_<id>` (unit test added).
- nsenter step inherited spurd's cwd → `current_dir(&work_dir)` set unconditionally (E2E added comparing batch vs step cwd).
- rootfs leaked when the future was dropped → `StepRootfsGuard` (Drop) makes cleanup cancel-safe.
- `kill_process_tree` lost `killpg` coverage and the `warn!` → `signal_step_tree` does both and warns.
- entrypoint NUL → `bash -c ""` false success; hardcoded `/bin/bash`; swallowed execve error → NUL rejected pre-fork, shell probed, failure surfaced.
- non-shell-safe step command silently dropped args → `invalid_argument`.
- `/proc` walk under the `active_steps` lock + pid recycling → snapshot-then-signal + epoch guard.
- nested `srun --container-image B` silently ignored under image A → `warn!`.
- step container env replaced the job's wholesale → merged, step-wins.
- docs: `--container-entrypoint` description + help strings corrected; the `salloc` example rewritten (per-node `-w`/`--overlap` caveats noted).
- weak nsenter-precedence unit test strengthened to assert on observable output.
- The fd double-close and the cancelled-step `Err`-vs-`Ok` comments are resolved by the spool-file refactor.

## Relationship to #818 / #819 / #821

- **#819** (per-step spool-file output streaming) is merged; this PR builds on it, so step output streams rather than being buffered inline.
- Adopts **#821**'s two architectural ideas: the `ContainerSpec` proto message and spool-file-native step output.
- Retains all of **#818**'s capability (Case 1 nsenter + rootless fix, flag parity, `--container-readonly` rejection, GPU injection, cancellation, the full E2E suite) — the test depth is unchanged from #818.
- **#818 should be closed in favor of this PR.**

## Related issues

#777, #780 (`--pty`) and #781 (output streaming, landed via #819) share the same bare-metal step-dispatch root. This addresses #777.

## Test plan

- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean
- [x] `cargo test --locked` — passes (spurd/spurctld/spur-cli); unit coverage: container path taken vs silent host fallthrough, nsenter precedence (observable-branch assertion), rootless nsenter preserves credentials / skips setgroups, cancellation signals in-flight steps, rootfs base-name disjointness, `--container-readonly` rejection
- [x] Bare-metal E2E (`tests/native_host/e2e/test_srun_container.py`): standalone `srun`; `salloc` + `srun`; `sbatch` + nested `srun` (nsenter) and `spur exec`; nested-step cwd; concurrent `--overlap`; single multi-node `srun -N2`; bind mounts / workdir / home / user identity / DNS; GPU device injection (both paths, auto-skips without GPUs); `--container-name`, `--container-entrypoint`; cancellation via `scancel` and Ctrl-C; `--container-readonly` rejection
