### PR TITLE
test(e2e): pin the allocation in multi-node -w step tests

### DIFF
--- a/tests/native_host/e2e/test_srun_container.py
+++ b/tests/native_host/e2e/test_srun_container.py
@@ -642,7 +642,11 @@ class TestSrunContainerStepMultiNode:
             f"--container-image='{img}' cat '{MARKER_PATH}' > '{out2}' 2>&1 &\n"
             f"wait"
         )
-        code, out = cluster.salloc_run(body, salloc_args=["-N", "2", "-t", "0:03"])
+        # Pin both nodes: a bare -N 2 is a node count, so the scheduler may
+        # exclude node2 and the -w step below would then fail.
+        code, out = cluster.salloc_run(
+            body, salloc_args=["-N", "2", "-w", f"{node1},{node2}", "-t", "0:03"]
+        )
         assert code == 0, f"salloc overlap run failed (exit {code}):\n{out}"
         # Both srun clients run in the salloc shell (node 0), so both outputs
         # land on node 0.

--- a/tests/native_host/e2e/test_srun_pty.py
+++ b/tests/native_host/e2e/test_srun_pty.py
@@ -106,13 +106,15 @@ class TestSrunPtyStepMultiNode:
         # controller falls back to the first allocated node.
         cluster = multi_node_cluster
         first, target = cluster.node_names[0], cluster.node_names[1]
+        assert first != target, "fixture must provide two distinct nodes"
+        # Pin the allocation to both nodes: a bare -N 2 is a node count, so the
+        # scheduler may exclude `target` and the step's -w below would then fail.
         # Tagged: salloc echoes the whole nodelist, so a bare name match would
         # hold even if the step ran on the wrong node.
         code, out = cluster.salloc_run(
             f'srun --pty -w {target} bash -c \'echo NODE=${{SPUR_TARGET_NODE:-$(hostname)}}\'\n',
-            salloc_args=["-N", "2", "-t", "0:05"],
+            salloc_args=["-N", "2", "-w", f"{first},{target}", "-t", "0:05"],
         )
         assert code == 0, out
-        assert first != target, "fixture must provide two distinct nodes"
         hosts = {ln.split("=", 1)[1].strip() for ln in out.splitlines() if ln.startswith("NODE=")}
         assert hosts == {target}, out


### PR DESCRIPTION
A bare -N 2 is a node count, so the scheduler could allocate a subset that excludes the -w step's target node, failing with "not allocated".