### PR TITLE
test(e2e): wait for registered nodes and reuse an existing CRD

### DIFF
--- a/tests/k8s/e2e/k8s_cluster.py
+++ b/tests/k8s/e2e/k8s_cluster.py
@@ -28,9 +28,13 @@ _DEFAULT_IMAGE = "ghcr.io/rocm/spur:ci"
 SPUR_JOB_GROUP = "spur.amd.com"
 SPUR_JOB_VERSION = "v1alpha1"
 SPUR_JOB_PLURAL = "spurjobs"
+CRD_NAME = f"{SPUR_JOB_PLURAL}.{SPUR_JOB_GROUP}"
 DEFAULT_TIMEOUT = 60
 WAIT_INTERVAL = 2
 HA_TIMEOUT = 90
+# The operator registers the nodes only after it reaches a ready controller;
+# measured at about three minutes after the controller Pods are ready.
+NODE_REGISTER_TIMEOUT = 300
 CLUSTER_SCOPED_KINDS = frozenset({"ClusterRole", "ClusterRoleBinding"})
 
 
@@ -93,6 +97,10 @@ def _is_not_found(exc: ApiException) -> bool:
 
 
 def _is_already_exists(exc: ApiException) -> bool:
+    return exc.status == 409
+
+
+def _is_conflict(exc: ApiException) -> bool:
     return exc.status == 409
 
 
@@ -201,7 +209,7 @@ class SuiteContext:
                 raise
 
         try:
-            self.ext_v1.delete_custom_resource_definition("spurjobs.spur.amd.com")
+            self.ext_v1.delete_custom_resource_definition(CRD_NAME)
         except ApiException as exc:
             if not _is_not_found(exc):
                 raise
@@ -231,10 +239,37 @@ class SuiteContext:
         except ApiException as exc:
             if not _is_already_exists(exc):
                 raise
-            self.ext_v1.replace_custom_resource_definition(
-                "spurjobs.spur.amd.com", crd_body
-            )
+            self._replace_crd(crd_body)
         logger.info("SpurJob CRD applied")
+
+    def _replace_crd(self, crd_body: dict) -> None:
+        # A replace needs the live resourceVersion, which can move between the
+        # read and the write, so try once more on a conflict.
+        for attempt in range(2):
+            live = self.ext_v1.read_custom_resource_definition(CRD_NAME)
+            if live.metadata.deletion_timestamp is not None:
+                # The previous session's teardown is still removing the CRD. A
+                # replace would land on an object that vanishes mid-run.
+                self._wait_crd_gone()
+                self.ext_v1.create_custom_resource_definition(crd_body)
+                return
+            crd_body["metadata"]["resourceVersion"] = live.metadata.resource_version
+            try:
+                self.ext_v1.replace_custom_resource_definition(CRD_NAME, crd_body)
+                return
+            except ApiException as exc:
+                if not _is_conflict(exc) or attempt == 1:
+                    raise
+
+    def _wait_crd_gone(self) -> None:
+        def gone() -> bool:
+            try:
+                self.ext_v1.read_custom_resource_definition(CRD_NAME)
+                return False
+            except ApiException as exc:
+                return _is_not_found(exc)
+
+        wait_until(gone, DEFAULT_TIMEOUT * 2, "CRD still terminating")
 
 
 class ClusterFixture:
@@ -418,6 +453,14 @@ class ClusterFixture:
         )
         logger.info("controller pod(s) ready: %s", self._ready_controller_count())
 
+        wait_until(
+            lambda: self._registered_node_count() >= 1,
+            NODE_REGISTER_TIMEOUT,
+            "no node registered with the controller",
+            interval=5,
+        )
+        logger.info("node(s) registered: %s", self._registered_node_count())
+
     def _operator_available(self) -> bool:
         try:
             dep = self.apps_v1.read_namespaced_deployment(
@@ -429,6 +472,14 @@ class ClusterFixture:
 
     def _ready_controller_count(self) -> int:
         return count_ready_pods(self.namespace, "app=spurctld")
+
+    def _registered_node_count(self) -> int:
+        """Nodes the controller lists; a follower answers this from local state."""
+        try:
+            out = exec_in_pod(self.namespace, "spurctld-0", ["spur", "nodes", "-N", "-h"])
+        except ApiException:
+            return 0
+        return sum(1 for line in out.splitlines() if line.strip())
 
     def teardown_workloads(self) -> None:
         self._force_delete_pods("app=spurctld")


### PR DESCRIPTION
Two faults in the Kubernetes e2e harness, both seen on a real three-node cluster. Neither is caused by the code under test.

## What this fixes

**The fixture returns before the controller has a node.** `ClusterFixture.deploy` waits until the controller Pods are ready and returns. The e2e manifests run no `spurd`; the operator registers the Kubernetes nodes with the controller over its own watch, which happens after the controller is ready. The first test that submits a `SpurJob` on a new cluster then hits the 60 s job timeout while the controller still has no node, and every later test passes. Measured at about three minutes on a fresh cluster. This explains `test_simple_spurjob_completes`, `test_state_survives_leader_failover` and `test_new_leader_accepts_writes` failing on a clean cluster and passing on a rerun.

**`apply_crd` fails when the CRD already exists.** The fallback from `create` to `replace` sends the manifest as is, but a replace needs the live `metadata.resourceVersion`:

```
ApiException: (422) ... metadata.resourceVersion: Invalid value: 0: must be specified for an update
```

CI never hits this path because its cluster is new. It fails on any cluster that already holds the CRD, such as a rerun after a partial teardown.

## Approach

`wait_ready` now waits, after the controller Pods, until the controller lists at least one node. The list is read with `spur nodes -N -h` inside `spurctld-0`, which a follower answers from local state, so the leader does not matter. The wait has its own timeout, `NODE_REGISTER_TIMEOUT`, instead of a larger `DEFAULT_TIMEOUT`, which guards every other wait in the suite and would hide slow tests.

`apply_crd` reads the live CRD on `AlreadyExists`, copies its `resourceVersion` into the manifest, replaces, and tries once more on a conflict, because the version can move between the read and the write. The create path for a new cluster is unchanged. When the live CRD is still terminating, because the previous session's teardown has not finished, `apply_crd` waits until it is gone and creates it anew; a replace would otherwise land on an object that vanishes during the run, after which every SpurJob call answers `404 page not found`. This was seen in every second back-to-back run on the test cluster.

The delay itself is an operator fault: its connect to the client Service hangs for the kernel's SYN retry time when the Service has no endpoint yet. That is fixed in https://github.com/ROCm/spur/pull/854. This change is still needed: the fixture must not return before the controller has a node, and with that fix the wait is seconds.

## Testing

`uvx flake8 --config tests/.flake8 tests/` is clean.

Run on a three-node k0s cluster built by `spur k8s up`, with the CRD applied before the suite so that the replace path runs: `test_spurjob.py` and `test_raft_ha.py`, twice in a row: 12 of 13 passed on the first run and 13 of 13 on the second. The one failure was `test_new_leader_accepts_writes`, which the operator caused (a stalled channel to a killed controller Pod, an operator fault fixed in https://github.com/ROCm/spur/pull/854), not the harness. Before this change the same two files failed the three tests named above on a new cluster.

CI cannot exercise the replace path, because its cluster is new.
