### PR TITLE
feat(spurd): add opt-in native SSH allocation adoption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3804,6 +3804,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "spur-pam"
+version = "0.10.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "spur-proto"
 version = "0.10.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/spurd",
     "crates/spur-cli",
     "crates/spur-ffi",
+    "crates/spur-pam",
     "crates/spur-spank",
     "crates/spur-mpi-pmix",
     "crates/spur-k8s",

--- a/crates/spur-pam/Cargo.toml
+++ b/crates/spur-pam/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "spur-pam"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[lib]
+name = "pam_spur"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+libc = "0.2"

--- a/crates/spur-pam/src/lib.rs
+++ b/crates/spur-pam/src/lib.rs
@@ -1,0 +1,534 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(target_os = "linux")]
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use libc::{c_char, c_int, c_void};
+use std::ffi::{CStr, CString};
+use std::io::{Read, Write};
+use std::mem::size_of;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::net::UnixStream;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::Path;
+use std::ptr;
+use std::time::{Duration, Instant};
+
+const PAM_SUCCESS: c_int = 0;
+const PAM_SYSTEM_ERR: c_int = 4;
+const PAM_PERM_DENIED: c_int = 6;
+const PAM_SERVICE: c_int = 1;
+const IO_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_RESPONSE: usize = 4096;
+
+extern "C" {
+    fn pam_get_user(pamh: *mut c_void, user: *mut *const c_char, prompt: *const c_char) -> c_int;
+    fn pam_get_item(pamh: *const c_void, item: c_int, value: *mut *const c_void) -> c_int;
+    fn pam_putenv(pamh: *mut c_void, assignment: *const c_char) -> c_int;
+}
+
+type PamResult<T> = Result<T, c_int>;
+
+#[derive(Debug, PartialEq, Eq)]
+struct Allocation {
+    job_id: String,
+    gpu_csv: String,
+}
+
+fn valid_username(user: &[u8]) -> bool {
+    !user.is_empty()
+        && user.len() <= 128
+        && user != b"root"
+        && user
+            .iter()
+            .all(|c| c.is_ascii_alphanumeric() || b"_.-".contains(c))
+}
+
+fn decimal(value: &str) -> Option<u64> {
+    if value.is_empty() || !value.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    value.parse().ok()
+}
+
+fn parse_response(line: &[u8]) -> PamResult<Allocation> {
+    if line.len() > MAX_RESPONSE || !line.is_ascii() || !line.ends_with(b"\n") {
+        return Err(PAM_SYSTEM_ERR);
+    }
+    if line == b"DENY\n" {
+        return Err(PAM_PERM_DENIED);
+    }
+    let text = std::str::from_utf8(&line[..line.len() - 1]).map_err(|_| PAM_SYSTEM_ERR)?;
+    let mut fields = text.split(' ');
+    if fields.next() != Some("OK") {
+        return Err(PAM_SYSTEM_ERR);
+    }
+    let job_id = fields.next().ok_or(PAM_SYSTEM_ERR)?;
+    let gpu_csv = fields.next().ok_or(PAM_SYSTEM_ERR)?;
+    if fields.next().is_some() || !matches!(decimal(job_id), Some(1..)) {
+        return Err(PAM_SYSTEM_ERR);
+    }
+    if gpu_csv != "-1" {
+        let mut seen = std::collections::HashSet::new();
+        for gpu in gpu_csv.split(',') {
+            let index = decimal(gpu).ok_or(PAM_SYSTEM_ERR)?;
+            if index > c_int::MAX as u64 || !seen.insert(index) {
+                return Err(PAM_SYSTEM_ERR);
+            }
+        }
+    }
+    Ok(Allocation {
+        job_id: job_id.to_owned(),
+        gpu_csv: gpu_csv.to_owned(),
+    })
+}
+
+fn require_root(uid: libc::uid_t) -> PamResult<()> {
+    if uid == 0 {
+        Ok(())
+    } else {
+        Err(PAM_PERM_DENIED)
+    }
+}
+
+fn check_peer(stream: &UnixStream, expected_uid: libc::uid_t) -> PamResult<()> {
+    let mut credentials = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            (&mut credentials as *mut libc::ucred).cast(),
+            &mut len,
+        )
+    };
+    if result != 0 || len as usize != std::mem::size_of::<libc::ucred>() {
+        return Err(PAM_SYSTEM_ERR);
+    }
+    if credentials.uid != expected_uid || credentials.pid <= 0 {
+        return Err(PAM_PERM_DENIED);
+    }
+    Ok(())
+}
+
+fn daemon_uid() -> libc::uid_t {
+    #[cfg(not(test))]
+    {
+        0
+    }
+    #[cfg(test)]
+    {
+        tests::EXPECTED_UID.with(|uid| uid.get())
+    }
+}
+
+fn caller_uid() -> libc::uid_t {
+    #[cfg(not(test))]
+    {
+        unsafe { libc::geteuid() }
+    }
+    #[cfg(test)]
+    {
+        tests::CALLER_UID.with(|uid| uid.get())
+    }
+}
+
+fn remaining(deadline: Instant) -> PamResult<Duration> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .filter(|duration| !duration.is_zero())
+        .ok_or(PAM_SYSTEM_ERR)
+}
+
+fn wait_connected(stream: &UnixStream, deadline: Instant) -> PamResult<()> {
+    loop {
+        let budget = remaining(deadline)?;
+        let millis = budget.as_millis() + u128::from(budget.subsec_nanos() % 1_000_000 != 0);
+        let timeout = c_int::try_from(millis).unwrap_or(c_int::MAX);
+        let mut descriptor = libc::pollfd {
+            fd: stream.as_raw_fd(),
+            events: libc::POLLOUT,
+            revents: 0,
+        };
+        // SAFETY: descriptor is valid for one pollfd and stream owns its open descriptor.
+        let result = unsafe { libc::poll(&mut descriptor, 1, timeout) };
+        remaining(deadline)?;
+        if result < 0 {
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(PAM_SYSTEM_ERR);
+        }
+        if result == 0 {
+            continue;
+        }
+        if descriptor.revents & libc::POLLNVAL != 0
+            || stream.take_error().map_err(|_| PAM_SYSTEM_ERR)?.is_some()
+            || descriptor.revents & libc::POLLOUT == 0
+        {
+            return Err(PAM_SYSTEM_ERR);
+        }
+        return Ok(());
+    }
+}
+
+fn connect(path: &Path, deadline: Instant) -> PamResult<UnixStream> {
+    remaining(deadline)?;
+    let bytes = path.as_os_str().as_bytes();
+    let mut address = libc::sockaddr_un {
+        sun_family: libc::AF_UNIX as libc::sa_family_t,
+        sun_path: [0; 108],
+    };
+    if bytes.is_empty() || bytes.len() >= address.sun_path.len() || bytes.contains(&0) {
+        return Err(PAM_SYSTEM_ERR);
+    }
+    for (target, byte) in address.sun_path.iter_mut().zip(bytes) {
+        *target = *byte as c_char;
+    }
+    let length = std::mem::offset_of!(libc::sockaddr_un, sun_path) + bytes.len() + 1;
+    let length = libc::socklen_t::try_from(length).map_err(|_| PAM_SYSTEM_ERR)?;
+    // SAFETY: AF_UNIX stream socket creation has no pointer arguments.
+    let fd = unsafe {
+        libc::socket(
+            libc::AF_UNIX,
+            libc::SOCK_STREAM | libc::SOCK_CLOEXEC | libc::SOCK_NONBLOCK,
+            0,
+        )
+    };
+    if fd < 0 {
+        return Err(PAM_SYSTEM_ERR);
+    }
+    // SAFETY: fd is a new, valid stream socket whose sole ownership is transferred here.
+    let stream = unsafe { UnixStream::from_raw_fd(fd) };
+    remaining(deadline)?;
+    // SAFETY: address is initialized and length includes only its bounded, NUL-terminated path.
+    let result = unsafe {
+        libc::connect(
+            stream.as_raw_fd(),
+            (&address as *const libc::sockaddr_un).cast(),
+            length,
+        )
+    };
+    if result != 0 {
+        // Linux AF_UNIX EAGAIN means a full queue, not a pending connection.
+        if std::io::Error::last_os_error().raw_os_error() != Some(libc::EINPROGRESS) {
+            return Err(PAM_SYSTEM_ERR);
+        }
+        wait_connected(&stream, deadline)?;
+    }
+    remaining(deadline)?;
+    stream.set_nonblocking(false).map_err(|_| PAM_SYSTEM_ERR)?;
+    Ok(stream)
+}
+
+fn write_request(stream: &mut UnixStream, mut request: &[u8], deadline: Instant) -> PamResult<()> {
+    while !request.is_empty() {
+        stream
+            .set_write_timeout(Some(remaining(deadline)?))
+            .map_err(|_| PAM_SYSTEM_ERR)?;
+        match stream.write(request) {
+            Ok(0) => return Err(PAM_SYSTEM_ERR),
+            Ok(written) => request = &request[written..],
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(_) => return Err(PAM_SYSTEM_ERR),
+        }
+    }
+    remaining(deadline)?;
+    Ok(())
+}
+
+fn read_response(stream: &mut UnixStream, deadline: Instant) -> PamResult<Allocation> {
+    let mut line = Vec::with_capacity(128);
+    loop {
+        // An absolute deadline also bounds a peer that trickles bytes indefinitely.
+        stream
+            .set_read_timeout(Some(remaining(deadline)?))
+            .map_err(|_| PAM_SYSTEM_ERR)?;
+        let mut byte = [0];
+        match stream.read(&mut byte) {
+            Ok(1) => {
+                remaining(deadline)?;
+                line.push(byte[0]);
+                if byte[0] == b'\n' {
+                    return parse_response(&line);
+                }
+                if line.len() >= MAX_RESPONSE {
+                    return Err(PAM_SYSTEM_ERR);
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            _ => return Err(PAM_SYSTEM_ERR),
+        }
+    }
+}
+
+fn receive_membership(stream: &UnixStream, deadline: Instant) -> PamResult<OwnedFd> {
+    const MAX_FDS: usize = 8;
+    let control_size = unsafe { libc::CMSG_SPACE((MAX_FDS * size_of::<c_int>()) as u32) } as usize;
+    // cmsghdr storage guarantees alignment, unlike a byte array.
+    let mut control = vec![
+        unsafe { std::mem::zeroed::<libc::cmsghdr>() };
+        control_size.div_ceil(size_of::<libc::cmsghdr>())
+    ];
+    loop {
+        stream
+            .set_read_timeout(Some(remaining(deadline)?))
+            .map_err(|_| PAM_SYSTEM_ERR)?;
+        let mut byte = [0u8];
+        let mut iov = libc::iovec {
+            iov_base: byte.as_mut_ptr().cast(),
+            iov_len: 1,
+        };
+        let mut message: libc::msghdr = unsafe { std::mem::zeroed() };
+        message.msg_iov = &mut iov;
+        message.msg_iovlen = 1;
+        message.msg_control = control.as_mut_ptr().cast();
+        message.msg_controllen = control_size;
+        // One byte preserves the following stream response; CLOEXEC is atomic with receipt.
+        let received =
+            unsafe { libc::recvmsg(stream.as_raw_fd(), &mut message, libc::MSG_CMSG_CLOEXEC) };
+        if received < 0 {
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(PAM_SYSTEM_ERR);
+        }
+        let mut descriptors = Vec::with_capacity(MAX_FDS);
+        let mut malformed = message.msg_flags & (libc::MSG_CTRUNC | libc::MSG_TRUNC) != 0;
+        let mut rights_messages = 0;
+        let header_size = unsafe { libc::CMSG_LEN(0) } as usize;
+        let mut offset = 0;
+        let length = message.msg_controllen.min(control_size);
+        malformed |= message.msg_controllen > control_size;
+        while length.saturating_sub(offset) >= size_of::<libc::cmsghdr>() {
+            // The kernel supplies aligned headers, but unaligned reads also bound malformed input.
+            let base = unsafe { message.msg_control.cast::<u8>().add(offset) };
+            let header = unsafe { ptr::read_unaligned(base.cast::<libc::cmsghdr>()) };
+            if header.cmsg_len < header_size {
+                malformed = true;
+                break;
+            }
+            let available = length - offset;
+            let bounded_length = header.cmsg_len.min(available);
+            malformed |= header.cmsg_len > available;
+            if header.cmsg_level == libc::SOL_SOCKET && header.cmsg_type == libc::SCM_RIGHTS {
+                rights_messages += 1;
+                let payload = bounded_length.saturating_sub(header_size);
+                malformed |= payload == 0 || payload % size_of::<c_int>() != 0;
+                for index in 0..payload / size_of::<c_int>() {
+                    let fd = unsafe {
+                        ptr::read_unaligned(
+                            base.add(header_size + index * size_of::<c_int>()).cast(),
+                        )
+                    };
+                    if fd < 0 {
+                        malformed = true;
+                    } else {
+                        // Own every delivered descriptor before any error/deadline return.
+                        descriptors.push(unsafe { OwnedFd::from_raw_fd(fd) });
+                    }
+                }
+            } else {
+                malformed = true;
+            }
+            if header.cmsg_len > available {
+                break;
+            }
+            let aligned_length = header.cmsg_len.div_ceil(size_of::<usize>()) * size_of::<usize>();
+            offset += aligned_length;
+        }
+        remaining(deadline)?;
+        if malformed || received != 1 {
+            return Err(PAM_SYSTEM_ERR);
+        }
+        if byte[0] == b'D' && descriptors.is_empty() && rights_messages == 0 {
+            return Err(PAM_PERM_DENIED);
+        }
+        if byte[0] != b'F' || descriptors.len() != 1 || rights_messages != 1 {
+            return Err(PAM_SYSTEM_ERR);
+        }
+        let fd = descriptors.pop().ok_or(PAM_SYSTEM_ERR)?;
+        let flags = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GETFL) };
+        let descriptor_flags = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GETFD) };
+        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+        if flags < 0
+            || !matches!(flags & libc::O_ACCMODE, libc::O_WRONLY | libc::O_RDWR)
+            || descriptor_flags < 0
+            || descriptor_flags & libc::FD_CLOEXEC == 0
+            || unsafe { libc::fstat(fd.as_raw_fd(), stat.as_mut_ptr()) } != 0
+        {
+            return Err(PAM_SYSTEM_ERR);
+        }
+        if unsafe { stat.assume_init() }.st_mode & libc::S_IFMT != libc::S_IFREG {
+            return Err(PAM_SYSTEM_ERR);
+        }
+        return Ok(fd);
+    }
+}
+
+fn join_membership(fd: OwnedFd, deadline: Instant) -> PamResult<()> {
+    // A single cgroup write of zero adopts this caller, never a reusable numeric PID.
+    loop {
+        remaining(deadline)?;
+        let written = unsafe { libc::write(fd.as_raw_fd(), b"0\n".as_ptr().cast(), 2) };
+        if written == 2 {
+            break;
+        }
+        if written < 0 && std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted
+        {
+            continue;
+        }
+        return Err(PAM_SYSTEM_ERR);
+    }
+    drop(fd);
+    remaining(deadline)?;
+    Ok(())
+}
+
+fn exchange(path: &Path, user: &str, adopt: bool) -> PamResult<Allocation> {
+    let deadline = Instant::now() + IO_TIMEOUT;
+    // Never cache this connection: ADOPT's SO_PEERCRED must identify the session caller.
+    let mut stream = connect(path, deadline)?;
+    check_peer(&stream, daemon_uid())?;
+    let operation = if adopt { "ADOPT" } else { "CHECK" };
+    write_request(
+        &mut stream,
+        format!("SPURSSH1 {operation} {user}\n").as_bytes(),
+        deadline,
+    )?;
+    if adopt {
+        let fd = receive_membership(&stream, deadline)?;
+        join_membership(fd, deadline)?;
+        write_request(&mut stream, b"JOINED\n", deadline)?;
+    }
+    read_response(&mut stream, deadline)
+}
+
+unsafe fn context<'a>(
+    pamh: *mut c_void,
+    argc: c_int,
+    argv: *const *const c_char,
+) -> PamResult<(&'a Path, &'a str)> {
+    if pamh.is_null() || argc != 1 || argv.is_null() {
+        return Err(PAM_SYSTEM_ERR);
+    }
+    require_root(caller_uid())?;
+    let option = unsafe { *argv };
+    if option.is_null() {
+        return Err(PAM_SYSTEM_ERR);
+    }
+    let option = unsafe { CStr::from_ptr(option) }.to_bytes();
+    let socket = option.strip_prefix(b"socket=").ok_or(PAM_SYSTEM_ERR)?;
+    let path = Path::new(std::ffi::OsStr::from_bytes(socket));
+    if !path.is_absolute() {
+        return Err(PAM_SYSTEM_ERR);
+    }
+    let mut service = ptr::null();
+    let status = unsafe { pam_get_item(pamh, PAM_SERVICE, &mut service) };
+    if status != PAM_SUCCESS {
+        return Err(status);
+    }
+    if service.is_null() || unsafe { CStr::from_ptr(service.cast()) }.to_bytes() != b"sshd" {
+        return Err(PAM_PERM_DENIED);
+    }
+    let mut user = ptr::null();
+    let status = unsafe { pam_get_user(pamh, &mut user, ptr::null()) };
+    if status != PAM_SUCCESS {
+        return Err(status);
+    }
+    if user.is_null() {
+        return Err(PAM_PERM_DENIED);
+    }
+    let user = unsafe { CStr::from_ptr(user) }.to_bytes();
+    if !valid_username(user) {
+        return Err(PAM_PERM_DENIED);
+    }
+    Ok((
+        path,
+        std::str::from_utf8(user).map_err(|_| PAM_PERM_DENIED)?,
+    ))
+}
+
+unsafe fn export_allocation(pamh: *mut c_void, allocation: Allocation) -> PamResult<()> {
+    // Only allocation metadata is replaced; sshd/PAM retain HOME, SHELL and login context.
+    for (key, value) in [
+        ("SPUR_JOB_ID", &allocation.job_id),
+        ("SLURM_JOB_ID", &allocation.job_id),
+        ("ROCR_VISIBLE_DEVICES", &allocation.gpu_csv),
+        ("CUDA_VISIBLE_DEVICES", &allocation.gpu_csv),
+        ("GPU_DEVICE_ORDINAL", &allocation.gpu_csv),
+    ] {
+        let assignment = CString::new(format!("{key}={value}")).map_err(|_| PAM_SYSTEM_ERR)?;
+        let status = unsafe { pam_putenv(pamh, assignment.as_ptr()) };
+        if status != PAM_SUCCESS {
+            return Err(status);
+        }
+    }
+    Ok(())
+}
+
+fn boundary(action: impl FnOnce() -> PamResult<()>) -> c_int {
+    match catch_unwind(AssertUnwindSafe(action)) {
+        Ok(Ok(())) => PAM_SUCCESS,
+        Ok(Err(status)) => status,
+        Err(_) => PAM_SYSTEM_ERR,
+    }
+}
+
+/// # Safety
+/// Arguments must satisfy the Linux-PAM module ABI, including valid C strings.
+#[no_mangle]
+pub unsafe extern "C" fn pam_sm_acct_mgmt(
+    pamh: *mut c_void,
+    _flags: c_int,
+    argc: c_int,
+    argv: *const *const c_char,
+) -> c_int {
+    boundary(|| {
+        let (path, user) = unsafe { context(pamh, argc, argv) }?;
+        exchange(path, user, false)?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// Arguments must satisfy the Linux-PAM module ABI, including valid C strings.
+#[no_mangle]
+pub unsafe extern "C" fn pam_sm_open_session(
+    pamh: *mut c_void,
+    _flags: c_int,
+    argc: c_int,
+    argv: *const *const c_char,
+) -> c_int {
+    boundary(|| {
+        let (path, user) = unsafe { context(pamh, argc, argv) }?;
+        let allocation = exchange(path, user, true)?;
+        unsafe { export_allocation(pamh, allocation) }
+    })
+}
+
+/// # Safety
+/// Arguments must satisfy the Linux-PAM module ABI, including valid C strings.
+#[no_mangle]
+pub unsafe extern "C" fn pam_sm_close_session(
+    pamh: *mut c_void,
+    _flags: c_int,
+    argc: c_int,
+    argv: *const *const c_char,
+) -> c_int {
+    boundary(|| {
+        unsafe { context(pamh, argc, argv) }?;
+        // Allocation lifetime belongs to the scheduler, not any individual SSH session.
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/spur-pam/src/tests.rs
+++ b/crates/spur-pam/src/tests.rs
@@ -1,0 +1,746 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use std::cell::Cell;
+use std::collections::BTreeMap;
+use std::os::unix::net::UnixListener;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+thread_local! {
+    pub(super) static EXPECTED_UID: Cell<libc::uid_t> = Cell::new(unsafe { libc::geteuid() });
+    pub(super) static CALLER_UID: Cell<libc::uid_t> = const { Cell::new(0) };
+}
+
+struct FakePam {
+    user: Option<CString>,
+    service: Option<CString>,
+    user_error: c_int,
+    item_error: c_int,
+    env_error: c_int,
+    env: BTreeMap<String, String>,
+}
+
+impl FakePam {
+    fn new() -> Self {
+        Self {
+            user: Some(CString::new("alice").unwrap()),
+            service: Some(CString::new("sshd").unwrap()),
+            user_error: 0,
+            item_error: 0,
+            env_error: 0,
+            env: BTreeMap::from([
+                ("HOME".into(), "/home/alice".into()),
+                ("SHELL".into(), "/bin/bash".into()),
+                ("USER".into(), "alice".into()),
+                ("LOGNAME".into(), "alice".into()),
+                ("CUDA_VISIBLE_DEVICES".into(), "untrusted".into()),
+                ("SPUR_JOB_ID".into(), "untrusted".into()),
+            ]),
+        }
+    }
+
+    fn handle(&mut self) -> *mut c_void {
+        (self as *mut Self).cast()
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn pam_get_user(
+    pamh: *mut c_void,
+    user: *mut *const c_char,
+    _prompt: *const c_char,
+) -> c_int {
+    let pam = unsafe { &mut *pamh.cast::<FakePam>() };
+    unsafe { *user = pam.user.as_ref().map_or(ptr::null(), |s| s.as_ptr()) };
+    pam.user_error
+}
+
+#[no_mangle]
+unsafe extern "C" fn pam_get_item(
+    pamh: *const c_void,
+    item: c_int,
+    value: *mut *const c_void,
+) -> c_int {
+    if item != PAM_SERVICE {
+        return PAM_SYSTEM_ERR;
+    }
+    let pam = unsafe { &*pamh.cast::<FakePam>() };
+    unsafe {
+        *value = pam
+            .service
+            .as_ref()
+            .map_or(ptr::null(), |s| s.as_ptr().cast())
+    };
+    pam.item_error
+}
+
+#[no_mangle]
+unsafe extern "C" fn pam_putenv(pamh: *mut c_void, assignment: *const c_char) -> c_int {
+    let pam = unsafe { &mut *pamh.cast::<FakePam>() };
+    if pam.env_error != 0 {
+        return pam.env_error;
+    }
+    let Ok(text) = (unsafe { CStr::from_ptr(assignment) }).to_str() else {
+        return PAM_SYSTEM_ERR;
+    };
+    let Some((key, value)) = text.split_once('=') else {
+        return PAM_SYSTEM_ERR;
+    };
+    pam.env.insert(key.into(), value.into());
+    PAM_SUCCESS
+}
+
+struct SocketPath(std::path::PathBuf);
+impl SocketPath {
+    fn new() -> Self {
+        static NEXT: AtomicUsize = AtomicUsize::new(0);
+        Self(std::env::temp_dir().join(format!(
+            "spur-pam-{}-{}.sock",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        )))
+    }
+    fn option(&self) -> CString {
+        CString::new(format!("socket={}", self.0.display())).unwrap()
+    }
+}
+impl Drop for SocketPath {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+type Entry = unsafe extern "C" fn(*mut c_void, c_int, c_int, *const *const c_char) -> c_int;
+
+fn call(entry: Entry, pam: &mut FakePam, options: &[&str]) -> c_int {
+    let strings: Vec<_> = options.iter().map(|s| CString::new(*s).unwrap()).collect();
+    let args: Vec<_> = strings.iter().map(|s| s.as_ptr()).collect();
+    unsafe { entry(pam.handle(), 0, args.len() as c_int, args.as_ptr()) }
+}
+
+fn request(stream: &mut UnixStream) -> String {
+    let mut bytes = Vec::new();
+    loop {
+        let mut byte = [0];
+        stream.read_exact(&mut byte).unwrap();
+        bytes.push(byte[0]);
+        if byte[0] == b'\n' {
+            break;
+        }
+        assert!(bytes.len() < 256);
+    }
+    String::from_utf8(bytes).unwrap()
+}
+
+fn membership_file() -> (SocketPath, std::fs::File) {
+    let path = SocketPath::new();
+    let file = std::fs::OpenOptions::new()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .open(&path.0)
+        .unwrap();
+    (path, file)
+}
+
+fn send_fds(mut stream: &UnixStream, bytes: &[u8], fds: &[c_int]) {
+    assert!(!bytes.is_empty());
+    if fds.is_empty() {
+        stream.write_all(bytes).unwrap();
+        return;
+    }
+    let payload = std::mem::size_of_val(fds);
+    let control_size = unsafe { libc::CMSG_SPACE(payload as u32) } as usize;
+    let mut control = vec![
+        unsafe { std::mem::zeroed::<libc::cmsghdr>() };
+        control_size.div_ceil(size_of::<libc::cmsghdr>())
+    ];
+    let mut iov = libc::iovec {
+        iov_base: bytes.as_ptr().cast_mut().cast(),
+        iov_len: bytes.len(),
+    };
+    let mut message: libc::msghdr = unsafe { std::mem::zeroed() };
+    message.msg_iov = &mut iov;
+    message.msg_iovlen = 1;
+    message.msg_control = control.as_mut_ptr().cast();
+    message.msg_controllen = control_size;
+    unsafe {
+        let header = libc::CMSG_FIRSTHDR(&message);
+        (*header).cmsg_level = libc::SOL_SOCKET;
+        (*header).cmsg_type = libc::SCM_RIGHTS;
+        (*header).cmsg_len = libc::CMSG_LEN(payload as u32) as usize;
+        ptr::copy_nonoverlapping(fds.as_ptr().cast::<u8>(), libc::CMSG_DATA(header), payload);
+        assert_eq!(
+            libc::sendmsg(stream.as_raw_fd(), &message, libc::MSG_NOSIGNAL),
+            bytes.len() as isize
+        );
+    }
+}
+
+fn handoff(stream: &mut UnixStream) {
+    let (path, file) = membership_file();
+    send_fds(stream, b"F", &[file.as_raw_fd()]);
+    assert_eq!(request(stream), "JOINED\n");
+    assert_eq!(references_to(&file), 1);
+    assert_eq!(std::fs::read(&path.0).unwrap(), b"0\n");
+}
+
+fn serve_once(entry: Entry, pam: &mut FakePam, response: Vec<u8>) -> (c_int, String) {
+    let path = SocketPath::new();
+    let listener = UnixListener::bind(&path.0).unwrap();
+    let worker = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let line = request(&mut stream);
+        if line.starts_with("SPURSSH1 ADOPT ") && response.starts_with(b"OK ") {
+            handoff(&mut stream);
+        }
+        let _ = stream.write_all(&response);
+        line
+    });
+    let result = call(entry, pam, &[path.option().to_str().unwrap()]);
+    (result, worker.join().unwrap())
+}
+
+#[test]
+fn exported_check_then_adopt_connect_separately_and_preserve_login_context() {
+    let path = SocketPath::new();
+    let listener = UnixListener::bind(&path.0).unwrap();
+    let worker = thread::spawn(move || {
+        let (mut monitor, _) = listener.accept().unwrap();
+        assert_eq!(request(&mut monitor), "SPURSSH1 CHECK alice\n");
+        monitor.write_all(b"OK 21 0\n").unwrap();
+        assert_eq!(monitor.read(&mut [0]).unwrap(), 0);
+        let (mut session, _) = listener.accept().unwrap();
+        check_peer(&session, unsafe { libc::geteuid() }).unwrap();
+        assert_eq!(request(&mut session), "SPURSSH1 ADOPT alice\n");
+        handoff(&mut session);
+        session.write_all(b"OK 42 2,5\n").unwrap();
+    });
+    let mut pam = FakePam::new();
+    let before = pam.env.clone();
+    let option = path.option();
+    assert_eq!(
+        call(pam_sm_acct_mgmt, &mut pam, &[option.to_str().unwrap()]),
+        PAM_SUCCESS
+    );
+    assert_eq!(pam.env, before);
+    assert_eq!(
+        call(pam_sm_open_session, &mut pam, &[option.to_str().unwrap()]),
+        PAM_SUCCESS
+    );
+    worker.join().unwrap();
+    for key in ["SPUR_JOB_ID", "SLURM_JOB_ID"] {
+        assert_eq!(pam.env[key], "42");
+    }
+    for key in [
+        "ROCR_VISIBLE_DEVICES",
+        "CUDA_VISIBLE_DEVICES",
+        "GPU_DEVICE_ORDINAL",
+    ] {
+        assert_eq!(pam.env[key], "2,5");
+    }
+    for key in ["HOME", "SHELL", "USER", "LOGNAME"] {
+        assert_eq!(pam.env[key], before[key]);
+    }
+    let adopted = pam.env.clone();
+    // The listener is gone: close must neither contact it nor release anything.
+    assert_eq!(
+        call(pam_sm_close_session, &mut pam, &[option.to_str().unwrap()]),
+        PAM_SUCCESS
+    );
+    assert_eq!(pam.env, adopted);
+}
+
+#[test]
+fn valid_responses_and_no_gpu_mask() {
+    for line in [
+        b"OK 1 0\n".as_slice(),
+        b"OK 18446744073709551615 0,2,17\n",
+        b"OK 42 -1\n",
+    ] {
+        assert!(parse_response(line).is_ok());
+    }
+    let mut pam = FakePam::new();
+    assert_eq!(
+        serve_once(pam_sm_open_session, &mut pam, b"OK 8 -1\n".to_vec()).0,
+        0
+    );
+    for key in [
+        "ROCR_VISIBLE_DEVICES",
+        "CUDA_VISIBLE_DEVICES",
+        "GPU_DEVICE_ORDINAL",
+    ] {
+        assert_eq!(pam.env[key], "-1");
+    }
+}
+
+#[test]
+fn parser_rejects_malformed_and_oversized_responses() {
+    for line in [
+        "",
+        "DENY",
+        "DENY \n",
+        "OK 1 0",
+        "OK 1 0\r\n",
+        "OK 1 0\nDENY\n",
+        "OK 1 0 extra\n",
+        "OK  1 0\n",
+        "OK\t1 0\n",
+        "OK 0 0\n",
+        "OK -1 0\n",
+        "OK +1 0\n",
+        "OK 18446744073709551616 0\n",
+        "OK 1 \n",
+        "OK 1 -2\n",
+        "OK 1 -1,0\n",
+        "OK 1 1,\n",
+        "OK 1 ,1\n",
+        "OK 1 0,,1\n",
+        "OK 1 a\n",
+        "OK 1 0,0\n",
+        "OK 1 0,00\n",
+        "OK 1 2147483648\n",
+        "OK 1 0=evil\n",
+        "OK 1 0\0\n",
+        "OK 1 é\n",
+        "ok 1 0\n",
+    ] {
+        assert_eq!(
+            parse_response(line.as_bytes()),
+            Err(PAM_SYSTEM_ERR),
+            "{line:?}"
+        );
+    }
+    assert_eq!(
+        parse_response(&[b'x'; MAX_RESPONSE + 1]),
+        Err(PAM_SYSTEM_ERR)
+    );
+    assert_eq!(parse_response(b"DENY\n"), Err(PAM_PERM_DENIED));
+}
+
+#[test]
+fn bounded_socket_reader_handles_fragmentation_eof_and_oversize() {
+    let (mut reader, mut writer) = UnixStream::pair().unwrap();
+    let worker = thread::spawn(move || {
+        for part in [b"OK ".as_slice(), b"7", b" 1,3", b"\n"] {
+            writer.write_all(part).unwrap();
+        }
+    });
+    assert_eq!(
+        read_response(&mut reader, Instant::now() + IO_TIMEOUT)
+            .unwrap()
+            .gpu_csv,
+        "1,3"
+    );
+    worker.join().unwrap();
+    for data in [b"OK 1 0".to_vec(), vec![], vec![b'x'; MAX_RESPONSE + 1]] {
+        let (mut reader, mut writer) = UnixStream::pair().unwrap();
+        writer.write_all(&data).unwrap();
+        drop(writer);
+        assert_eq!(
+            read_response(&mut reader, Instant::now() + IO_TIMEOUT),
+            Err(PAM_SYSTEM_ERR)
+        );
+    }
+}
+
+#[test]
+fn validates_username_exact_ascii_bounds() {
+    for user in ["a", "Alice_09.foo-bar", ".", "ROOT"] {
+        assert!(valid_username(user.as_bytes()));
+    }
+    assert!(valid_username(&[b'a'; 128]));
+    assert!(!valid_username(&[b'a'; 129]));
+    for user in [
+        "", "root", "a b", "alice\n", "alice/", "é", "a=1", "a\t", "a\0",
+    ] {
+        assert!(!valid_username(user.as_bytes()), "{user:?}");
+    }
+}
+
+#[test]
+fn exported_abi_rejects_bad_context_and_options() {
+    for entry in [
+        pam_sm_acct_mgmt as Entry,
+        pam_sm_open_session,
+        pam_sm_close_session,
+    ] {
+        for options in [
+            vec![],
+            vec!["socket=relative"],
+            vec!["socket="],
+            vec!["debug"],
+            vec!["socket=/tmp/test", "permissive"],
+            vec!["socket=/a", "socket=/b"],
+        ] {
+            assert_eq!(call(entry, &mut FakePam::new(), &options), PAM_SYSTEM_ERR);
+        }
+        let arg = CString::new("socket=/unused").unwrap();
+        assert_eq!(
+            unsafe { entry(ptr::null_mut(), 0, 1, &arg.as_ptr()) },
+            PAM_SYSTEM_ERR
+        );
+        assert_eq!(
+            unsafe { entry(FakePam::new().handle(), 0, 1, ptr::null()) },
+            PAM_SYSTEM_ERR
+        );
+        assert_eq!(
+            unsafe { entry(FakePam::new().handle(), 0, 1, &ptr::null()) },
+            PAM_SYSTEM_ERR
+        );
+        assert_eq!(
+            unsafe { entry(FakePam::new().handle(), 0, -1, &arg.as_ptr()) },
+            PAM_SYSTEM_ERR
+        );
+        for service in [None, Some("login"), Some("SSHD"), Some("sshd ")] {
+            let mut pam = FakePam::new();
+            pam.service = service.map(|s| CString::new(s).unwrap());
+            assert_eq!(call(entry, &mut pam, &["socket=/unused"]), PAM_PERM_DENIED);
+        }
+        for user in [None, Some("root"), Some("bad\nuser"), Some("")] {
+            let mut pam = FakePam::new();
+            pam.user = user.map(|s| CString::new(s).unwrap());
+            assert_eq!(call(entry, &mut pam, &["socket=/unused"]), PAM_PERM_DENIED);
+        }
+        CALLER_UID.with(|uid| uid.set(1000));
+        let result = call(entry, &mut FakePam::new(), &["socket=/unused"]);
+        CALLER_UID.with(|uid| uid.set(0));
+        assert_eq!(result, PAM_PERM_DENIED);
+    }
+    assert_eq!(require_root(0), Ok(()));
+    assert_eq!(require_root(1000), Err(PAM_PERM_DENIED));
+}
+
+#[test]
+fn pam_and_daemon_errors_fail_closed() {
+    for entry in [pam_sm_acct_mgmt as Entry, pam_sm_open_session] {
+        let mut pam = FakePam::new();
+        pam.item_error = 3;
+        assert_eq!(call(entry, &mut pam, &["socket=/unused"]), 3);
+        pam.item_error = 0;
+        pam.user_error = 10;
+        assert_eq!(call(entry, &mut pam, &["socket=/unused"]), 10);
+        pam.user_error = 0;
+        let path = SocketPath::new();
+        assert_eq!(
+            call(entry, &mut pam, &[path.option().to_str().unwrap()]),
+            PAM_SYSTEM_ERR
+        );
+        for (response, expected) in [
+            (b"DENY\n".to_vec(), PAM_PERM_DENIED),
+            (b"garbage\n".to_vec(), PAM_SYSTEM_ERR),
+            (vec![], PAM_SYSTEM_ERR),
+            (vec![b'x'; MAX_RESPONSE + 1], PAM_SYSTEM_ERR),
+        ] {
+            let before = pam.env.clone();
+            assert_eq!(serve_once(entry, &mut pam, response).0, expected);
+            assert_eq!(pam.env, before);
+        }
+    }
+    let mut pam = FakePam::new();
+    pam.env_error = 5;
+    assert_eq!(
+        serve_once(pam_sm_open_session, &mut pam, b"OK 1 0\n".to_vec()).0,
+        5
+    );
+}
+
+#[test]
+fn kernel_peer_credentials_reject_wrong_owner_before_sending_username() {
+    let uid = unsafe { libc::geteuid() };
+    let (stream, _other) = UnixStream::pair().unwrap();
+    assert_eq!(check_peer(&stream, uid), Ok(()));
+    assert_eq!(
+        check_peer(&stream, uid.wrapping_add(1)),
+        Err(PAM_PERM_DENIED)
+    );
+    for entry in [pam_sm_acct_mgmt as Entry, pam_sm_open_session] {
+        let path = SocketPath::new();
+        let listener = UnixListener::bind(&path.0).unwrap();
+        let worker = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            assert_eq!(stream.read(&mut [0]).unwrap(), 0);
+        });
+        EXPECTED_UID.with(|expected| expected.set(uid.wrapping_add(1)));
+        let result = call(
+            entry,
+            &mut FakePam::new(),
+            &[path.option().to_str().unwrap()],
+        );
+        EXPECTED_UID.with(|expected| expected.set(uid));
+        assert_eq!(result, PAM_PERM_DENIED);
+        worker.join().unwrap();
+    }
+}
+
+#[test]
+fn connect_rejects_missing_refused_and_invalid_paths() {
+    let path = SocketPath::new();
+    assert_eq!(
+        UnixStream::connect(&path.0).unwrap_err().raw_os_error(),
+        Some(libc::ENOENT)
+    );
+    assert_eq!(
+        connect(&path.0, Instant::now() + IO_TIMEOUT).unwrap_err(),
+        PAM_SYSTEM_ERR
+    );
+    let listener = UnixListener::bind(&path.0).unwrap();
+    drop(listener);
+    assert_eq!(
+        UnixStream::connect(&path.0).unwrap_err().raw_os_error(),
+        Some(libc::ECONNREFUSED)
+    );
+    assert_eq!(
+        connect(&path.0, Instant::now() + IO_TIMEOUT).unwrap_err(),
+        PAM_SYSTEM_ERR
+    );
+    for bytes in [
+        vec![b'x'; 108],
+        vec![b'x'; 4096],
+        vec![],
+        b"/tmp/a\0b".to_vec(),
+    ] {
+        let path = Path::new(std::ffi::OsStr::from_bytes(&bytes));
+        assert_eq!(
+            connect(path, Instant::now() + IO_TIMEOUT).unwrap_err(),
+            PAM_SYSTEM_ERR
+        );
+    }
+}
+
+#[test]
+fn full_backlog_fails_closed_and_connected_socket_is_blocking_cloexec() {
+    let path = SocketPath::new();
+    let listener = UnixListener::bind(&path.0).unwrap();
+    // SAFETY: listener owns a valid listening socket; zero gives one pending slot on Linux.
+    assert_eq!(unsafe { libc::listen(listener.as_raw_fd(), 0) }, 0);
+    let stream = connect(&path.0, Instant::now() + IO_TIMEOUT).unwrap();
+    // SAFETY: F_GETFL and F_GETFD inspect a valid descriptor without additional arguments.
+    let status_flags = unsafe { libc::fcntl(stream.as_raw_fd(), libc::F_GETFL) };
+    let descriptor_flags = unsafe { libc::fcntl(stream.as_raw_fd(), libc::F_GETFD) };
+    assert!(status_flags >= 0);
+    assert_eq!(status_flags & libc::O_NONBLOCK, 0);
+    assert!(descriptor_flags >= 0);
+    assert_ne!(descriptor_flags & libc::FD_CLOEXEC, 0);
+    assert_eq!(
+        connect(&path.0, Instant::now() + IO_TIMEOUT).unwrap_err(),
+        PAM_SYSTEM_ERR
+    );
+    let (_accepted, _) = listener.accept().unwrap();
+    assert!(connect(&path.0, Instant::now() + IO_TIMEOUT).is_ok());
+}
+
+#[test]
+fn expired_deadline_is_shared_by_connect_poll_write_and_read() {
+    let path = SocketPath::new();
+    let listener = UnixListener::bind(&path.0).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let deadline = Instant::now();
+    assert_eq!(connect(&path.0, deadline).unwrap_err(), PAM_SYSTEM_ERR);
+    assert_eq!(
+        listener.accept().unwrap_err().kind(),
+        std::io::ErrorKind::WouldBlock
+    );
+    let (mut stream, mut peer) = UnixStream::pair().unwrap();
+    assert_eq!(wait_connected(&stream, deadline), Err(PAM_SYSTEM_ERR));
+    assert_eq!(
+        write_request(&mut stream, b"SPURSSH1 CHECK alice\n", deadline),
+        Err(PAM_SYSTEM_ERR)
+    );
+    peer.set_nonblocking(true).unwrap();
+    assert_eq!(
+        peer.read(&mut [0]).unwrap_err().kind(),
+        std::io::ErrorKind::WouldBlock
+    );
+    peer.write_all(b"OK 1 0\n").unwrap();
+    assert_eq!(read_response(&mut stream, deadline), Err(PAM_SYSTEM_ERR));
+    let mut untouched = [0; 7];
+    stream.read_exact(&mut untouched).unwrap();
+    assert_eq!(&untouched, b"OK 1 0\n");
+}
+
+#[test]
+fn connection_poll_checks_socket_error() {
+    let (stream, _peer) = UnixStream::pair().unwrap();
+    assert_eq!(wait_connected(&stream, Instant::now() + IO_TIMEOUT), Ok(()));
+    let path = SocketPath::new();
+    let listener = UnixListener::bind(&path.0).unwrap();
+    let stream = connect(&path.0, Instant::now() + IO_TIMEOUT).unwrap();
+    drop(listener);
+    assert_eq!(
+        wait_connected(&stream, Instant::now() + IO_TIMEOUT),
+        Err(PAM_SYSTEM_ERR)
+    );
+    assert!(stream.take_error().unwrap().is_none());
+}
+
+#[test]
+fn membership_fd_is_cloexec_and_receipt_consumes_only_one_byte() {
+    let (path, file) = membership_file();
+    let (mut reader, writer) = UnixStream::pair().unwrap();
+    send_fds(&writer, b"FOK 9 1\n", &[file.as_raw_fd()]);
+    let fd = receive_membership(&reader, Instant::now() + IO_TIMEOUT).unwrap();
+    assert_ne!(
+        unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GETFD) } & libc::FD_CLOEXEC,
+        0
+    );
+    assert!(std::fs::read(&path.0).unwrap().is_empty());
+    join_membership(fd, Instant::now() + IO_TIMEOUT).unwrap();
+    assert_eq!(std::fs::read(&path.0).unwrap(), b"0\n");
+    assert_eq!(
+        read_response(&mut reader, Instant::now() + IO_TIMEOUT)
+            .unwrap()
+            .job_id,
+        "9"
+    );
+}
+
+fn references_to(file: &std::fs::File) -> usize {
+    use std::os::unix::fs::MetadataExt;
+    let expected = file.metadata().unwrap();
+    std::fs::read_dir("/proc/self/fd")
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter_map(|entry| std::fs::metadata(entry.path()).ok())
+        .filter(|metadata| metadata.dev() == expected.dev() && metadata.ino() == expected.ino())
+        .count()
+}
+
+#[test]
+fn invalid_membership_handoffs_fail_closed_without_descriptor_leaks() {
+    let (path, file) = membership_file();
+    let readonly = std::fs::File::open(&path.0).unwrap();
+    let path_c = CString::new(path.0.as_os_str().as_bytes()).unwrap();
+    let path_fd = unsafe { libc::open(path_c.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
+    assert!(path_fd >= 0);
+    let path_fd = unsafe { OwnedFd::from_raw_fd(path_fd) };
+    let initial = references_to(&file);
+    for (byte, fds, expected) in [
+        (b'F', vec![], PAM_SYSTEM_ERR),
+        (b'X', vec![file.as_raw_fd()], PAM_SYSTEM_ERR),
+        (b'D', vec![], PAM_PERM_DENIED),
+        (b'D', vec![file.as_raw_fd()], PAM_SYSTEM_ERR),
+        (b'F', vec![file.as_raw_fd(); 2], PAM_SYSTEM_ERR),
+        (b'F', vec![file.as_raw_fd(); 16], PAM_SYSTEM_ERR),
+        (b'F', vec![readonly.as_raw_fd()], PAM_SYSTEM_ERR),
+        (b'F', vec![path_fd.as_raw_fd()], PAM_SYSTEM_ERR),
+    ] {
+        let (reader, writer) = UnixStream::pair().unwrap();
+        send_fds(&writer, &[byte], &fds);
+        assert_eq!(
+            receive_membership(&reader, Instant::now() + IO_TIMEOUT).unwrap_err(),
+            expected
+        );
+        // Count only this unique inode, so concurrently running tests cannot perturb it.
+        assert_eq!(references_to(&file), initial);
+        assert!(std::fs::read(&path.0).unwrap().is_empty());
+    }
+}
+
+#[test]
+fn membership_rejects_pipe_socket_and_directory() {
+    let mut pipe = [-1; 2];
+    assert_eq!(
+        unsafe { libc::pipe2(pipe.as_mut_ptr(), libc::O_CLOEXEC) },
+        0
+    );
+    let _pipe_reader = unsafe { OwnedFd::from_raw_fd(pipe[0]) };
+    let pipe_writer = unsafe { OwnedFd::from_raw_fd(pipe[1]) };
+    let (socket, _peer) = UnixStream::pair().unwrap();
+    let directory = std::fs::File::open(std::env::temp_dir()).unwrap();
+    for fd in [
+        pipe_writer.as_raw_fd(),
+        socket.as_raw_fd(),
+        directory.as_raw_fd(),
+    ] {
+        let (reader, writer) = UnixStream::pair().unwrap();
+        send_fds(&writer, b"F", &[fd]);
+        assert_eq!(
+            receive_membership(&reader, Instant::now() + IO_TIMEOUT).unwrap_err(),
+            PAM_SYSTEM_ERR
+        );
+    }
+}
+
+#[test]
+fn final_ack_failure_never_exports_environment() {
+    for response in [b"DENY\n".as_slice(), b"JOINED\n", b"OK 0 1\n", b""] {
+        let path = SocketPath::new();
+        let listener = UnixListener::bind(&path.0).unwrap();
+        let worker = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            assert_eq!(request(&mut stream), "SPURSSH1 ADOPT alice\n");
+            handoff(&mut stream);
+            stream.write_all(response).unwrap();
+        });
+        let mut pam = FakePam::new();
+        let before = pam.env.clone();
+        let result = call(
+            pam_sm_open_session,
+            &mut pam,
+            &[path.option().to_str().unwrap()],
+        );
+        assert_eq!(
+            result,
+            if response == b"DENY\n" {
+                PAM_PERM_DENIED
+            } else {
+                PAM_SYSTEM_ERR
+            }
+        );
+        assert_eq!(pam.env, before);
+        worker.join().unwrap();
+    }
+}
+
+#[test]
+fn check_never_writes_membership_even_if_peer_sends_rights() {
+    let path = SocketPath::new();
+    let listener = UnixListener::bind(&path.0).unwrap();
+    let (membership_path, file) = membership_file();
+    let worker = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        assert_eq!(request(&mut stream), "SPURSSH1 CHECK alice\n");
+        send_fds(&stream, b"OK 7 2\n", &[file.as_raw_fd()]);
+        assert_eq!(stream.read(&mut [0]).unwrap(), 0);
+        assert_eq!(references_to(&file), 1);
+    });
+    let mut pam = FakePam::new();
+    let before = pam.env.clone();
+    assert_eq!(
+        call(
+            pam_sm_acct_mgmt,
+            &mut pam,
+            &[path.option().to_str().unwrap()]
+        ),
+        PAM_SUCCESS
+    );
+    worker.join().unwrap();
+    assert_eq!(pam.env, before);
+    assert!(std::fs::read(&membership_path.0).unwrap().is_empty());
+}
+
+#[test]
+fn membership_deadline_closes_fd_without_writing() {
+    let (path, file) = membership_file();
+    let (reader, writer) = UnixStream::pair().unwrap();
+    send_fds(&writer, b"F", &[file.as_raw_fd()]);
+    assert_eq!(
+        receive_membership(&reader, Instant::now()).unwrap_err(),
+        PAM_SYSTEM_ERR
+    );
+    let fd = receive_membership(&reader, Instant::now() + IO_TIMEOUT).unwrap();
+    assert_eq!(references_to(&file), 2);
+    assert_eq!(join_membership(fd, Instant::now()), Err(PAM_SYSTEM_ERR));
+    assert_eq!(references_to(&file), 1);
+    assert!(std::fs::read(&path.0).unwrap().is_empty());
+}
+
+#[test]
+fn panic_boundary_returns_system_error() {
+    assert_eq!(boundary(|| panic!("injected failure")), PAM_SYSTEM_ERR);
+    assert_eq!(boundary(|| Err(PAM_PERM_DENIED)), PAM_PERM_DENIED);
+    assert_eq!(boundary(|| Ok(())), PAM_SUCCESS);
+}

--- a/crates/spur-pam/tests/test_real_pam.py
+++ b/crates/spur-pam/tests/test_real_pam.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Exercise the production module through Linux-PAM without changing host configuration."""
+
+import ctypes
+import os
+from pathlib import Path
+import socket
+import sys
+import tempfile
+import unittest
+
+PAM_SUCCESS = 0
+PAM_SYSTEM_ERR = 4
+PAM_PERM_DENIED = 6
+PAM_CONV_ERR = 19
+
+
+class PamMessage(ctypes.Structure):
+    _fields_ = [("msg_style", ctypes.c_int), ("msg", ctypes.c_char_p)]
+
+
+class PamResponse(ctypes.Structure):
+    _fields_ = [("resp", ctypes.c_void_p), ("resp_retcode", ctypes.c_int)]
+
+
+ConversationCallback = ctypes.CFUNCTYPE(
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.POINTER(ctypes.POINTER(PamMessage)),
+    ctypes.POINTER(ctypes.POINTER(PamResponse)),
+    ctypes.c_void_p,
+)
+
+
+class PamConversation(ctypes.Structure):
+    _fields_ = [("conv", ConversationCallback), ("appdata_ptr", ctypes.c_void_p)]
+
+
+@unittest.skipUnless(sys.platform == "linux", "Linux-PAM is required")
+@unittest.skipIf(os.geteuid() == 0, "requires a genuinely unprivileged caller")
+class ProductionPamTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        root = Path(__file__).resolve().parents[3]
+        cls.module = Path(os.environ.get(
+            "SPUR_PAM_MODULE", str(root / "target/debug/libpam_spur.so")
+        )).resolve(strict=True)
+        if any(char.isspace() for char in str(cls.module)):
+            raise ValueError("PAM module fixture path must not contain whitespace")
+        # RTLD_GLOBAL lets the production module resolve real PAM ABI symbols.
+        cls.pam = ctypes.CDLL("libpam.so.0", mode=ctypes.RTLD_GLOBAL)
+        cls.pam.pam_start_confdir.argtypes = [
+            ctypes.c_char_p, ctypes.c_char_p,
+            ctypes.POINTER(PamConversation), ctypes.c_char_p,
+            ctypes.POINTER(ctypes.c_void_p),
+        ]
+        cls.pam.pam_start_confdir.restype = ctypes.c_int
+        for name in ("pam_acct_mgmt", "pam_open_session", "pam_close_session", "pam_end"):
+            function = getattr(cls.pam, name)
+            function.argtypes = [ctypes.c_void_p, ctypes.c_int]
+            function.restype = ctypes.c_int
+        cls.pam.pam_getenv.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+        cls.pam.pam_getenv.restype = ctypes.c_char_p
+        cls.pam.pam_get_item.argtypes = [
+            ctypes.c_void_p, ctypes.c_int, ctypes.POINTER(ctypes.c_void_p),
+        ]
+        cls.pam.pam_get_item.restype = ctypes.c_int
+        # Eager loading makes missing symbols a failure, not a false denial pass.
+        cls.loaded_module = ctypes.CDLL(str(cls.module), mode=os.RTLD_NOW)
+        for symbol in ("pam_sm_acct_mgmt", "pam_sm_open_session", "pam_sm_close_session"):
+            getattr(cls.loaded_module, symbol)
+
+    def setUp(self):
+        self.assertNotEqual(os.geteuid(), 0)
+        self.directory = tempfile.TemporaryDirectory(prefix="spur-pam-", dir="/tmp")
+        self.addCleanup(self.directory.cleanup)
+        self.base = Path(self.directory.name)
+        self.socket_path = self.base / "agent.sock"
+        self.listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.addCleanup(self.listener.close)
+        self.listener.bind(str(self.socket_path))
+        self.listener.listen(8)
+        self.listener.setblocking(False)
+        self.conversation_calls = []
+
+        def reject_conversation(count, messages, response, appdata):
+            self.conversation_calls.append(count)
+            return PAM_CONV_ERR
+
+        self.callback = ConversationCallback(reject_conversation)
+        self.conversation = PamConversation(self.callback, None)
+
+    def start(self, options):
+        (self.base / "sshd").write_text(
+            f"account required {self.module} {options}\n"
+            f"session required {self.module} {options}\n"
+        )
+        handle = ctypes.c_void_p()
+        status = self.pam.pam_start_confdir(
+            b"sshd", b"spur_fixture", ctypes.byref(self.conversation),
+            os.fsencode(self.base), ctypes.byref(handle),
+        )
+        self.assertEqual(status, PAM_SUCCESS, "temporary PAM service must initialize")
+        self.assertTrue(handle.value)
+        self.addCleanup(self.end, handle)
+        service = ctypes.c_void_p()
+        self.assertEqual(self.pam.pam_get_item(handle, 1, ctypes.byref(service)), PAM_SUCCESS)
+        self.assertEqual(ctypes.string_at(service), b"sshd")
+        return handle
+
+    def end(self, handle):
+        self.assertEqual(self.pam.pam_end(handle, PAM_SUCCESS), PAM_SUCCESS)
+
+    def assert_no_side_effects(self, handle):
+        self.assertEqual(self.conversation_calls, [])
+        for key in (b"SPUR_JOB_ID", b"SLURM_JOB_ID", b"ROCR_VISIBLE_DEVICES",
+                    b"CUDA_VISIBLE_DEVICES", b"GPU_DEVICE_ORDINAL"):
+            self.assertIsNone(self.pam.pam_getenv(handle, key), key)
+        try:
+            connection, _ = self.listener.accept()
+        except BlockingIOError:
+            pass
+        else:
+            connection.close()
+            self.fail("unprivileged caller contacted the mock agent")
+
+    def test_account_rejects_unprivileged_caller(self):
+        handle = self.start(f"socket={self.socket_path}")
+        self.assertEqual(self.pam.pam_acct_mgmt(handle, 0), PAM_PERM_DENIED)
+        self.assert_no_side_effects(handle)
+
+    def test_open_session_rejects_even_without_account_call(self):
+        handle = self.start(f"socket={self.socket_path}")
+        self.assertEqual(self.pam.pam_open_session(handle, 0), PAM_PERM_DENIED)
+        self.assert_no_side_effects(handle)
+
+    def test_close_session_rejects_unprivileged_caller(self):
+        handle = self.start(f"socket={self.socket_path}")
+        self.assertEqual(self.pam.pam_close_session(handle, 0), PAM_PERM_DENIED)
+        self.assert_no_side_effects(handle)
+
+    def test_account_then_session_both_fail_closed(self):
+        handle = self.start(f"socket={self.socket_path}")
+        for operation in (self.pam.pam_acct_mgmt, self.pam.pam_open_session):
+            self.assertEqual(operation(handle, 0), PAM_PERM_DENIED)
+        self.assert_no_side_effects(handle)
+
+    def test_missing_option_is_module_system_error(self):
+        # Distinguish execution of this module from PAM's generic load failure.
+        handle = self.start("")
+        for operation in (self.pam.pam_acct_mgmt, self.pam.pam_open_session,
+                          self.pam.pam_close_session):
+            self.assertEqual(operation(handle, 0), PAM_SYSTEM_ERR)
+        self.assert_no_side_effects(handle)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -382,6 +382,7 @@ impl SlurmAccounting for AccountingService {
                 time_min: None,
                 requeue: false,
                 restarts: 0,
+                run_attempt: None,
                 batch_flag: false,
                 exclusive: false,
                 planned_start_time: None,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -31,6 +31,7 @@ use crate::sched_stats::SchedStatsCollector;
 
 const FORWARDED_HEADER: &str = "x-spur-forwarded";
 const LEADER_HEADER: &str = "x-spur-leader";
+const SSH_ADMISSION_HEADER: &str = "x-spur-ssh-admission";
 
 /// Resolve the comm address for an agent registration.
 ///
@@ -275,7 +276,59 @@ impl ControllerService {
         }
     }
 
-    /// Reads never require the leader (every node applies the committed log),
+    async fn get_job_for_ssh_admission(
+        &self,
+        request: Request<GetJobRequest>,
+    ) -> Result<Response<JobInfo>, Status> {
+        let identity = Self::verified_identity(&request)
+            .ok_or_else(|| {
+                Status::unauthenticated("SSH admission requires an authenticated identity")
+            })?
+            .clone();
+
+        if !self.raft.is_leader() {
+            if request.metadata().get(FORWARDED_HEADER).is_some() {
+                return Err(self.not_leader_status());
+            }
+            let mut client = self.leader_proxy.get_leader_client().await?;
+            let mut forwarded = Self::forward_request(request);
+            forwarded
+                .metadata_mut()
+                .insert(SSH_ADMISSION_HEADER, MetadataValue::from_static("1"));
+            let response = client.get_job(forwarded).await?;
+            // An older leader can answer GetJob without enforcing the admission read contract.
+            if response
+                .metadata()
+                .get(SSH_ADMISSION_HEADER)
+                .is_none_or(|value| value != "1")
+            {
+                return Err(Status::unavailable(
+                    "leader did not confirm SSH admission read",
+                ));
+            }
+            return Ok(response);
+        }
+
+        if !self.raft.ensure_leader().await {
+            return Err(self.not_leader_status());
+        }
+        let job_id = request.get_ref().job_id;
+        // Array-parent display records are synthesized, not actual allocations.
+        let job = self
+            .cluster
+            .get_job(job_id)
+            .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))?;
+        let info = self
+            .scoped_job_info(&job, Some(&identity))
+            .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))?;
+        let mut response = Response::new(info);
+        response
+            .metadata_mut()
+            .insert(SSH_ADMISSION_HEADER, MetadataValue::from_static("1"));
+        Ok(response)
+    }
+
+    /// Ordinary reads never require the leader (every node applies the committed log),
     /// so forwarding is only an optional freshness hop. Skipping already-
     /// forwarded requests avoids forward loops between non-leaders.
     fn read_should_forward<T>(&self, request: &Request<T>) -> bool {
@@ -887,6 +940,14 @@ impl SlurmController for ControllerService {
     }
 
     async fn get_job(&self, request: Request<GetJobRequest>) -> Result<Response<JobInfo>, Status> {
+        if request
+            .metadata()
+            .get(SSH_ADMISSION_HEADER)
+            .is_some_and(|value| value == "1")
+        {
+            return self.get_job_for_ssh_admission(request).await;
+        }
+
         let forward = self.read_should_forward(&request);
         let meta = request.metadata().clone();
         // Capture identity before the forward so the serving node (leader or read-allowed follower)
@@ -4159,6 +4220,7 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
         // plan lives on the cluster, not the job record.
         planned_start_time: None,
         sched_nodelist: String::new(),
+        run_attempt: Some(job.run_attempt),
     }
 }
 
@@ -4963,6 +5025,123 @@ mod tests {
             cpus_per_task: 1,
             ..Default::default()
         }
+    }
+
+    fn ssh_admission_req(
+        job_id: u32,
+        identity: Option<spur_core::auth::Identity>,
+    ) -> Request<GetJobRequest> {
+        let mut request = get_job_req(job_id, identity);
+        request
+            .metadata_mut()
+            .insert(SSH_ADMISSION_HEADER, MetadataValue::from_static("1"));
+        request
+    }
+
+    #[tokio::test]
+    async fn get_job_ssh_admission_rejects_missing_identity() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cluster = Arc::new(ClusterManager::new(test_slurm_config(), dir.path()).unwrap());
+        let svc = no_leader_service(cluster, dir.path()).await;
+        let mut request = ssh_admission_req(1, None);
+        request.metadata_mut().insert(
+            "authorization",
+            MetadataValue::from_static("Bearer unverified"),
+        );
+        let err = svc.get_job(request).await.unwrap_err();
+        assert_eq!(err.code(), Code::Unauthenticated);
+        svc.raft.raft.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn get_job_ssh_admission_fails_without_leader_while_ordinary_read_succeeds() {
+        use crate::raft::StateMachineApply;
+        use spur_core::wal::WalOperation;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let cluster = Arc::new(ClusterManager::new(test_slurm_config(), dir.path()).unwrap());
+        cluster.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(owned_job("bob", "/home/bob")),
+        });
+        let svc = no_leader_service(cluster, dir.path()).await;
+
+        for forwarded in [false, true] {
+            let mut request = ssh_admission_req(1, Some(viewer("bob", false)));
+            if forwarded {
+                request
+                    .metadata_mut()
+                    .insert(FORWARDED_HEADER, MetadataValue::from_static("true"));
+            }
+            let err = svc.get_job(request).await.unwrap_err();
+            assert_eq!(err.code(), Code::Unavailable);
+        }
+
+        for identity in [None, Some(viewer("bob", false))] {
+            let response = svc.get_job(get_job_req(1, identity)).await.unwrap();
+            assert!(response.metadata().get(SSH_ADMISSION_HEADER).is_none());
+            assert_eq!(response.get_ref().job_id, 1);
+            assert_eq!(response.get_ref().work_dir, "/home/bob");
+        }
+        svc.raft.raft.shutdown().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_job_ssh_admission_confirms_single_node_leader_and_preserves_disclosure() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = svc
+            .cluster
+            .submit_job(owned_job("bob", "/home/bob"))
+            .unwrap()
+            .job_id;
+
+        for (identity, expected_work_dir) in [
+            (viewer("bob", false), "/home/bob"),
+            (viewer("carol", true), "/home/bob"),
+            (viewer("alice", false), ""),
+        ] {
+            let response = svc
+                .get_job(ssh_admission_req(job_id, Some(identity)))
+                .await
+                .unwrap();
+            assert_eq!(response.metadata().get(SSH_ADMISSION_HEADER).unwrap(), "1");
+            assert_eq!(response.get_ref().job_id, job_id);
+            assert_eq!(response.get_ref().work_dir, expected_work_dir);
+            assert_eq!(response.get_ref().run_attempt, Some(0));
+        }
+        let err = svc
+            .get_job(ssh_admission_req(u32::MAX, Some(viewer("bob", false))))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), Code::NotFound);
+        svc.raft.raft.shutdown().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_job_ssh_admission_rejects_cached_leadership_without_confirmation() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = svc
+            .cluster
+            .submit_job(owned_job("bob", "/home/bob"))
+            .unwrap()
+            .job_id;
+        svc.raft.raft.shutdown().await.unwrap();
+        assert!(
+            svc.raft.is_leader(),
+            "shutdown retains the cached leader metric"
+        );
+
+        let err = svc
+            .get_job(ssh_admission_req(job_id, Some(viewer("bob", false))))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), Code::Unavailable);
+        assert!(svc
+            .get_job(get_job_req(job_id, Some(viewer("bob", false))))
+            .await
+            .is_ok());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -7670,6 +7849,16 @@ mod tests {
             ..Default::default()
         }));
         assert!(!with(JobSpec::default()));
+    }
+
+    #[test]
+    fn job_to_proto_carries_run_attempt_with_presence() {
+        let mut job = spur_core::job::Job::new(7, owned_job("bob", "/home/bob"));
+        assert_eq!(JobInfo::default().run_attempt, None);
+        for attempt in [0, 1, 7, u32::MAX] {
+            job.run_attempt = attempt;
+            assert_eq!(job_to_proto(&job).run_attempt, Some(attempt));
+        }
     }
 
     #[test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -4107,7 +4107,7 @@ impl AgentService {
     }
 
     async fn revoke_ssh(&self, job_id: u32) {
-        let _lifecycle = self.lifecycle.acquire(job_id).await;
+        // Launch holds the lifecycle lock while cancellation must remain able to release its reservation.
         if let Some(tracked) = self.running.lock().await.get_mut(&job_id) {
             tracked.ssh_eligible = false;
         }
@@ -4278,7 +4278,6 @@ impl AgentService {
 
     /// Freeze (SIGSTOP) or thaw (SIGCONT) a running job's process(es).
     async fn suspend_signal(&self, job_id: u32, resume: bool) {
-        let _lifecycle = self.lifecycle.acquire(job_id).await;
         let mut jobs = self.running.lock().await;
         let Some(tracked) = jobs.get_mut(&job_id) else {
             return;
@@ -7564,6 +7563,104 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ssh_admission_revocation_during_handoff_preserves_generation() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("cgroup.procs"),
+            format!("{}\n", std::process::id()),
+        )
+        .unwrap();
+        svc.running
+            .lock()
+            .await
+            .insert(7, TrackedJob::ssh_fixture(dir.path().into(), true));
+        let jobs = svc.ssh_jobs();
+        let snapshot = svc.running.lock().await[&7]
+            .ssh_snapshot(7, "alice", 1001)
+            .unwrap();
+        let controller = JobInfo {
+            job_id: 7,
+            user: "alice".into(),
+            uid: 1001,
+            state: spur_proto::proto::JobState::JobRunning as i32,
+            exclusive: true,
+            nodelist: "test-node".into(),
+            run_attempt: Some(snapshot.run_attempt),
+            start_time: Some(prost_types::Timestamp {
+                seconds: 1,
+                nanos: 0,
+            }),
+            ..Default::default()
+        };
+        let (mut client, mut server) = tokio::net::UnixStream::pair().unwrap();
+        let admission = jobs.finish(&snapshot, &controller, "test-node", &mut server, true);
+        let revoke = async {
+            assert_eq!(client.read_u8().await.unwrap(), b'F');
+            let mut revocation = std::pin::pin!(svc.revoke_ssh(7));
+            let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+            assert!(std::future::Future::poll(revocation.as_mut(), &mut context).is_ready());
+            let running = svc.running.lock().await;
+            assert!(Arc::ptr_eq(
+                &snapshot.generation,
+                &running[&7].ssh_generation
+            ));
+            drop(running);
+            client.write_all(b"JOINED\n").await.unwrap();
+        };
+        let (result, ()) = tokio::join!(admission, revoke);
+        assert!(
+            result.is_err(),
+            "revoked allocation must not complete admission"
+        );
+        drop(server);
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).await.unwrap();
+        assert!(
+            response.is_empty(),
+            "revoked allocation must not receive OK"
+        );
+        drop(jobs.lifecycle.acquire(7).await);
+    }
+
+    #[tokio::test]
+    async fn ssh_admission_cancel_releases_launch_reservation_without_lifecycle_wait() {
+        use std::future::Future;
+        use std::task::{Context, Poll, Waker};
+
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        for signal in [0, libc::SIGTERM] {
+            let _launch = svc.lifecycle.acquire(7).await;
+            svc.allocation
+                .lock()
+                .await
+                .allocate_for_job(7, 1, 0, &[])
+                .unwrap();
+            let mut request = Request::new(AgentCancelJobRequest { job_id: 7, signal });
+            request.extensions_mut().insert(controller_identity());
+            let mut cancel = std::pin::pin!(svc.cancel_job(request));
+            let mut context = Context::from_waker(Waker::noop());
+            match cancel.as_mut().poll(&mut context) {
+                Poll::Ready(result) => result.unwrap(),
+                Poll::Pending => panic!("cancellation must not wait behind the launch it cancels"),
+            };
+            assert!(!svc.allocation.lock().await.commit_job(7));
+        }
+    }
+
+    #[tokio::test]
     async fn ssh_admission_revocation_and_suspend_keep_generation_ineligible() {
         let svc = AgentService::new(
             test_reporter(),
@@ -7578,12 +7675,21 @@ mod tests {
                 .await
                 .insert(7, TrackedJob::ssh_fixture(dir.path().into(), true));
             let before = svc.running.lock().await[&7].ssh_generation.clone();
-            if suspend {
-                svc.suspend_signal(7, false).await;
-                svc.suspend_signal(7, true).await;
-            } else {
-                svc.revoke_ssh(7).await;
-            }
+            let _adoption = svc.lifecycle.acquire(7).await;
+            let operation = async {
+                if suspend {
+                    svc.suspend_signal(7, false).await;
+                    svc.suspend_signal(7, true).await;
+                } else {
+                    svc.revoke_ssh(7).await;
+                }
+            };
+            let mut operation = std::pin::pin!(operation);
+            let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+            assert!(
+                std::future::Future::poll(operation.as_mut(), &mut context).is_ready(),
+                "revocation must not wait for an in-flight adoption"
+            );
             let jobs = svc.running.lock().await;
             let tracked = &jobs[&7];
             assert!(Arc::ptr_eq(&before, &tracked.ssh_generation));

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -88,12 +88,45 @@ pub(crate) struct TrackedJob {
     mpi: String,
     /// Run epoch; echoed on completion and guards the grace-period SIGKILL.
     run_attempt: u32,
+    ssh_eligible: bool,
+    ssh_generation: Arc<()>,
     /// The job's cgroup, owned here so every launch path into the job can reach
     /// it. `None` when cgroup enforcement is off or no cgroup was created.
     cgroup_path: Option<std::path::PathBuf>,
 }
 
 impl TrackedJob {
+    pub(crate) fn ssh_snapshot(
+        &self,
+        job_id: u32,
+        user: &str,
+        uid: u32,
+    ) -> Option<crate::ssh_admission::Snapshot> {
+        if !self.ssh_eligible || uid == 0 || self.uid != uid || self.user != user {
+            return None;
+        }
+        Some(crate::ssh_admission::Snapshot {
+            job_id,
+            user: self.user.clone(),
+            uid,
+            run_attempt: self.run_attempt,
+            generation: self.ssh_generation.clone(),
+            cgroup: self.cgroup_path.clone()?,
+            gpu_devices: self.gpu_devices.clone(),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn ssh_fixture(cgroup: std::path::PathBuf, eligible: bool) -> Self {
+        Self {
+            uid: 1001,
+            user: "alice".into(),
+            ssh_eligible: eligible,
+            gpu_devices: vec![0, 2],
+            ..Self::allocation_only(Some(cgroup))
+        }
+    }
+
     /// Take the cgroup path, leaving `None`. Whichever teardown path reaches
     /// the job first takes it, so the removal it authorizes happens once.
     fn take_cgroup(&mut self) -> Option<std::path::PathBuf> {
@@ -2544,6 +2577,8 @@ impl SlurmAgent for AgentService {
                         nodelist: launch_cfg.nodelist,
                         mpi: spec.mpi.clone(),
                         run_attempt,
+                        ssh_eligible: spec.exclusive && !is_container,
+                        ssh_generation: Arc::new(()),
                         cgroup_path: result.cgroup_path,
                     },
                 );
@@ -2924,6 +2959,8 @@ impl SlurmAgent for AgentService {
                 // srun allocation-only jobs use their own cancel lifecycle;
                 // epoch 0 leaves the stale-report guard disabled for them.
                 run_attempt: 0,
+                ssh_eligible: false,
+                ssh_generation: Arc::new(()),
                 cgroup_path,
             },
         );
@@ -4062,6 +4099,20 @@ impl SlurmAgent for AgentService {
 }
 
 impl AgentService {
+    pub(crate) fn ssh_jobs(&self) -> crate::ssh_admission::LocalJobs {
+        crate::ssh_admission::LocalJobs {
+            running: self.running.clone(),
+            lifecycle: self.lifecycle.clone(),
+        }
+    }
+
+    async fn revoke_ssh(&self, job_id: u32) {
+        let _lifecycle = self.lifecycle.acquire(job_id).await;
+        if let Some(tracked) = self.running.lock().await.get_mut(&job_id) {
+            tracked.ssh_eligible = false;
+        }
+    }
+
     async fn drop_tracked_job(&self, job_id: u32) {
         // The cgroup removal and the release below both key off the id, so a launch
         // reusing it must not interleave with them.
@@ -4203,6 +4254,7 @@ impl AgentService {
 
     /// Send a user-specified signal to a running job.
     async fn send_explicit_signal(&self, job_id: u32, signal: i32) {
+        self.revoke_ssh(job_id).await;
         let is_allocation_only = {
             let jobs = self.running.lock().await;
             jobs.get(&job_id)
@@ -4226,10 +4278,14 @@ impl AgentService {
 
     /// Freeze (SIGSTOP) or thaw (SIGCONT) a running job's process(es).
     async fn suspend_signal(&self, job_id: u32, resume: bool) {
-        let jobs = self.running.lock().await;
-        let Some(tracked) = jobs.get(&job_id) else {
+        let _lifecycle = self.lifecycle.acquire(job_id).await;
+        let mut jobs = self.running.lock().await;
+        let Some(tracked) = jobs.get_mut(&job_id) else {
             return;
         };
+        if !resume {
+            tracked.ssh_eligible = false;
+        }
         let sig = if resume {
             nix::sys::signal::Signal::SIGCONT
         } else {
@@ -4297,6 +4353,7 @@ impl AgentService {
     }
 
     async fn graceful_cancel(&self, job_id: u32) {
+        self.revoke_ssh(job_id).await;
         let is_allocation_only = {
             let jobs = self.running.lock().await;
             jobs.get(&job_id)
@@ -4773,6 +4830,8 @@ impl TrackedJob {
             nodelist: String::new(),
             mpi: String::new(),
             run_attempt: 0,
+            ssh_eligible: false,
+            ssh_generation: Arc::new(()),
             cgroup_path,
         }
     }
@@ -7504,6 +7563,35 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn ssh_admission_revocation_and_suspend_keep_generation_ineligible() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let dir = tempfile::tempdir().unwrap();
+        for suspend in [false, true] {
+            svc.running
+                .lock()
+                .await
+                .insert(7, TrackedJob::ssh_fixture(dir.path().into(), true));
+            let before = svc.running.lock().await[&7].ssh_generation.clone();
+            if suspend {
+                svc.suspend_signal(7, false).await;
+                svc.suspend_signal(7, true).await;
+            } else {
+                svc.revoke_ssh(7).await;
+            }
+            let jobs = svc.running.lock().await;
+            let tracked = &jobs[&7];
+            assert!(Arc::ptr_eq(&before, &tracked.ssh_generation));
+            assert!(tracked.ssh_snapshot(7, "alice", 1001).is_none());
+        }
+        assert!(dir.path().read_dir().unwrap().next().is_none());
+    }
+
     /// Helper: poll until the job is removed from `running` (by the monitor).
     async fn wait_job_reaped(svc: &AgentService, job_id: u32, timeout_ms: u64) -> bool {
         let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
@@ -7578,6 +7666,8 @@ mod tests {
             nodelist: String::new(),
             mpi: String::new(),
             run_attempt: 0,
+            ssh_eligible: false,
+            ssh_generation: Arc::new(()),
             cgroup_path: None,
         };
         svc.insert_test_job(job_id, tracked).await;
@@ -7636,6 +7726,8 @@ mod tests {
                 nodelist: String::new(),
                 mpi: String::new(),
                 run_attempt,
+                ssh_eligible: false,
+                ssh_generation: Arc::new(()),
                 cgroup_path: None,
             };
             (t, pid)

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -15,6 +15,8 @@ pub(crate) mod privdrop;
 pub(crate) mod pty;
 mod reporter;
 mod seccomp;
+mod ssh_admission;
+mod ssh_identity;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -185,6 +187,14 @@ struct Args {
     #[arg(long = "token", env = "SPUR_JOIN_TOKEN")]
     token: Option<String>,
 
+    /// Root-only Unix socket for native SSH admission (requires strict cgroups and auth)
+    #[arg(long, requires = "ssh_admission_token_file")]
+    ssh_admission_socket: Option<std::path::PathBuf>,
+
+    /// Root-owned mode 0600/0400 file containing an administrator read credential
+    #[arg(long, requires = "ssh_admission_socket")]
+    ssh_admission_token_file: Option<std::path::PathBuf>,
+
     /// Foreground mode
     #[arg(short = 'D', long)]
     foreground: bool,
@@ -260,6 +270,17 @@ async fn main() -> anyhow::Result<()> {
             );
             None
         }
+    };
+    let ssh_listener = match (&args.ssh_admission_socket, &args.ssh_admission_token_file) {
+        (Some(socket), Some(token)) => {
+            let cfg = config.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("SSH admission requires a valid explicit configuration")
+            })?;
+            ssh_admission::validate_startup(cfg, nix::unistd::geteuid().as_raw())?;
+            Some(ssh_admission::AdmissionListener::bind(socket, token)?)
+        }
+        (None, None) => None,
+        _ => anyhow::bail!("SSH admission socket and token file must be specified together"),
     };
     let hooks_config = config.as_ref().map(|c| c.hooks.clone()).unwrap_or_default();
 
@@ -498,6 +519,17 @@ async fn main() -> anyhow::Result<()> {
         ),
     }
 
+    let ssh_jobs = agent_service.ssh_jobs();
+    let ssh_future = async move {
+        match ssh_listener {
+            Some(listener) => {
+                listener
+                    .serve(ssh_jobs, hostname, args.controller.clone())
+                    .await
+            }
+            None => std::future::pending::<anyhow::Result<()>>().await,
+        }
+    };
     let server_future = tonic::transport::Server::builder()
         .layer(crate::auth_middleware::AgentAuthLayer::new(
             auth_mode, &jwt_key,
@@ -509,6 +541,7 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::select! {
         result = server_future => { result?; }
+        result = ssh_future => { result?; anyhow::bail!("SSH admission listener stopped"); }
         _ = sigterm.recv() => {
             info!("received SIGTERM, deregistering from controller");
             let dereg_reporter = reporter.clone();

--- a/crates/spurd/src/ssh_admission.rs
+++ b/crates/spurd/src/ssh_admission.rs
@@ -1,0 +1,1354 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::{self, OpenOptions};
+use std::future::Future;
+use std::io::{self, Read};
+use std::os::fd::{AsRawFd, BorrowedFd};
+use std::os::unix::fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{bail, ensure, Context};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, Interest};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::task::JoinSet;
+use tonic::metadata::{Ascii, MetadataValue};
+
+use crate::agent_server::RunningJobs;
+use crate::job_lifecycle::JobLifecycle;
+use crate::ssh_identity::IdentityResolver;
+use spur_proto::proto::{GetJobRequest, JobInfo, JobState};
+
+const MAX_REQUEST: usize = 256;
+const STRICT_HEADER: &str = "x-spur-ssh-admission";
+
+#[derive(Clone)]
+pub(crate) struct Snapshot {
+    pub job_id: u32,
+    pub user: String,
+    pub uid: u32,
+    pub run_attempt: u32,
+    pub generation: Arc<()>,
+    pub cgroup: PathBuf,
+    pub gpu_devices: Vec<u32>,
+}
+
+#[derive(Clone)]
+pub(crate) struct LocalJobs {
+    pub running: RunningJobs,
+    pub lifecycle: JobLifecycle,
+}
+
+fn unique_snapshot(
+    jobs: &std::collections::HashMap<u32, crate::agent_server::TrackedJob>,
+    user: &str,
+    uid: u32,
+) -> anyhow::Result<Snapshot> {
+    let mut matches = jobs
+        .iter()
+        .filter_map(|(&id, job)| job.ssh_snapshot(id, user, uid));
+    let snapshot = matches.next().context("no eligible job")?;
+    ensure!(matches.next().is_none(), "ambiguous allocation");
+    ensure!(snapshot.job_id != 0, "invalid job id");
+    ensure!(snapshot.cgroup.is_dir(), "missing cgroup");
+    Ok(snapshot)
+}
+
+impl LocalJobs {
+    async fn snapshot(&self, user: &str, uid: u32) -> anyhow::Result<Snapshot> {
+        unique_snapshot(&*self.running.lock().await, user, uid)
+    }
+
+    async fn finish(
+        &self,
+        snapshot: &Snapshot,
+        controller: &JobInfo,
+        hostname: &str,
+        stream: &mut UnixStream,
+        adopt: bool,
+    ) -> anyhow::Result<()> {
+        let _lifecycle = self.lifecycle.acquire(snapshot.job_id).await;
+        let jobs = self.running.lock().await;
+        let current = unique_snapshot(&jobs, &snapshot.user, snapshot.uid)?;
+        ensure!(
+            Arc::ptr_eq(&current.generation, &snapshot.generation)
+                && current.cgroup == snapshot.cgroup,
+            "allocation replaced"
+        );
+        validate_controller(controller, &current, hostname, SystemTime::now())?;
+        let gpu_csv = if current.gpu_devices.is_empty() {
+            "-1".to_owned()
+        } else {
+            let mut seen = std::collections::HashSet::new();
+            ensure!(
+                current
+                    .gpu_devices
+                    .iter()
+                    .all(|&id| id <= i32::MAX as u32 && seen.insert(id)),
+                "invalid GPU allocation"
+            );
+            current
+                .gpu_devices
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(",")
+        };
+        let response = format!("OK {} {gpu_csv}\n", current.job_id);
+        ensure!(response.len() <= 4096, "allocation response too large");
+        drop(jobs);
+        if adopt {
+            let file = open_membership(&current.cgroup)?;
+            send_membership_fd(stream, std::os::fd::AsFd::as_fd(&file)).await?;
+            drop(file);
+            let mut receipt = [0; 7];
+            stream.read_exact(&mut receipt).await?;
+            ensure!(&receipt == b"JOINED\n", "invalid adoption receipt");
+            let peer = stream.peer_cred()?;
+            let pid = peer.pid().context("missing peer PID")?;
+            verify_membership(&current.cgroup, pid)?;
+            validate_controller(controller, &current, hostname, SystemTime::now())?;
+        }
+        let jobs = self.running.lock().await;
+        let final_snapshot = unique_snapshot(&jobs, &snapshot.user, snapshot.uid)?;
+        ensure!(
+            Arc::ptr_eq(&final_snapshot.generation, &snapshot.generation)
+                && final_snapshot.cgroup == snapshot.cgroup,
+            "allocation replaced during adoption"
+        );
+        validate_controller(controller, &final_snapshot, hostname, SystemTime::now())?;
+        drop(jobs);
+        // The per-job lifecycle guard prevents teardown without blocking other allocations.
+        stream.write_all(response.as_bytes()).await?;
+        Ok(())
+    }
+}
+
+fn valid_username(user: &str) -> bool {
+    !user.is_empty()
+        && user.len() <= 128
+        && user != "root"
+        && user
+            .bytes()
+            .all(|c| c.is_ascii_alphanumeric() || b"_.-".contains(&c))
+}
+
+fn parse_request(line: &[u8]) -> anyhow::Result<(bool, &str)> {
+    ensure!(
+        line.len() <= MAX_REQUEST && line.is_ascii(),
+        "invalid request"
+    );
+    let text = std::str::from_utf8(line)?
+        .strip_suffix('\n')
+        .context("missing newline")?;
+    let mut fields = text.split(' ');
+    ensure!(fields.next() == Some("SPURSSH1"), "unknown protocol");
+    let adopt = match fields.next() {
+        Some("CHECK") => false,
+        Some("ADOPT") => true,
+        _ => bail!("unknown operation"),
+    };
+    let user = fields.next().context("missing username")?;
+    ensure!(
+        fields.next().is_none() && valid_username(user),
+        "invalid username"
+    );
+    Ok((adopt, user))
+}
+
+fn validate_peer(uid: u32, pid: Option<i32>, expected_uid: u32) -> anyhow::Result<i32> {
+    ensure!(uid == expected_uid, "non-root peer");
+    let pid = pid.context("missing peer PID")?;
+    ensure!(pid > 1, "invalid peer PID");
+    Ok(pid)
+}
+
+fn validate_controller(
+    info: &JobInfo,
+    snapshot: &Snapshot,
+    hostname: &str,
+    now: SystemTime,
+) -> anyhow::Result<()> {
+    ensure!(
+        info.job_id == snapshot.job_id
+            && info.uid == snapshot.uid
+            && info.user == snapshot.user
+            && info.run_attempt == Some(snapshot.run_attempt)
+            && info.state == JobState::JobRunning as i32
+            && info.exclusive
+            && info.end_time.is_none(),
+        "controller allocation not eligible"
+    );
+    ensure!(
+        spur_core::hostlist::expand(&info.nodelist)?
+            .iter()
+            .any(|node| node == hostname),
+        "node not allocated"
+    );
+    let start = info.start_time.as_ref().context("missing start time")?;
+    ensure!(
+        start.seconds >= 0 && (0..1_000_000_000).contains(&start.nanos),
+        "invalid start time"
+    );
+    let start = UNIX_EPOCH
+        .checked_add(Duration::new(start.seconds as u64, start.nanos as u32))
+        .context("start time overflow")?;
+    ensure!(start <= now, "future start time");
+    if let Some(limit) = &info.time_limit {
+        ensure!(
+            limit.seconds >= 0 && (0..1_000_000_000).contains(&limit.nanos),
+            "invalid time limit"
+        );
+        let limit = Duration::new(limit.seconds as u64, limit.nanos as u32);
+        ensure!(!limit.is_zero(), "zero time limit");
+        let deadline = start.checked_add(limit).context("deadline overflow")?;
+        ensure!(now < deadline, "allocation expired");
+    }
+    Ok(())
+}
+
+fn open_membership(cgroup: &Path) -> anyhow::Result<fs::File> {
+    // No create or truncate: a removed cgroup must never become a regular file.
+    let file = OpenOptions::new()
+        .write(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(cgroup.join("cgroup.procs"))?;
+    ensure!(file.metadata()?.is_file(), "invalid membership file");
+    Ok(file)
+}
+
+async fn send_membership_fd(stream: &UnixStream, fd: BorrowedFd<'_>) -> io::Result<()> {
+    loop {
+        stream.writable().await?;
+        let result = stream.try_io(Interest::WRITABLE, || {
+            let mut marker = b'F';
+            let mut iov = libc::iovec {
+                iov_base: std::ptr::addr_of_mut!(marker).cast(),
+                iov_len: 1,
+            };
+            // cmsghdr storage provides the alignment required by CMSG_*.
+            let mut control = [unsafe { std::mem::zeroed::<libc::cmsghdr>() }; 2];
+            let mut message: libc::msghdr = unsafe { std::mem::zeroed() };
+            message.msg_iov = &mut iov;
+            message.msg_iovlen = 1;
+            message.msg_control = control.as_mut_ptr().cast();
+            message.msg_controllen =
+                unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::c_int>() as _) } as usize;
+            assert!(message.msg_controllen <= std::mem::size_of_val(&control));
+            // All pointers refer to live, aligned storage through this synchronous syscall.
+            let sent = unsafe {
+                let header = libc::CMSG_FIRSTHDR(&message);
+                (*header).cmsg_level = libc::SOL_SOCKET;
+                (*header).cmsg_type = libc::SCM_RIGHTS;
+                (*header).cmsg_len =
+                    libc::CMSG_LEN(std::mem::size_of::<libc::c_int>() as _) as usize;
+                libc::CMSG_DATA(header)
+                    .cast::<libc::c_int>()
+                    .write(fd.as_raw_fd());
+                libc::sendmsg(stream.as_raw_fd(), &message, libc::MSG_NOSIGNAL)
+            };
+            match sent {
+                1 => Ok(()),
+                -1 => Err(io::Error::last_os_error()),
+                _ => Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "descriptor not sent",
+                )),
+            }
+        });
+        match result {
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted
+                ) =>
+            {
+                continue
+            }
+            result => return result,
+        }
+    }
+}
+
+fn verify_membership(cgroup: &Path, pid: i32) -> anyhow::Result<()> {
+    ensure!(pid > 1, "invalid peer PID");
+    // Numeric PIDs are used only for observation; only the client may join itself.
+    let read = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(cgroup.join("cgroup.procs"))?;
+    ensure!(read.metadata()?.is_file(), "invalid membership file");
+    let mut members = String::new();
+    read.take(1024 * 1024 + 1).read_to_string(&mut members)?;
+    ensure!(members.len() <= 1024 * 1024, "membership too large");
+    ensure!(
+        members
+            .lines()
+            .any(|line| line.parse::<i32>().ok() == Some(pid)),
+        "membership not confirmed"
+    );
+    Ok(())
+}
+
+async fn handle<R, RF, Q, F>(
+    mut stream: UnixStream,
+    jobs: LocalJobs,
+    hostname: &str,
+    expected_uid: u32,
+    resolve: R,
+    query: Q,
+) -> anyhow::Result<()>
+where
+    R: FnOnce(String) -> RF,
+    RF: Future<Output = anyhow::Result<u32>>,
+    Q: FnOnce(u32) -> F,
+    F: Future<Output = anyhow::Result<JobInfo>>,
+{
+    let result = async {
+        let peer = stream.peer_cred()?;
+        validate_peer(peer.uid(), peer.pid(), expected_uid)?;
+        let mut line = Vec::with_capacity(MAX_REQUEST);
+        loop {
+            let byte = stream.read_u8().await?;
+            line.push(byte);
+            if byte == b'\n' {
+                break;
+            }
+            ensure!(line.len() < MAX_REQUEST, "request too long");
+        }
+        let (adopt, user) = parse_request(&line)?;
+        let uid = resolve(user.to_owned()).await?;
+        let snapshot = jobs.snapshot(user, uid).await?;
+        let controller = query(snapshot.job_id).await?;
+        jobs.finish(&snapshot, &controller, hostname, &mut stream, adopt)
+            .await
+    }
+    .await;
+    if result.is_err() {
+        stream.write_all(b"DENY\n").await?;
+    }
+    Ok(())
+}
+
+fn safe_parent(path: &Path, uid: u32, trust_root: &Path, private: bool) -> anyhow::Result<()> {
+    ensure!(
+        path.is_absolute() && trust_root.is_absolute(),
+        "absolute path required"
+    );
+    ensure!(
+        path.components()
+            .all(|c| matches!(c, Component::RootDir | Component::Normal(_))),
+        "non-normal path"
+    );
+    ensure!(
+        path.starts_with(trust_root) && path != trust_root,
+        "path outside trust root"
+    );
+    let parent = path.parent().context("missing parent")?;
+    let mut dir = parent;
+    loop {
+        let meta = fs::symlink_metadata(dir)?;
+        ensure!(
+            meta.is_dir() && meta.uid() == uid && meta.mode() & 0o022 == 0,
+            "unsafe parent directory"
+        );
+        if dir == parent && private {
+            ensure!(
+                meta.mode() & 0o7777 == 0o700,
+                "socket parent must be mode 0700"
+            );
+        }
+        if dir == trust_root {
+            break;
+        }
+        dir = dir.parent().context("invalid trust root")?;
+    }
+    Ok(())
+}
+
+fn read_token(path: &Path, uid: u32, trust_root: &Path) -> anyhow::Result<MetadataValue<Ascii>> {
+    safe_parent(path, uid, trust_root, false)?;
+    let metadata = fs::symlink_metadata(path)?;
+    ensure!(
+        metadata.is_file()
+            && metadata.uid() == uid
+            && matches!(metadata.mode() & 0o7777, 0o400 | 0o600),
+        "unsafe token file"
+    );
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)?;
+    let opened = file.metadata()?;
+    ensure!(
+        opened.dev() == metadata.dev()
+            && opened.ino() == metadata.ino()
+            && opened.uid() == uid
+            && matches!(opened.mode() & 0o7777, 0o400 | 0o600),
+        "token changed"
+    );
+    let mut token = String::new();
+    file.take(16385).read_to_string(&mut token)?;
+    ensure!(token.len() <= 16384, "token too large");
+    let token = token.strip_suffix('\n').unwrap_or(&token);
+    ensure!(
+        !token.is_empty() && token.bytes().all(|c| c.is_ascii_graphic()),
+        "invalid token"
+    );
+    let mut bearer: MetadataValue<Ascii> = format!("Bearer {token}").parse()?;
+    bearer.set_sensitive(true);
+    Ok(bearer)
+}
+
+struct OwnedSocket {
+    path: PathBuf,
+    dev: u64,
+    ino: u64,
+    uid: u32,
+    trust_root: PathBuf,
+}
+
+impl Drop for OwnedSocket {
+    fn drop(&mut self) {
+        if safe_parent(&self.path, self.uid, &self.trust_root, true).is_err() {
+            return;
+        }
+        if let Ok(meta) = fs::symlink_metadata(&self.path) {
+            if meta.file_type().is_socket()
+                && meta.uid() == self.uid
+                && meta.dev() == self.dev
+                && meta.ino() == self.ino
+                && meta.mode() & 0o7777 == 0o600
+            {
+                let _ = fs::remove_file(&self.path);
+            }
+        }
+    }
+}
+
+pub(crate) struct AdmissionListener {
+    listener: UnixListener,
+    _owned: OwnedSocket,
+    bearer: MetadataValue<Ascii>,
+}
+
+impl AdmissionListener {
+    pub(crate) fn bind(path: &Path, token: &Path) -> anyhow::Result<Self> {
+        Self::bind_with_policy(path, token, 0, Path::new("/"))
+    }
+
+    fn bind_with_policy(
+        path: &Path,
+        token: &Path,
+        uid: u32,
+        trust_root: &Path,
+    ) -> anyhow::Result<Self> {
+        let bearer = read_token(token, uid, trust_root)?;
+        safe_parent(path, uid, trust_root, true)?;
+        match fs::symlink_metadata(path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            _ => bail!("socket path already exists or cannot be inspected"),
+        }
+        let listener = UnixListener::bind(path)?;
+        let meta = fs::symlink_metadata(path)?;
+        ensure!(
+            meta.file_type().is_socket() && meta.uid() == uid,
+            "invalid socket"
+        );
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+        let owned = OwnedSocket {
+            path: path.into(),
+            dev: meta.dev(),
+            ino: meta.ino(),
+            uid,
+            trust_root: trust_root.into(),
+        };
+        Ok(Self {
+            listener,
+            _owned: owned,
+            bearer,
+        })
+    }
+
+    pub(crate) async fn serve(
+        self,
+        jobs: LocalJobs,
+        hostname: String,
+        controller: String,
+    ) -> anyhow::Result<()> {
+        let mut handlers = JoinSet::new();
+        let resolver = IdentityResolver::new();
+        loop {
+            tokio::select! {
+                result = handlers.join_next(), if !handlers.is_empty() => {
+                    result.context("missing handler")??;
+                }
+                accepted = self.listener.accept(), if handlers.len() < 32 => {
+                    let (stream, _) = accepted?;
+                    let (jobs, hostname, controller, bearer) = (jobs.clone(), hostname.clone(), controller.clone(), self.bearer.clone());
+                    let resolver = resolver.clone();
+                    handlers.spawn(async move {
+                        let _ = tokio::time::timeout(Duration::from_secs(5), handle(
+                            stream, jobs, &hostname, 0, move |user| async move { resolver.resolve(user).await },
+                            move |job_id| async move {
+                                let channel = spur_client::connect_channel(&controller).await?;
+                                let mut client = spur_proto::controller_client(channel);
+                                let mut request = tonic::Request::new(GetJobRequest { job_id });
+                                request.metadata_mut().insert("authorization", bearer);
+                                request.metadata_mut().insert(STRICT_HEADER, MetadataValue::from_static("1"));
+                                let response = client.get_job(request).await?;
+                                ensure!(response.metadata().get(STRICT_HEADER).is_some_and(|v| v == "1"), "controller did not acknowledge strict admission");
+                                Ok(response.into_inner())
+                            },
+                        )).await;
+                    });
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn validate_startup(
+    config: &spur_core::config::SlurmConfig,
+    uid: u32,
+) -> anyhow::Result<()> {
+    use spur_core::config::AuthMode;
+    ensure!(uid == 0, "SSH admission requires root");
+    ensure!(
+        config.auth.mode == AuthMode::Required
+            && !config
+                .auth
+                .jwt_key
+                .as_deref()
+                .unwrap_or_default()
+                .is_empty(),
+        "SSH admission requires authenticated agent RPCs"
+    );
+    ensure!(
+        !config.auth.allow_root_jobs,
+        "SSH admission forbids root jobs"
+    );
+    let c = &config.cgroup;
+    ensure!(
+        c.enabled
+            && c.required
+            && c.constrain_devices
+            && c.constrain_cores
+            && c.constrain_ram_space,
+        "SSH admission requires device, CPU and memory cgroup enforcement"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_server::{new_running_jobs, TrackedJob};
+    use std::io::Write;
+    use std::os::fd::FromRawFd;
+
+    async fn receive_first(stream: &UnixStream) -> (u8, Option<fs::File>) {
+        loop {
+            stream.readable().await.unwrap();
+            let result = stream.try_io(Interest::READABLE, || {
+                let mut byte = 0u8;
+                let mut iov = libc::iovec {
+                    iov_base: std::ptr::addr_of_mut!(byte).cast(),
+                    iov_len: 1,
+                };
+                let mut control = [unsafe { std::mem::zeroed::<libc::cmsghdr>() }; 2];
+                let mut message: libc::msghdr = unsafe { std::mem::zeroed() };
+                message.msg_iov = &mut iov;
+                message.msg_iovlen = 1;
+                message.msg_control = control.as_mut_ptr().cast();
+                message.msg_controllen = std::mem::size_of_val(&control);
+                let received = unsafe {
+                    libc::recvmsg(stream.as_raw_fd(), &mut message, libc::MSG_CMSG_CLOEXEC)
+                };
+                if received == -1 {
+                    return Err(io::Error::last_os_error());
+                }
+                assert_eq!(received, 1);
+                assert_eq!(message.msg_flags & (libc::MSG_CTRUNC | libc::MSG_TRUNC), 0);
+                let file = unsafe {
+                    let header = libc::CMSG_FIRSTHDR(&message);
+                    if header.is_null() {
+                        None
+                    } else {
+                        assert_eq!((*header).cmsg_level, libc::SOL_SOCKET);
+                        assert_eq!((*header).cmsg_type, libc::SCM_RIGHTS);
+                        assert_eq!(
+                            (*header).cmsg_len,
+                            libc::CMSG_LEN(std::mem::size_of::<libc::c_int>() as _) as usize
+                        );
+                        let fd = libc::CMSG_DATA(header).cast::<libc::c_int>().read();
+                        let file = fs::File::from_raw_fd(fd);
+                        assert!(libc::CMSG_NXTHDR(&message, header).is_null());
+                        let flags = libc::fcntl(fd, libc::F_GETFL);
+                        assert!(flags >= 0);
+                        assert_eq!(flags & libc::O_ACCMODE, libc::O_WRONLY);
+                        assert_ne!(flags & libc::O_NONBLOCK, 0);
+                        assert_ne!(flags & libc::O_NOFOLLOW, 0);
+                        let descriptor_flags = libc::fcntl(fd, libc::F_GETFD);
+                        assert!(descriptor_flags >= 0);
+                        assert_ne!(descriptor_flags & libc::FD_CLOEXEC, 0);
+                        Some(file)
+                    }
+                };
+                Ok((byte, file))
+            });
+            match result {
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted
+                    ) =>
+                {
+                    continue
+                }
+                result => return result.unwrap(),
+            }
+        }
+    }
+
+    async fn response_line(client: &mut UnixStream) -> String {
+        let mut response = String::new();
+        loop {
+            let byte = client.read_u8().await.unwrap();
+            response.push(char::from(byte));
+            if byte == b'\n' {
+                return response;
+            }
+            assert!(response.len() < 4096);
+        }
+    }
+
+    fn info() -> JobInfo {
+        JobInfo {
+            job_id: 7,
+            user: "alice".into(),
+            uid: 1001,
+            state: JobState::JobRunning as i32,
+            exclusive: true,
+            run_attempt: Some(0),
+            nodelist: "node[01-02]".into(),
+            start_time: Some(prost_types::Timestamp {
+                seconds: 1,
+                nanos: 0,
+            }),
+            ..Default::default()
+        }
+    }
+
+    async fn fixture(eligible: bool) -> (tempfile::TempDir, LocalJobs) {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("cgroup.procs"), "").unwrap();
+        let jobs = LocalJobs {
+            running: new_running_jobs(),
+            lifecycle: JobLifecycle::default(),
+        };
+        jobs.running
+            .lock()
+            .await
+            .insert(7, TrackedJob::ssh_fixture(dir.path().into(), eligible));
+        (dir, jobs)
+    }
+
+    async fn exchange<Q, F>(jobs: LocalJobs, request: &[u8], uid: u32, query: Q) -> String
+    where
+        Q: FnOnce(u32) -> F,
+        F: Future<Output = anyhow::Result<JobInfo>>,
+    {
+        let (mut client, server) = UnixStream::pair().unwrap();
+        client.write_all(request).await.unwrap();
+        if !request.ends_with(b"\n") {
+            client.shutdown().await.unwrap();
+        }
+        let serving = handle(
+            server,
+            jobs,
+            "node01",
+            uid,
+            |name| async move {
+                ensure!(name == "alice", "unexpected user");
+                Ok(1001)
+            },
+            query,
+        );
+        let reading = async {
+            let (first, descriptor) = receive_first(&client).await;
+            if first == b'F' {
+                assert_eq!(request, b"SPURSSH1 ADOPT alice\n");
+                let mut file = descriptor.expect("ADOPT must pass a descriptor");
+                file.write_all(b"0\n").unwrap();
+                drop(file);
+                client.write_all(b"JOINED\n").await.unwrap();
+                response_line(&mut client).await
+            } else {
+                assert!(
+                    descriptor.is_none(),
+                    "CHECK and DENY must not pass descriptors"
+                );
+                format!("{}{}", char::from(first), response_line(&mut client).await)
+            }
+        };
+        let (result, response) = tokio::join!(serving, reading);
+        result.unwrap();
+        response
+    }
+
+    fn test_uid() -> u32 {
+        nix::unistd::geteuid().as_raw()
+    }
+
+    #[test]
+    fn parser_is_strict_and_bounded() {
+        assert_eq!(
+            parse_request(b"SPURSSH1 CHECK alice\n").unwrap(),
+            (false, "alice")
+        );
+        assert_eq!(
+            parse_request(b"SPURSSH1 ADOPT a_1.-\n").unwrap(),
+            (true, "a_1.-")
+        );
+        for line in [
+            b"SPURSSH1 CHECK root\n".as_slice(),
+            b"SPURSSH1 CHECK alice\r\n",
+            b"SPURSSH1 CHECK alice extra\n",
+            b"SPURSSH1  CHECK alice\n",
+            b"SPURSSH1 CHECK a/b\n",
+            b"SPURSSH1 CHECK alice",
+            b"SPURSSH1 ADOPT \n",
+            b"SPURSSH1 CHECK a\xff\n",
+        ] {
+            assert!(parse_request(line).is_err(), "{line:?}");
+        }
+        assert!(parse_request(&vec![b'x'; 257]).is_err());
+        assert!(parse_request(format!("SPURSSH1 CHECK {}\n", "a".repeat(129)).as_bytes()).is_err());
+        for pid in [None, Some(-1), Some(0), Some(1)] {
+            assert!(validate_peer(0, pid, 0).is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn real_handler_refuses_peer_and_malformed_requests() {
+        let (_dir, jobs) = fixture(true).await;
+        let unexpected = |_| async {
+            panic!("controller must not be queried");
+            #[allow(unreachable_code)]
+            Ok(info())
+        };
+        assert_eq!(
+            exchange(
+                jobs.clone(),
+                b"SPURSSH1 CHECK alice\n",
+                test_uid().wrapping_add(1),
+                unexpected
+            )
+            .await,
+            "DENY\n"
+        );
+        assert_eq!(
+            exchange(
+                jobs.clone(),
+                b"SPURSSH1 CHECK root\n",
+                test_uid(),
+                unexpected
+            )
+            .await,
+            "DENY\n"
+        );
+        assert_eq!(
+            exchange(jobs, &vec![b'x'; 257], test_uid(), unexpected).await,
+            "DENY\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_never_passes_fd_and_only_client_writes_zero() {
+        let (dir, jobs) = fixture(true).await;
+        assert_eq!(
+            exchange(
+                jobs.clone(),
+                b"SPURSSH1 CHECK alice\n",
+                test_uid(),
+                |_| async { Ok(info()) }
+            )
+            .await,
+            "OK 7 0,2\n"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.path().join("cgroup.procs")).unwrap(),
+            ""
+        );
+        let members = format!("0\n{}\n", std::process::id());
+        fs::write(dir.path().join("cgroup.procs"), &members).unwrap();
+        assert_eq!(
+            exchange(jobs, b"SPURSSH1 ADOPT alice\n", test_uid(), |_| async {
+                Ok(info())
+            })
+            .await,
+            "OK 7 0,2\n"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.path().join("cgroup.procs")).unwrap(),
+            members
+        );
+    }
+
+    #[tokio::test]
+    async fn receipt_wrong_truncated_or_disconnected_fails_closed() {
+        for receipt in [b"WRONG!\n".as_slice(), b"JOINED", b""] {
+            let (dir, jobs) = fixture(true).await;
+            let members = format!("0\n{}\n", std::process::id());
+            fs::write(dir.path().join("cgroup.procs"), &members).unwrap();
+            let (mut client, server) = UnixStream::pair().unwrap();
+            client.write_all(b"SPURSSH1 ADOPT alice\n").await.unwrap();
+            let serving = handle(
+                server,
+                jobs.clone(),
+                "node01",
+                test_uid(),
+                |_| async { Ok(1001) },
+                |_| async { Ok(info()) },
+            );
+            let reading = async {
+                let (marker, file) = receive_first(&client).await;
+                assert_eq!(marker, b'F');
+                drop(file.unwrap());
+                assert!(jobs.running.try_lock().is_ok());
+                let lifecycle = jobs.lifecycle.acquire(7);
+                tokio::pin!(lifecycle);
+                assert!(
+                    std::future::poll_fn(|cx| std::task::Poll::Ready(
+                        lifecycle.as_mut().poll(cx).is_pending()
+                    ))
+                    .await
+                );
+                client.write_all(receipt).await.unwrap();
+                client.shutdown().await.unwrap();
+                assert_eq!(response_line(&mut client).await, "DENY\n");
+            };
+            let (result, ()) = tokio::join!(serving, reading);
+            result.unwrap();
+            assert!(jobs.running.try_lock().is_ok());
+            drop(jobs.lifecycle.acquire(7).await);
+            assert_eq!(
+                fs::read_to_string(dir.path().join("cgroup.procs")).unwrap(),
+                members
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn client_zero_without_peer_membership_is_denied() {
+        let (dir, jobs) = fixture(true).await;
+        assert_eq!(
+            exchange(jobs, b"SPURSSH1 ADOPT alice\n", test_uid(), |_| async {
+                Ok(info())
+            })
+            .await,
+            "DENY\n"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.path().join("cgroup.procs")).unwrap(),
+            "0\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn disconnect_after_fd_releases_locks_without_writes() {
+        let (dir, jobs) = fixture(true).await;
+        let (mut client, server) = UnixStream::pair().unwrap();
+        client.write_all(b"SPURSSH1 ADOPT alice\n").await.unwrap();
+        let serving = handle(
+            server,
+            jobs.clone(),
+            "node01",
+            test_uid(),
+            |_| async { Ok(1001) },
+            |_| async { Ok(info()) },
+        );
+        let disconnect = async move {
+            let (marker, file) = receive_first(&client).await;
+            assert_eq!(marker, b'F');
+            drop(file.unwrap());
+            drop(client);
+        };
+        let (result, ()) = tokio::join!(serving, disconnect);
+        assert!(result.is_err());
+        assert!(jobs.running.try_lock().is_ok());
+        drop(jobs.lifecycle.acquire(7).await);
+        assert_eq!(
+            fs::read_to_string(dir.path().join("cgroup.procs")).unwrap(),
+            ""
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn outer_deadline_cancels_handshake_and_releases_both_locks() {
+        let (dir, jobs) = fixture(true).await;
+        let (mut client, server) = UnixStream::pair().unwrap();
+        client.write_all(b"SPURSSH1 ADOPT alice\n").await.unwrap();
+        let serving = tokio::time::timeout(
+            Duration::from_secs(5),
+            handle(
+                server,
+                jobs.clone(),
+                "node01",
+                test_uid(),
+                |_| async { Ok(1001) },
+                |_| async { Ok(info()) },
+            ),
+        );
+        let stalled = async {
+            let (marker, file) = receive_first(&client).await;
+            assert_eq!(marker, b'F');
+            drop(file.unwrap());
+            assert!(jobs.running.try_lock().is_ok());
+            tokio::time::advance(Duration::from_secs(5)).await;
+        };
+        let (result, ()) = tokio::join!(serving, stalled);
+        assert!(result.is_err());
+        assert!(jobs.running.try_lock().is_ok());
+        drop(jobs.lifecycle.acquire(7).await);
+        assert_eq!(
+            fs::read_to_string(dir.path().join("cgroup.procs")).unwrap(),
+            ""
+        );
+    }
+
+    #[tokio::test]
+    async fn allocation_removed_during_handoff_cannot_receive_final_ok() {
+        let (dir, jobs) = fixture(true).await;
+        fs::write(
+            dir.path().join("cgroup.procs"),
+            format!("0\n{}\n", std::process::id()),
+        )
+        .unwrap();
+        let (mut client, server) = UnixStream::pair().unwrap();
+        client.write_all(b"SPURSSH1 ADOPT alice\n").await.unwrap();
+        let serving = handle(
+            server,
+            jobs.clone(),
+            "node01",
+            test_uid(),
+            |_| async { Ok(1001) },
+            |_| async { Ok(info()) },
+        );
+        let removed = async {
+            let (marker, file) = receive_first(&client).await;
+            assert_eq!(marker, b'F');
+            drop(file.unwrap());
+            jobs.running.lock().await.remove(&7);
+            client.write_all(b"JOINED\n").await.unwrap();
+            assert_eq!(response_line(&mut client).await, "DENY\n");
+        };
+        let (result, ()) = tokio::join!(serving, removed);
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn membership_is_rechecked_after_receipt() {
+        let (dir, jobs) = fixture(true).await;
+        let members = format!("0\n{}\n", std::process::id());
+        fs::write(dir.path().join("cgroup.procs"), &members).unwrap();
+        let (mut client, server) = UnixStream::pair().unwrap();
+        client.write_all(b"SPURSSH1 ADOPT alice\n").await.unwrap();
+        let serving = handle(
+            server,
+            jobs,
+            "node01",
+            test_uid(),
+            |_| async { Ok(1001) },
+            |_| async { Ok(info()) },
+        );
+        let reading = async {
+            let (marker, file) = receive_first(&client).await;
+            assert_eq!(marker, b'F');
+            drop(file.unwrap());
+            // Removing membership during the exchange must prevent final success.
+            fs::write(dir.path().join("cgroup.procs"), "0\n").unwrap();
+            client.write_all(b"JOINED\n").await.unwrap();
+            assert_eq!(response_line(&mut client).await, "DENY\n");
+        };
+        let (result, ()) = tokio::join!(serving, reading);
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn inactive_missing_and_ambiguous_allocations_deny() {
+        let (dir, jobs) = fixture(false).await;
+        let unexpected = |_| async {
+            panic!("controller must not be queried");
+            #[allow(unreachable_code)]
+            Ok(info())
+        };
+        assert_eq!(
+            exchange(
+                jobs.clone(),
+                b"SPURSSH1 CHECK alice\n",
+                test_uid(),
+                unexpected
+            )
+            .await,
+            "DENY\n"
+        );
+        {
+            let mut running = jobs.running.lock().await;
+            running.insert(7, TrackedJob::ssh_fixture(dir.path().into(), true));
+            running.insert(8, TrackedJob::ssh_fixture(dir.path().into(), true));
+        }
+        assert_eq!(
+            exchange(
+                jobs.clone(),
+                b"SPURSSH1 ADOPT alice\n",
+                test_uid(),
+                unexpected
+            )
+            .await,
+            "DENY\n"
+        );
+        jobs.running.lock().await.clear();
+        assert_eq!(
+            exchange(jobs, b"SPURSSH1 CHECK alice\n", test_uid(), unexpected).await,
+            "DENY\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn replacement_with_same_attempt_and_revocation_deny() {
+        for eligible in [true, false] {
+            let (dir, jobs) = fixture(true).await;
+            let mutate = jobs.clone();
+            let path = dir.path().to_owned();
+            assert_eq!(
+                exchange(
+                    jobs,
+                    b"SPURSSH1 ADOPT alice\n",
+                    test_uid(),
+                    |_| async move {
+                        mutate
+                            .running
+                            .lock()
+                            .await
+                            .insert(7, TrackedJob::ssh_fixture(path, eligible));
+                        Ok(info())
+                    }
+                )
+                .await,
+                "DENY\n"
+            );
+            assert_eq!(
+                fs::read_to_string(dir.path().join("cgroup.procs")).unwrap(),
+                ""
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn controller_mismatch_and_errors_fail_closed() {
+        let (dir, jobs) = fixture(true).await;
+        let mut bad = Vec::new();
+        let mut v = info();
+        v.state = JobState::JobSuspended as i32;
+        bad.push(v);
+        let mut v = info();
+        v.run_attempt = Some(1);
+        bad.push(v);
+        let mut v = info();
+        v.run_attempt = None;
+        bad.push(v);
+        let mut v = info();
+        v.uid = 0;
+        bad.push(v);
+        let mut v = info();
+        v.user = "bob".into();
+        bad.push(v);
+        let mut v = info();
+        v.job_id = 8;
+        bad.push(v);
+        let mut v = info();
+        v.exclusive = false;
+        bad.push(v);
+        let mut v = info();
+        v.nodelist = "elsewhere".into();
+        bad.push(v);
+        let mut v = info();
+        v.start_time = None;
+        bad.push(v);
+        let mut v = info();
+        v.end_time = v.start_time;
+        bad.push(v);
+        let mut v = info();
+        v.time_limit = Some(prost_types::Duration {
+            seconds: 1,
+            nanos: 0,
+        });
+        bad.push(v);
+        let mut v = info();
+        v.time_limit = Some(prost_types::Duration {
+            seconds: -1,
+            nanos: 0,
+        });
+        bad.push(v);
+        let mut v = info();
+        v.time_limit = Some(prost_types::Duration {
+            seconds: 0,
+            nanos: 0,
+        });
+        bad.push(v);
+        for v in bad {
+            assert_eq!(
+                exchange(
+                    jobs.clone(),
+                    b"SPURSSH1 ADOPT alice\n",
+                    test_uid(),
+                    |_| async { Ok(v) }
+                )
+                .await,
+                "DENY\n"
+            );
+        }
+        assert_eq!(
+            exchange(jobs, b"SPURSSH1 ADOPT alice\n", test_uid(), |_| async {
+                bail!("controller unavailable")
+            })
+            .await,
+            "DENY\n"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.path().join("cgroup.procs")).unwrap(),
+            ""
+        );
+    }
+
+    #[tokio::test]
+    async fn same_generation_controller_revocation_denies_finish() {
+        let (dir, jobs) = fixture(true).await;
+        let snapshot = jobs.snapshot("alice", 1001).await.unwrap();
+        for state in [JobState::JobSuspended, JobState::JobCancelled] {
+            let mut controller = info();
+            controller.state = state as i32;
+            for adopt in [false, true] {
+                let (_client, mut server) = UnixStream::pair().unwrap();
+                assert!(jobs
+                    .finish(&snapshot, &controller, "node01", &mut server, adopt)
+                    .await
+                    .is_err());
+                let current = jobs.snapshot("alice", 1001).await.unwrap();
+                assert!(Arc::ptr_eq(&snapshot.generation, &current.generation));
+            }
+        }
+        assert_eq!(
+            fs::read_to_string(dir.path().join("cgroup.procs")).unwrap(),
+            ""
+        );
+        let (mut client, mut server) = UnixStream::pair().unwrap();
+        jobs.finish(&snapshot, &info(), "node01", &mut server, false)
+            .await
+            .unwrap();
+        assert_eq!(response_line(&mut client).await, "OK 7 0,2\n");
+    }
+
+    #[test]
+    fn production_startup_requires_every_enforcement_flag() {
+        use spur_core::config::{AuthMode, SlurmConfig};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spur.conf");
+        fs::write(
+            &path,
+            r#"
+cluster_name = "ssh-admission-test"
+[auth]
+plugin = "jwt"
+mode = "required"
+jwt_key = "test-only-not-a-production-key"
+allow_root_jobs = false
+[cgroup]
+enabled = true
+required = true
+constrain_devices = true
+constrain_cores = true
+constrain_ram_space = true
+"#,
+        )
+        .unwrap();
+        let valid = SlurmConfig::load_from_file(&path).unwrap();
+        validate_startup(&valid, 0).unwrap();
+        assert!(validate_startup(&valid, 1001).is_err());
+        for mode in [AuthMode::Disabled, AuthMode::Permissive] {
+            let mut config = valid.clone();
+            config.auth.mode = mode;
+            assert!(validate_startup(&config, 0).is_err(), "{mode:?}");
+        }
+        for key in [None, Some(String::new())] {
+            let mut config = valid.clone();
+            config.auth.jwt_key = key;
+            assert!(validate_startup(&config, 0).is_err());
+        }
+        let mut config = valid.clone();
+        config.auth.allow_root_jobs = true;
+        assert!(validate_startup(&config, 0).is_err());
+        for flag in [
+            "enabled",
+            "required",
+            "constrain_devices",
+            "constrain_cores",
+            "constrain_ram_space",
+        ] {
+            let mut config = valid.clone();
+            match flag {
+                "enabled" => config.cgroup.enabled = false,
+                "required" => config.cgroup.required = false,
+                "constrain_devices" => config.cgroup.constrain_devices = false,
+                "constrain_cores" => config.cgroup.constrain_cores = false,
+                "constrain_ram_space" => config.cgroup.constrain_ram_space = false,
+                _ => unreachable!(),
+            }
+            assert!(validate_startup(&config, 0).is_err(), "missing {flag}");
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_controller_timestamps_deny_before_membership_write() {
+        let (dir, jobs) = fixture(true).await;
+        for (seconds, nanos) in [(-1, 0), (1, -1), (1, 1_000_000_000)] {
+            for malformed_start in [true, false] {
+                let mut controller = info();
+                if malformed_start {
+                    controller.start_time = Some(prost_types::Timestamp { seconds, nanos });
+                } else {
+                    controller.time_limit = Some(prost_types::Duration { seconds, nanos });
+                }
+                assert_eq!(
+                    exchange(
+                        jobs.clone(),
+                        b"SPURSSH1 ADOPT alice\n",
+                        test_uid(),
+                        |_| async { Ok(controller) }
+                    )
+                    .await,
+                    "DENY\n",
+                    "start={malformed_start}, seconds={seconds}, nanos={nanos}"
+                );
+            }
+        }
+        assert_eq!(
+            fs::read_to_string(dir.path().join("cgroup.procs")).unwrap(),
+            ""
+        );
+    }
+
+    #[tokio::test]
+    async fn controller_deadline_is_exclusive_at_nanosecond_precision() {
+        let (_dir, jobs) = fixture(true).await;
+        let snapshot = jobs.snapshot("alice", 1001).await.unwrap();
+        let mut controller = info();
+        controller.start_time = Some(prost_types::Timestamp {
+            seconds: 10,
+            nanos: 999_999_999,
+        });
+        controller.time_limit = Some(prost_types::Duration {
+            seconds: 0,
+            nanos: 2,
+        });
+        let start = UNIX_EPOCH + Duration::new(10, 999_999_999);
+        let deadline = UNIX_EPOCH + Duration::new(11, 1);
+        assert!(validate_controller(
+            &controller,
+            &snapshot,
+            "node01",
+            start - Duration::from_nanos(1)
+        )
+        .is_err());
+        for now in [start, deadline - Duration::from_nanos(1)] {
+            validate_controller(&controller, &snapshot, "node01", now).unwrap();
+        }
+        for now in [deadline, deadline + Duration::from_nanos(1)] {
+            assert!(validate_controller(&controller, &snapshot, "node01", now).is_err());
+        }
+        controller.time_limit = None;
+        validate_controller(&controller, &snapshot, "node01", deadline).unwrap();
+    }
+
+    #[test]
+    fn membership_never_creates_truncates_or_follows_symlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cgroup.procs");
+        assert!(open_membership(dir.path()).is_err());
+        assert!(verify_membership(dir.path(), 123).is_err());
+        assert!(!path.exists());
+        fs::write(&path, "999\n456\n").unwrap();
+        let file = open_membership(dir.path()).unwrap();
+        assert_ne!(
+            unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) } & libc::FD_CLOEXEC,
+            0
+        );
+        drop(file);
+        verify_membership(dir.path(), 456).unwrap();
+        assert!(verify_membership(dir.path(), 123).is_err());
+        assert_eq!(fs::read_to_string(&path).unwrap(), "999\n456\n");
+        fs::remove_file(&path).unwrap();
+        let target = dir.path().join("target");
+        fs::write(&target, "untouched").unwrap();
+        std::os::unix::fs::symlink(&target, &path).unwrap();
+        assert!(open_membership(dir.path()).is_err());
+        assert!(verify_membership(dir.path(), 123).is_err());
+        assert_eq!(fs::read_to_string(target).unwrap(), "untouched");
+        fs::remove_file(&path).unwrap();
+        let fifo = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo.as_ptr(), 0o600) }, 0);
+        assert!(open_membership(dir.path()).is_err());
+        assert!(verify_membership(dir.path(), 123).is_err());
+    }
+
+    #[tokio::test]
+    async fn unsafe_paths_and_existing_sockets_are_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let token = dir.path().join("token");
+        fs::write(&token, "explicit-admin-credential\n").unwrap();
+        fs::set_permissions(&token, fs::Permissions::from_mode(0o600)).unwrap();
+        let socket = dir.path().join("admission.sock");
+        let bind = || AdmissionListener::bind_with_policy(&socket, &token, test_uid(), dir.path());
+        let listener = bind().unwrap();
+        assert_eq!(fs::metadata(&socket).unwrap().mode() & 0o777, 0o600);
+        assert!(bind().is_err());
+        drop(listener);
+        assert!(!socket.exists());
+        for mode in [0o644, 0o660, 0o700] {
+            fs::set_permissions(&token, fs::Permissions::from_mode(mode)).unwrap();
+            assert!(bind().is_err());
+        }
+        fs::set_permissions(&token, fs::Permissions::from_mode(0o400)).unwrap();
+        assert!(read_token(&token, test_uid().wrapping_add(1), dir.path()).is_err());
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(bind().is_err());
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let actual = dir.path().join("actual");
+        fs::rename(&token, &actual).unwrap();
+        std::os::unix::fs::symlink(&actual, &token).unwrap();
+        assert!(bind().is_err());
+        assert!(safe_parent(&dir.path().join("../escape"), test_uid(), dir.path(), true).is_err());
+    }
+
+    #[tokio::test]
+    async fn cleanup_preserves_replacement_path() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let token = dir.path().join("token");
+        fs::write(&token, "credential").unwrap();
+        fs::set_permissions(&token, fs::Permissions::from_mode(0o600)).unwrap();
+        let socket = dir.path().join("socket");
+        let listener =
+            AdmissionListener::bind_with_policy(&socket, &token, test_uid(), dir.path()).unwrap();
+        fs::remove_file(&socket).unwrap();
+        fs::write(&socket, "replacement").unwrap();
+        drop(listener);
+        assert_eq!(fs::read_to_string(socket).unwrap(), "replacement");
+    }
+}

--- a/crates/spurd/src/ssh_admission.rs
+++ b/crates/spurd/src/ssh_admission.rs
@@ -61,7 +61,7 @@ impl LocalJobs {
         unique_snapshot(&*self.running.lock().await, user, uid)
     }
 
-    async fn finish(
+    pub(crate) async fn finish(
         &self,
         snapshot: &Snapshot,
         controller: &JobInfo,

--- a/crates/spurd/src/ssh_identity.rs
+++ b/crates/spurd/src/ssh_identity.rs
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use anyhow::{ensure, Context, Result};
+use nix::unistd::User;
+use tokio::sync::Semaphore;
+
+const MAX_LOOKUPS: usize = 4;
+
+#[derive(Clone)]
+pub(crate) struct IdentityResolver {
+    slots: Arc<Semaphore>,
+}
+
+impl Default for IdentityResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IdentityResolver {
+    pub(crate) fn new() -> Self {
+        Self {
+            slots: Arc::new(Semaphore::new(MAX_LOOKUPS)),
+        }
+    }
+
+    pub(crate) async fn resolve(&self, user: String) -> Result<u32> {
+        self.bounded_lookup(move || {
+            let record = User::from_name(&user)
+                .context("NSS identity lookup failed")?
+                .context("SSH user does not exist")?;
+            validate_identity(&user, record)
+        })
+        .await
+    }
+
+    async fn bounded_lookup<F>(&self, lookup: F) -> Result<u32>
+    where
+        F: FnOnce() -> Result<u32> + Send + 'static,
+    {
+        let permit = self
+            .slots
+            .clone()
+            .try_acquire_owned()
+            .context("SSH identity resolver is busy")?;
+        tokio::task::spawn_blocking(move || {
+            // NSS cannot be cancelled: retain capacity even if its async waiter is dropped.
+            let _permit = permit;
+            lookup()
+        })
+        .await
+        .context("SSH identity lookup task failed")?
+    }
+}
+
+fn validate_identity(user: &str, record: User) -> Result<u32> {
+    ensure!(record.name == user, "NSS returned a different SSH user");
+    let uid = record.uid.as_raw();
+    ensure!(uid != 0, "SSH admission refuses uid 0");
+    Ok(uid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{mpsc, Barrier};
+    use tokio::sync::oneshot;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancelled_waiters_keep_all_four_slots_until_blocking_work_finishes() {
+        let resolver = IdentityResolver::new();
+        let mut waiters = Vec::new();
+        let mut releases = Vec::new();
+        let barrier = Arc::new(Barrier::new(MAX_LOOKUPS + 1));
+
+        for _ in 0..MAX_LOOKUPS {
+            let clone = resolver.clone();
+            let barrier = barrier.clone();
+            let (started_tx, started_rx) = oneshot::channel();
+            let (release_tx, release_rx) = mpsc::channel();
+            releases.push(release_tx);
+            waiters.push(tokio::spawn(async move {
+                clone
+                    .bounded_lookup(move || {
+                        started_tx.send(()).unwrap();
+                        release_rx.recv().unwrap();
+                        barrier.wait();
+                        Ok(1000)
+                    })
+                    .await
+            }));
+            started_rx.await.unwrap();
+        }
+
+        let (responsive_tx, responsive_rx) = oneshot::channel();
+        tokio::spawn(async move { responsive_tx.send(()).unwrap() });
+        responsive_rx.await.unwrap();
+        let busy_before_cancel = resolver.bounded_lookup(|| Ok(1001)).await;
+
+        for waiter in waiters {
+            waiter.abort();
+            assert!(waiter.await.unwrap_err().is_cancelled());
+        }
+        let held_after_cancel = resolver.slots.available_permits();
+        let busy_after_cancel = resolver.clone().bounded_lookup(|| Ok(1001)).await;
+
+        for release in releases {
+            release.send(()).unwrap();
+        }
+        let (finished_tx, finished_rx) = oneshot::channel();
+        let barrier_waiter = tokio::task::spawn_blocking(move || {
+            barrier.wait();
+            finished_tx.send(()).unwrap();
+        });
+        finished_rx.await.unwrap();
+        barrier_waiter.await.unwrap();
+        // Acquiring every permit also synchronizes with the closures' final destructors.
+        let all_slots = resolver
+            .slots
+            .clone()
+            .acquire_many_owned(MAX_LOOKUPS as u32)
+            .await
+            .unwrap();
+        drop(all_slots);
+
+        assert!(busy_before_cancel.is_err());
+        assert_eq!(held_after_cancel, 0);
+        assert!(busy_after_cancel.is_err());
+        assert_eq!(resolver.bounded_lookup(|| Ok(1001)).await.unwrap(), 1001);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn errors_and_panics_release_capacity() {
+        let resolver = IdentityResolver::default();
+        assert!(resolver
+            .bounded_lookup(|| anyhow::bail!("lookup failed"))
+            .await
+            .is_err());
+        assert_eq!(resolver.slots.available_permits(), MAX_LOOKUPS);
+        assert!(resolver
+            .bounded_lookup(|| panic!("lookup panicked"))
+            .await
+            .is_err());
+        assert_eq!(resolver.slots.available_permits(), MAX_LOOKUPS);
+        assert_eq!(resolver.bounded_lookup(|| Ok(1000)).await.unwrap(), 1000);
+    }
+
+    fn user(name: &str, uid: u32) -> User {
+        User {
+            name: name.into(),
+            passwd: Default::default(),
+            uid: nix::unistd::Uid::from_raw(uid),
+            gid: nix::unistd::Gid::from_raw(1000),
+            gecos: Default::default(),
+            dir: "/home/alice".into(),
+            shell: "/bin/sh".into(),
+        }
+    }
+
+    #[test]
+    fn requires_exact_name_and_non_root_uid() {
+        assert_eq!(
+            validate_identity("alice", user("alice", 1000)).unwrap(),
+            1000
+        );
+        assert!(validate_identity("alice", user("bob", 1000)).is_err());
+        assert!(validate_identity("alice", user("Alice", 1000)).is_err());
+        assert!(validate_identity("alice", user("alice", 0)).is_err());
+    }
+}

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -204,7 +204,8 @@ Admission fails closed when the local allocation is missing, ambiguous, revoked,
 ineligible, or not cgroup-enforced; when the controller is unavailable; or when
 owner, placement, generation, running state, or time-limit checks fail. Container
 allocations and allocation-only standalone ``srun`` registrations are not supported.
-Suspension revokes further admission for that local generation; resume does not
+Suspension and explicit job signals revoke further admission for that local
+generation, including nonterminating signals such as ``SIGUSR1``; resume does not
 restore it. Existing batch jobs, ``spur exec``, and ``spur run`` retain their APIs.
 
 Limits and deployment gate

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -114,6 +114,148 @@ The two daemons are configured with command-line flags. The most common are belo
    falls back to defaults for those sections, which is fine when none of them are
    in use.
 
+Native SSH allocation adoption (experimental)
+---------------------------------------------
+
+Spur can admit ordinary OpenSSH connections into an existing exclusive native
+allocation. The scheduler, allocation ID, and ``salloc`` lifetime remain unchanged:
+keep the allocating shell open, then use ``ssh user@allocated-node``. Closing an
+SSH connection does not release the allocation. No replacement shell, mandatory
+container, or per-command ``spur exec`` proxy is involved.
+
+This integration is opt-in and is not installed or enabled by the normal binary
+installer. It is intended for evaluation on disposable development nodes, not as
+a complete hostile-tenant isolation or guaranteed-preemption solution. Existing
+privileged job launch paths also require security review before untrusted users
+are admitted; authentication and this PAM module do not repair those paths.
+
+Build the Linux PAM module separately:
+
+.. code-block:: bash
+
+   cargo build --release -p spur-pam
+
+The artifact is ``target/release/libpam_spur.so``. Install it in a root-controlled
+PAM module directory appropriate to the distribution. Do not install it or edit
+PAM on a shared machine merely to test the build.
+
+Agent prerequisites
+~~~~~~~~~~~~~~~~~~~
+
+The node agent must run as root with authenticated RPCs (``auth.mode = "required"``),
+root jobs disabled, and mandatory cgroup CPU, memory, and device enforcement.
+The controller must support the strict SSH admission read. Ordinary job queries
+retain their existing behavior; an older controller cannot authorize adoption.
+Protect the controller transport with the deployment's trusted network or tunnel,
+and do not expose the unauthenticated REST API.
+
+Create a dedicated root-owned directory with mode ``0700`` and a root-owned
+regular token file with mode ``0600`` or ``0400``. The token must authorize reading
+the full job records for the users being admitted; never use an SSH-provided token
+or a developer's home-directory configuration. Add these flags to the agent's
+existing command:
+
+.. code-block:: text
+
+   --ssh-admission-socket /run/spur-ssh/admission.sock
+   --ssh-admission-token-file /etc/spur/ssh-admission.token
+
+The socket is mode ``0600`` and accepts only root peers. Existing socket paths
+are not silently removed; investigate stale paths before restarting. Neither flag
+changes the node's SSH or PAM configuration.
+
+PAM integration
+~~~~~~~~~~~~~~~
+
+On a disposable validation node, keep an independent administrative access path.
+For the developer SSH service, enable ``UsePAM yes`` and add the following to the
+appropriate account and session stacks, using the actual installed module path:
+
+.. code-block:: text
+
+   account requisite /path/to/libpam_spur.so socket=/run/spur-ssh/admission.sock
+   session requisite /path/to/libpam_spur.so socket=/run/spur-ssh/admission.sock
+
+Place the adoption session entry after any module that changes cgroup membership,
+including ``pam_systemd``. Audit the entire PAM stack for control-flow shortcuts
+and verify the final cgroup of the connection process and its descendants. The
+module accepts only service ``sshd`` and non-root users. Administrative bypasses,
+if needed, must be separately controlled by the operator, not a permissive module
+argument.
+
+Account management checks authorization without moving its caller. Session setup
+opens a fresh connection to the agent, which verifies kernel peer credentials and
+passes an opened allocation membership descriptor using ``SCM_RIGHTS``. PAM writes
+``0`` to adopt itself, closes the descriptor, and awaits the agent's membership
+confirmation. Allocation lifecycle locks cover this handshake. The agent never
+moves a numeric PID, avoiding adoption of an unrelated process after PID reuse.
+No caller-selected PID, cgroup path, or environment variable is trusted. Validate the exact OpenSSH build:
+portable OpenSSH calls PAM session setup before its post-authentication fork, so
+this adopts the per-connection process and its subsequently forked descendants,
+not the listening SSH daemon. A multiplexed connection stays with its original
+allocation; open a new connection when changing allocations.
+
+The login keeps its normal UID, groups, HOME, and shell. PAM adds ``SPUR_JOB_ID``,
+``SLURM_JOB_ID``, and GPU visibility variables. These variables assist applications;
+the cgroup is the resource-enforcement boundary. Zero-GPU allocations receive
+``-1`` visibility masks.
+
+Admission fails closed when the local allocation is missing, ambiguous, revoked,
+ineligible, or not cgroup-enforced; when the controller is unavailable; or when
+owner, placement, generation, running state, or time-limit checks fail. Container
+allocations and allocation-only standalone ``srun`` registrations are not supported.
+Suspension revokes further admission for that local generation; resume does not
+restore it. Existing batch jobs, ``spur exec``, and ``spur run`` retain their APIs.
+
+Limits and deployment gate
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This change does not replace the scheduler's accounting or teardown implementation.
+It does not implement GPU-hour budgets, external fencing, a checkpoint protocol,
+or a verified all-node cleanup barrier. Controller connectivity loss denies new
+admissions, but does not itself terminate previously admitted connections.
+
+Socket operations have a five-second budget, but the kernel cgroup-migration
+write can block independently of that budget. If migration returns after timeout,
+PAM refuses the session and does not export allocation metadata; migration itself
+may already have happened. Verify the installed OpenSSH build denies command and
+forwarding access on PAM session failure, and quarantine nodes with stalled
+migration rather than assuming an application-level timeout can undo it.
+
+Before deployment, verify cancellation, expiry, suspension, and preemption against
+real connection descendants, detached workloads, and the actual cgroup hierarchy.
+Existing batch-process signals do not necessarily reach SSH descendants immediately;
+cleanup still depends on the agent's allocation teardown. A successful cancel RPC
+is not evidence that all SSH work has stopped.
+
+Also validate remote commands, SFTP/scp, rsync, tmux, connection multiplexing, and
+IDE connections. Disable forwarding until its lifetime and access policy have been
+validated; a PAM session failure must not leave a usable forwarding-only connection.
+Unrestricted sudo, shared Docker sockets, cron, or user service managers can bypass
+session containment and require separate policy. Docker labels alone do not place
+daemon-created containers in the allocation cgroup. This integration does not grant
+host root or make unrestricted-root leases safe.
+
+CPU-only development checks
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   cargo test -p spur-pam --locked
+   cargo test -p spurd ssh_admission --locked
+   cargo test -p spurctld ssh_admission --locked
+   cargo build -p spur-pam --locked
+   python3 crates/spur-pam/tests/test_real_pam.py
+
+The Python integration uses the production shared library and Linux-PAM with a
+temporary service directory. Run it as a non-root user; it verifies real rejection
+paths, not a successful SSH login. ``SPUR_PAM_MODULE`` can select a different built
+module path.
+
+These tests use PAM ABI fixtures, Unix sockets, and temporary files rather than
+GPUs or the host's cgroups. They do not install a PAM module, modify ``/etc/pam.d``,
+start the node agent, or prove a production SSH deployment safe.
+
 Quick Start: Two-Node Cluster
 -----------------------------
 

--- a/docs/user-guide/interactive.rst
+++ b/docs/user-guide/interactive.rst
@@ -133,6 +133,15 @@ Examples:
    salloc -N1 --gres=gpu:2 -t 2:00:00
    spur alloc --partition gpu --exclusive
 
+On nodes where an administrator has enabled experimental native SSH adoption,
+you can use ordinary ``ssh user@allocated-node`` while an exclusive native
+allocation is running. Keep the allocating shell open; SSH disconnects do not
+release the allocation, and reconnecting does not create a new quota or deadline.
+The normal login environment is preserved and the connection joins the existing
+allocation's cgroup. Container allocations and ambiguous allocation selection are
+not supported. See :doc:`/deployment/native-host` for prerequisites and validation
+limits; SSH support is disabled unless explicitly installed and configured.
+
 Attach to a Running Job — ``sattach``
 -------------------------------------
 

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -295,6 +295,9 @@ message JobInfo {
   string sched_nodelist = 78;
 
   bool min_memory_is_per_cpu = 79;
+
+  // Presence distinguishes generation-aware controllers from older peers.
+  optional uint32 run_attempt = 80;
 }
 
 message NodeInfo {


### PR DESCRIPTION
## Summary
- Add an opt-in Linux PAM module and root-only node-agent socket so ordinary OpenSSH connections can join existing exclusive native allocations; preserve current salloc lifetime and existing exec/run interfaces.
- Authorize against a leader-confirmed authenticated GetJob read, matching owner, node, run generation and deadline. Add optional JobInfo.run_attempt at field 80; ordinary GetJob behavior remains unchanged and older controllers cannot authorize SSH admission.
- Pass an opened cgroup membership descriptor via SCM_RIGHTS; PAM writes zero to adopt itself, closes the descriptor, and waits for membership confirmation. This avoids numeric-PID reuse races. Bound socket operations and isolate NSS lookups behind four blocking-worker permits; do not hold the global job map while awaiting a client.

## Scope and draft gate
This is an experimental integration, not a production deployment or a complete quota/preemption implementation. Only exclusive native batch/salloc allocations are supported; no root jobs, container allocations, or allocation-only srun registrations. No SSH/PAM configuration is installed automatically.

Portable OpenSSH invokes PAM session setup in the privileged per-connection process before its post-authentication fork. Adoption therefore applies to that connection and its descendants, not the listening daemon. This source-level behavior was checked against upstream 8.9p1 and current source; a successful real-sshd login remains untested.

Before merge/deployment, validate privileged SSH/cgroup inheritance, PAM failure handling, forwarding/multiplexing, remote commands, SFTP/rsync, IDEs, and allocation teardown on a disposable node. Existing cleanup is not a verified multinode reclamation barrier. Socket deadlines cannot interrupt a kernel-blocked cgroup migration; a late/failed handshake denies session admission but cannot undo migration. Existing privileged-launch security boundaries need separate review before untrusted tenancy.

## Test plan
All executed checks were CPU-only, unprivileged, with two build workers. No GPUs or GPU tools were used, no host cgroups or SSH/PAM configuration were changed, and no existing services were restarted. Build tooling was installed only inside the checkout.

- [x] PAM module: 19 unit tests, including exported ABI, real Unix sockets/SCM_RIGHTS, descriptor cleanup, backlog saturation, malformed replies and final-ack failures.
- [x] Agent: 25 focused tests (22 admission/revocation + 3 identity), including cancellation while a launch holds the lifecycle lock and same-generation revocation during the descriptor handshake. The cancellation and revocation lock regressions were confirmed failing before the fix and passing afterward.
- [x] Controller: 4 strict-read tests; job-read regression group 14 passed / 1 PostgreSQL test skipped; 4 protobuf conversion tests passed.
- [x] Production shared library through real Linux-PAM and temporary pam_start_confdir configuration: 5 unprivileged denial-path tests passed.
- [x] cargo clippy -p spurd -p spurctld -p spur-pam --all-targets --locked -- -D warnings
- [x] cargo check -p spur-cli -p spur-ffi --locked
- [x] cargo fmt --all -- --check; git diff --check
- [ ] Privileged disposable-node SSH success and actual cgroup adoption/cleanup.
- [ ] Full workspace and native-host integration suites (not run on the shared development host).

Generated with Claude Code.

## Follow-up verification
Commit 5ecfea7 removes an SSH-introduced lifecycle-lock wait that could block ordinary cancellation behind a slow launch, even with SSH disabled. Teardown remains serialized, and in-flight admission rechecks eligibility before success. Explicit-signal revocation is now documented.

Reran 54 focused CPU-only tests: 19 PAM unit, 25 agent/identity, 4 strict controller reads, 1 generation conversion, and 5 production Linux-PAM denial-path tests. Targeted Clippy with warnings denied, CLI/FFI checks, formatting, and diff checks passed. All builds used at most two workers; tests used temporary files/sockets, with host SPANK plugin loading disabled. No GPU access, host cgroup writes, SSH/PAM configuration changes, or service changes. Privileged SSH success/cleanup and full integration coverage remain unchecked.
