### PR TITLE
fix(spurd): re-adopt running batch jobs across an agent restart

### DIFF
--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -151,6 +151,57 @@ pub(crate) fn new_running_jobs() -> RunningJobs {
     Arc::new(Mutex::new(HashMap::new()))
 }
 
+/// Re-adopt batch jobs that survived a spurd restart. For each persisted
+/// manifest whose cgroup still holds live processes, insert a tracked `Adopted`
+/// job so the agent acknowledges it (attach/`--overlap`), can reap it, and
+/// reports it in heartbeats — instead of leaving it orphaned with the controller
+/// believing it RUNNING forever. Manifests for jobs that ended during the
+/// downtime are discarded; the running monitor loop then reports and cleans up a
+/// re-adopted job when its cgroup empties.
+pub(crate) async fn readopt_surviving_jobs(running: &RunningJobs) {
+    for m in crate::manifest::load_all() {
+        if !crate::manifest::cgroup_has_live_procs(&m.cgroup_path) {
+            info!(
+                job_id = m.job_id,
+                "job ended while spurd was down; discarding manifest"
+            );
+            crate::manifest::remove(m.job_id);
+            continue;
+        }
+        info!(
+            job_id = m.job_id,
+            cgroup = %m.cgroup_path,
+            "re-adopting job that survived a spurd restart"
+        );
+        running.lock().await.insert(
+            m.job_id,
+            TrackedJob {
+                job: executor::RunningJob::Adopted {
+                    cgroup_path: std::path::PathBuf::from(&m.cgroup_path),
+                },
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                stdout_path: String::new(),
+                stderr_path: String::new(),
+                has_pid_namespace: m.has_pid_namespace,
+                has_user_namespace: m.has_user_namespace,
+                has_mount_namespace: m.has_mount_namespace,
+                _pty_master: None,
+                work_dir: m.work_dir,
+                uid: m.uid,
+                gid: m.gid,
+                user: m.user,
+                partition: m.partition,
+                gpu_devices: m.gpu_devices,
+                cpus: m.cpus,
+                memory_mb: m.memory_mb,
+                nodelist: m.nodelist,
+                mpi: m.mpi,
+                run_attempt: m.run_attempt,
+            },
+        );
+    }
+}
+
 type PmixLaunchSetup = (
     PmixLaunchGuard,
     PmixLaunchPlan,
@@ -786,6 +837,9 @@ impl AgentService {
 
                 for c in &completed {
                     jobs.remove(&c.job_id);
+                    // The job has ended; drop its re-adoption manifest (spur#803)
+                    // so a later restart does not try to recover a dead job.
+                    crate::manifest::remove(c.job_id);
                     crate::container::cleanup_rootfs(
                         &crate::container::job_rootfs_base(c.job_id),
                         &c.rootfs_mode,
@@ -1942,6 +1996,33 @@ impl SlurmAgent for AgentService {
                 // surface where output actually landed (e.g. the /tmp fallback).
                 let stdout_path = result.stdout_path.clone();
                 let stderr_path = result.stderr_path.clone();
+                // Persist a manifest so a spurd restart can re-adopt this running
+                // job (spur#803). Re-adoption manages a survivor through its
+                // cgroup, so only cgroup-confined, non-interactive batch jobs are
+                // recorded — an interactive (pty) job has no detached workload to
+                // recover. Built here because launch_cfg is moved into TrackedJob.
+                let readopt_manifest = result
+                    .job
+                    .cgroup()
+                    .filter(|_| result.pty_master.is_none())
+                    .map(|cg| crate::manifest::JobManifest {
+                        job_id,
+                        uid: launch_cfg.uid,
+                        gid: launch_cfg.gid,
+                        user: launch_cfg.user.clone(),
+                        work_dir: launch_cfg.work_dir.clone(),
+                        partition: launch_cfg.partition.clone(),
+                        nodelist: launch_cfg.nodelist.clone(),
+                        gpu_devices: launch_cfg.gpu_devices.clone(),
+                        cpus: launch_cfg.cpus,
+                        memory_mb: launch_cfg.memory_mb,
+                        mpi: spec.mpi.clone(),
+                        run_attempt,
+                        cgroup_path: cg.to_string_lossy().into_owned(),
+                        has_pid_namespace: is_root || is_container,
+                        has_user_namespace: is_container && !is_root,
+                        has_mount_namespace: is_root || is_container,
+                    });
                 let displaced = jobs.insert(
                     job_id,
                     TrackedJob {
@@ -1967,6 +2048,9 @@ impl SlurmAgent for AgentService {
                     },
                 );
                 drop(jobs);
+                if let Some(m) = readopt_manifest {
+                    crate::manifest::write(&m);
+                }
                 // Re-dispatch onto the same node reuses job_id and displaces an
                 // older run. If its process ignored SIGTERM and outlived the
                 // requeue, kill and reap it here — the monitor loop no longer
@@ -3397,6 +3481,7 @@ impl SlurmAgent for AgentService {
 impl AgentService {
     async fn drop_tracked_job(&self, job_id: u32) {
         if self.running.lock().await.remove(&job_id).is_some() {
+            crate::manifest::remove(job_id);
             self.allocation.lock().await.release_job(job_id);
             if let Err(e) = self.mpi_host.stop_pmix_server(job_id) {
                 warn!(job_id, error = %e, "PMIx stop failed on job drop");

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -313,6 +313,20 @@ pub enum RunningJob {
     },
     /// Allocation registered without a batch process (standalone srun).
     AllocationOnly,
+    /// A batch job re-adopted after a spurd restart: the workload survived in
+    /// its cgroup but the OS process handle was lost, so it is tracked and
+    /// managed through the cgroup — done when the cgroup empties, killed by
+    /// signalling every member.
+    Adopted { cgroup_path: PathBuf },
+}
+
+/// Read the pids currently in a cgroup (`cgroup.procs`), empty if unreadable.
+fn cgroup_member_pids(cgroup_path: &Path) -> Vec<i32> {
+    std::fs::read_to_string(cgroup_path.join("cgroup.procs"))
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|l| l.trim().parse::<i32>().ok())
+        .collect()
 }
 
 /// Split a finished process's wait status into (exit_code, signal).
@@ -368,6 +382,10 @@ impl RunningJob {
             RunningJob::Managed { child, .. } => child.id(),
             RunningJob::Forked { pid, .. } => Some(*pid as u32),
             RunningJob::AllocationOnly => None,
+            // A representative member for attach/status; the group is the cgroup.
+            RunningJob::Adopted { cgroup_path } => {
+                cgroup_member_pids(cgroup_path).first().map(|p| *p as u32)
+            }
         }
     }
 
@@ -408,6 +426,15 @@ impl RunningJob {
                 }
             }
             RunningJob::AllocationOnly => Ok(None),
+            // A re-adopted job is done when nothing is left in its cgroup. The
+            // real exit code was lost with the process handle across the restart.
+            RunningJob::Adopted { cgroup_path } => {
+                if cgroup_member_pids(cgroup_path).is_empty() {
+                    Ok(Some((0, 0)))
+                } else {
+                    Ok(None)
+                }
+            }
         }
     }
 
@@ -436,6 +463,13 @@ impl RunningJob {
                 Ok(())
             }
             RunningJob::AllocationOnly => Ok(()),
+            // Signal every process in the cgroup — the group is all we have.
+            RunningJob::Adopted { cgroup_path } => {
+                for pid in cgroup_member_pids(cgroup_path) {
+                    let _ = signal::kill(Pid::from_raw(pid), sig);
+                }
+                Ok(())
+            }
         }
     }
 
@@ -443,6 +477,17 @@ impl RunningJob {
         match self {
             RunningJob::Managed { cgroup_path, .. } => cgroup_path.take(),
             RunningJob::Forked { cgroup_path, .. } => cgroup_path.take(),
+            RunningJob::AllocationOnly => None,
+            RunningJob::Adopted { cgroup_path } => Some(cgroup_path.clone()),
+        }
+    }
+
+    /// The job's cgroup without taking it (for persisting a re-adoption manifest).
+    pub fn cgroup(&self) -> Option<&Path> {
+        match self {
+            RunningJob::Managed { cgroup_path, .. } => cgroup_path.as_deref(),
+            RunningJob::Forked { cgroup_path, .. } => cgroup_path.as_deref(),
+            RunningJob::Adopted { cgroup_path } => Some(cgroup_path),
             RunningJob::AllocationOnly => None,
         }
     }

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -8,6 +8,7 @@ pub mod container;
 mod executor;
 pub(crate) mod job_entry;
 mod landlock;
+mod manifest;
 mod mpi_plugin;
 pub(crate) mod privdrop;
 pub(crate) mod pty;
@@ -331,6 +332,11 @@ async fn main() -> anyhow::Result<()> {
     // Shared between the reporter (reads held ids for heartbeats) and the agent
     // service (owns/mutates it) so the controller can reconcile stale allocations.
     let running_jobs = agent_server::new_running_jobs();
+
+    // Re-adopt batch jobs that survived a spurd restart (spur#803): their
+    // processes are still alive in their cgroups, so re-track them before the
+    // reporter's first heartbeat rather than leaving them orphaned.
+    agent_server::readopt_surviving_jobs(&running_jobs).await;
 
     // Create the node reporter
     let reporter = Arc::new(NodeReporter::new(

--- a/crates/spurd/src/manifest.rs
+++ b/crates/spurd/src/manifest.rs
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Persisted job manifests for re-adoption across a spurd restart.
+//!
+//! A batch job's workload survives a spurd restart in its cgroup, but the agent
+//! starts with an empty job map and loses the OS process handle. Without a
+//! record the job is orphaned: the agent refuses to acknowledge it and the
+//! controller keeps reporting it RUNNING forever (spur#803).
+//!
+//! On launch the agent writes a small manifest per job; on startup it reads them
+//! back and re-adopts every job whose cgroup still holds live processes, and
+//! discards the manifests of jobs that ended while the agent was down.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use tracing::warn;
+
+/// Durable manifest directory (under the node-owned spool root, not `/tmp`).
+const MANIFEST_DIR: &str = "/var/spool/spur/manifests";
+
+/// Enough of a job's state to re-track and manage it through its cgroup after a
+/// restart. The process handle and exit code cannot be recovered, so a
+/// re-adopted job is managed via its cgroup and reports a zero exit when it ends.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobManifest {
+    pub job_id: u32,
+    pub uid: u32,
+    pub gid: u32,
+    pub user: String,
+    pub work_dir: String,
+    pub partition: String,
+    pub nodelist: String,
+    pub gpu_devices: Vec<u32>,
+    pub cpus: u32,
+    pub memory_mb: u64,
+    pub mpi: String,
+    pub run_attempt: u32,
+    pub cgroup_path: String,
+    pub has_pid_namespace: bool,
+    pub has_user_namespace: bool,
+    pub has_mount_namespace: bool,
+}
+
+fn manifest_path(job_id: u32) -> PathBuf {
+    PathBuf::from(MANIFEST_DIR).join(format!("{job_id}.json"))
+}
+
+/// Persist a job's manifest. Best-effort: a failure only costs re-adoption of
+/// this one job after a restart, so it must never fail the launch.
+pub fn write(manifest: &JobManifest) {
+    if let Err(e) = std::fs::create_dir_all(MANIFEST_DIR) {
+        warn!(error = %e, "could not create job manifest dir; re-adoption disabled for this job");
+        return;
+    }
+    match serde_json::to_vec_pretty(manifest) {
+        Ok(bytes) => {
+            if let Err(e) = std::fs::write(manifest_path(manifest.job_id), bytes) {
+                warn!(job_id = manifest.job_id, error = %e, "could not write job manifest");
+            }
+        }
+        Err(e) => warn!(job_id = manifest.job_id, error = %e, "could not serialize job manifest"),
+    }
+}
+
+/// Remove a job's manifest once it has ended.
+pub fn remove(job_id: u32) {
+    let _ = std::fs::remove_file(manifest_path(job_id));
+}
+
+/// Load all persisted manifests, skipping any that are unreadable or corrupt.
+pub fn load_all() -> Vec<JobManifest> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(MANIFEST_DIR) {
+        Ok(e) => e,
+        Err(_) => return out, // no manifests (fresh node, or nothing was running)
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        match std::fs::read(&path)
+            .ok()
+            .and_then(|b| serde_json::from_slice::<JobManifest>(&b).ok())
+        {
+            Some(m) => out.push(m),
+            None => warn!(path = %path.display(), "skipping unreadable job manifest"),
+        }
+    }
+    out
+}
+
+/// Whether a cgroup currently holds any process, i.e. the job is still alive.
+pub fn cgroup_has_live_procs(cgroup_path: &str) -> bool {
+    std::fs::read_to_string(Path::new(cgroup_path).join("cgroup.procs"))
+        .map(|s| s.lines().any(|l| !l.trim().is_empty()))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> JobManifest {
+        JobManifest {
+            job_id: 42,
+            uid: 1000,
+            gid: 1000,
+            user: "alice".into(),
+            work_dir: "/home/alice".into(),
+            partition: "gpu".into(),
+            nodelist: "node0".into(),
+            gpu_devices: vec![0, 1],
+            cpus: 8,
+            memory_mb: 4096,
+            mpi: "pmix".into(),
+            run_attempt: 1,
+            cgroup_path: "/sys/fs/cgroup/spur/job_42".into(),
+            has_pid_namespace: true,
+            has_user_namespace: false,
+            has_mount_namespace: true,
+        }
+    }
+
+    #[test]
+    fn manifest_survives_a_json_roundtrip() {
+        let m = sample();
+        let bytes = serde_json::to_vec(&m).unwrap();
+        let back: JobManifest = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(back.job_id, m.job_id);
+        assert_eq!(back.cgroup_path, m.cgroup_path);
+        assert_eq!(back.gpu_devices, m.gpu_devices);
+        assert_eq!(back.run_attempt, m.run_attempt);
+        assert_eq!(back.has_pid_namespace, m.has_pid_namespace);
+    }
+
+    #[test]
+    fn cgroup_liveness_reflects_procs_file_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let cg = dir.path().to_str().unwrap();
+
+        // No cgroup.procs at all → treated as dead (nothing to re-adopt).
+        assert!(!cgroup_has_live_procs(cg));
+
+        // Empty file → dead.
+        std::fs::write(dir.path().join("cgroup.procs"), b"").unwrap();
+        assert!(!cgroup_has_live_procs(cg));
+
+        // Whitespace only → dead (a trailing newline is not a live pid).
+        std::fs::write(dir.path().join("cgroup.procs"), b"\n").unwrap();
+        assert!(!cgroup_has_live_procs(cg));
+
+        // A pid present → alive.
+        std::fs::write(dir.path().join("cgroup.procs"), b"12345\n").unwrap();
+        assert!(cgroup_has_live_procs(cg));
+    }
+}

--- a/tests/native_host/e2e/test_restart_readopt.py
+++ b/tests/native_host/e2e/test_restart_readopt.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E test for agent re-adoption of running jobs across a spurd crash (spur#803).
+
+A batch job's workload lives in its own cgroup, so it survives a spurd crash.
+Before this fix the restarted agent started with an empty job map: it no longer
+tracked the survivor, could not reap it, and the controller still reported it
+RUNNING while the processes ran on untracked. The agent now persists a per-job
+manifest at launch and re-adopts every survivor (a live cgroup) on startup.
+
+This exercises a *crash* (SIGKILL), not a graceful SIGTERM: SIGTERM makes the
+agent deregister and its jobs fail over, which is a different path entirely.
+"""
+
+import time
+
+from cluster import job_state, parse_job_id
+
+
+def _sudo(cluster) -> str:
+    return cluster._sudo_prefix() if cluster.agent_as_root else ""
+
+
+def _cgroup_procs(cluster, job_id: int) -> list[str]:
+    """PIDs in the job's cgroup on node 0 (empty once the job is gone)."""
+    path = f"/sys/fs/cgroup/spur/job_{job_id}/cgroup.procs"
+    out = cluster.nodes[0].exec_allow_fail(
+        f"{_sudo(cluster)}cat {path} 2>/dev/null || true"
+    )
+    return [line for line in out.split() if line.strip()]
+
+
+def _manifest_exists(cluster, job_id: int) -> bool:
+    out = cluster.nodes[0].exec_allow_fail(
+        f"{_sudo(cluster)}test -f /var/spool/spur/manifests/{job_id}.json "
+        f"&& echo YES || echo NO"
+    )
+    return "YES" in out
+
+
+def _crash_and_restart_agent(cluster, node_index: int = 0) -> None:
+    """SIGKILL spurd (no deregister) and start it again, as a crash-restart."""
+    node = cluster.nodes[node_index]
+    node.exec_allow_fail(
+        f"{_sudo(cluster)}pkill -9 -f '{cluster.bin_dir}/spurd' 2>/dev/null || true"
+    )
+    time.sleep(1)
+    node.exec(cluster._spurd_start_cmd(node_index))
+    time.sleep(5)
+
+
+def _wait_running(cluster, job_id: int, timeout: int = 60) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if job_state(cluster.squeue_all(), job_id) == "R":
+            return
+        time.sleep(2)
+    raise AssertionError(f"job {job_id} never reached RUNNING within {timeout}s")
+
+
+class TestRestartReadopt:
+    def test_batch_job_survives_agent_crash_and_stays_reapable(self, cgroup_cluster):
+        cluster = cgroup_cluster
+        node0 = cluster.node_names[0]
+
+        # Ignore SIGTERM so cancelling the job has to reach into its cgroup —
+        # which the restarted agent can only do if it re-adopted the job.
+        script = cluster.write_file(
+            "readopt-long.sh",
+            "#!/bin/bash\ntrap '' TERM\nsleep 600\n",
+        )
+        sb = cluster.sbatch(
+            ["-J", "readopt", "-N", "1", "-w", node0,
+             "--cpus-per-task=1", "--mem=256", script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None, f"sbatch failed: {sb}"
+
+        _wait_running(cluster, job_id)
+        assert _cgroup_procs(cluster, job_id), (
+            "job cgroup should hold the sleep before the crash"
+        )
+        assert _manifest_exists(cluster, job_id), (
+            "agent must persist a re-adoption manifest at launch"
+        )
+
+        # Crash the agent (SIGKILL: no deregister, controller still thinks
+        # RUNNING) and bring it back. The sleep survives in its cgroup.
+        _crash_and_restart_agent(cluster, 0)
+
+        assert _cgroup_procs(cluster, job_id), (
+            "job should survive the agent crash (its cgroup outlives spurd)"
+        )
+
+        # The re-adopted job is still reapable: scancel reaches its cgroup and
+        # kills the SIGTERM-ignoring sleep. Without re-adoption the fresh agent
+        # would not know the job and the sleep would leak on a released node.
+        cluster.scancel(str(job_id))
+        deadline = time.time() + 20
+        while time.time() < deadline:
+            if not _cgroup_procs(cluster, job_id):
+                break
+            time.sleep(1)
+        else:
+            raise AssertionError(
+                "scancel after the crash did not reap the re-adopted job's "
+                "procs — the agent did not re-adopt it"
+            )
+
+        # The manifest is dropped once the job ends, so a later restart does not
+        # try to recover a dead job.
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            if not _manifest_exists(cluster, job_id):
+                break
+            time.sleep(1)
+        else:
+            raise AssertionError("manifest should be removed after the job ends")


### PR DESCRIPTION
## Summary

Fixes #803. A batch job's workload lives in its own cgroup and survives a spurd crash, but the restarted agent started with an empty job map: it no longer tracked the survivor, could not reap it, and the controller kept reporting it RUNNING while the processes ran on untracked.

The agent now persists a small per-job manifest at launch and, on startup, **re-adopts** every job whose cgroup still holds live processes (discarding manifests for jobs that ended while it was down). A re-adopted job is managed entirely through its cgroup, so the **existing monitor loop** detects its completion, cleans it up, and reports it — no new completion path needed.

## Changes

- **`manifest.rs` (new):** durable per-job manifest under `/var/spool/spur/manifests/<id>.json` (`write`/`remove`/`load_all`/`cgroup_has_live_procs`). Best-effort: a write failure only costs re-adoption of that one job, so it never fails the launch.
- **`executor.rs`:** new `RunningJob::Adopted { cgroup_path }` variant, managed through the cgroup — `try_wait` reports done when `cgroup.procs` empties, `kill_signal` signals every member, `pid` returns a representative member; plus a non-taking `cgroup()` getter for persisting the manifest at launch.
- **`agent_server.rs`:** write the manifest at batch launch (cgroup-confined, non-interactive jobs only), remove it on completion and forced drop, and `readopt_surviving_jobs()` to re-track survivors on startup.
- **`main.rs`:** re-adopt before the reporter's first heartbeat.

## Scope

Agent-side re-adoption only (the plan's primary fix: kills nothing valid, keeps valid jobs, makes them reapable again). The controller-side reap-with-grace-guard backstop (belief-fixing when an agent reports a job gone) is left for a follow-up.

## Testing (shark-a, gfx1201 host)

- `cargo clippy -p spurd --all-targets` clean; `cargo fmt --check` clean.
- **spurd unit tests: 278 pass** (added 2 hermetic `manifest` tests — JSON round-trip and cgroup-liveness).
- **New E2E `test_restart_readopt.py`:** submit a `trap '' TERM` batch job → **SIGKILL spurd (crash, no deregister — controller still thinks RUNNING)** → restart → confirm the job survived in its cgroup, then `scancel` reaps it through the re-adopted cgroup handle, and the manifest is cleaned up. **Passes.**
- **Negative control:** with the `readopt_surviving_jobs` call disabled, the same E2E **fails** at the scancel-reap assertion — the orphan's `sleep` leaks. Confirms the test is non-vacuous and the re-adoption is what makes it reapable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
