### PR TITLE
docs(cgroup): add the reload column and make sample enablement explicit

### DIFF
--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -1204,28 +1204,28 @@ cgroups.
 
 .. note::
 
-   **Reload: Not implemented.** ``spurd`` reads this section once at startup, so
-   ``scontrol reconfigure`` does not apply changes here. Restart the agent.
-
    Upgrading a cluster whose ``spur.conf`` has no ``[cgroup]`` section changes
    what gets enforced — see :ref:`cgroup-upgrade-notes`.
 
 .. list-table::
    :header-rows: 1
-   :widths: 22 8 10 60
+   :widths: 20 8 10 14 48
 
    * - Field
      - Type
      - Default
+     - Reload
      - Description
    * - ``enabled``
      - bool
      - ``true``
+     - Agent restart
      - Master switch. When ``false``, no cgroup is created and no limit is
        applied.
    * - ``required``
      - bool
      - ``false``
+     - Agent restart
      - Refuse the work when a requested constraint cannot be applied, instead of
        warning and running it unconstrained. This gates a batch launch, the
        registration of an interactive allocation (``salloc``, standalone
@@ -1234,23 +1234,27 @@ cgroups.
    * - ``constrain_cores``
      - bool
      - ``true``
+     - Agent restart
      - Pin the job to its allocated cores via ``cpuset.cpus``. With
        ``cpu_quota`` off this is the only CPU bound, so a job whose allocation
        yields no cores runs CPU-unconstrained and ``spurd`` logs a warning.
    * - ``cpu_quota``
      - bool
      - ``false``
+     - Agent restart
      - Additionally cap CPU time with a CFS quota (``cpu.max``). Off because the
        cpuset already bounds whole-core allocations; enabling it adds a hard
        throttle on top.
    * - ``constrain_ram_space``
      - bool
      - ``true``
+     - Agent restart
      - Cap memory via ``memory.max`` and ``memory.high``. Costs some per-node job
        throughput — see the note below.
    * - ``allowed_ram_percent``
      - int
      - ``100``
+     - Agent restart
      - Hard ceiling (``memory.max``) as a percentage of the allocated memory.
        ``memory.high`` stays at 100% of the allocation, so the default makes the
        two equal and a value above 100 opens a soft-throttle band. Must be at
@@ -1259,6 +1263,7 @@ cgroups.
    * - ``constrain_swap``
      - bool
      - ``false``
+     - Agent restart
      - Bound swap via ``memory.swap.max``. Off by default, as in Slurm: while
        off, ``memory.max`` bounds resident memory only and a job that outgrows
        ``--mem`` swaps instead of being killed. Turning it on with
@@ -1266,22 +1271,26 @@ cgroups.
    * - ``allowed_swap_percent``
      - int
      - ``0``
+     - Agent restart
      - Swap allowance as a percentage of the allocated memory. ``0`` means no
        swap. Not capped at 100 — a swap-rich node may grant more swap than RAM,
        and Slurm places no upper bound on ``AllowedSwapSpace`` either.
    * - ``min_ram_mb``
      - int
      - ``30``
+     - Agent restart
      - Floor for the memory ceilings, in MiB. Guards against a tiny ``--mem``
        creating a cgroup so small the job dies during its own startup.
    * - ``oom_kill_job``
      - bool
      - ``true``
+     - Agent restart
      - On OOM, kill every process in the job (``memory.oom.group``) instead of
        letting the kernel pick one.
    * - ``constrain_devices``
      - bool
      - ``true``
+     - Agent restart
      - Restrict the job to the device nodes its allocation granted, using a
        cgroup-v2 BPF device filter. Default-deny: a job allocated no GPUs can open
        only the nodes listed under :ref:`device-filter-implicit-allow` below, and
@@ -1292,6 +1301,7 @@ cgroups.
    * - ``extra_device_paths``
      - [string]
      - ``[]``
+     - Agent restart
      - Additional device node paths **every** job on this node may open, on top of
        its allocation and the implicit set below. The escape hatch for a site
        device the defaults miss, short of turning the filter off. A path that is

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -149,25 +149,28 @@ format = "text"
 memlock = "unlimited"
 
 # cgroup-v2 limits spurd applies to each batch and container job, derived from the
-# per-node allocation the scheduler granted. Cores and memory are bounded by
-# default; the settings below are the ones worth a decision.
+# per-node allocation the scheduler granted. Core, memory, and device enforcement
+# are spelled out below; with required = true a node that cannot apply them refuses
+# the job rather than running it unconstrained, so spurd must run as root.
 [cgroup]
-# Bound swap as well as RAM, which is what makes --mem a hard cap: without it
-# memory.max limits resident memory only, and a job that outgrows its allocation
-# pages out and finishes slowly instead of being killed. Recommended, but it does
-# start killing jobs that were quietly surviving on swap — leave it off while
-# migrating a workload you have not sized yet. No effect on a node without swap.
-constrain_swap = true
+enabled = true               # master switch for the whole section
+required = true              # refuse to launch a job when a limit cannot be applied,
+                             # instead of running it unconstrained (needs spurd as root)
+constrain_cores = true       # pin each job to its allocated cores (cpuset.cpus)
+constrain_ram_space = true   # cap memory at the allocation (memory.max + memory.high)
+oom_kill_job = true          # on OOM, kill the whole job (memory.oom.group), not one
+                             # process; a partial kill leaves the job in a murky state
+constrain_devices = true     # a job may open only the device nodes its allocation
+                             # granted. The one toggle here that can deny a device a
+                             # running job used to open — roll it out node by node and
+                             # watch job output for EPERM on device paths
+constrain_swap = true        # bound swap too, so --mem is a hard cap; without it a
+                             # job that outgrows its memory swaps instead of dying.
+                             # Recommended, but it kills jobs that were quietly
+                             # surviving on swap — leave off while sizing a workload
 # allowed_ram_percent = 125  # hard ceiling above the allocation; reclaim still
                              # starts at 100%, so jobs get headroom before the kill
-# required = false           # refuse to launch when limits cannot be applied,
-                             # instead of warning and running the job unconstrained
 # cpu_quota = false          # add a CFS quota on top of the cpuset; off as in Slurm
-# constrain_devices = true   # a job may open only the device nodes its allocation
-                             # granted, enforced by the kernel. On by default, and
-                             # the one setting here that can deny a device a running
-                             # job used to open — roll it out node by node and watch
-                             # job output for EPERM on device paths
 # extra_device_paths = []    # device nodes every job on this node may open on top
                              # of its allocation, e.g. ["/dev/site-accel0"]. Reach
                              # for this when the filter denies a device your jobs


### PR DESCRIPTION
The [cgroup] reference table gains a Reload column (Agent restart); examples/spur.conf now enables the cgroup toggles explicitly with required = true (fail-closed).