### PR TITLE
feat(spurd): implement --container-remap-root (rootless root)

### DIFF
--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -239,7 +239,8 @@ pub struct SbatchArgs {
     #[arg(long, overrides_with = "container_entrypoint")]
     pub container_entrypoint: Option<String>,
 
-    /// Remap user to root inside container
+    /// Remap the submitting user to root inside the container.
+    /// NOT YET IMPLEMENTED: rejected at submission rather than silently ignored.
     #[arg(long, overrides_with = "container_remap_root")]
     pub container_remap_root: bool,
 

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -239,8 +239,9 @@ pub struct SbatchArgs {
     #[arg(long, overrides_with = "container_entrypoint")]
     pub container_entrypoint: Option<String>,
 
-    /// Remap the submitting user to root inside the container.
-    /// NOT YET IMPLEMENTED: rejected at submission rather than silently ignored.
+    /// Run the container as root (uid 0) inside a user namespace while staying
+    /// the submitting user on the host (rootless-root via idmapped mounts).
+    /// Requires a root spurd; the job never becomes host root.
     #[arg(long, overrides_with = "container_remap_root")]
     pub container_remap_root: bool,
 

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -240,8 +240,9 @@ pub struct SbatchArgs {
     pub container_entrypoint: Option<String>,
 
     /// Run the container as root (uid 0) inside a user namespace while staying
-    /// the submitting user on the host (rootless-root via idmapped mounts).
-    /// Requires a root spurd; the job never becomes host root.
+    /// the submitting user on the host; the job never becomes host root. Takes
+    /// effect on a root daemon (a non-root daemon already runs the container as
+    /// root inside a user namespace).
     #[arg(long, overrides_with = "container_remap_root")]
     pub container_remap_root: bool,
 

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -239,10 +239,9 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     if args.container_remap_root {
         anyhow::bail!(
-            "--container-remap-root is not yet implemented; the container would run as the \
-             submitting user despite the flag. Rootless UID/GID remapping (submitter -> root \
-             inside the container, unprivileged on the host) is planned but not yet available. \
-             Omit the flag rather than rely on it."
+            "--container-remap-root is not yet supported for srun steps. Run it as a batch \
+             container job instead (sbatch --container-image ... --container-remap-root), \
+             where the container runs as root inside a user namespace, unprivileged on the host."
         );
     }
 
@@ -2993,8 +2992,8 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains("--container-remap-root") && msg.contains("not yet implemented"),
-            "expected a not-yet-implemented rejection, got: {msg}"
+            msg.contains("--container-remap-root") && msg.contains("not yet supported"),
+            "expected a not-yet-supported-for-steps rejection, got: {msg}"
         );
     }
 

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -179,7 +179,8 @@ pub struct SrunArgs {
     #[arg(long)]
     pub container_entrypoint: Option<String>,
 
-    /// Remap user to root inside container
+    /// Remap the submitting user to root inside the container.
+    /// NOT YET IMPLEMENTED: rejected at submission rather than silently ignored.
     #[arg(long)]
     pub container_remap_root: bool,
 
@@ -233,6 +234,15 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         anyhow::bail!(
             "--container-readonly is not yet implemented; the container root would be \
              writable despite the flag. Omit it rather than rely on a read-only rootfs."
+        );
+    }
+
+    if args.container_remap_root {
+        anyhow::bail!(
+            "--container-remap-root is not yet implemented; the container would run as the \
+             submitting user despite the flag. Rootless UID/GID remapping (submitter -> root \
+             inside the container, unprivileged on the host) is planned but not yet available. \
+             Omit the flag rather than rely on it."
         );
     }
 
@@ -2965,6 +2975,25 @@ mod tests {
         let msg = format!("{}", result.unwrap_err());
         assert!(
             msg.contains("--container-readonly") && msg.contains("not yet implemented"),
+            "expected a not-yet-implemented rejection, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn container_remap_root_is_rejected() {
+        // The flag was parsed, propagated, and silently ignored; it must now
+        // fail at submission rather than run the container as the submitting user.
+        let result = main_with_args(vec![
+            "srun".into(),
+            "--container-image=img.sqsh".into(),
+            "--container-remap-root".into(),
+            "hostname".into(),
+        ])
+        .await;
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("--container-remap-root") && msg.contains("not yet implemented"),
             "expected a not-yet-implemented rejection, got: {msg}"
         );
     }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -783,6 +783,18 @@ impl SlurmController for ControllerService {
         let mut core_spec = proto_to_job_spec(spec)?;
         Self::bind_spec_to_identity(&mut core_spec, identity.as_ref())?;
 
+        // --container-remap-root is parsed and propagated but rootless UID/GID
+        // remapping is not implemented. Reject it at submission rather than
+        // accept it and silently run the container as the submitting user.
+        if core_spec.container_remap_root {
+            return Err(Status::invalid_argument(
+                "--container-remap-root is not yet implemented; rootless UID/GID remapping \
+                 (submitter -> root inside the container, unprivileged on the host) is planned \
+                 but not available. Resubmit without the flag — the container runs as the \
+                 submitting user.",
+            ));
+        }
+
         // Clamp a non-privileged caller's base priority to the configured ceiling before it reaches
         // the scheduler, so one submission cannot front-run the whole queue. Non-fatal: clamp + warn.
         let priority_warning = Self::clamp_priority(
@@ -5217,6 +5229,35 @@ mod tests {
             .expect_err("submit_job must not serve locally when there is no leader");
         assert_eq!(status.code(), Code::Unavailable);
         assert_eq!(status.message(), "not the Raft leader");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_job_rejects_container_remap_root() {
+        // The flag was parsed and propagated but never honored; submission must
+        // fail rather than run the container as the submitting user.
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let spec = spur_proto::proto::JobSpec {
+            name: "remap".into(),
+            user: "alice".into(),
+            work_dir: "/home/alice".into(),
+            num_nodes: 1,
+            num_tasks: 1,
+            cpus_per_task: 1,
+            container_image: "img.sqsh".into(),
+            container_remap_root: true,
+            ..Default::default()
+        };
+        let status = svc
+            .submit_job(Request::new(SubmitJobRequest { spec: Some(spec) }))
+            .await
+            .expect_err("container_remap_root must be rejected at submission");
+        assert_eq!(status.code(), Code::InvalidArgument);
+        assert!(
+            status.message().contains("--container-remap-root"),
+            "rejection should name the flag, got: {}",
+            status.message()
+        );
     }
 
     #[test]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -783,18 +783,6 @@ impl SlurmController for ControllerService {
         let mut core_spec = proto_to_job_spec(spec)?;
         Self::bind_spec_to_identity(&mut core_spec, identity.as_ref())?;
 
-        // --container-remap-root is parsed and propagated but rootless UID/GID
-        // remapping is not implemented. Reject it at submission rather than
-        // accept it and silently run the container as the submitting user.
-        if core_spec.container_remap_root {
-            return Err(Status::invalid_argument(
-                "--container-remap-root is not yet implemented; rootless UID/GID remapping \
-                 (submitter -> root inside the container, unprivileged on the host) is planned \
-                 but not available. Resubmit without the flag — the container runs as the \
-                 submitting user.",
-            ));
-        }
-
         // Clamp a non-privileged caller's base priority to the configured ceiling before it reaches
         // the scheduler, so one submission cannot front-run the whole queue. Non-fatal: clamp + warn.
         let priority_warning = Self::clamp_priority(
@@ -5229,35 +5217,6 @@ mod tests {
             .expect_err("submit_job must not serve locally when there is no leader");
         assert_eq!(status.code(), Code::Unavailable);
         assert_eq!(status.message(), "not the Raft leader");
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn submit_job_rejects_container_remap_root() {
-        // The flag was parsed and propagated but never honored; submission must
-        // fail rather than run the container as the submitting user.
-        let dir = tempfile::TempDir::new().unwrap();
-        let svc = test_service(&dir).await;
-        let spec = spur_proto::proto::JobSpec {
-            name: "remap".into(),
-            user: "alice".into(),
-            work_dir: "/home/alice".into(),
-            num_nodes: 1,
-            num_tasks: 1,
-            cpus_per_task: 1,
-            container_image: "img.sqsh".into(),
-            container_remap_root: true,
-            ..Default::default()
-        };
-        let status = svc
-            .submit_job(Request::new(SubmitJobRequest { spec: Some(spec) }))
-            .await
-            .expect_err("container_remap_root must be rejected at submission");
-        assert_eq!(status.code(), Code::InvalidArgument);
-        assert!(
-            status.message().contains("--container-remap-root"),
-            "rejection should name the flag, got: {}",
-            status.message()
-        );
     }
 
     #[test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -458,20 +458,23 @@ async fn run_containerized_step(
                 libc::dup2(stderr_fd, libc::STDERR_FILENO);
             }
 
-            crate::container::close_inherited_fds(ready_w_fd);
+            crate::container::close_inherited_fds(&[ready_w_fd]);
 
             executor::apply_memlock(memlock);
 
-            let hook_env = match crate::container::container_init(&container_cfg, &rootfs_clone) {
-                Ok(env) => env,
-                Err(e) => {
-                    let msg = format!("E:{e:#}");
-                    unsafe {
-                        libc::write(ready_w_fd, msg.as_ptr() as *const _, msg.len());
+            // Step containers do not support --container-remap-root yet (it is
+            // rejected at submission); pass None.
+            let hook_env =
+                match crate::container::container_init(&container_cfg, &rootfs_clone, None) {
+                    Ok(env) => env,
+                    Err(e) => {
+                        let msg = format!("E:{e:#}");
+                        unsafe {
+                            libc::write(ready_w_fd, msg.as_ptr() as *const _, msg.len());
+                        }
+                        std::process::exit(1);
                     }
-                    std::process::exit(1);
-                }
-            };
+                };
 
             unsafe { libc::write(ready_w_fd, b"OK".as_ptr() as *const _, 2) };
             drop(ready_w);

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2333,6 +2333,16 @@ impl SlurmAgent for AgentService {
         if req.command.is_empty() {
             return Err(Status::invalid_argument("no command specified"));
         }
+        // --container-remap-root is not yet supported for job steps (only batch
+        // containers implement it). Reject rather than silently run as the
+        // submitting user: the srun CLI already rejects it, but a direct gRPC
+        // client would otherwise bypass that guard.
+        if req.container.as_ref().is_some_and(|c| c.remap_root) {
+            return Err(Status::invalid_argument(
+                "--container-remap-root is not yet supported for job steps; run it as a \
+                 batch container job (sbatch --container-image ... --container-remap-root)",
+            ));
+        }
         // Steps carry their own uid straight from the wire — gate them exactly like a batch launch.
         if let Err(msg) = crate::privdrop::check_root_execution_allowed(
             req.uid,
@@ -5214,6 +5224,38 @@ mod tests {
         assert!(
             err.message().contains("not found"),
             "expected an image-resolution failure, got: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn run_command_rejects_container_remap_root_on_steps() {
+        // --container-remap-root is batch-only; a step that sets it (even a
+        // direct gRPC client bypassing the srun CLI guard) must be refused, not
+        // silently run as the submitting user.
+        let (svc, job_id) = run_command_test_setup().await;
+        let req = Request::new(RunCommandRequest {
+            command: vec!["echo".into(), "hi".into()],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+            job_id,
+            container: Some(spur_proto::proto::ContainerSpec {
+                image: "/some/image.sqsh".into(),
+                remap_root: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        let err = svc
+            .run_command(req)
+            .await
+            .expect_err("a step with --container-remap-root must be rejected");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(
+            err.message().contains("--container-remap-root"),
+            "rejection should name the flag, got: {}",
             err.message()
         );
     }

--- a/crates/spurd/src/container.rs
+++ b/crates/spurd/src/container.rs
@@ -1009,6 +1009,102 @@ fn setup_user_namespace(uid: u32, gid: u32) -> anyhow::Result<()> {
     Ok(())
 }
 
+// ---- Rootless-root (--container-remap-root) ---------------------------------
+//
+// Runs an image as UID 0 inside a user namespace while the host-side identity is
+// the unprivileged submitter, AND keeps root-owned image paths (/root, caches,
+// site-packages) writable. The extracted rootfs is a private per-job tree, so
+// the caller chowns it to the submitter; the container then runs as UID 0 in a
+// user namespace mapping 0 -> submitter, so container-root owns every path and
+// writes succeed — while the process is never host root. The user namespace is
+// created last (after all mount setup) and its map is written by the (root)
+// parent, since an unprivileged post-unshare process cannot self-map an
+// arbitrary host id (validated on hardware; see the parent/child dance in
+// `container_init` + executor's `launch_container_job`).
+//
+// (An idmapped-mount variant would avoid the recursive chown for large images,
+// but needs overlay-mode rootfs + overlay-over-idmap handling — a perf follow-up.)
+
+/// Write `0 <id> 1` uid/gid maps for `pid` (setgroups denied first). The caller
+/// must be root (it maps an arbitrary host id) AND must only call this AFTER the
+/// target has finished `unshare(CLONE_NEWUSER)` — writing earlier fails EPERM.
+pub fn write_container_id_maps(pid: i32, uid: u32, gid: u32) -> anyhow::Result<()> {
+    std::fs::write(format!("/proc/{pid}/uid_map"), format!("0 {uid} 1\n"))
+        .with_context(|| format!("write /proc/{pid}/uid_map"))?;
+    // setgroups must be denied before gid_map; ignore ENOENT on old kernels.
+    let _ = std::fs::write(format!("/proc/{pid}/setgroups"), "deny");
+    std::fs::write(format!("/proc/{pid}/gid_map"), format!("0 {gid} 1\n"))
+        .with_context(|| format!("write /proc/{pid}/gid_map"))?;
+    Ok(())
+}
+
+/// Recursively chown a private per-job extracted rootfs to the submitter, so a
+/// container-root process mapped to that uid owns every path and its writes
+/// succeed. Root-only; runs before the container forks.
+pub fn chown_rootfs_to_submitter(rootfs: &Path, uid: u32, gid: u32) -> anyhow::Result<()> {
+    // `-h` chowns symlinks themselves (never dereferences), matching how the
+    // files were owned in the image. The rootfs is a private per-job tree.
+    let status = std::process::Command::new("chown")
+        .arg("-Rh")
+        .arg(format!("{uid}:{gid}"))
+        .arg(rootfs)
+        .status()
+        .with_context(|| format!("run chown on {}", rootfs.display()))?;
+    if !status.success() {
+        bail!(
+            "chown -Rh {}:{} {} failed ({status})",
+            uid,
+            gid,
+            rootfs.display()
+        );
+    }
+    Ok(())
+}
+
+/// What `container_init` needs to run a `--container-remap-root` job. Built by
+/// the (root) parent before the fork; the fds are inherited across it.
+pub struct RemapSetup {
+    /// Child -> parent: after `unshare(CLONE_NEWUSER)`, the child writes its PID
+    /// as seen in the host pid namespace (4 bytes, native endian) so the parent
+    /// can address `/proc/<pid>/uid_map`.
+    pub map_req_fd: RawFd,
+    /// Parent -> child: one byte once the id maps are written (0 = failure).
+    pub map_go_fd: RawFd,
+}
+
+/// This process's PID in the OUTERMOST (host / spurd) pid namespace, which
+/// `/proc/self/status` reports first in `NSpid`. The remap child is PID 1 in its
+/// own nested pid namespace, so `getpid()` is useless to the parent.
+fn host_pid_from_status() -> anyhow::Result<i32> {
+    let status = std::fs::read_to_string("/proc/self/status").context("read /proc/self/status")?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("NSpid:") {
+            if let Some(first) = rest.split_whitespace().next() {
+                return first.parse::<i32>().context("parse NSpid host pid");
+            }
+        }
+    }
+    bail!("NSpid not present in /proc/self/status");
+}
+
+/// Final step of a remap-root container: create the user namespace and have the
+/// (root) parent write our `0 <submitter> 1` map. Called AFTER dropping to the
+/// submitter and AFTER all mount setup — an unprivileged post-unshare process
+/// may only self-map its own uid, so the arbitrary map must come from the parent.
+fn enter_remap_userns(r: &RemapSetup, host_pid: i32) -> anyhow::Result<()> {
+    use std::os::unix::io::BorrowedFd;
+    nix::sched::unshare(CloneFlags::CLONE_NEWUSER).context("unshare(CLONE_NEWUSER) for remap")?;
+    let req = unsafe { BorrowedFd::borrow_raw(r.map_req_fd) };
+    nix::unistd::write(req, &host_pid.to_ne_bytes()).context("send host pid to parent")?;
+    let go = unsafe { BorrowedFd::borrow_raw(r.map_go_fd) };
+    let mut b = [0u8; 1];
+    nix::unistd::read(go, &mut b).context("wait for parent id-map write")?;
+    if b[0] != 1 {
+        bail!("parent could not write container id maps for --container-remap-root");
+    }
+    Ok(())
+}
+
 /// Make all mounts private so pivot_root works and mount/unmount events
 /// don't propagate between the container and host.
 fn set_mount_propagation_private() -> anyhow::Result<()> {
@@ -1042,7 +1138,7 @@ fn fork_into_pid_namespace() -> anyhow::Result<()> {
 ///
 /// Prevents gRPC sockets, other jobs' output files, etc. from leaking
 /// into the container process.
-pub fn close_inherited_fds(preserve_fd: RawFd) {
+pub fn close_inherited_fds(preserve_fds: &[RawFd]) {
     let fd_dir = Path::new("/proc/self/fd");
     // Collect fds first — iterating /proc/self/fd holds a directory fd
     // that we must not close while the iterator is alive.
@@ -1051,7 +1147,7 @@ pub fn close_inherited_fds(preserve_fd: RawFd) {
         .flatten()
         .flatten()
         .filter_map(|entry| entry.file_name().to_string_lossy().parse::<RawFd>().ok())
-        .filter(|&fd| fd > 2 && fd != preserve_fd)
+        .filter(|&fd| fd > 2 && !preserve_fds.contains(&fd))
         .collect();
     for fd in fds {
         unsafe {
@@ -1064,6 +1160,7 @@ pub fn close_inherited_fds(preserve_fd: RawFd) {
 pub fn container_init(
     config: &ContainerConfig,
     rootfs: &Path,
+    remap: Option<&RemapSetup>,
 ) -> anyhow::Result<HashMap<String, String>> {
     let is_root = nix::unistd::geteuid().is_root();
 
@@ -1076,7 +1173,11 @@ pub fn container_init(
         }
     }
 
-    if is_root {
+    if is_root || remap.is_some() {
+        // Root path (including remap): create the mount + pid namespaces as root.
+        // For remap the USER namespace is created last (below), after every mount
+        // op, because a userns child cannot change the propagation of inherited
+        // mounts (both MS_PRIVATE and MS_SLAVE fail EPERM there).
         nix::sched::unshare(CloneFlags::CLONE_NEWNS | CloneFlags::CLONE_NEWPID)
             .context("unshare(CLONE_NEWNS | CLONE_NEWPID)")?;
     } else {
@@ -1087,6 +1188,18 @@ pub fn container_init(
     set_mount_propagation_private()?;
     fork_into_pid_namespace()?;
 
+    // Remap: read our host-namespace PID NOW, while the host /proc is still
+    // visible. After mount_filesystems mounts the container's own /proc,
+    // /proc/self/status only reports the in-namespace PID (1), which the parent
+    // (in the host pid namespace) cannot address for the id-map write.
+    let remap_host_pid = match remap {
+        Some(_) => Some(host_pid_from_status().context("read remap host pid")?),
+        None => None,
+    };
+
+    // Remap: the rootfs was already chowned to the submitter by the parent, so
+    // all setup here runs as root on a submitter-owned tree (no EOVERFLOW), and
+    // the container-root the submitter maps to owns every path afterwards.
     mount_filesystems(rootfs)?;
 
     // Registry-based device injection
@@ -1107,8 +1220,19 @@ pub fn container_init(
     let workdir = config.workdir.as_deref().unwrap_or("/tmp");
     pivot_into_rootfs(rootfs, workdir)?;
 
-    if is_root {
-        drop_privileges(config.uid, config.gid, &supplementary_gids)?;
+    match remap {
+        Some(r) => {
+            // Drop to the submitter (carrying the GPU groups) FIRST, so the
+            // keep-groups user namespace preserves host device access, then
+            // enter the userns (mapped to container-root by the parent).
+            drop_privileges(config.uid, config.gid, &supplementary_gids)?;
+            enter_remap_userns(r, remap_host_pid.expect("host pid read for remap"))?;
+        }
+        None => {
+            if is_root {
+                drop_privileges(config.uid, config.gid, &supplementary_gids)?;
+            }
+        }
     }
 
     Ok(hook_env)
@@ -1852,7 +1976,7 @@ mod tests {
                 std::mem::forget(f2);
                 std::mem::forget(preserve);
 
-                close_inherited_fds(preserve_fd);
+                close_inherited_fds(&[preserve_fd]);
 
                 let preserved_ok = fd_is_open(preserve_fd);
                 let f1_closed = !fd_is_open(f1_fd);

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1744,6 +1744,27 @@ async fn launch_container_job(
         -1
     };
 
+    // --container-remap-root (root spurd only): chown the private per-job rootfs
+    // to the submitter so the container-root it maps to owns every path, and set
+    // up the parent<->child map-handshake pipes BEFORE the fork so the fds are
+    // inherited. Rootless-root cannot be done by the child alone: an unprivileged
+    // post-unshare process may only self-map its own uid, so the (root) parent
+    // must write the container's `0 <submitter> 1` map after the child unshares.
+    let remap = config.remap_root && nix::unistd::geteuid().is_root();
+    let mut remap_pipes: Option<(OwnedFd, OwnedFd, OwnedFd, OwnedFd)> = None;
+    if remap {
+        crate::container::chown_rootfs_to_submitter(&rootfs, cfg.uid, cfg.gid)
+            .context("chown rootfs for --container-remap-root")?;
+        let (req_r, req_w) = nix::unistd::pipe().context("remap map-request pipe")?;
+        let (go_r, go_w) = nix::unistd::pipe().context("remap map-go pipe")?;
+        remap_pipes = Some((req_r, req_w, go_r, go_w));
+    }
+    // Raw fds the child needs (captured before fork): its request write end and
+    // its go read end.
+    let remap_child_fds: Option<(RawFd, RawFd)> = remap_pipes
+        .as_ref()
+        .map(|(_req_r, req_w, go_r, _go_w)| (req_w.as_raw_fd(), go_r.as_raw_fd()));
+
     match unsafe { nix::unistd::fork().context("fork for container job")? } {
         nix::unistd::ForkResult::Child => {
             // === CHILD PROCESS ===
@@ -1770,22 +1791,31 @@ async fn launch_container_job(
                 join_cgroup_self(procs, cgroup_log_fd);
             }
 
-            crate::container::close_inherited_fds(ready_w);
+            let remap_setup = remap_child_fds.map(|(req_w, go_r)| crate::container::RemapSetup {
+                map_req_fd: req_w,
+                map_go_fd: go_r,
+            });
+            let mut preserve = vec![ready_w];
+            if let Some(ref rs) = remap_setup {
+                preserve.extend([rs.map_req_fd, rs.map_go_fd]);
+            }
+            crate::container::close_inherited_fds(&preserve);
 
             // RLIMIT_MEMLOCK: raise while still root, before container_init drops privileges.
             apply_memlock(cfg.memlock);
 
             // Run container init: namespaces, mounts, pivot_root, priv drop
-            let hook_env = match crate::container::container_init(config, &rootfs) {
-                Ok(env) => env,
-                Err(e) => {
-                    let msg = format!("E:{:#}", e);
-                    unsafe {
-                        libc::write(ready_w, msg.as_ptr() as *const _, msg.len());
+            let hook_env =
+                match crate::container::container_init(config, &rootfs, remap_setup.as_ref()) {
+                    Ok(env) => env,
+                    Err(e) => {
+                        let msg = format!("E:{:#}", e);
+                        unsafe {
+                            libc::write(ready_w, msg.as_ptr() as *const _, msg.len());
+                        }
+                        std::process::exit(1);
                     }
-                    std::process::exit(1);
-                }
-            };
+                };
 
             // Signal parent: setup complete
             unsafe {
@@ -1853,6 +1883,29 @@ async fn launch_container_job(
             let pidfd = pidfd_open(child_pid).ok();
             if pidfd.is_none() {
                 debug!("pidfd_open unavailable, falling back to raw PID tracking");
+            }
+
+            // --container-remap-root handshake: the container (PID 1 in its pid
+            // namespace) unshares its user namespace and sends its HOST pid; we
+            // (root) write its `0 <submitter> 1` id maps and release it. This must
+            // complete before the child can finish container_init and report OK.
+            if let Some((req_r, req_w, go_r, go_w)) = remap_pipes {
+                // Close the child's ends so our read sees EOF if it dies early.
+                drop(req_w);
+                drop(go_r);
+                let mut pid_bytes = [0u8; 4];
+                let n =
+                    unsafe { libc::read(req_r.as_raw_fd(), pid_bytes.as_mut_ptr() as *mut _, 4) };
+                if n == 4 {
+                    let host_pid = i32::from_ne_bytes(pid_bytes);
+                    let ok = crate::container::write_container_id_maps(host_pid, cfg.uid, cfg.gid)
+                        .map_err(|e| warn!(job_id, error = %e, "failed to write container id maps"))
+                        .is_ok();
+                    let byte = [u8::from(ok)];
+                    let _ = unsafe { libc::write(go_w.as_raw_fd(), byte.as_ptr() as *const _, 1) };
+                }
+                drop(req_r);
+                drop(go_w);
             }
 
             let mut buf = [0u8; 512];

--- a/docs/user-guide/running-containers.rst
+++ b/docs/user-guide/running-containers.rst
@@ -70,7 +70,12 @@ runs inside the container.
      - Shell command run inside the container immediately before the job script
        (``<cmd> && <script>``). It does not replace the image's ENTRYPOINT.
    * - ``--container-remap-root``
-     - Map the job user to root inside the container.
+     - Run the container as root (uid 0) inside a user namespace while the
+       host-side identity stays the unprivileged submitter, so a root-layout
+       image can write ``/root`` and other root-owned paths. The job never
+       becomes host root. Batch (``sbatch``) container jobs only; not yet
+       supported for ``srun`` steps. Takes effect on a root daemon — a non-root
+       daemon already runs the container as root inside a user namespace.
 
 A GPU training job with a read-only data mount:
 

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -1056,17 +1056,27 @@ done
         if result.returncode != 0:
             raise RuntimeError(f"rootfs build failed: {result.stderr}")
 
-    def build_container_image(self, tmp_path: Path) -> str:
+    def build_container_image(
+        self, tmp_path: Path, rootfs_extra: str = "", all_root: bool = False
+    ) -> str:
         """
         Build a minimal squashfs container image locally, ship to all nodes.
         Returns the remote path to the .sqsh file.
+
+        *rootfs_extra* is shell appended to the rootfs build (with ``$R`` at the
+        rootfs root) before packing, so a test can plant marker files. When
+        *all_root* is set the image is packed with every file owned by root
+        (mksquashfs ``-all-root``), mimicking a real root-layout image — the
+        case ``--container-remap-root`` exists for.
         """
         remote_path = f"{self.remote_dir}/test-container.sqsh"
         rootfs = tmp_path / "rootfs"
         local_img = tmp_path / "test-container.sqsh"
+        opts = "-all-root" if all_root else ""
         self._build_test_rootfs(
             rootfs,
-            extra=f"""mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1""",
+            extra=f"""{rootfs_extra}
+mksquashfs "$R" '{local_img}' -noappend -quiet {opts} >/dev/null 2>&1""",
         )
 
         for node in self.nodes:

--- a/tests/native_host/e2e/test_container_remap_root.py
+++ b/tests/native_host/e2e/test_container_remap_root.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E for --container-remap-root (rootless-root via idmapped mounts, spur#778).
+
+A root-layout image (everything owned by root, including /root) is run both
+ways under a root spurd. Without the flag the job is the submitting user and
+cannot write root-owned image paths; with the flag it is uid 0 inside a user
+namespace and writes to /root succeed — while never becoming host root.
+"""
+
+import time
+
+import pytest
+
+from cluster import job_state, parse_job_id
+
+# Pure bash (minimal image). Report the in-container uid and whether a write to
+# the root-owned /root succeeds. The trailing sleep keeps the container running
+# past the controller's post-launch dispatch confirmation — a sub-second
+# container job otherwise exits before it is confirmed and gets requeued.
+PROBE = """#!/bin/bash
+echo "UID=$(id -u)"
+if echo hi > /root/remap-test 2>/dev/null; then echo "ROOT_WRITE=ok"; else echo "ROOT_WRITE=fail"; fi
+echo REMAP_PROBE_OK
+sleep 5
+"""
+
+# The image ships a root-owned /root (mkdir; -all-root packs it owned by root).
+ROOTFS_EXTRA = 'mkdir -p "$R/root"; chmod 700 "$R/root"'
+
+
+def _warmup(cluster) -> None:
+    # The first job after a fresh deploy races the controller's post-launch
+    # dispatch confirmation and gets requeued; a throwaway job absorbs that cold
+    # start so the job under test is not the first one.
+    script = cluster.write_file("warmup.sh", "#!/bin/bash\nsleep 3\necho WARM\n")
+    jid = parse_job_id(cluster.sbatch(["-J", "warmup", "-N", "1", script]))
+    deadline = time.time() + 40
+    while time.time() < deadline:
+        if job_state(cluster.squeue_all(), jid) in ("R", "CD", "F", None):
+            return
+        time.sleep(2)
+
+
+def _run(cluster, tmp_path, remap: bool) -> tuple[dict, str]:
+    cluster.container_preflight()
+    # Remap needs a root daemon (chown + parent-written id maps).
+    cluster.start(agent_as_root=True)
+    _warmup(cluster)
+    img = cluster.build_container_image(tmp_path, rootfs_extra=ROOTFS_EXTRA, all_root=True)
+    probe = cluster.write_file("remap-probe.sh", PROBE)
+    out = f"{cluster.remote_dir}/remap-{remap}.out"
+    args = ["-J", "remap", "-N", "1", f"--container-image={img}", "-o", out]
+    if remap:
+        args.append("--container-remap-root")
+    args.append(probe)
+    sb = cluster.sbatch(args)
+    job_id = parse_job_id(sb)
+    assert job_id is not None, f"sbatch failed: {sb}"
+    content = cluster.wait_output(out, "REMAP_PROBE_OK", timeout=120)
+    vals: dict[str, str] = {}
+    for line in content.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            vals[key.strip()] = value.strip()
+    return vals, content
+
+
+class TestContainerRemapRoot:
+    def test_without_remap_runs_as_submitter(self, unstarted_cluster, tmp_path):
+        # Baseline: the container runs as the submitting user and cannot write a
+        # root-owned image path — the failure --container-remap-root fixes.
+        vals, content = _run(unstarted_cluster, tmp_path, remap=False)
+        assert vals.get("UID") not in (None, "0"), (
+            f"without the flag the job should run as the submitter, not root:\n{content}"
+        )
+        assert vals.get("ROOT_WRITE") == "fail", (
+            f"the submitter must NOT be able to write root-owned /root:\n{content}"
+        )
+
+    def test_remap_runs_as_root_and_writes_root_paths(self, unstarted_cluster, tmp_path):
+        # With the flag: uid 0 inside, and root-owned /root is writable.
+        vals, content = _run(unstarted_cluster, tmp_path, remap=True)
+        assert vals.get("UID") == "0", (
+            f"--container-remap-root should make `id -u` == 0 inside:\n{content}"
+        )
+        assert vals.get("ROOT_WRITE") == "ok", (
+            f"the mapped container-root must be able to write root-owned /root:\n{content}"
+        )

--- a/tests/native_host/e2e/test_container_remap_root.py
+++ b/tests/native_host/e2e/test_container_remap_root.py
@@ -11,8 +11,6 @@ namespace and writes to /root succeed — while never becoming host root.
 
 import time
 
-import pytest
-
 from cluster import job_state, parse_job_id
 
 # Pure bash (minimal image). Report the in-container uid and whether a write to


### PR DESCRIPTION
## Summary

Implements #778 (stacked on #840, which rejected the flag as an interim). Replaces the batch-path rejection with a real implementation: a container runs as UID/GID 0 inside a **user namespace** while the host-side identity stays the **unprivileged submitter**, and root-owned image paths (`/root`, HF cache, venv/site-packages, compile caches) are **writable** — the job never becomes host root. This is what root-layout ROCm/AI images need.

**Base this PR on `users/powderluv/fix-778-remap-root` (#840)** so the diff is just the implementation.

## Approach

The per-job rootfs runs in **extracted** mode, so it's `chown`ed to the submitter, then the container runs as UID 0 in a userns mapping `0 → submitter`; container-root then owns every path. The userns is created **last** — after all mount/pivot setup, which runs as root on the (submitter-owned) tree — and its map is written by the **root parent** via a fork handshake, since an unprivileged post-`unshare` process can only self-map its own uid. The child sends its **host-namespace PID** (read from `/proc/self/status` `NSpid` *before* the container's own `/proc` is mounted) so the parent can address `/proc/<pid>/uid_map`.

Validated the primitive in isolation on real hardware before wiring it in; the R&D also proved an idmapped-mount variant (see "Follow-ups").

## Changes

- `container.rs`: `RemapSetup`, `enter_remap_userns`, `host_pid_from_status`, `write_container_id_maps`, `chown_rootfs_to_submitter`; `container_init` takes an optional remap and, for it, drops + enters the userns after setup. `close_inherited_fds` preserves multiple fds.
- `executor.rs`: `launch_container_job` chowns the rootfs, sets up the map-handshake pipes, and writes the container id maps once the child unshares.
- `agent_server.rs`: `has_user_namespace` is true for a remapped root job (so exec/attach enter it with credential preservation); the srun-step path passes `None`.
- `spurctld/server.rs`: drop the batch-submission reject (now implemented); `sbatch` help updated. The **srun-step reject is kept** (that path is a follow-up).

## Testing (shark-a, gfx1201, root spurd)

New E2E `test_container_remap_root.py` — **2/2 pass**:
- without the flag → the job is the submitter and **cannot** write root-owned `/root`;
- with the flag → **`id -u` == 0 inside** and writes to `/root` **succeed**.

`spurd` 276 + `spurctld` 1027 unit tests pass; clippy/fmt clean.

Two issues found + fixed en route: EOVERFLOW from root writing an idmapped mount during setup (resolved by the chown ordering); and the child sending PID 1 instead of its host PID (`NSpid` reads the ns-local pid post-pivot).

## Scope / follow-ups

- **Batch containers only.** srun-step containers stay rejected at submission (#840's srun guard) — a follow-up.
- **Idmapped-mount optimization** to avoid the `chown` cost on large images (the perf-correct path) — needs overlay-mode rootfs + overlay-over-idmap; the validated primitive is recorded for that work.
- A sub-second or first-after-deploy container job races the controller's post-launch dispatch confirmation and requeues (worked around in the E2E with a warmup + trailing sleep) — likely a real product bug worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
