### PR TITLE
fix(spurctld)!: enforce qos preemption policy

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -84,6 +84,7 @@ scontrol
 scrontab
 sdiag
 seccomp
+selectable
 setgid
 setuid
 shmem

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -518,10 +518,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 .ok_or_else(|| anyhow::anyhow!("name= required"))?;
             let desc = p.get("description").cloned().unwrap_or_default();
             let priority: i32 = p.get("priority").and_then(|v| v.parse().ok()).unwrap_or(0);
-            let preempt = p
-                .get("preemptmode")
-                .cloned()
-                .unwrap_or_else(|| "off".into());
+            let preempt = p.get("preemptmode").cloned().unwrap_or_default();
             let usage_factor: f64 = p
                 .get("usagefactor")
                 .and_then(|v| v.parse().ok())
@@ -960,7 +957,7 @@ async fn show(
             if qos_list.is_empty() && !has_name_filter {
                 let default_qos = QosInfo {
                     name: "normal".into(),
-                    preempt_mode: "off".into(),
+                    preempt_mode: String::new(),
                     usage_factor: 1.0,
                     ..Default::default()
                 };

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -714,7 +714,11 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                 );
                 print!(
                     "   PreemptMode={} PriorityTier={}",
-                    part.preempt_mode.to_uppercase(),
+                    if part.preempt_mode.is_empty() {
+                        "NONE"
+                    } else {
+                        &part.preempt_mode
+                    },
                     part.priority_tier
                 );
                 if let Some(t) = part.preempt_exempt_time {
@@ -1189,7 +1193,7 @@ async fn parse_and_create_partition(controller: &str, params: &[String]) -> Resu
     let mut deny_accounts = String::new();
     let mut deny_qos = String::new();
     let mut priority_tier: u32 = 1;
-    let mut preempt_mode = "OFF".to_string();
+    let mut preempt_mode = String::new();
     let mut preempt_exempt_time: Option<u32> = None;
 
     for param in params {

--- a/crates/spur-core/src/accounting.rs
+++ b/crates/spur-core/src/accounting.rs
@@ -4,8 +4,6 @@
 //! Accounting data models: accounts, users, QOS, associations, TRES.
 
 use std::collections::HashMap;
-use std::convert::Infallible;
-use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
@@ -294,7 +292,8 @@ pub struct Qos {
     pub name: String,
     pub description: String,
     pub priority: i32,
-    pub preempt_mode: QosPreemptMode,
+    #[serde(default)]
+    pub preempt_mode: Option<QosPreemptMode>,
     pub limits: QosLimits,
     /// Usage factor — multiplier for fair-share usage accounting.
     /// 0.0 = don't charge, 1.0 = normal, 2.0 = double charge.
@@ -321,16 +320,29 @@ pub enum QosPreemptMode {
     Suspend,
 }
 
-impl FromStr for QosPreemptMode {
-    type Err = Infallible;
+/// Parse a configured QOS preempt mode. Empty means "not configured", which
+/// resolves the same as `off`.
+pub fn parse_qos_preempt_mode(value: &str) -> Result<Option<QosPreemptMode>, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "none" => Ok(None),
+        "off" => Ok(Some(QosPreemptMode::Off)),
+        "cancel" => Ok(Some(QosPreemptMode::Cancel)),
+        "requeue" => Ok(Some(QosPreemptMode::Requeue)),
+        "suspend" => Ok(Some(QosPreemptMode::Suspend)),
+        other => Err(format!(
+            "unknown preemptmode '{other}'; expected none, off, cancel, requeue, or suspend"
+        )),
+    }
+}
 
-    fn from_str(s: &str) -> Result<Self, Infallible> {
-        Ok(match s.to_lowercase().as_str() {
-            "cancel" => Self::Cancel,
-            "requeue" => Self::Requeue,
-            "suspend" => Self::Suspend,
-            _ => Self::Off,
-        })
+/// Wire form of a configured QOS preempt mode; empty when unset.
+pub fn qos_preempt_mode_str(mode: Option<QosPreemptMode>) -> &'static str {
+    match mode {
+        None => "",
+        Some(QosPreemptMode::Off) => "off",
+        Some(QosPreemptMode::Cancel) => "cancel",
+        Some(QosPreemptMode::Requeue) => "requeue",
+        Some(QosPreemptMode::Suspend) => "suspend",
     }
 }
 
@@ -377,7 +389,7 @@ impl Default for Qos {
             name: String::new(),
             description: String::new(),
             priority: 0,
-            preempt_mode: QosPreemptMode::Off,
+            preempt_mode: None,
             limits: QosLimits::default(),
             usage_factor: 1.0,
             preempt: Vec::new(),
@@ -577,17 +589,26 @@ mod tests {
     #[test]
     fn test_qos_preempt_mode() {
         assert_eq!(
-            "cancel".parse::<QosPreemptMode>().unwrap(),
-            QosPreemptMode::Cancel
+            parse_qos_preempt_mode("cancel"),
+            Ok(Some(QosPreemptMode::Cancel))
         );
-        assert_eq!(
-            "off".parse::<QosPreemptMode>().unwrap(),
-            QosPreemptMode::Off
-        );
-        assert_eq!(
-            "unknown".parse::<QosPreemptMode>().unwrap(),
-            QosPreemptMode::Off
-        );
+        assert_eq!(parse_qos_preempt_mode("off"), Ok(Some(QosPreemptMode::Off)));
+        assert_eq!(parse_qos_preempt_mode(""), Ok(None));
+        assert_eq!(parse_qos_preempt_mode("none"), Ok(None));
+        assert!(parse_qos_preempt_mode("unknown").is_err());
+    }
+
+    #[test]
+    fn qos_preempt_mode_str_round_trips() {
+        for mode in [
+            None,
+            Some(QosPreemptMode::Off),
+            Some(QosPreemptMode::Cancel),
+            Some(QosPreemptMode::Requeue),
+            Some(QosPreemptMode::Suspend),
+        ] {
+            assert_eq!(parse_qos_preempt_mode(qos_preempt_mode_str(mode)), Ok(mode));
+        }
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use thiserror::Error;
 
-use crate::partition::{Partition, PartitionState, PreemptMode, PreemptType};
+use crate::partition::{Partition, PartitionState, PreemptType};
 
 #[derive(Debug, Error)]
 pub enum ConfigError {
@@ -653,10 +653,8 @@ pub struct SchedulerConfig {
     /// operator-only. Raise it to grant users a band above the baseline.
     #[serde(default = "default_max_user_priority")]
     pub max_user_priority: u32,
-    /// Controls which jobs are eligible to preempt which. `None` (default)
-    /// enforces no cross-QOS restrictions — any job with sufficient priority gap
-    /// may preempt any other. `QosPriority` requires the pending job's QOS to
-    /// list the running job's QOS in its `preempt` allow-list. Mirrors Slurm's
+    /// Selects the preemption engine. `none` (default, also spelled `off`)
+    /// disables preemption entirely; `qos_priority` enables it. Mirrors Slurm's
     /// `PreemptType`.
     #[serde(default)]
     pub preempt_type: PreemptType,
@@ -1662,6 +1660,14 @@ impl SlurmConfig {
                 ),
             });
         }
+        for pc in &self.partitions {
+            crate::partition::parse_preempt_mode(&pc.preempt_mode).map_err(|value| {
+                ConfigError::InvalidValue {
+                    field: format!("partitions.{}.preempt_mode", pc.name),
+                    value,
+                }
+            })?;
+        }
         // Keepalive detection is interval + timeout, so an hour-long interval silently disables
         // the liveness this exists to provide.
         for (field, value) in [
@@ -1947,12 +1953,8 @@ impl SlurmConfig {
                 deny_qos: pc.deny_qos.clone(),
                 allow_qos: pc.allow_qos.clone(),
                 priority_tier: pc.priority_tier,
-                preempt_mode: match pc.preempt_mode.to_lowercase().as_str() {
-                    "cancel" => PreemptMode::Cancel,
-                    "requeue" => PreemptMode::Requeue,
-                    "suspend" => PreemptMode::Suspend,
-                    _ => PreemptMode::Off,
-                },
+                preempt_mode: crate::partition::parse_preempt_mode(&pc.preempt_mode)
+                    .unwrap_or(None),
                 preempt_exempt_time: pc.preempt_exempt_time,
                 ..Default::default()
             })
@@ -3166,6 +3168,56 @@ deny_accounts = ["student"]
             vec!["research".to_string(), "faculty".to_string()]
         );
         assert_eq!(parts[0].deny_accounts, vec!["student".to_string()]);
+    }
+
+    #[test]
+    fn partition_preempt_mode_defaults_to_unset() {
+        let cfg = SlurmConfig::load_from_str(
+            "cluster_name = \"test\"\n\n[[partitions]]\nname = \"gpu\"\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.build_partitions()[0].preempt_mode, None);
+
+        let explicit = SlurmConfig::load_from_str(
+            "cluster_name = \"test\"\n\n[[partitions]]\nname = \"gpu\"\npreempt_mode = \"off\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            explicit.build_partitions()[0].preempt_mode,
+            Some(crate::partition::PreemptMode::Off)
+        );
+    }
+
+    #[test]
+    fn partition_preempt_mode_typo_is_rejected_at_load() {
+        let err = SlurmConfig::load_from_str(
+            "cluster_name = \"test\"\n\n[[partitions]]\nname = \"gpu\"\npreempt_mode = \"cancle\"\n",
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err}").contains("preempt_mode"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn preempt_type_defaults_to_disabled_and_accepts_off_synonym() {
+        let unset = SlurmConfig::load_from_str("cluster_name = \"test\"\n").unwrap();
+        assert_eq!(unset.scheduler.preempt_type, PreemptType::None);
+
+        for value in ["none", "off"] {
+            let cfg = SlurmConfig::load_from_str(&format!(
+                "cluster_name = \"test\"\n\n[scheduler]\npreempt_type = \"{value}\"\n"
+            ))
+            .unwrap();
+            assert_eq!(cfg.scheduler.preempt_type, PreemptType::None, "{value}");
+        }
+
+        let enabled = SlurmConfig::load_from_str(
+            "cluster_name = \"test\"\n\n[scheduler]\npreempt_type = \"qos_priority\"\n",
+        )
+        .unwrap();
+        assert_eq!(enabled.scheduler.preempt_type, PreemptType::QosPriority);
     }
 
     #[test]

--- a/crates/spur-core/src/partition.rs
+++ b/crates/spur-core/src/partition.rs
@@ -34,8 +34,10 @@ pub struct Partition {
     pub deny_accounts: Vec<String>,
     pub deny_qos: Vec<String>,
 
-    /// Scheduling
-    pub preempt_mode: PreemptMode,
+    /// Scheduling. `None` means nothing was configured at this scope; it
+    /// resolves the same as `Off`.
+    #[serde(default)]
+    pub preempt_mode: Option<PreemptMode>,
     pub priority_tier: u32,
     /// Partition-level override for the minimum seconds a job must have been
     /// running before it is eligible for preemption. `None` defers to the
@@ -69,16 +71,16 @@ impl std::fmt::Display for PartitionState {
     }
 }
 
-/// Controls cross-QOS preemption eligibility. Mirrors Slurm's `PreemptType`.
+/// Selects the preemption engine. Mirrors Slurm's `PreemptType`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum PreemptType {
-    /// No QOS-level restrictions — eligibility is determined solely by priority
-    /// gap, partition mode, and reservation tier (existing behaviour).
+    /// Preemption is disabled. `off` is accepted as a synonym.
     #[default]
+    #[serde(alias = "off")]
     None,
-    /// A pending job may only preempt a running job when the pending job's QOS
-    /// lists the running job's QOS in its `preempt` allow-list.
+    /// A pending job may preempt a running job only when the pending job's QOS
+    /// lists the running job's QOS in its `preempt` allow-list and outranks it.
     QosPriority,
 }
 
@@ -104,6 +106,33 @@ impl PreemptMode {
             Self::Requeue => 2,
             Self::Cancel => 3,
         }
+    }
+}
+
+/// Parse a configured partition preempt mode. An empty value means "not
+/// configured", which resolves the same as `off`. Unrecognized values are an
+/// error so a typo cannot silently disable preemption.
+pub fn parse_preempt_mode(value: &str) -> Result<Option<PreemptMode>, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "none" => Ok(None),
+        "off" => Ok(Some(PreemptMode::Off)),
+        "cancel" => Ok(Some(PreemptMode::Cancel)),
+        "requeue" => Ok(Some(PreemptMode::Requeue)),
+        "suspend" => Ok(Some(PreemptMode::Suspend)),
+        other => Err(format!(
+            "unknown preempt_mode '{other}'; expected none, off, cancel, requeue, or suspend"
+        )),
+    }
+}
+
+/// Wire form of a configured preempt mode; empty when unset.
+pub fn preempt_mode_str(mode: Option<PreemptMode>) -> &'static str {
+    match mode {
+        None => "",
+        Some(PreemptMode::Off) => "OFF",
+        Some(PreemptMode::Cancel) => "CANCEL",
+        Some(PreemptMode::Requeue) => "REQUEUE",
+        Some(PreemptMode::Suspend) => "SUSPEND",
     }
 }
 
@@ -154,7 +183,7 @@ impl Default for Partition {
             allow_qos: Vec::new(),
             deny_accounts: Vec::new(),
             deny_qos: Vec::new(),
-            preempt_mode: PreemptMode::Off,
+            preempt_mode: None,
             priority_tier: 1,
             preempt_exempt_time: None,
         }
@@ -164,6 +193,30 @@ impl Default for Partition {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn preempt_mode_parses_unset_off_and_actions() {
+        assert_eq!(parse_preempt_mode(""), Ok(None));
+        assert_eq!(parse_preempt_mode("  "), Ok(None));
+        assert_eq!(parse_preempt_mode("none"), Ok(None));
+        assert_eq!(parse_preempt_mode("off"), Ok(Some(PreemptMode::Off)));
+        assert_eq!(parse_preempt_mode("OFF"), Ok(Some(PreemptMode::Off)));
+        assert_eq!(parse_preempt_mode("Cancel"), Ok(Some(PreemptMode::Cancel)));
+        assert!(parse_preempt_mode("cancle").is_err());
+    }
+
+    #[test]
+    fn preempt_mode_str_round_trips() {
+        for mode in [
+            None,
+            Some(PreemptMode::Off),
+            Some(PreemptMode::Cancel),
+            Some(PreemptMode::Requeue),
+            Some(PreemptMode::Suspend),
+        ] {
+            assert_eq!(parse_preempt_mode(preempt_mode_str(mode)), Ok(mode));
+        }
+    }
 
     #[test]
     fn preempt_mode_aggressiveness_orders_cancel_over_requeue_over_suspend_over_off() {

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -20,13 +20,12 @@ impl From<QosPreemptMode> for PreemptMode {
     }
 }
 
-/// A QOS-level preempt mode override, or `None` if unset. `Off` can't be
-/// told apart from "unset" on the wire, so it's treated as no override.
+/// A QOS-level preempt mode override. Unset and explicit `Off` both mean
+/// "no override"; the partition action applies.
 pub fn qos_preempt_override(qos: &Qos) -> Option<PreemptMode> {
-    match qos.preempt_mode {
-        QosPreemptMode::Off => None,
-        other => Some(other.into()),
-    }
+    qos.preempt_mode
+        .filter(|mode| *mode != QosPreemptMode::Off)
+        .map(Into::into)
 }
 
 /// Result of QOS limit check.
@@ -1113,7 +1112,7 @@ mod tests {
     #[test]
     fn test_qos_preempt_override_off_is_none() {
         let qos = Qos {
-            preempt_mode: QosPreemptMode::Off,
+            preempt_mode: Some(QosPreemptMode::Off),
             ..Default::default()
         };
         assert_eq!(qos_preempt_override(&qos), None);
@@ -1122,19 +1121,19 @@ mod tests {
     #[test]
     fn test_qos_preempt_override_maps_variants() {
         let requeue = Qos {
-            preempt_mode: QosPreemptMode::Requeue,
+            preempt_mode: Some(QosPreemptMode::Requeue),
             ..Default::default()
         };
         assert_eq!(qos_preempt_override(&requeue), Some(PreemptMode::Requeue));
 
         let cancel = Qos {
-            preempt_mode: QosPreemptMode::Cancel,
+            preempt_mode: Some(QosPreemptMode::Cancel),
             ..Default::default()
         };
         assert_eq!(qos_preempt_override(&cancel), Some(PreemptMode::Cancel));
 
         let suspend = Qos {
-            preempt_mode: QosPreemptMode::Suspend,
+            preempt_mode: Some(QosPreemptMode::Suspend),
             ..Default::default()
         };
         assert_eq!(qos_preempt_override(&suspend), Some(PreemptMode::Suspend));

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -944,6 +944,43 @@ mod deregistration_wal_tests {
         }
     }
 
+    // Frozen pre-optional-preempt_mode PartitionCreate entry; `preempt_mode` was a
+    // bare `PreemptMode` whose default serialized as "Off". Never regenerate.
+    #[test]
+    fn partition_create_pre_optional_preempt_mode_still_deserializes() {
+        const PARTITION_CREATE_PRE_OPTIONAL: &str = r#"{"PartitionCreate":{"partition":{"name":"gpu","state":"Up","is_default":true,"nodes":"ALL","selector":{},"max_time_minutes":1440,"default_time_minutes":10,"max_nodes":null,"min_nodes":1,"allow_root":true,"exclusive_user":false,"allow_accounts":[],"allow_groups":[],"allow_qos":[],"deny_accounts":[],"deny_qos":[],"preempt_mode":"Off","priority_tier":1,"preempt_exempt_time":null}}}"#;
+
+        let op: WalOperation = serde_json::from_str(PARTITION_CREATE_PRE_OPTIONAL)
+            .expect("legacy PartitionCreate must deserialize; a new field needs #[serde(default)]");
+        match op {
+            WalOperation::PartitionCreate { partition } => {
+                assert_eq!(partition.name, "gpu");
+                // Legacy "Off" decodes to an explicit Off, which resolves the
+                // same as unset — an upgraded cluster keeps its behaviour.
+                assert_eq!(
+                    partition.preempt_mode,
+                    Some(crate::partition::PreemptMode::Off)
+                );
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    // A legacy entry that carried a real action must keep it.
+    #[test]
+    fn partition_create_pre_optional_preserves_configured_action() {
+        const LEGACY_CANCEL: &str = r#"{"PartitionCreate":{"partition":{"name":"gpu","state":"Up","is_default":false,"nodes":"ALL","selector":{},"max_time_minutes":null,"default_time_minutes":null,"max_nodes":null,"min_nodes":1,"allow_root":true,"exclusive_user":false,"allow_accounts":[],"allow_groups":[],"allow_qos":[],"deny_accounts":[],"deny_qos":[],"preempt_mode":"Cancel","priority_tier":1,"preempt_exempt_time":null}}}"#;
+
+        let op: WalOperation = serde_json::from_str(LEGACY_CANCEL).expect("must deserialize");
+        match op {
+            WalOperation::PartitionCreate { partition } => assert_eq!(
+                partition.preempt_mode,
+                Some(crate::partition::PreemptMode::Cancel)
+            ),
+            _ => panic!("wrong variant"),
+        }
+    }
+
     // Frozen pre-multi-CP K0sSetPhase entry (no control_plane_nodes field); must still deserialize
     // or spurctld crashes on upgrade replay. Never regenerate.
     #[test]

--- a/crates/spur-tests/src/t17_submit.rs
+++ b/crates/spur-tests/src/t17_submit.rs
@@ -195,17 +195,17 @@ mod tests {
 
         let part_off = Partition {
             name: "nopreempt".into(),
-            preempt_mode: PreemptMode::Off,
+            preempt_mode: Some(PreemptMode::Off),
             ..Default::default()
         };
-        assert_eq!(part_off.preempt_mode, PreemptMode::Off);
+        assert_eq!(part_off.preempt_mode, Some(PreemptMode::Off));
 
         let part_requeue = Partition {
             name: "requeue".into(),
-            preempt_mode: PreemptMode::Requeue,
+            preempt_mode: Some(PreemptMode::Requeue),
             ..Default::default()
         };
-        assert_eq!(part_requeue.preempt_mode, PreemptMode::Requeue);
+        assert_eq!(part_requeue.preempt_mode, Some(PreemptMode::Requeue));
     }
 
     #[test]

--- a/crates/spur-tests/src/t21_acctmgr.rs
+++ b/crates/spur-tests/src/t21_acctmgr.rs
@@ -92,28 +92,23 @@ mod tests {
     fn t21_8_qos_defaults() {
         let qos = Qos::default();
         assert_eq!(qos.priority, 0);
-        assert_eq!(qos.preempt_mode, QosPreemptMode::Off);
+        assert_eq!(qos.preempt_mode, None);
         assert_eq!(qos.usage_factor, 1.0);
     }
 
     #[test]
     fn t21_9_qos_preempt_modes() {
-        assert_eq!(
-            "cancel".parse::<QosPreemptMode>().unwrap(),
-            QosPreemptMode::Cancel
-        );
-        assert_eq!(
-            "requeue".parse::<QosPreemptMode>().unwrap(),
-            QosPreemptMode::Requeue
-        );
-        assert_eq!(
-            "suspend".parse::<QosPreemptMode>().unwrap(),
-            QosPreemptMode::Suspend
-        );
-        assert_eq!(
-            "off".parse::<QosPreemptMode>().unwrap(),
-            QosPreemptMode::Off
-        );
+        use spur_core::accounting::parse_qos_preempt_mode;
+        for (text, want) in [
+            ("cancel", QosPreemptMode::Cancel),
+            ("requeue", QosPreemptMode::Requeue),
+            ("suspend", QosPreemptMode::Suspend),
+            ("off", QosPreemptMode::Off),
+        ] {
+            assert_eq!(parse_qos_preempt_mode(text), Ok(Some(want)), "{text}");
+        }
+        assert_eq!(parse_qos_preempt_mode(""), Ok(None));
+        assert!(parse_qos_preempt_mode("cancle").is_err());
     }
 
     // ── T21.10: QOS limit enforcement ────────────────────────────

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -92,7 +92,7 @@ CREATE TABLE IF NOT EXISTS qos (
     name            TEXT PRIMARY KEY,
     description     TEXT NOT NULL DEFAULT '',
     priority        INTEGER NOT NULL DEFAULT 0,
-    preempt_mode    TEXT NOT NULL DEFAULT 'off',
+    preempt_mode    TEXT NOT NULL DEFAULT '',
     preempt         TEXT NOT NULL DEFAULT '',
     usage_factor    REAL NOT NULL DEFAULT 1.0,
     max_jobs_per_user INTEGER,
@@ -161,6 +161,7 @@ ALTER TABLE qos ADD COLUMN IF NOT EXISTS flags TEXT NOT NULL DEFAULT '';
 ALTER TABLE associations ADD COLUMN IF NOT EXISTS grp_submit_jobs INTEGER;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS grp_tres TEXT;
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS preempt TEXT NOT NULL DEFAULT '';
+ALTER TABLE qos ALTER COLUMN preempt_mode SET DEFAULT '';
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS preempt_exempt_time INTEGER;
 ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempted_by BIGINT;
 ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempt_mode TEXT NOT NULL DEFAULT '';

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -706,10 +706,21 @@ impl SlurmAccounting for AccountingService {
             .as_deref()
             .map(canonicalize_qos_flags)
             .transpose()?;
+        // Canonicalize so a typo is rejected here rather than silently reading
+        // back as "no override" once the cache reloads.
+        let preempt_mode = req
+            .preempt_mode
+            .as_deref()
+            .map(|mode| {
+                spur_core::accounting::parse_qos_preempt_mode(mode)
+                    .map(spur_core::accounting::qos_preempt_mode_str)
+                    .map_err(Status::invalid_argument)
+            })
+            .transpose()?;
         let update = db::QosUpdate {
             description: req.description.as_deref(),
             priority: req.priority,
-            preempt_mode: req.preempt_mode.as_deref(),
+            preempt_mode,
             preempt: preempt_normalized.as_deref(),
             usage_factor: req.usage_factor,
             max_jobs_per_user: nullable_limit(req.max_jobs_per_user, "max_jobs_per_user")?,

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4008,12 +4008,7 @@ impl ClusterManager {
             .iter()
             .filter(|p| current_names.contains(&p.name))
         {
-            let preempt_str = match part.preempt_mode {
-                spur_core::partition::PreemptMode::Cancel => "cancel",
-                spur_core::partition::PreemptMode::Requeue => "requeue",
-                spur_core::partition::PreemptMode::Suspend => "suspend",
-                spur_core::partition::PreemptMode::Off => "off",
-            };
+            let preempt_str = spur_core::partition::preempt_mode_str(part.preempt_mode);
             self.propose(WalOperation::PartitionUpdate {
                 name: part.name.clone(),
                 nodes: Some(part.nodes.clone()),
@@ -5086,19 +5081,6 @@ impl ClusterManager {
         }
 
         Ok(())
-    }
-
-    /// Recompute a job's live effective priority. A running job's stored
-    /// `priority` is stale; this recalculates from age, fair-share, and tier.
-    pub(crate) fn current_effective_priority(&self, job: &Job, partitions: &[Partition]) -> u32 {
-        let now = Utc::now();
-        let age_minutes = (now - job.submit_time).num_minutes().max(0);
-        let partition_tier =
-            spur_core::partition::max_priority_tier(job.spec.partition.as_deref(), partitions);
-        let fair_share = self
-            .fairshare_cache
-            .get(&job.spec.user, job.spec.account.as_deref().unwrap_or(""));
-        compute_effective_priority(job.priority, fair_share, age_minutes, partition_tier)
     }
 
     /// Persist a mutation via Raft consensus. The apply callback
@@ -6292,12 +6274,10 @@ impl ClusterManager {
                             part.priority_tier = *pt;
                         }
                         if let Some(pm) = preempt_mode {
-                            part.preempt_mode = match pm.to_lowercase().as_str() {
-                                "cancel" => spur_core::partition::PreemptMode::Cancel,
-                                "requeue" => spur_core::partition::PreemptMode::Requeue,
-                                "suspend" => spur_core::partition::PreemptMode::Suspend,
-                                _ => spur_core::partition::PreemptMode::Off,
-                            };
+                            match spur_core::partition::parse_preempt_mode(pm) {
+                                Ok(mode) => part.preempt_mode = mode,
+                                Err(e) => warn!(name, error = %e, "ignoring preempt_mode"),
+                            }
                         }
                         if let Some(def) = is_default {
                             part.is_default = *def;
@@ -8393,6 +8373,34 @@ mod tests {
             JobState::Pending,
             "after reconfigure raised the cap, the consumer must requeue the job"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reconfigure_round_trips_partition_preempt_mode_through_the_wal() {
+        use spur_core::partition::PreemptMode;
+        let dir = TempDir::new().unwrap();
+        let base = "cluster_name = \"test\"\n\n[[partitions]]\nname = \"gpu\"\nnodes = \"ALL\"\n";
+        let (cm, conf_path) =
+            test_cluster_with_conf_file(&dir, &format!("{base}preempt_mode = \"cancel\"\n")).await;
+
+        let gpu = |cm: &Arc<ClusterManager>| {
+            cm.get_partitions()
+                .into_iter()
+                .find(|p| p.name == "gpu")
+                .unwrap()
+                .preempt_mode
+        };
+        assert_eq!(gpu(&cm), Some(PreemptMode::Cancel));
+
+        // Omitting the key must clear it back to unset, which only works if
+        // preempt_mode_str and parse_preempt_mode agree across the WAL.
+        std::fs::write(&conf_path, base).unwrap();
+        cm.reconfigure().unwrap();
+        assert_eq!(gpu(&cm), None);
+
+        std::fs::write(&conf_path, format!("{base}preempt_mode = \"off\"\n")).unwrap();
+        cm.reconfigure().unwrap();
+        assert_eq!(gpu(&cm), Some(PreemptMode::Off));
     }
 
     #[tokio::test]
@@ -14933,43 +14941,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn current_effective_priority_multi_partition_uses_highest_priority_tier() {
-        let dir = TempDir::new().unwrap();
-        let cm = test_cluster(&dir).await;
-        {
-            let mut partitions = cm.partitions.write();
-            partitions.push(Partition {
-                name: "low".into(),
-                priority_tier: 1,
-                ..Default::default()
-            });
-            partitions.push(Partition {
-                name: "high".into(),
-                priority_tier: 9,
-                ..Default::default()
-            });
-        }
-
-        // Built directly (not submitted) to isolate priority resolution from
-        // unrelated eligibility filters like partition_block().
-        let job = Job::new(
-            1,
-            JobSpec {
-                partition: Some("low,high".into()),
-                priority: Some(1000),
-                ..basic_spec("multi")
-            },
-        );
-
-        let priority = cm.current_effective_priority(&job, &cm.get_partitions());
-        assert_eq!(
-            priority, 9000,
-            "multi-partition job should use the highest matched priority_tier (9), \
-             not fall back to 1 because \"low,high\" isn't an exact partition name"
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn resv_overrun_grace_delays_cancel() {
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
@@ -15006,11 +14977,34 @@ mod tests {
         assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Running);
     }
 
+    /// Config with the preemption engine on and a cancel-mode partition.
+    fn preempting_config() -> spur_core::config::SlurmConfig {
+        let mut config = test_config();
+        config.partitions[0].preempt_mode = "cancel".into();
+        config.scheduler.preempt_type = spur_core::partition::PreemptType::QosPriority;
+        config
+    }
+
+    /// Register a victim QOS and a hunter QOS that allow-lists and outranks it,
+    /// so only the guard under test can block preemption.
+    fn insert_preempting_qos_pair(cm: &Arc<ClusterManager>, victim: &str, hunter: &str) {
+        cm.qos_cache().insert(Qos {
+            name: victim.into(),
+            priority: 100,
+            ..Default::default()
+        });
+        cm.qos_cache().insert(Qos {
+            name: hunter.into(),
+            priority: 10_000,
+            preempt: vec![victim.into()],
+            ..Default::default()
+        });
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn preempt_skips_jobs_in_active_reservation_at_same_tier() {
         let dir = TempDir::new().unwrap();
-        let mut config = test_config();
-        config.partitions[0].preempt_mode = "cancel".into();
+        let config = preempting_config();
         let cm = test_cluster_with_config(&dir, config).await;
         register_node(&cm, "n1", 8, 16000);
         let now = chrono::Utc::now();
@@ -15025,9 +15019,10 @@ mod tests {
             owner: String::new(),
         })
         .unwrap();
+        insert_preempting_qos_pair(&cm, "low", "high");
 
         let mut low = basic_spec("low");
-        low.priority = Some(100);
+        low.qos = Some("low".into());
         low.reservation = Some("r1".into());
         let low_id = submit_and_wait(&cm, low);
         let res = scalar_alloc(1, 1000);
@@ -15041,7 +15036,7 @@ mod tests {
         settle(&cm, low_id, JobState::Running);
 
         let mut high = basic_spec("high");
-        high.priority = Some(10_000);
+        high.qos = Some("high".into());
         let high_id = submit_and_wait(&cm, high);
         let high_job = cm.get_job(high_id).unwrap();
         let partitions = cm.get_partitions();
@@ -15054,14 +15049,14 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn preempt_skips_jobs_on_unrelated_nodes() {
         let dir = TempDir::new().unwrap();
-        let mut config = test_config();
-        config.partitions[0].preempt_mode = "cancel".into();
+        let config = preempting_config();
         let cm = test_cluster_with_config(&dir, config).await;
         register_node(&cm, "n1", 8, 16000);
         register_node(&cm, "n2", 8, 16000);
+        insert_preempting_qos_pair(&cm, "low", "high");
 
         let mut low = basic_spec("low");
-        low.priority = Some(100);
+        low.qos = Some("low".into());
         low.nodelist = Some("n2".into());
         let low_id = submit_and_wait(&cm, low);
         let res = scalar_alloc(1, 1000);
@@ -15075,7 +15070,7 @@ mod tests {
         settle(&cm, low_id, JobState::Running);
 
         let mut high = basic_spec("high");
-        high.priority = Some(10_000);
+        high.qos = Some("high".into());
         high.nodelist = Some("n1".into());
         let high_id = submit_and_wait(&cm, high);
         let high_job = cm.get_job(high_id).unwrap();
@@ -15089,22 +15084,13 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn preempt_triggers_when_qos_priority_differentiates_pending_job() {
         let dir = TempDir::new().unwrap();
-        let mut config = test_config();
-        config.partitions[0].preempt_mode = "cancel".into();
+        let config = preempting_config();
         let cm = test_cluster_with_config(&dir, config).await;
         register_node(&cm, "n1", 8, 16000);
+        insert_preempting_qos_pair(&cm, "low", "high");
 
-        cm.qos_cache().insert(Qos {
-            name: "high".into(),
-            priority: 5000,
-            ..Default::default()
-        });
-
-        // low job has no QOS (base=DEFAULT_PRIORITY=1000); high job's QOS
-        // priority (5000) becomes its base, making it >2x the low job's
-        // effective priority and crossing the preemption threshold.
         let mut low = basic_spec("low");
-        low.priority = Some(1000);
+        low.qos = Some("low".into());
         let low_id = submit_and_wait(&cm, low);
         let res = scalar_alloc(2, 4000);
         cm.start_job(
@@ -15135,21 +15121,10 @@ mod tests {
         // Neither sets --priority; both get their base from QOS.
         // burst (100) must be evicted to make room for primus (10000).
         let dir = TempDir::new().unwrap();
-        let mut config = test_config();
-        config.partitions[0].preempt_mode = "cancel".into();
+        let config = preempting_config();
         let cm = test_cluster_with_config(&dir, config).await;
         register_node(&cm, "n1", 8, 16000);
-
-        cm.qos_cache().insert(Qos {
-            name: "burst".into(),
-            priority: 100,
-            ..Default::default()
-        });
-        cm.qos_cache().insert(Qos {
-            name: "primus".into(),
-            priority: 10000,
-            ..Default::default()
-        });
+        insert_preempting_qos_pair(&cm, "burst", "primus");
 
         let mut burst = basic_spec("burst");
         burst.qos = Some("burst".into());
@@ -15168,19 +15143,9 @@ mod tests {
         primus.qos = Some("primus".into());
         submit_and_wait(&cm, primus);
 
-        // Confirm that primus effective > 2x burst effective (preemption threshold).
         let pending = cm.pending_jobs();
         let pending_refs: Vec<&Job> = pending.iter().collect();
         let partitions = cm.get_partitions();
-
-        let burst_job = cm.get_job(burst_id).unwrap();
-        let burst_effective = cm.current_effective_priority(&burst_job, &partitions);
-        let primus_effective = pending_refs[0].priority;
-        assert!(
-            primus_effective >= burst_effective * 2,
-            "primus effective ({primus_effective}) must be ≥2x burst ({burst_effective}) \
-             for preemption to fire"
-        );
 
         crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler)
             .await;
@@ -15194,27 +15159,14 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn explicit_priority_disables_qos_based_preemption() {
-        // When --priority is set explicitly on both jobs, QOS priority is not
-        // applied as the base seed. Both jobs land at the same effective
-        // priority and preemption does not fire — this is intentional: explicit
-        // --priority opts the job out of QOS-based scheduling.
+    async fn qos_rank_decides_preemption_despite_equal_explicit_job_priority() {
+        // Eligibility is QOS rank, not effective job priority: identical
+        // --priority on both jobs must not stop a higher-ranked QOS.
         let dir = TempDir::new().unwrap();
-        let mut config = test_config();
-        config.partitions[0].preempt_mode = "cancel".into();
+        let config = preempting_config();
         let cm = test_cluster_with_config(&dir, config).await;
         register_node(&cm, "n1", 8, 16000);
-
-        cm.qos_cache().insert(Qos {
-            name: "burst".into(),
-            priority: 100,
-            ..Default::default()
-        });
-        cm.qos_cache().insert(Qos {
-            name: "primus".into(),
-            priority: 10000,
-            ..Default::default()
-        });
+        insert_preempting_qos_pair(&cm, "burst", "primus");
 
         let mut burst = basic_spec("burst");
         burst.priority = Some(1000);
@@ -15241,13 +15193,7 @@ mod tests {
         crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler)
             .await;
 
-        // burst job must still be running — equal explicit priorities, no preemption.
-        let burst_job = cm.get_job(burst_id).unwrap();
-        assert_eq!(
-            burst_job.state,
-            JobState::Running,
-            "burst job must keep running when both jobs have identical explicit --priority"
-        );
+        settle(&cm, burst_id, JobState::Cancelled);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -15356,19 +15302,60 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preemption_is_disabled_unless_preempt_type_is_qos_priority() {
+        // Same setup as the allow-list test, but with the engine left at its
+        // default: nothing may be preempted.
+        let dir = TempDir::new().unwrap();
+        let mut config = preempting_config();
+        config.scheduler.preempt_type = spur_core::partition::PreemptType::None;
+        let cm = test_cluster_with_config(&dir, config).await;
+        register_node(&cm, "n1", 8, 16000);
+        insert_preempting_qos_pair(&cm, "low", "high");
+
+        let mut low = basic_spec("low");
+        low.qos = Some("low".into());
+        let low_id = submit_and_wait(&cm, low);
+        let res = scalar_alloc(2, 4000);
+        cm.start_job(
+            low_id,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res),
+        )
+        .unwrap();
+        settle(&cm, low_id, JobState::Running);
+
+        let mut high = basic_spec("high");
+        high.qos = Some("high".into());
+        submit_and_wait(&cm, high);
+
+        let pending = cm.pending_jobs();
+        let pending_refs: Vec<&Job> = pending.iter().collect();
+        let partitions = cm.get_partitions();
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler)
+            .await;
+
+        assert_eq!(
+            cm.get_job(low_id).unwrap().state,
+            JobState::Running,
+            "preempt_type must gate preemption even when QOS policy would allow it"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn preempt_exempt_time_protects_recently_started_job() {
         // A job that started less than preempt_exempt_time seconds ago must not
         // be preempted even when the priority gap is large enough.
         let dir = TempDir::new().unwrap();
-        let mut config = test_config();
-        config.partitions[0].preempt_mode = "cancel".into();
+        let mut config = preempting_config();
         // Set a very large exempt window so a job started "just now" is always protected.
         config.scheduler.preempt_exempt_time = 3600;
         let cm = test_cluster_with_config(&dir, config).await;
         register_node(&cm, "n1", 8, 16000);
+        insert_preempting_qos_pair(&cm, "low", "high");
 
         let mut low = basic_spec("low");
-        low.priority = Some(100);
+        low.qos = Some("low".into());
         let low_id = submit_and_wait(&cm, low);
         let res = scalar_alloc(2, 4000);
         cm.start_job(
@@ -15388,7 +15375,7 @@ mod tests {
         );
 
         let mut high = basic_spec("high");
-        high.priority = Some(10_000);
+        high.qos = Some("high".into());
         submit_and_wait(&cm, high);
 
         let pending = cm.pending_jobs();
@@ -15448,20 +15435,25 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn preempt_uses_candidate_qos_preempt_mode_over_partition() {
         let dir = TempDir::new().unwrap();
-        let mut config = test_config();
         // Partition says Cancel; the candidate's QoS overrides it to Suspend.
-        config.partitions[0].preempt_mode = "cancel".into();
+        let config = preempting_config();
         let cm = test_cluster_with_config(&dir, config).await;
         register_node(&cm, "n1", 8, 16000);
 
         cm.qos_cache().insert(Qos {
             name: "suspend-me".into(),
-            preempt_mode: spur_core::accounting::QosPreemptMode::Suspend,
+            priority: 100,
+            preempt_mode: Some(spur_core::accounting::QosPreemptMode::Suspend),
+            ..Default::default()
+        });
+        cm.qos_cache().insert(Qos {
+            name: "high".into(),
+            priority: 10_000,
+            preempt: vec!["suspend-me".into()],
             ..Default::default()
         });
 
         let mut low = basic_spec("low");
-        low.priority = Some(100);
         low.qos = Some("suspend-me".into());
         let low_id = submit_and_wait(&cm, low);
         let res = scalar_alloc(2, 4000);
@@ -15475,7 +15467,7 @@ mod tests {
         settle(&cm, low_id, JobState::Running);
 
         let mut high = basic_spec("high");
-        high.priority = Some(10_000);
+        high.qos = Some("high".into());
         let high_id = submit_and_wait(&cm, high);
         let high_job = cm.get_job(high_id).unwrap();
         let partitions = cm.get_partitions();

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -15,7 +15,7 @@ use parking_lot::RwLock;
 use sqlx::PgPool;
 use tracing::{info, warn};
 
-use spur_core::accounting::{Qos, QosLimits, QosPreemptMode, TresRecord};
+use spur_core::accounting::{Qos, QosLimits, TresRecord};
 
 struct Snapshot {
     qos: HashMap<String, Qos>,
@@ -238,7 +238,8 @@ fn qos_from_record(r: crate::accounting::db::QosRecord) -> Qos {
         name: r.name,
         description: r.description,
         priority: r.priority,
-        preempt_mode: r.preempt_mode.parse::<QosPreemptMode>().unwrap_or_default(),
+        preempt_mode: spur_core::accounting::parse_qos_preempt_mode(&r.preempt_mode)
+            .unwrap_or(None),
         preempt: r
             .preempt
             .split(',')
@@ -276,6 +277,7 @@ fn parse_deny_on_limit(flags: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use spur_core::accounting::QosPreemptMode;
     use spur_core::accounting::TresType;
     use spur_core::job::{Job, JobSpec, PendingReason};
     use spur_core::qos::{check_qos_limits, QosCheckResult};
@@ -361,6 +363,50 @@ mod tests {
         );
     }
 
+    fn qos_record_with_preempt_mode(mode: &str) -> crate::accounting::db::QosRecord {
+        crate::accounting::db::QosRecord {
+            name: "q".into(),
+            description: String::new(),
+            priority: 0,
+            preempt_mode: mode.into(),
+            preempt: String::new(),
+            usage_factor: 1.0,
+            max_jobs_per_user: None,
+            max_wall_min: None,
+            max_tres_per_job: None,
+            max_submit_per_user: None,
+            max_submit_per_account: None,
+            grp_submit_jobs: None,
+            max_tres_per_user: None,
+            grp_tres: None,
+            grp_wall_min: None,
+            preempt_exempt_time: None,
+            flags: String::new(),
+        }
+    }
+
+    // Rows written before preempt_mode became optional hold the literal 'off'
+    // the CLI injected when the field was omitted; it must keep resolving the
+    // same as unset or preemption dies silently on an upgraded cluster.
+    #[test]
+    fn legacy_off_qos_row_resolves_like_unset() {
+        use spur_core::qos::qos_preempt_override;
+
+        let legacy = qos_from_record(qos_record_with_preempt_mode("off"));
+        assert_eq!(legacy.preempt_mode, Some(QosPreemptMode::Off));
+        assert_eq!(qos_preempt_override(&legacy), None);
+
+        let unset = qos_from_record(qos_record_with_preempt_mode(""));
+        assert_eq!(unset.preempt_mode, None);
+        assert_eq!(qos_preempt_override(&unset), None);
+
+        let configured = qos_from_record(qos_record_with_preempt_mode("requeue"));
+        assert_eq!(
+            qos_preempt_override(&configured),
+            Some(spur_core::partition::PreemptMode::Requeue)
+        );
+    }
+
     #[test]
     fn test_qos_from_record_parses_limits() {
         let record = crate::accounting::db::QosRecord {
@@ -390,7 +436,7 @@ mod tests {
         assert_eq!(qos.limits.max_submit_jobs_per_account, Some(40));
         assert_eq!(qos.limits.grp_submit_jobs, Some(30));
         assert_eq!(qos.priority, 100);
-        assert_eq!(qos.preempt_mode, QosPreemptMode::Cancel);
+        assert_eq!(qos.preempt_mode, Some(QosPreemptMode::Cancel));
         assert_eq!(qos.usage_factor, 2.0);
         assert_eq!(qos.limits.max_jobs_per_user, Some(10));
         assert_eq!(qos.limits.max_wall_minutes, Some(60));

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -590,7 +590,7 @@ fn busy_until_from_running_jobs(running: &[spur_core::job::Job]) -> HashMap<Stri
     busy_until
 }
 
-/// Resolve the effective PreemptMode for a job: QoS override wins if set
+/// Resolve the effective PreemptMode for a job: QOS override wins if set
 /// (see `qos_preempt_override`), else the most aggressive matched partition.
 fn job_preempt_mode(
     job: &spur_core::job::Job,
@@ -605,9 +605,30 @@ fn job_preempt_mode(
 
     spur_core::partition::matched_partitions(job.spec.partition.as_deref(), partitions)
         .into_iter()
-        .map(|p| p.preempt_mode)
+        .filter_map(|p| p.preempt_mode)
         .max_by_key(|m| m.aggressiveness())
         .unwrap_or(PreemptMode::Off)
+}
+
+/// Within one self-listing QOS rank can never separate two jobs, so submit order
+/// decides; being immutable across a requeue, it cannot cycle.
+fn qos_preempt_allowed(
+    pending: &spur_core::job::Job,
+    pending_qos: &spur_core::accounting::Qos,
+    victim: &spur_core::job::Job,
+    victim_qos: &spur_core::accounting::Qos,
+) -> bool {
+    if !pending_qos.preempt.contains(&victim_qos.name) {
+        return false;
+    }
+    if pending_qos.name != victim_qos.name {
+        return pending_qos.priority > victim_qos.priority;
+    }
+    pending.submit_time > victim.submit_time
+}
+
+fn qos_priority_preemption_enabled(sched: &spur_core::config::SchedulerConfig) -> bool {
+    sched.preempt_type == spur_core::partition::PreemptType::QosPriority
 }
 
 /// Effective preempt-exempt seconds for a running job: QOS > partition > global.
@@ -630,8 +651,8 @@ fn effective_exempt_secs(
         .unwrap_or(sched.preempt_exempt_time)
 }
 
-/// Preempt lower-priority running jobs per their partition PreemptMode
-/// (Off jobs are never preempted).
+/// Preempt running jobs to make room for pending ones. Only runs under
+/// `preempt_type = qos_priority`; see the decision table in the admin guide.
 pub(crate) async fn try_preempt(
     cluster: &Arc<ClusterManager>,
     partitions: &[spur_core::partition::Partition],
@@ -640,17 +661,22 @@ pub(crate) async fn try_preempt(
 ) {
     use crate::cluster::PreemptOutcome;
     use spur_core::job::JobState;
-    use spur_core::partition::{Partition, PreemptMode, PreemptType};
+    use spur_core::partition::{Partition, PreemptMode};
     use spur_core::reservation::job_runs_in_active_reservation;
+
+    if !qos_priority_preemption_enabled(sched) {
+        return;
+    }
 
     let now = chrono::Utc::now();
     let reservations = cluster.get_reservations();
     let cluster_nodes = cluster.get_nodes();
 
+    // Only the reservation tier check reads this, so pick the highest tier.
     let partition_for = |job: &spur_core::job::Job| -> Option<&Partition> {
         spur_core::partition::matched_partitions(job.spec.partition.as_deref(), partitions)
             .into_iter()
-            .max_by_key(|p| p.preempt_mode.aggressiveness())
+            .max_by_key(|partition| partition.priority_tier)
     };
 
     let mut running: Vec<spur_core::job::Job> = cluster
@@ -660,21 +686,15 @@ pub(crate) async fn try_preempt(
         })
         .into_iter()
         .collect();
-    // Resolve once, reuse for both the priority recompute and the
-    // preempt-mode decision below.
+    // Resolve once for the policy checks and action decision below.
     let running_qos: std::collections::HashMap<spur_core::job::JobId, spur_core::accounting::Qos> =
         running
             .iter()
             .map(|j| (j.job_id, cluster.resolve_qos(j)))
             .collect();
-    // Running jobs' stored `priority` is the raw base value, unlike
-    // `pending`'s fully adjusted one; recompute a comparable value.
-    let running_priority: std::collections::HashMap<spur_core::job::JobId, u32> = running
-        .iter()
-        .map(|j| (j.job_id, cluster.current_effective_priority(j, partitions)))
-        .collect();
-    running.sort_by_key(|j| running_priority[&j.job_id]);
-
+    // `get_jobs` iterates a HashMap, so without this the victim picked among
+    // equally eligible candidates varies run to run. Least important first.
+    running.sort_by_key(|j| (running_qos[&j.job_id].priority, j.job_id));
     // Pending job's QOS is resolved once per pending job; used for the
     // QosPriority hierarchy check.
     let pending_qos_map: std::collections::HashMap<
@@ -689,18 +709,10 @@ pub(crate) async fn try_preempt(
         let Some(pending_part) = partition_for(pending) else {
             continue;
         };
-        if pending_part.preempt_mode == PreemptMode::Off {
-            continue;
-        }
         let pending_tier = pending_part.priority_tier;
         let pending_qos = &pending_qos_map[&pending.job_id];
 
         for candidate in &running {
-            let candidate_priority = running_priority[&candidate.job_id];
-            if candidate_priority >= pending.priority / 2 {
-                continue;
-            }
-
             if !preempt_overlaps_pending_nodes(pending, candidate, &cluster_nodes) {
                 continue;
             }
@@ -717,9 +729,7 @@ pub(crate) async fn try_preempt(
             // QOS hierarchy: pending job may only preempt candidate when the
             // pending QOS explicitly lists the candidate's QOS in its allow-list.
             let candidate_qos = &running_qos[&candidate.job_id];
-            if sched.preempt_type == PreemptType::QosPriority
-                && !pending_qos.preempt.contains(&candidate_qos.name)
-            {
+            if !qos_preempt_allowed(pending, pending_qos, candidate, candidate_qos) {
                 continue;
             }
 
@@ -742,17 +752,15 @@ pub(crate) async fn try_preempt(
             }
             info!(
                 preempted_job = candidate.job_id,
-                preempted_priority = candidate_priority,
+                preempted_qos = %candidate_qos.name,
+                preempted_qos_priority = candidate_qos.priority,
                 pending_job = pending.job_id,
-                pending_priority = pending.priority,
+                pending_qos = %pending_qos.name,
+                pending_qos_priority = pending_qos.priority,
                 mode = ?mode,
-                "preempting lower-priority job"
+                "preempting job"
             );
-            let preempt_qos = if sched.preempt_type == PreemptType::QosPriority {
-                Some(pending_qos.name.clone())
-            } else {
-                None
-            };
+            let preempt_qos = Some(pending_qos.name.clone());
             match cluster.preempt_job(candidate.job_id, mode, pending.job_id, preempt_qos) {
                 Ok(PreemptOutcome::Killed) => {
                     // Signal 0 = graceful cancel (SIGTERM then SIGKILL).
@@ -770,7 +778,7 @@ pub(crate) async fn try_preempt(
                     continue;
                 }
             }
-            break; // One preemption per cycle, re-evaluate next cycle
+            break; // At most one victim per pending job; re-evaluate next cycle
         }
     }
 }
@@ -2833,7 +2841,7 @@ mod tests {
     ) -> spur_core::partition::Partition {
         spur_core::partition::Partition {
             name: name.into(),
-            preempt_mode: mode,
+            preempt_mode: Some(mode),
             ..Default::default()
         }
     }
@@ -2847,7 +2855,7 @@ mod tests {
 
     fn qos_with_mode(mode: spur_core::accounting::QosPreemptMode) -> spur_core::accounting::Qos {
         spur_core::accounting::Qos {
-            preempt_mode: mode,
+            preempt_mode: Some(mode),
             ..Default::default()
         }
     }
@@ -2968,6 +2976,96 @@ mod tests {
         assert!(!permitted);
     }
 
+    fn job_submitted_at(secs: i64) -> spur_core::job::Job {
+        let mut job = job_with_spec(JobSpec::default());
+        job.submit_time = chrono::DateTime::from_timestamp(secs, 0).unwrap();
+        job
+    }
+
+    #[test]
+    fn qos_preempt_requires_a_strictly_higher_stable_qos_priority() {
+        let (older, newer) = (job_submitted_at(100), job_submitted_at(200));
+        let victim = spur_core::accounting::Qos {
+            name: "victim".into(),
+            priority: 100,
+            ..Default::default()
+        };
+        let listed = |priority| spur_core::accounting::Qos {
+            name: "hunter".into(),
+            priority,
+            preempt: vec!["victim".into()],
+            ..Default::default()
+        };
+
+        assert!(qos_preempt_allowed(&newer, &listed(101), &older, &victim));
+        assert!(!qos_preempt_allowed(&newer, &listed(100), &older, &victim));
+        assert!(!qos_preempt_allowed(&newer, &listed(99), &older, &victim));
+
+        let not_listed = spur_core::accounting::Qos {
+            name: "hunter".into(),
+            priority: 500,
+            ..Default::default()
+        };
+        assert!(!qos_preempt_allowed(&newer, &not_listed, &older, &victim));
+
+        // Rank alone decides across different QOS; submit order is irrelevant.
+        assert!(qos_preempt_allowed(&older, &listed(101), &newer, &victim));
+    }
+
+    #[test]
+    fn qos_that_lists_itself_preempts_only_older_jobs() {
+        let self_listed = spur_core::accounting::Qos {
+            name: "burst".into(),
+            priority: 100,
+            preempt: vec!["burst".into()],
+            ..Default::default()
+        };
+        let (older, newer) = (job_submitted_at(100), job_submitted_at(200));
+
+        assert!(qos_preempt_allowed(
+            &newer,
+            &self_listed,
+            &older,
+            &self_listed
+        ));
+        // The reverse must never hold, or a requeued victim would preempt its
+        // own preemptor back and neither job would ever finish.
+        assert!(!qos_preempt_allowed(
+            &older,
+            &self_listed,
+            &newer,
+            &self_listed
+        ));
+        assert!(!qos_preempt_allowed(
+            &older,
+            &self_listed,
+            &older,
+            &self_listed
+        ));
+
+        let not_self_listed = spur_core::accounting::Qos {
+            preempt: vec!["other".into()],
+            ..self_listed.clone()
+        };
+        assert!(!qos_preempt_allowed(
+            &newer,
+            &not_self_listed,
+            &older,
+            &not_self_listed
+        ));
+    }
+
+    #[test]
+    fn only_qos_priority_enables_preemption() {
+        use spur_core::partition::PreemptType;
+        assert!(!qos_priority_preemption_enabled(&sched_config_default()));
+        let enabled = spur_core::config::SchedulerConfig {
+            preempt_type: PreemptType::QosPriority,
+            ..Default::default()
+        };
+        assert!(qos_priority_preemption_enabled(&enabled));
+    }
+
     #[test]
     fn job_preempt_mode_single_partition() {
         use spur_core::partition::PreemptMode;
@@ -3021,6 +3119,44 @@ mod tests {
         assert_eq!(
             job_preempt_mode(&job_in_partitions("gpu,cpu"), &parts, &no_qos_override()),
             PreemptMode::Off
+        );
+    }
+
+    #[test]
+    fn job_preempt_mode_unset_partition_matches_explicit_off() {
+        use spur_core::partition::PreemptMode;
+        let unset = vec![spur_core::partition::Partition {
+            name: "gpu".into(),
+            ..Default::default()
+        }];
+        let explicit = vec![partition_with_mode("gpu", PreemptMode::Off)];
+        let job = job_in_partitions("gpu");
+        assert_eq!(unset[0].preempt_mode, None);
+        assert_eq!(
+            job_preempt_mode(&job, &unset, &no_qos_override()),
+            job_preempt_mode(&job, &explicit, &no_qos_override()),
+        );
+        assert_eq!(
+            job_preempt_mode(&job, &unset, &no_qos_override()),
+            PreemptMode::Off
+        );
+    }
+
+    #[test]
+    fn job_preempt_mode_qos_action_works_without_partition_action() {
+        use spur_core::accounting::QosPreemptMode;
+        use spur_core::partition::PreemptMode;
+        let parts = vec![spur_core::partition::Partition {
+            name: "gpu".into(),
+            ..Default::default()
+        }];
+        assert_eq!(
+            job_preempt_mode(
+                &job_in_partitions("gpu"),
+                &parts,
+                &qos_with_mode(QosPreemptMode::Requeue),
+            ),
+            PreemptMode::Requeue
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2298,18 +2298,8 @@ impl SlurmController for ControllerService {
             }
         };
 
-        let preempt_mode = match req.preempt_mode.to_uppercase().as_str() {
-            "" | "OFF" => spur_core::partition::PreemptMode::Off,
-            "CANCEL" => spur_core::partition::PreemptMode::Cancel,
-            "REQUEUE" => spur_core::partition::PreemptMode::Requeue,
-            "SUSPEND" => spur_core::partition::PreemptMode::Suspend,
-            other => {
-                return Err(Status::invalid_argument(format!(
-                    "unknown preempt_mode '{}'; expected OFF, CANCEL, REQUEUE, or SUSPEND",
-                    other
-                )))
-            }
-        };
+        let preempt_mode = spur_core::partition::parse_preempt_mode(&req.preempt_mode)
+            .map_err(Status::invalid_argument)?;
 
         let partition = spur_core::partition::Partition {
             name: req.name,
@@ -2376,12 +2366,10 @@ impl SlurmController for ControllerService {
 
         let preempt_mode = req
             .preempt_mode
-            .map(|pm| match pm.to_uppercase().as_str() {
-                v @ ("OFF" | "CANCEL" | "REQUEUE" | "SUSPEND") => Ok(v.to_string()),
-                other => Err(Status::invalid_argument(format!(
-                    "unknown preempt_mode '{}'; expected OFF, CANCEL, REQUEUE, or SUSPEND",
-                    other
-                ))),
+            .map(|pm| {
+                spur_core::partition::parse_preempt_mode(&pm)
+                    .map(|mode| spur_core::partition::preempt_mode_str(mode).to_string())
+                    .map_err(Status::invalid_argument)
             })
             .transpose()?;
 
@@ -4432,7 +4420,7 @@ fn partition_to_proto(part: &spur_core::partition::Partition) -> PartitionInfo {
         allow_qos: part.allow_qos.join(","),
         deny_accounts: part.deny_accounts.join(","),
         deny_qos: part.deny_qos.join(","),
-        preempt_mode: format!("{:?}", part.preempt_mode),
+        preempt_mode: spur_core::partition::preempt_mode_str(part.preempt_mode).to_string(),
         priority_tier: part.priority_tier,
         preempt_exempt_time: part.preempt_exempt_time,
     }

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -437,16 +437,21 @@ QOS keys
      - Base priority seed for jobs submitted under this QOS. When a job is
        submitted without an explicit ``--priority``, this value becomes the
        job's base priority and is amplified by the multiplicative scheduling
-       formula (fair-share × age × partition tier). Higher values run sooner
-       and are more likely to preempt lower-priority running jobs. ``0``
-       leaves the job at the scheduler default (1000).
+       formula (fair-share × age × partition tier). Higher values run sooner.
+       ``0`` leaves the job at the scheduler default (1000).
+
+       Preemption reads this raw QOS ``priority`` directly and never the job's
+       effective priority, so eligibility does not drift as fair-share and age
+       change. A higher number on its own never authorizes preemption: the
+       pending job's QOS must *also* list the victim's QOS in its ``preempt``
+       allow-list.
    * - ``preemptmode``
-     - ``off``
-     - What happens to a job in this QOS when it gets kicked out by a
-       higher-priority job. This setting overrides whatever the partition says,
-       but only for *how* the job is removed — it does not control *whether*
-       preemption happens (that depends on the partition's ``preempt_mode``
-       and the priority gap).
+     - unset
+     - What happens to a job in this QOS when an eligible pending job kicks it
+       out. A value other than unset or ``off`` overrides whatever the victim's
+       partitions say, for that job only. Unset (the default) and ``off``
+       both mean "no QOS override"; they resolve identically and differ only in
+       that ``sacctmgr show qos`` leaves the column blank when unset.
 
        ``cancel`` — the job is stopped and removed from the queue. Its final
        state is ``CANCELLED`` (``PREEMPTED`` in accounting records).
@@ -454,9 +459,9 @@ QOS keys
        start again automatically once a slot is free.
        ``suspend`` — the job is paused, keeping its node allocation. It
        resumes automatically once the higher-priority job finishes.
-       ``off`` (default) — no change from what the partition says. Setting
-       ``preemptmode=off`` on a QOS is the same as leaving it unset. It does
-       **not** protect the job from being preempted.
+       ``off`` (default) — no QOS override; the partition's ``preempt_mode``
+       decides what happens. It does **not** protect the job from being
+       preempted.
 
        **Example of the override:** a partition is set to ``cancel`` but a
        specific QOS is set to ``preemptmode=requeue``. When a job in that QOS
@@ -466,15 +471,21 @@ QOS keys
        to any other QOS's ``preempt`` allow-list. When
        ``preempt_type = "qos_priority"`` is enabled (see :doc:`configuration`),
        a QOS that nobody has permission to preempt will never lose its running
-       jobs, no matter how large the priority gap is.
+       jobs. ``preemptmode=off`` does not do this — it only defers the action
+       to the partition, which may itself be set to ``cancel``.
    * - ``preempt``
-     - ``""`` (no restriction)
+     - ``""`` (preempt nothing)
      - Comma-separated list of QOS names that jobs in this QOS are allowed to
        preempt. Only enforced when ``scheduler.preempt_type = "qos_priority"``
        (see :doc:`configuration`). An empty value means this QOS may not preempt
        any other QOS under that mode. Example: ``preempt=low,batch`` allows jobs
-       in this QOS to preempt ``low`` and ``batch`` jobs. To clear the list:
-       ``sacctmgr modify qos name=<name> set preempt=`` (empty value).
+       in this QOS to preempt ``low`` and ``batch`` jobs. Being listed is
+       necessary but not sufficient — the preempting QOS must also have a
+       strictly higher ``priority`` than the QOS it preempts, unless the two are
+       the same QOS, where submit order decides instead (see
+       :ref:`preempting within a QOS <qos-preempt-same-qos>`).
+       To clear the list: ``sacctmgr modify qos name=<name> set preempt=``
+       (empty value).
    * - ``preemptexempttime``
      - unset (inherits partition / global)
      - Per-QOS override for the minimum seconds a job must have been running
@@ -741,115 +752,142 @@ database available.
    upgrading starts from zero and fills over the following
    ``grp_wall_window_days``.
 
-How the priority gap is computed
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+QOS preemption hierarchy
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, Spur's preemption eligibility is based purely on the numeric
-priority gap: a pending job may preempt a running job when
+Preemption is off by default. To restrict which QOS tiers may preempt which —
+and to enable preemption at all — turn on the QOS preemption hierarchy in
+``spur.conf``:
+
+.. code-block:: toml
+
+   [scheduler]
+   preempt_type = "qos_priority"
+
+With ``preempt_type = "qos_priority"``, a job may only preempt a running job
+when the pending job's QOS lists the running job's QOS name in its ``preempt``
+allow-list. An empty allow-list means the QOS may not preempt anything.
 
 .. code-block:: text
 
-   candidate_effective_priority < pending_effective_priority / 2
+   can_preempt =
+     scheduler.preempt_type == qos_priority
+     AND pending job needs a node the victim currently occupies
+     AND (victim is not in an active reservation
+          OR pending partition priority_tier > victim partition priority_tier)
+     AND pending_qos.preempt contains victim_qos.name
+     AND (pending_qos.priority > victim_qos.priority
+          OR (pending_qos.name == victim_qos.name
+              AND pending.submit_time > victim.submit_time))
+     AND victim has been running at least its preempt_exempt_time
+     AND resolved_action != off
 
-Effective priority is:
+   resolved_action =
+     victim_qos.preemptmode                            if it is not off
+     else most aggressive preempt_mode among the victim's partitions
+          (cancel > requeue > suspend > off)
+     else off
 
-.. code-block:: text
+Nothing else is consulted. Fair-share, job age, partition ``priority_tier``,
+and an explicit ``--priority`` order pending jobs for scheduling but have no
+bearing on preemption eligibility; the sole exception is the reservation guard
+below, which compares partition tiers.
 
-   effective_priority = base_priority × min(fair_share, 10.0) × age_factor × max(partition_tier, 1)
-   age_factor = 1.0 + min(waiting_minutes / 10080, 1.0)   # 1.0 -> 2.0 over 7 days
+.. list-table:: Resolved victim action under ``preempt_type = "qos_priority"``
+   :header-rows: 1
+   :widths: 28 26 46
 
-``base_priority`` is the explicit ``--priority`` if given; otherwise it is
-``1000 + qos.priority`` (see the QOS ``priority`` field, above) — so a QOS's
-priority contributes to the base *before* the multiplicative factors, and is
-scaled by fair-share/age/tier along with everything else, not added on top of
-them. Both sides of the comparison go through the same formula: a pending
-job's stored priority is kept refreshed with it every scheduling pass, and a
-running job's is recomputed the same way at preemption-check time (a running
-job's own priority field is frozen at whatever it was when dispatched).
+   * - Victim partition ``preempt_mode``
+     - Victim QOS ``preemptmode``
+     - Resolved action
+   * - unset (default) or ``off``
+     - unset (default) or ``off``
+     - None — the victim is skipped
+   * - unset or ``off``
+     - ``cancel`` / ``requeue`` / ``suspend``
+     - The QOS action. A QOS action overrides a partition ``off``.
+   * - ``cancel`` / ``requeue`` / ``suspend``
+     - unset or ``off``
+     - The partition action
+   * - ``cancel``
+     - ``requeue``
+     - ``requeue`` — the QOS action overrides the partition's
+   * - Several partitions, e.g. ``suspend`` and ``cancel``
+     - unset or ``off``
+     - ``cancel`` — the most aggressive matched partition action wins
 
-The gap must exceed 2× — not merely be larger — for preemption to fire.
+The table assumes the allow-list, rank, node-overlap, reservation, and exempt-time
+guards have all passed; any of those failing skips the victim regardless of the
+action configured.
 
-**Scenarios where preemption fires**
+``preemptmode=off`` on a QOS is **not** a protection — it means "no override,
+use the partition's action". Equally, ``preempt_mode = "off"`` on a partition
+is not absolute, because a QOS action overrides it. The only way to keep a
+QOS's jobs from ever being selected is to keep its name out of every other
+QOS's ``preempt`` allow-list.
+
+``suspend`` is a fully selectable action: the victim is paused with SIGSTOP and
+keeps its node allocation. Nothing resumes it automatically — that needs an
+explicit ``scontrol resume`` — and the node stays occupied either way, so
+choose ``cancel`` or ``requeue`` when the pending job needs capacity freed.
+
+.. _qos-preempt-same-qos:
+
+**Preempting within a QOS**
+
+The rank test is strict, so two different QOSes with equal ``priority`` can
+never preempt each other. There is one deliberate exception: a QOS that lists
+*its own name* in its ``preempt`` field may preempt its own jobs. This is the
+only way to express "work in this tier may displace older work in the same
+tier", since a strict rank test can never hold between a QOS and itself.
+
+.. code-block:: bash
+
+   sacctmgr modify qos name=burst set preempt=burst
+
+Use ``modify``, not ``add`` — the allow-list is validated against existing QOS
+names, so a QOS cannot name itself in the command that creates it.
+
+Within one QOS the rank test can never separate two jobs, so **submit order
+decides**: a pending job may only displace a job submitted before it. That order
+never changes, so a victim requeued by preemption can never turn around and
+preempt the job that displaced it. Without that rule a self-listing QOS using
+``preemptmode=requeue`` would ping-pong indefinitely and neither job would
+finish.
+
+Victims are considered least-important-first (by QOS priority, then job ID), so
+within a single QOS the oldest eligible job is picked. At most one victim is
+preempted per pending job per scheduling cycle.
+
+**Guards checked before a victim is selected**
+
+Every guard below must pass. They are checked in this order, and the first
+failure moves the scheduler on to the next candidate.
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 40 30
-
-   * - Cause
-     - Example
-     - Result
-   * - Higher base priority
-     - Pending base 1000 vs. running base 100 (both otherwise equal)
-     - ``100 × 1.0 = 100 < 1000 / 2 = 500`` → fires
-   * - Higher QOS priority
-     - Pending on a QOS with ``priority=2000`` (base ``1000+2000=3000``) vs.
-       running with no QOS (base 1000), otherwise equal
-     - ``1000 < 3000 / 2 = 1500`` → fires
-   * - Fair-share divergence alone
-     - Same base/QOS/tier; pending's user has low usage
-       (``fair_share=2.0``, fully aged), running's user is heavy
-       (``fair_share=0.1``, no age boost)
-     - ``1000×0.1×1.0=100 < (1000×2.0×2.0)/2=2000`` → fires
-   * - Higher partition tier (≥ 3×)
-     - Pending on a ``priority_tier=3`` partition vs. running on
-       ``priority_tier=1``, otherwise equal
-     - ``1000 < 3000 / 2 = 1500`` → fires
-   * - Combination of smaller gaps
-     - No single factor differs by 2×, but several compound: base 500 both
-       sides; pending has ``fair_share=2.0``, full age boost, ``tier=2``;
-       running has ``fair_share=0.5``, no age boost, ``tier=1``
-     - ``250 < 4000 / 2 = 2000`` → fires
-
-A 2×+ gap in fair-share, age, or partition tier alone is exactly as effective
-as a 2×+ base-priority gap — this is the main **silent** path: two jobs
-submitted with identical priority and QOS by different users can still
-trigger preemption purely from fair-share divergence, with no priority or
-QOS change involved.
-
-**Scenarios where the priority gap alone cannot fire preemption**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 45 55
-
-   * - Scenario
-     - Why it cannot fire
-   * - Same base, QOS, fair-share, and partition tier
-     - The age factor tops out at 2.0×, exactly cancelling the 2× threshold:
-       worst case is pending at ``2P`` and running at ``P``, and ``P < P`` is
-       false (strict ``<`` is required).
-   * - Pending on ``priority_tier=2`` vs. running on ``priority_tier=1``,
-       otherwise equal
-     - Same cancellation: ``2000 / 2 = 1000``, not strictly less than the
-       running job's 1000.
-
-**Configuration guards checked after the priority gap** (any one blocks
-preemption regardless of how large the gap is):
-
-.. list-table::
-   :header-rows: 1
-   :widths: 45 55
+   :widths: 30 70
 
    * - Guard
-     - Condition
-   * - Pending partition preempt mode
-     - The pending job's own partition ``preempt_mode`` (no QOS override
-       here) is ``off`` — checked once per pending job, before any
-       candidate is considered.
-   * - QOS allow-list
-     - ``preempt_type = "qos_priority"`` and the pending job's QOS does not
-       list the running job's QOS in its ``preempt`` field.
-   * - Preempt mode
-     - The running job's effective ``preempt_mode`` (QOS override, else
-       partition) is ``off``.
+     - Condition to pass
+   * - Node overlap
+     - The pending job must need a node the running job currently occupies. A
+       running job elsewhere in the cluster is never a candidate.
+   * - Active reservation
+     - If the running job is executing inside an active reservation, the
+       pending job's partition ``priority_tier`` must be **strictly greater**
+       than the running job's. Outside a reservation this guard does not apply
+       and tiers are not compared at all.
+   * - QOS allow-list and rank
+     - The pending job's QOS must list the running job's QOS in ``preempt``,
+       and must either outrank it on QOS ``priority`` or be that same QOS with
+       the running job submitted earlier.
    * - Exempt time
-     - The running job has not yet been running for ``preempt_exempt_time``
-       (QOS > partition > global).
-   * - Reservation protection
-     - The running job is in an active reservation and the pending job's
-       partition tier is not strictly higher than the running job's.
-   * - No node overlap
-     - The pending job does not need any node the running job occupies.
+     - The running job must already have run for its effective
+       ``preempt_exempt_time`` — the QOS value, else the highest override among
+       its matched partitions, else the global
+       ``scheduler.preempt_exempt_time``. A job with no recorded start time
+       gets no protection from this guard.
 
 **Comparison with Slurm**
 
@@ -861,37 +899,21 @@ preemption regardless of how large the gap is):
      - Spur
      - Slurm (``PreemptType=preempt/qos``)
    * - Preemption gate
-     - Effective priority gap > 2×
-     - QOS ``Preempt=`` allow-list only
+     - QOS ``preempt`` allow-list plus a strictly higher QOS priority
+     - QOS ``Preempt=`` allow-list
    * - Does fair-share affect preemption?
-     - Yes, via the effective-priority formula
      - No — fair-share affects scheduling order only
-   * - Does age affect preemption?
-     - Yes, via the effective-priority formula
+     - No — fair-share affects scheduling order only
+   * - Does job age affect preemption?
+     - No
      - No
    * - Can priority alone trigger preemption with no QOS config?
-     - Yes (``preempt_type = "none"``, the default)
+     - No — preemption is disabled unless ``preempt_type`` is set, and always
+       requires an explicit allow-list
      - No — QOS preemption always requires an explicit allow-list
 
-The practical difference: in Spur, preemption eligibility can shift day to
-day as fair-share and age change, even with no configuration change. In
-Slurm's QOS-priority model, eligibility is fixed by the allow-list and does
-not drift on its own.
-
-QOS preemption hierarchy
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-To restrict which QOS tiers may preempt which, enable the QOS preemption
-hierarchy in ``spur.conf``:
-
-.. code-block:: toml
-
-   [scheduler]
-   preempt_type = "qos_priority"
-
-With ``preempt_type = "qos_priority"``, a job may only preempt a running job
-when the pending job's QOS lists the running job's QOS name in its ``preempt``
-allow-list. An empty allow-list means the QOS may not preempt anything.
+Eligibility is therefore fixed by configuration in both schedulers: it does not
+drift on its own as usage and queue times change.
 
 **Example: two-tier system**
 
@@ -909,13 +931,14 @@ allow-list. An empty allow-list means the QOS may not preempt anything.
 
 With this setup:
 
-- A ``priority`` job preempts ``burst`` jobs when the priority gap is large enough.
+- A ``priority`` job preempts ``burst`` jobs because its QOS priority is higher
+  and its allow-list contains ``burst``.
 - A ``priority`` job cannot preempt ``reserved`` jobs (``reserved`` is not in
   ``priority``'s allow-list).
 - A ``burst`` job never preempts anyone (empty allow-list).
 - ``reserved`` jobs are never kicked out because no other QOS lists
   ``reserved`` in its ``preempt`` field. That is what provides the protection
-  — not ``preemptmode=off``, which simply means "use the partition default".
+  — not ``preemptmode=off``, which simply means "use the partition's action".
 
 **Minimum exempt time**
 
@@ -974,8 +997,9 @@ With this setup:
 - ``burst`` jobs can never kick out ``normal`` jobs — ``burst`` has no
   entries in its ``preempt`` allow-list.
 - A QOS that no other QOS lists in its ``preempt`` field (for example, a
-  ``reserved`` tier) will never have its jobs kicked out, regardless of how
-  large a priority gap exists.
+  ``reserved`` tier) will never have its jobs kicked out, whatever the
+  priorities are. Setting ``preemptmode=off`` on that QOS adds nothing — it
+  only defers the action to the partition.
 
 How a job's QOS is resolved
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -488,14 +488,15 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
      - string
      - ``"none"``
      - Live
-     - Controls cross-QOS preemption eligibility. ``"none"`` (default) applies no
-       QOS-level restrictions — any job with a sufficient priority gap may preempt
-       any other. ``"qos_priority"`` enforces the per-QOS ``preempt`` allow-list:
-       a pending job may only preempt a running job when the pending job's QOS
-       explicitly lists the running job's QOS name in its ``preempt`` field. An
-       empty allow-list means the QOS may not preempt anything. Mirrors Slurm's
-       ``PreemptType=preempt/qos``. See :doc:`accounting` for the QOS
-       ``preempt`` field.
+     - Selects the preemption engine. ``"none"`` (the default; ``"off"`` is
+       accepted as a synonym) disables preemption entirely.
+       ``"qos_priority"`` is the only value that enables it: a pending job may
+       then preempt a running job when the pending job's QOS lists the running
+       job's QOS name in its ``preempt`` allow-list **and** has a strictly
+       higher QOS ``priority``. An empty allow-list means the QOS may not
+       preempt anything. Mirrors Slurm's ``PreemptType=preempt/qos``. See
+       :doc:`accounting` for the QOS ``preempt`` field and the full decision
+       table.
    * - ``preempt_exempt_time``
      - integer
      - ``0``
@@ -526,17 +527,17 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
    available capacity — it does not reclaim capacity already given to a
    running job. Configure:
 
-   - A priority gap of more than 2× between the jobs that must run and the
-     jobs they need to be able to displace (via base ``--priority``, QOS
-     ``priority``, or a combination — see :doc:`accounting` for how the
-     effective priority gap is computed).
-   - ``preempt_type`` (and, if a running job should not simply be killed,
-     ``preemptmode=requeue`` or ``suspend`` on its QOS) so that gap actually
-     triggers preemption instead of only affecting scheduling order.
+   - ``preempt_type = "qos_priority"``. Preemption is disabled by default.
+   - A QOS for the pending job that lists the running job's QOS in its
+     ``preempt`` allow-list and has a strictly higher QOS ``priority``
+     (see :doc:`accounting`).
+   - A non-``off`` action for the running job, from either its QOS
+     ``preemptmode`` or the ``preempt_mode`` of a partition it runs in. Use
+     ``cancel`` or ``requeue`` if the capacity must actually be freed —
+     ``suspend`` pauses the victim but leaves its nodes allocated.
 
-   With both in place, a high-priority job that cannot find free capacity
-   will preempt a lower-priority running job holding the capacity it needs,
-   rather than waiting for it to finish on its own.
+   With those policy settings in place, a pending job that cannot find free
+   capacity can preempt an eligible lower-QOS job holding the capacity it needs.
 
 .. note::
 
@@ -747,9 +748,9 @@ jobs is skipped rather than deleted (see :ref:`reload-scope`).
        tier among them.
    * - ``preempt_mode``
      - string
-     - ``"off"``
-     - What the scheduler does to a running job when a higher-priority job needs
-       its node.
+     - unset
+     - What the scheduler does to a running job in this partition when an
+       eligible pending job needs its node.
 
        ``"cancel"`` — the running job is stopped and removed from the queue.
        ``"requeue"`` — the running job is stopped and put back in the queue;
@@ -759,13 +760,22 @@ jobs is skipped rather than deleted (see :ref:`reload-scope`).
        finishes. Because the node stays occupied, any other job that also needs
        that node exclusively will have to wait until the paused job either
        finishes or is cancelled.
-       ``"off"`` (default) — running jobs in this partition are never kicked
-       out. The scheduler will wait for a free slot instead of preempting.
+       unset (default) — nothing configured, so this partition supplies no
+       action. ``"off"`` — an explicit no-action, which resolves identically to
+       unset; the two differ only in that ``scontrol show partition`` reports
+       ``PreemptMode=NONE`` versus ``PreemptMode=OFF``, so you can tell whether
+       anyone configured the field. Neither is a protection: a job's QOS
+       ``preemptmode`` overrides the partition, so a QOS action still applies.
 
-       A job's QOS can change what happens to *that specific job* when it is
-       kicked out (see ``preemptmode`` in :doc:`accounting`). The partition
-       field is the on/off switch: preemption is only attempted at all when
-       this is set to something other than ``"off"``.
+       Set the field back to unset with ``PreemptMode=NONE`` (or an empty
+       value) via ``scontrol update``.
+
+       A running job's QOS ``preemptmode`` overrides this field whenever it is
+       not ``off`` (see ``preemptmode`` in :doc:`accounting`). When a job spans
+       several partitions, the most aggressive ``preempt_mode`` among them wins
+       (``cancel`` > ``requeue`` > ``suspend`` > ``off``). Whether preemption is
+       attempted at all is governed by ``scheduler.preempt_type``, not by this
+       field. See :doc:`accounting` for the complete decision table.
    * - ``preempt_exempt_time``
      - integer or null
      - ``null`` (inherit global)

--- a/docs/deployment/upgrading.rst
+++ b/docs/deployment/upgrading.rst
@@ -371,6 +371,64 @@ An agent without them logs ``device filter not installed`` and runs the job with
 device isolation, so an unprivileged ``spurd`` behaves as before — unless ``required = true``, which
 turns that degradation into a refused launch.
 
+Job preemption policy (``preempt_type``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The release introducing ``scheduler.preempt_type`` makes preemption **opt-in**
+and narrows what makes a running job eligible. Both changes apply to a
+``spur.conf`` that is not edited.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 26 26 26
+
+   * - Behavior
+     - Before
+     - After
+     - Effect
+   * - Whether preemption runs
+     - On whenever the pending job's partition set a non-``off``
+       ``preempt_mode``
+     - Off unless ``scheduler.preempt_type = "qos_priority"``
+     - **A cluster that preempted before stops preempting entirely** until the
+       new field is set.
+   * - What makes a job eligible
+     - An effective-priority gap of more than 2×
+     - The pending job's QOS lists the victim's QOS in ``preempt`` **and** has
+       a strictly higher QOS ``priority``
+     - **Preemption no longer fires without a QOS allow-list.** Fair-share, job
+       age, and ``--priority`` no longer affect eligibility at all;
+       ``priority_tier`` matters only for the active-reservation guard.
+
+To restore preemption, enable the engine in ``spur.conf`` on the controller:
+
+.. code-block:: toml
+
+   [scheduler]
+   preempt_type = "qos_priority"
+
+then give each preempting QOS an allow-list and a higher priority than the QOS
+it should displace:
+
+.. code-block:: bash
+
+   sacctmgr modify qos name=burst set priority=100
+   sacctmgr modify qos name=normal set priority=10000 preempt=burst
+
+Both are live: ``preempt_type`` applies on ``scontrol reconfigure``, and QOS
+changes take effect without a restart. Each victim still needs a non-``off``
+action from its QOS ``preemptmode`` or one of its partitions' ``preempt_mode``,
+as before. See :doc:`/admin-guide/accounting` for the full decision table.
+
+A pending job's own partition ``preempt_mode`` no longer gates whether it may
+preempt. Previously a job sitting in an ``off`` partition could never trigger
+preemption; now only the victim's scope decides. Partitions used to hold
+pending work away from preemption need their *victims* protected instead.
+
+Leaving ``preempt_type`` at its ``"none"`` default is safe but silent: nothing
+logs that preemption was skipped, so verify with a test job rather than
+assuming the old behavior carried over.
+
 See Also
 --------
 

--- a/docs/user-guide/monitoring-jobs.rst
+++ b/docs/user-guide/monitoring-jobs.rst
@@ -334,9 +334,11 @@ per-field width with ``Field%N``, e.g. ``JobName%20``.
 
 ``PreemptedBy`` is the job ID of the higher-priority job that caused the
 preemption (``N/A`` when the job was not preempted). ``PreemptMode`` is one of
-``Requeue``, ``Cancel``, or ``Suspend``. ``PreemptQOS`` is the QOS name that
-authorized the preemption under ``preempt_type = qos_priority``; ``N/A`` for
-plain priority-based preemption. All three appear in the long format (``-l``).
+``Requeue``, ``Cancel``, or ``Suspend``. ``PreemptQOS`` is the QOS of that
+preempting job — the QOS whose ``preempt`` allow-list authorized the
+preemption. It is set for any job preempted by this release; jobs preempted by
+an earlier release, which recorded no authorizing QOS, show ``N/A`` even though
+they were preempted. All three appear in the long format (``-l``).
 
 The default columns are ``JobID JobName User Account Partition State Elapsed
 NNodes ExitCode``.
@@ -501,8 +503,10 @@ fields:
 * ``PreemptedBy=<job_id>`` — the ID of the higher-priority job that triggered
   the preemption. Only shown when the job has been preempted.
 * ``PreemptMode=Requeue|Cancel|Suspend`` — how the preemption was carried out.
-* ``PreemptQOS=<name>`` — the QOS that authorized the preemption under
-  ``preempt_type = qos_priority``; ``N/A`` for plain priority-based preemption.
+* ``PreemptQOS=<name>`` — the QOS of the preempting job, whose ``preempt``
+  allow-list authorized the preemption. Set for any job preempted by this
+  release; jobs preempted by an earlier release show ``N/A`` even though they
+  were preempted.
 
 **Quick reference — one command for any preempted job:**
 

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1697,7 +1697,7 @@ message CreatePartitionRequest {
   repeated string allow_accounts = 10;
   repeated string allow_groups = 11;
   uint32 priority_tier = 12;
-  string preempt_mode = 13;       // "OFF" | "CANCEL" | "REQUEUE" | "SUSPEND"
+  string preempt_mode = 13;       // "" (unset) | "OFF" | "CANCEL" | "REQUEUE" | "SUSPEND"
   repeated string deny_accounts = 14;
   repeated string deny_qos = 15;
   repeated string allow_qos = 16;

--- a/tests/native_host/e2e/test_burst_qos.py
+++ b/tests/native_host/e2e/test_burst_qos.py
@@ -68,7 +68,7 @@ class TestBurstQosPreemptedByNormal:
     """A burst job running on the only node must be cancelled when a normal job
     arrives, because:
       [1] normal QoS has burst in its preempt allow-list → preemption authorised
-      [2] burst has a deeply negative priority delta → gap exceeds the 2× threshold
+      [2] normal's QoS priority strictly exceeds burst's deeply negative one
     Both conditions must hold simultaneously for preemption to fire."""
 
     @pytest.fixture
@@ -103,7 +103,7 @@ class TestBurstQosPreemptedByNormal:
             wait_job_state(c, normal_id, "PD", timeout=30)
             _assert_scontrol_state(c, normal_id, "PENDING", "normal before preemption")
 
-            # Burst job must be cancelled — allow-list permits it, priority gap qualifies.
+            # Burst job must be cancelled — allow-list permits it, QoS rank qualifies.
             terminal = wait_job(c, burst_id, timeout=_WAIT_PREEMPT)
             assert terminal in ("CA", "GONE"), (
                 f"burst job must be preempted by normal job; got {terminal!r}"
@@ -125,9 +125,13 @@ class TestBurstQosPreemptedByNormal:
 
 
 class TestBurstQosNotPreemptedByAnotherBurst:
-    """Two burst jobs competing for the same node: neither must preempt the other.
-    Both have the same low priority, so the running burst job is not above the 2×
-    threshold that would qualify the pending one for preemption."""
+    """Two burst tiers competing for the same node: neither must preempt the other.
+
+    The allow-list is deliberately satisfied — burst-b names burst-a — so the only
+    thing standing between the pending job and the running one is that their QoS
+    priorities are equal, and the rank comparison is strict. Leaving the allow-list
+    empty as well would let this test pass without ever reaching the rank check.
+    """
 
     @pytest.fixture
     def cluster_config_overrides(self):
@@ -137,10 +141,11 @@ class TestBurstQosNotPreemptedByAnotherBurst:
         c = accounting_cluster
         node = c.node_names[0]
 
-        # Two burst QoSes with identical low priority; neither has the other
-        # in its allow-list, so even a modest priority gap would be blocked.
+        # Two burst QoSes with identical priority. burst-b is authorised to
+        # preempt burst-a, so only the equal rank can block it.
         c.sacctmgr(["add", "qos", "name=burst-a", "priority=-5000"])
-        c.sacctmgr(["add", "qos", "name=burst-b", "priority=-5000"])
+        c.sacctmgr(["add", "qos", "name=burst-b", "priority=-5000",
+                    "preempt=burst-a"])
         time.sleep(15)
 
         burst_a_id = None
@@ -162,12 +167,13 @@ class TestBurstQosNotPreemptedByAnotherBurst:
             wait_job_state(c, burst_b_id, "PD", timeout=30)
             _assert_scontrol_state(c, burst_b_id, "PENDING", "burst-b before guard")
 
-            # Neither condition for preemption is met: no allow-list entry AND
-            # equal priority. After several scheduler cycles nothing must change.
+            # The allow-list permits it; equal QoS rank does not. After several
+            # scheduler cycles nothing must change.
             time.sleep(_GUARD_SECS)
             sq = c.squeue_all()
             assert job_state(sq, burst_a_id) == "R", (
-                "running burst job must not be evicted by another burst job"
+                "running burst job must not be evicted by an equal-priority burst "
+                "QoS, even one that allow-lists it"
             )
             _assert_scontrol_state(c, burst_a_id, "RUNNING", "burst-a after guard")
             assert job_state(sq, burst_b_id) == "PD", (
@@ -183,8 +189,7 @@ class TestBurstQosNotPreemptedByAnotherBurst:
 
 class TestBurstQosNotPreemptedByQosWithoutAllowList:
     """A QoS that does NOT list burst in its preempt allow-list must not evict a
-    burst job, even when its priority gap would otherwise qualify it under a plain
-    priority-based preemption scheme."""
+    burst job, even when its QoS rank would otherwise qualify it."""
 
     @pytest.fixture
     def cluster_config_overrides(self):
@@ -220,8 +225,8 @@ class TestBurstQosNotPreemptedByQosWithoutAllowList:
             wait_job_state(c, stranger_id, "PD", timeout=30)
             _assert_scontrol_state(c, stranger_id, "PENDING", "stranger before guard")
 
-            # Under qos_priority mode the allow-list is the gate — priority gap
-            # alone is not sufficient. burst must stay running.
+            # Under qos_priority mode the allow-list is a gate in its own right —
+            # a QoS rank advantage alone is not sufficient. burst must stay running.
             time.sleep(_GUARD_SECS)
             sq = c.squeue_all()
             assert job_state(sq, burst_id) == "R", (
@@ -421,8 +426,10 @@ class TestBurstQosRequeueMode:
 
 
 class TestBurstQosPartitionOffBlocksPreemption:
-    """Even when the normal QoS has burst in its allow-list and the priority gap
-    qualifies, a partition with preempt_mode=off must block eviction entirely."""
+    """A partition preempt_mode=off blocks eviction when the victim's QoS
+    supplies no action of its own — the allow-list and QoS rank alone are not
+    enough. A victim QoS preemptmode would override it; see the decision table
+    in docs/admin-guide/accounting.rst."""
 
     @pytest.fixture
     def cluster_config_overrides(self):
@@ -475,13 +482,13 @@ class TestBurstQosPartitionOffBlocksPreemption:
             wait_job_state(c, normal_id, "PD", timeout=30)
             _assert_scontrol_state(c, normal_id, "PENDING", "normal before guard")
 
-            # Allow-list and priority gap both say "preempt", but partition says "off".
-            # Partition gate wins — burst must stay running.
+            # Allow-list and rank both qualify, but no action is configured at
+            # either scope (burst-noevict sets no preemptmode), so nothing fires.
             time.sleep(_GUARD_SECS)
             sq = c.squeue_all()
             assert job_state(sq, burst_id) == "R", (
-                "burst job must not be evicted when partition preempt_mode=off, "
-                "even when QoS allow-list and priority gap both qualify preemption"
+                "burst job must not be evicted when partition preempt_mode=off "
+                "and its QoS supplies no preemptmode of its own"
             )
             _assert_scontrol_state(c, burst_id, "RUNNING", "burst after guard")
             assert job_state(sq, normal_id) == "PD", (

--- a/tests/native_host/e2e/test_preemption.py
+++ b/tests/native_host/e2e/test_preemption.py
@@ -8,7 +8,14 @@ Covers the fix where a job repeatedly preempted (PreemptMode=Requeue) must
 never be held with JobHoldMaxRequeue: preemption requeues are tracked
 separately from failure requeues (dispatch failure/Timeout/NodeFail) and are
 never checked against `max_batch_requeue`.
+
+Requires:
+  - preempt_type=qos_priority (scheduler config); preemption is off otherwise
+  - a QOS pair where the aggressor allow-lists the victim and outranks it
+  - Postgres on node 0 (accounting_cluster fixture, skips when Docker is absent)
 """
+
+import time
 
 import pytest
 
@@ -19,6 +26,10 @@ from cluster import parse_job_id, wait_job, wait_job_state
 # release, scheduler pickup, and spurd relaunch, which is sensitive to CI host
 # load — not a latency assertion.
 RESCHEDULE_TIMEOUT = 60
+
+# QOS cache refreshes on the accounting interval; a freshly added QOS needs a
+# cycle before the scheduler acts on it.
+_CACHE_WARMUP_SECS = 15
 
 
 class TestChronicPreemption:
@@ -42,10 +53,25 @@ class TestChronicPreemption:
                     "preempt_mode": "requeue",
                 }
             ],
+            "scheduler": {
+                "preempt_type": "qos_priority",
+            },
+            # Required when the test runner SSHes in as root: spurd refuses to
+            # execute jobs as uid 0 unless this is explicitly enabled.
+            "auth": {"plugin": "none", "allow_root_jobs": True},
         }
 
-    def test_chronic_preemption_never_holds_job(self, cluster):
+    def test_chronic_preemption_never_holds_job(self, accounting_cluster):
+        cluster = accounting_cluster
         node0 = cluster.node_names[0]
+
+        # Neither QOS sets preemptmode, so both defer to the partition's
+        # `requeue` — the mode whose requeue accounting is under test.
+        cluster.sacctmgr(["add", "qos", "name=chronic-low", "priority=100"])
+        cluster.sacctmgr(["add", "qos", "name=chronic-high", "priority=10000",
+                          "preempt=chronic-low"])
+        time.sleep(_CACHE_WARMUP_SECS)
+
         low_id = None
         try:
             low_script = cluster.write_file(
@@ -53,7 +79,7 @@ class TestChronicPreemption:
             )
             sb = cluster.sbatch(
                 ["-J", "chronic-low", "-N", "1", f"--nodelist={node0}",
-                 "--exclusive", low_script]
+                 "--exclusive", "-q", "chronic-low", low_script]
             )
             low_id = parse_job_id(sb)
             assert low_id is not None, f"submit failed:\n{sb}"
@@ -71,13 +97,10 @@ class TestChronicPreemption:
                 )
                 hb = cluster.sbatch(
                     ["-J", f"chronic-high-{i}", "-N", "1", f"--nodelist={node0}",
-                     "--exclusive", hi_script]
+                     "--exclusive", "-q", "chronic-high", hi_script]
                 )
                 hi_id = parse_job_id(hb)
                 assert hi_id is not None, f"submit failed:\n{hb}"
-                # A high enough priority guarantees preemption eligibility
-                # (candidate.priority must be < pending.priority / 2).
-                cluster.scontrol("update", f"JobId={hi_id}", "Priority=1000000")
 
                 wait_job_state(cluster, low_id, "PD", timeout=15)
                 show = cluster.scontrol("show", "job", str(low_id))

--- a/tests/native_host/e2e/test_preemption_fairshare.py
+++ b/tests/native_host/e2e/test_preemption_fairshare.py
@@ -2,29 +2,36 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Black-box end-to-end tests for fair-share's influence on preemption eligibility.
+Black-box end-to-end tests proving fair-share has no say in preemption eligibility.
 
-Preemption fires on a gap in *effective* priority, and effective priority is a
-product:
+Fair-share used to feed the effective job priority that gated preemption:
 
     effective = base x min(fair_share, 10.0) x age_factor x max(partition_tier, 1)
-    base      = explicit --priority, else 1000 + qos.priority
 
-Because the terms multiply, fair-share does not merely break ties between jobs
-of equal QOS — it can overturn the QOS ordering outright. Fair-share spans
-roughly 33x in practice (capped at 10.0 above, sinking toward the account's
-target share below) while a QOS priority of 10000 against 100 spans only 10x
-(base 11000 against 1100). The wider range wins.
+Because the terms multiplied, fair-share (spanning roughly 33x in practice) could
+overturn the QOS ordering outright (a QOS priority of 10000 against 100 spans only
+10x on base). In production that let burst-QOS jobs at priority 100 repeatedly
+cancel team-QOS jobs at priority 10000 whose owners had drifted over their target
+share.
 
-These tests pin that behaviour down so a change to the priority model is a
-deliberate decision rather than an accident.
+Eligibility is now decided by the QOS allow-list plus QOS rank alone. Fair-share
+still orders pending jobs, but it can neither create nor block a preemption. These
+tests assert both halves of that:
+
+  FairShareCannotPreemptWithoutAllowList
+      An extreme fair-share disparity favouring the aggressor evicts nothing while
+      no allow-list permits it.
+
+  QosRankDecidesRegardlessOfFairShare
+      With an allow-list in place, QOS rank alone settles the outcome — a poor
+      fair-share does not stop the higher-ranked QOS from preempting, and a
+      stellar fair-share does not let the lower-ranked QOS preempt.
+
+Every fixture here sets preempt_type=qos_priority; without it preemption is off
+entirely and the negative tests would pass without exercising anything.
 
 Requires:
   - Postgres on node 0 (accounting_cluster fixture, skips when Docker is absent)
-
-Note the fixtures deliberately leave scheduler.preempt_type unset, so it
-defaults to `none` and the per-QOS `preempt` allow-list is not consulted. That
-is the configuration under test: eligibility rests entirely on the priority gap.
 """
 
 import time
@@ -41,14 +48,15 @@ _GUARD_SECS = 12
 
 # fairshare_refresh_secs is 10 in the harness config and FairshareCache clamps
 # its interval to a 10s floor, so a planted usage row needs two cycles plus
-# slack before the scheduler is guaranteed to see it.
+# slack before the scheduler is guaranteed to see it. The same wait covers the
+# QOS cache, which refreshes on the same interval.
 _FAIRSHARE_REFRESH_SECS = 30
 
 # Required when the test runner SSHes in as root: spurd refuses to execute jobs
 # as uid 0 unless this is explicitly enabled.
 _AUTH_ROOT = {"auth": {"plugin": "none", "allow_root_jobs": True}}
 
-_CANCEL_PARTITION = {
+_BASE_CONFIG = {
     "partitions": [
         {
             "name": "default",
@@ -60,7 +68,17 @@ _CANCEL_PARTITION = {
             "preempt_mode": "cancel",
         }
     ],
+    "scheduler": {
+        "preempt_type": "qos_priority",
+    },
+    **_AUTH_ROOT,
 }
+
+# Planted usage large enough that the account's actual share saturates, and
+# small enough (the counterpart) to hit the fair-share epsilon. Together they
+# drive the two accounts to opposite ends of the fair-share range.
+_HEAVY_USAGE = 999_000_000
+_LIGHT_USAGE = 1
 
 
 def _assert_scontrol_state(cluster, job_id: int, expected: str, label: str = "") -> None:
@@ -94,56 +112,50 @@ def _seed_usage(cluster, user: str, account: str, cpu_seconds: int) -> None:
     )
 
 
-class TestFairShareOverturnsQosPriority:
-    """A QOS priority of 100 must not be able to evict a QOS priority of 10000 —
-    yet it does, because fair-share is multiplied into the same number that gates
-    preemption.
+def _setup_skewed_accounts(cluster, user: str, heavy: str, light: str) -> None:
+    """Two accounts driven to opposite ends of the fair-share range.
 
-    Reproduces a production pattern where burst-QOS jobs (priority 100)
-    repeatedly cancelled team-QOS jobs (priority 10000) whose owners had drifted
-    over their fair-share target.
+    `heavy` gets the smaller weight and nearly all the recorded usage, so its
+    fair-share factor sinks; `light` gets the larger weight and effectively no
+    usage, so its factor pins to the 10.0 cap. That is the ~33x disparity that
+    used to be enough to overturn a 100x QOS priority ordering.
+    """
+    cluster.sacctmgr(["add", "account", f"name={heavy}", "fairshare=1"])
+    cluster.sacctmgr(["add", "account", f"name={light}", "fairshare=10"])
+    cluster.sacctmgr(["add", "user", f"name={user}", f"account={heavy}"])
+    cluster.sacctmgr(["add", "user", f"name={user}", f"account={light}"])
+    _seed_usage(cluster, user, heavy, _HEAVY_USAGE)
+    _seed_usage(cluster, user, light, _LIGHT_USAGE)
 
-    Arithmetic, with both accounts on the default partition (tier 1) and both
-    jobs freshly submitted (age_factor ~1.0):
 
-      target_share(heavy) = 1 / 11  = 0.0909      (fairshare weight 1 of 11)
-      target_share(light) = 10 / 11 = 0.909       (fairshare weight 10 of 11)
+class TestFairShareCannotPreemptWithoutAllowList:
+    """No fair-share disparity, however extreme, may evict a job that no QOS
+    allow-list permits preempting.
 
-      heavy holds ~all recorded usage  -> actual ~1.0  -> fs ~0.0909
-      light holds ~none                -> actual clamped to the 0.001 epsilon
-                                       -> fs 909, capped to 100, then to 10.0
-
-      victim  (team,  base 11000) effective ~ 11000 x 0.0909 =  1000
-      pending (burst, base  1100) effective ~  1100 x 10.0   = 11000
-
-      preemption fires when victim < pending / 2, i.e. 1000 < 5500. True, with
-      a 5.5x margin so the assertion does not sit on the threshold.
+    This is the direct regression test for the production defect: a burst QOS at
+    priority 100 cancelling team-QOS jobs at priority 10000 because the team's
+    owners had drifted over their fair-share target. The setup below reproduces
+    that disparity exactly — the aggressor holds the maximum fair-share factor and
+    the victim the minimum — and asserts that nothing happens, because the
+    aggressor's QOS names nothing in its preempt allow-list.
     """
 
     @pytest.fixture
     def cluster_config_overrides(self):
-        return {**_CANCEL_PARTITION, **_AUTH_ROOT}
+        return _BASE_CONFIG
 
-    def test_low_qos_priority_preempts_high_qos_priority_via_fairshare(
-        self, accounting_cluster
-    ):
+    def test_extreme_fairshare_disparity_evicts_nothing(self, accounting_cluster):
         c = accounting_cluster
         node = c.node_names[0]
         user = c.nodes[0].user
 
-        # Unequal fair-share weights give the two accounts very different
-        # targets; planted usage then drives their actual shares apart.
-        c.sacctmgr(["add", "account", "name=fs-heavy", "fairshare=1"])
-        c.sacctmgr(["add", "account", "name=fs-light", "fairshare=10"])
-        c.sacctmgr(["add", "user", f"name={user}", "account=fs-heavy"])
-        c.sacctmgr(["add", "user", f"name={user}", "account=fs-light"])
+        _setup_skewed_accounts(c, user, "fs-heavy", "fs-light")
 
-        # The victim outranks the aggressor by 100x on QOS priority alone.
+        # The victim also outranks the aggressor by 100x on QOS priority, so
+        # fair-share is the only thing that could possibly favour the aggressor.
+        # Neither QOS lists the other.
         c.sacctmgr(["add", "qos", "name=fs-team", "priority=10000", "preemptmode=cancel"])
         c.sacctmgr(["add", "qos", "name=fs-burst", "priority=100", "preemptmode=cancel"])
-
-        _seed_usage(c, user, "fs-heavy", 999_000_000)
-        _seed_usage(c, user, "fs-light", 1)
         time.sleep(_FAIRSHARE_REFRESH_SECS)
 
         victim_id = None
@@ -163,10 +175,10 @@ class TestFairShareOverturnsQosPriority:
             # Sample the counter before the aggressor exists: the scheduler runs
             # on a sub-second cycle and can preempt while the submit call is
             # still returning, so a baseline taken any later may already include
-            # the preemption this test is trying to observe.
+            # the preemption this test is trying to catch.
             preempted_before = c.sdiag_jobs_preempted()
 
-            aggressor_script = c.write_file("fs-aggressor.sh", _QUICK_SCRIPT)
+            aggressor_script = c.write_file("fs-aggressor.sh", _SLEEP_SCRIPT)
             aggressor_id = parse_job_id(
                 c.sbatch([
                     "-N1", "--exclusive", f"--nodelist={node}",
@@ -174,12 +186,88 @@ class TestFairShareOverturnsQosPriority:
                 ])
             )
             assert aggressor_id is not None, "aggressor submit failed"
+            wait_job_state(c, aggressor_id, "PD", timeout=30)
+
+            time.sleep(_GUARD_SECS)
+            sq = c.squeue_all()
+            assert job_state(sq, victim_id) == "R", (
+                "a fair-share advantage must not evict anything on its own; in "
+                "production this exact disparity let a QOS priority of 100 cancel "
+                "jobs at QOS priority 10000"
+            )
+            _assert_scontrol_state(c, victim_id, "RUNNING", "victim after guard")
+            assert job_state(sq, aggressor_id) == "PD", (
+                "the fair-share-favoured job must wait rather than displace the "
+                "higher-ranked QOS"
+            )
+            _assert_scontrol_state(c, aggressor_id, "PENDING", "aggressor after guard")
+            assert c.sdiag_jobs_preempted() == preempted_before, (
+                "no preemption decision may be recorded when no allow-list permits one"
+            )
+        finally:
+            for jid in (victim_id, aggressor_id):
+                if jid is not None:
+                    c.cli_allow_fail(["scancel", str(jid)])
+
+
+class TestQosRankDecidesRegardlessOfFairShare:
+    """With an allow-list in place, QOS rank settles the outcome and fair-share
+    cannot override it in either direction.
+
+    The two tests are mirror images: the same accounts and the same ~33x
+    fair-share disparity, with only the direction of the QOS rank swapped. If
+    fair-share still leaked into the eligibility decision, exactly one of them
+    would fail.
+    """
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return _BASE_CONFIG
+
+    def test_higher_qos_rank_preempts_despite_worse_fairshare(self, accounting_cluster):
+        c = accounting_cluster
+        node = c.node_names[0]
+        user = c.nodes[0].user
+
+        _setup_skewed_accounts(c, user, "fs-a-heavy", "fs-a-light")
+
+        # The aggressor outranks the victim on QOS but runs from the account with
+        # the exhausted fair-share; the victim sits on the pristine one.
+        c.sacctmgr(["add", "qos", "name=fs-a-victim", "priority=100",
+                    "preemptmode=cancel"])
+        c.sacctmgr(["add", "qos", "name=fs-a-hunter", "priority=10000",
+                    "preempt=fs-a-victim"])
+        time.sleep(_FAIRSHARE_REFRESH_SECS)
+
+        victim_id = None
+        aggressor_id = None
+        try:
+            victim_script = c.write_file("fs-a-victim.sh", _SLEEP_SCRIPT)
+            victim_id = parse_job_id(
+                c.sbatch([
+                    "-N1", "--exclusive", f"--nodelist={node}",
+                    "-A", "fs-a-light", "-q", "fs-a-victim", victim_script,
+                ])
+            )
+            assert victim_id is not None, "victim submit failed"
+            wait_job_state(c, victim_id, "R", timeout=30)
+            _assert_scontrol_state(c, victim_id, "RUNNING", "victim initial")
+
+            preempted_before = c.sdiag_jobs_preempted()
+
+            aggressor_script = c.write_file("fs-a-hunter.sh", _QUICK_SCRIPT)
+            aggressor_id = parse_job_id(
+                c.sbatch([
+                    "-N1", "--exclusive", f"--nodelist={node}",
+                    "-A", "fs-a-heavy", "-q", "fs-a-hunter", aggressor_script,
+                ])
+            )
+            assert aggressor_id is not None, "aggressor submit failed"
 
             terminal = wait_job(c, victim_id, timeout=_WAIT_PREEMPT)
             assert terminal in ("CA", "GONE"), (
-                "a QOS priority of 100 evicted a QOS priority of 10000 in production; "
-                "this test asserts that behaviour still reproduces, so that a change to "
-                f"the priority model is caught here. got {terminal!r}"
+                "an allow-listed, higher-ranked QOS must preempt even when its "
+                f"owner has exhausted their fair-share; got {terminal!r}"
             )
             if terminal != "GONE":
                 _assert_scontrol_state(c, victim_id, "CANCELLED", "victim after preemption")
@@ -201,64 +289,46 @@ class TestFairShareOverturnsQosPriority:
                 if jid is not None:
                     c.cli_allow_fail(["scancel", str(jid)])
 
-
-class TestEqualFairShareLeavesQosPriorityIntact:
-    """The control for the test above: with fair-share neutral on both sides, the
-    QOS priority ordering holds and the low-priority job cannot evict anyone.
-
-    Without this, the inversion test could pass for the wrong reason — a bug that
-    let *any* pending job preempt would satisfy it just as well.
-    """
-
-    @pytest.fixture
-    def cluster_config_overrides(self):
-        return {**_CANCEL_PARTITION, **_AUTH_ROOT}
-
-    def test_low_qos_cannot_preempt_high_qos_without_fairshare_divergence(
+    def test_lower_qos_rank_cannot_preempt_despite_better_fairshare(
         self, accounting_cluster
     ):
         c = accounting_cluster
         node = c.node_names[0]
         user = c.nodes[0].user
 
-        # Identical weights and identical planted usage: both accounts land on
-        # the same fair-share factor, so only QOS priority separates the jobs.
-        c.sacctmgr(["add", "account", "name=fs-even-a", "fairshare=1"])
-        c.sacctmgr(["add", "account", "name=fs-even-b", "fairshare=1"])
-        c.sacctmgr(["add", "user", f"name={user}", "account=fs-even-a"])
-        c.sacctmgr(["add", "user", f"name={user}", "account=fs-even-b"])
+        _setup_skewed_accounts(c, user, "fs-b-heavy", "fs-b-light")
 
-        c.sacctmgr(["add", "qos", "name=fs-even-team", "priority=10000", "preemptmode=cancel"])
-        c.sacctmgr(["add", "qos", "name=fs-even-burst", "priority=100", "preemptmode=cancel"])
-
-        _seed_usage(c, user, "fs-even-a", 1_000_000)
-        _seed_usage(c, user, "fs-even-b", 1_000_000)
+        # Mirror of the test above: the aggressor now holds the pristine
+        # fair-share but is outranked on QOS. The allow-list still names the
+        # victim, so the strict rank comparison is the only thing left to block
+        # eviction — and fair-share must not be able to substitute for it.
+        c.sacctmgr(["add", "qos", "name=fs-b-victim", "priority=10000",
+                    "preemptmode=cancel"])
+        c.sacctmgr(["add", "qos", "name=fs-b-hunter", "priority=100",
+                    "preempt=fs-b-victim"])
         time.sleep(_FAIRSHARE_REFRESH_SECS)
 
         victim_id = None
         aggressor_id = None
         try:
-            victim_script = c.write_file("fs-even-victim.sh", _SLEEP_SCRIPT)
+            victim_script = c.write_file("fs-b-victim.sh", _SLEEP_SCRIPT)
             victim_id = parse_job_id(
                 c.sbatch([
                     "-N1", "--exclusive", f"--nodelist={node}",
-                    "-A", "fs-even-a", "-q", "fs-even-team", victim_script,
+                    "-A", "fs-b-heavy", "-q", "fs-b-victim", victim_script,
                 ])
             )
             assert victim_id is not None, "victim submit failed"
             wait_job_state(c, victim_id, "R", timeout=30)
             _assert_scontrol_state(c, victim_id, "RUNNING", "victim initial")
 
-            # Baseline before the aggressor exists, matching the inversion test:
-            # a later sample could absorb the very preemption being guarded
-            # against and turn this assertion into a no-op.
             preempted_before = c.sdiag_jobs_preempted()
 
-            aggressor_script = c.write_file("fs-even-aggressor.sh", _SLEEP_SCRIPT)
+            aggressor_script = c.write_file("fs-b-hunter.sh", _SLEEP_SCRIPT)
             aggressor_id = parse_job_id(
                 c.sbatch([
                     "-N1", "--exclusive", f"--nodelist={node}",
-                    "-A", "fs-even-b", "-q", "fs-even-burst", aggressor_script,
+                    "-A", "fs-b-light", "-q", "fs-b-hunter", aggressor_script,
                 ])
             )
             assert aggressor_id is not None, "aggressor submit failed"
@@ -267,16 +337,17 @@ class TestEqualFairShareLeavesQosPriorityIntact:
             time.sleep(_GUARD_SECS)
             sq = c.squeue_all()
             assert job_state(sq, victim_id) == "R", (
-                "a QOS priority of 100 must not evict a QOS priority of 10000 when "
-                "fair-share is neutral on both sides"
+                "a lower-ranked QOS must not evict a higher-ranked one even with "
+                "an allow-list entry and a maximal fair-share advantage"
             )
             _assert_scontrol_state(c, victim_id, "RUNNING", "victim after guard")
             assert job_state(sq, aggressor_id) == "PD", (
-                "the low-QOS job must wait rather than displace the high-QOS job"
+                "the lower-ranked aggressor must wait its turn"
             )
             _assert_scontrol_state(c, aggressor_id, "PENDING", "aggressor after guard")
             assert c.sdiag_jobs_preempted() == preempted_before, (
-                "no preemption may be recorded while fair-share is neutral"
+                "no preemption decision may be recorded when the aggressor's QOS "
+                "does not outrank the victim's"
             )
         finally:
             for jid in (victim_id, aggressor_id):

--- a/tests/native_host/e2e/test_preemption_modes.py
+++ b/tests/native_host/e2e/test_preemption_modes.py
@@ -2,23 +2,35 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Black-box end-to-end tests for partition preempt_mode behaviour and priority thresholds.
+Black-box end-to-end tests for partition preempt_mode behaviour and the QOS rank gate.
 
 Each class covers one user-observable property:
 
-  CancelMode         — a preempted job is permanently removed from the queue
-  RequeueMode        — a preempted job returns to PENDING and reruns automatically
-  SuspendMode        — a preempted job is frozen in place and thaws once the slot is free
-  PreemptOff         — no eviction occurs regardless of how high the pending job's priority is
-  PriorityThreshold  — preemption requires a substantially higher priority; equal priority
-                       must not displace a running job
-  PriorityTier       — a higher partition priority_tier raises effective job priority enough
-                       to preempt a running job on a lower-tier partition, even when both
-                       jobs carry the same raw sbatch priority
+  CancelMode    — a preempted job is permanently removed from the queue
+  RequeueMode   — a preempted job returns to PENDING and reruns automatically
+  SuspendMode   — a preempted job is frozen in place and keeps its node allocation
+  PreemptOff    — no eviction occurs even when every other gate would permit it
+  QosRankGate   — an allow-listed victim is evicted only when the pending job's QOS
+                  priority is *strictly* higher; equal QOS priority must not displace,
+                  and a raw job-priority boost cannot substitute for QOS rank
+
+Preemption is off unless `scheduler.preempt_type = qos_priority`, and eligibility is
+decided solely by the QOS allow-list plus QOS rank. Every fixture here therefore turns
+the gate on and every test creates a QOS pair, so the partition's preempt_mode (or the
+QOS rank, for QosRankGate) is the only variable between classes. A negative test that
+merely left the gate off would pass without exercising anything.
+
+Effective *job* priority (fair-share, age, partition priority_tier) no longer affects
+preemption eligibility, so the former PriorityTier class — which asserted that a higher
+partition priority_tier alone could evict a lower-tier job — has been deleted rather
+than rewritten. priority_tier still matters for the active-reservation guard, but
+covering that needs reservation fixture plumbing this module does not have.
 
 Every state transition is verified through both squeue (the primary user-facing queue view)
 and scontrol show job (the detailed record view) so that a divergence between the two
 surfaces is caught as a test failure rather than silently masked.
+
+Requires Postgres on node 0 (accounting_cluster fixture, skips when Docker is absent).
 
 NOTE: REST API cross-verification is not yet covered here — the e2e infrastructure
 does not have a REST client helper. That is tracked as a separate gap.
@@ -37,6 +49,10 @@ _WAIT_PREEMPT = 30  # seconds to wait for preemption to fire
 _WAIT_RESUME = 60  # seconds to wait for a suspended/requeued job to come back up
 _GUARD_SECS = 10  # seconds to hold before asserting "nothing happened"
 
+# QOS cache refreshes on the accounting interval; a freshly added QOS needs a
+# cycle before the scheduler acts on it.
+_CACHE_WARMUP_SECS = 15
+
 _PARTITION = {
     "name": "default",
     "state": "UP",
@@ -49,6 +65,38 @@ _PARTITION = {
 # Required when the test runner SSHes in as root: spurd refuses to execute jobs
 # as uid 0 unless this is explicitly enabled.
 _AUTH_ROOT = {"auth": {"allow_root_jobs": True}}
+
+_VICTIM_QOS = "mode-victim"
+_HUNTER_QOS = "mode-hunter"
+
+# Applied to the pending job in the negative tests to prove raw job priority is
+# not a substitute for QOS rank: preemption must still be decided by the QOS
+# gates alone.
+_AGGRESSOR_PRIORITY = 1_000_000
+
+
+def _config(preempt_mode: str) -> dict:
+    """Cluster config with the QOS-priority gate on and one partition mode set."""
+    return {
+        **_AUTH_ROOT,
+        "partitions": [{**_PARTITION, "preempt_mode": preempt_mode}],
+        "scheduler": {"preempt_type": "qos_priority"},
+    }
+
+
+def _create_qos_pair(cluster, *, hunter_priority: int = 10000,
+                     victim_priority: int = 100) -> None:
+    """Victim QOS plus a hunter QOS that allow-lists it.
+
+    Neither QOS sets preemptmode, so the resolved PreemptMode comes from the
+    partition — the variable this module varies. The victim is created first
+    because CreateQos validates every allow-list name against the QOS table.
+    """
+    cluster.sacctmgr(["add", "qos", f"name={_VICTIM_QOS}",
+                      f"priority={victim_priority}"])
+    cluster.sacctmgr(["add", "qos", f"name={_HUNTER_QOS}",
+                      f"priority={hunter_priority}", f"preempt={_VICTIM_QOS}"])
+    time.sleep(_CACHE_WARMUP_SECS)
 
 
 def _scontrol_state(cluster, job_id: int) -> str:
@@ -65,39 +113,51 @@ def _assert_scontrol_state(cluster, job_id: int, expected: str, label: str = "")
     )
 
 
+def _run_victim(cluster, node: str, prefix: str) -> int:
+    """Submit a long-running victim under the victim QOS and wait for it to run."""
+    script = cluster.write_file(f"{prefix}-victim.sh", _SLEEP_SCRIPT)
+    victim_id = parse_job_id(
+        cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}",
+                        "-q", _VICTIM_QOS, script])
+    )
+    assert victim_id is not None, "victim submit failed"
+    wait_job_state(cluster, victim_id, "R", timeout=30)
+    _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim initial")
+    return victim_id
+
+
+def _queue_aggressor(cluster, node: str, prefix: str,
+                     body: str = _QUICK_SCRIPT) -> int:
+    """Queue an aggressor under the hunter QOS behind the victim on the same node."""
+    script = cluster.write_file(f"{prefix}-aggressor.sh", body)
+    aggressor_id = parse_job_id(
+        cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}",
+                        "-q", _HUNTER_QOS, script])
+    )
+    assert aggressor_id is not None, "aggressor submit failed"
+    return aggressor_id
+
+
 class TestCancelMode:
     """preempt_mode=cancel: the evicted job is terminated and must never re-enter the queue."""
 
     @pytest.fixture
     def cluster_config_overrides(self):
-        return {**_AUTH_ROOT, "partitions": [{**_PARTITION, "preempt_mode": "cancel"}]}
+        return _config("cancel")
 
-    def test_preempt_mode_cancel_removes_job_permanently(self, cluster):
+    def test_preempt_mode_cancel_removes_job_permanently(self, accounting_cluster):
+        cluster = accounting_cluster
         node = cluster.node_names[0]
+        _create_qos_pair(cluster)
 
-        victim = cluster.write_file("victim.sh", _SLEEP_SCRIPT)
-        aggressor = cluster.write_file("aggressor.sh", _QUICK_SCRIPT)
-
-        victim_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", victim])
-        )
-        wait_job_state(cluster, victim_id, "R", timeout=30)
-        _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim initial")
-
-        aggressor_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", aggressor])
-        )
-        # Aggressor must be pending — the node is fully occupied by the victim.
-        wait_job_state(cluster, aggressor_id, "PD", timeout=30)
-        _assert_scontrol_state(cluster, aggressor_id, "PENDING", "aggressor before preemption")
-
-        cluster.scontrol("update", f"JobId={aggressor_id}", "Priority=1000000")
+        victim_id = _run_victim(cluster, node, "cancel")
+        aggressor_id = _queue_aggressor(cluster, node, "cancel")
 
         try:
             # Victim must be cancelled.
             terminal = wait_job(cluster, victim_id, timeout=_WAIT_PREEMPT)
             assert terminal in ("CA", "GONE"), (
-                f"victim should have been cancelled by the higher-priority aggressor; got {terminal!r}"
+                f"victim should have been cancelled by the higher-QOS aggressor; got {terminal!r}"
             )
             if terminal != "GONE":
                 _assert_scontrol_state(cluster, victim_id, "CANCELLED", "victim after preemption")
@@ -128,27 +188,15 @@ class TestRequeueMode:
 
     @pytest.fixture
     def cluster_config_overrides(self):
-        return {**_AUTH_ROOT, "partitions": [{**_PARTITION, "preempt_mode": "requeue"}]}
+        return _config("requeue")
 
-    def test_preempt_mode_requeue_returns_job_to_pending(self, cluster):
+    def test_preempt_mode_requeue_returns_job_to_pending(self, accounting_cluster):
+        cluster = accounting_cluster
         node = cluster.node_names[0]
+        _create_qos_pair(cluster)
 
-        victim = cluster.write_file("victim.sh", _SLEEP_SCRIPT)
-        aggressor = cluster.write_file("aggressor.sh", _QUICK_SCRIPT)
-
-        victim_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", victim])
-        )
-        wait_job_state(cluster, victim_id, "R", timeout=30)
-        _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim initial")
-
-        aggressor_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", aggressor])
-        )
-        wait_job_state(cluster, aggressor_id, "PD", timeout=30)
-        _assert_scontrol_state(cluster, aggressor_id, "PENDING", "aggressor before preemption")
-
-        cluster.scontrol("update", f"JobId={aggressor_id}", "Priority=1000000")
+        victim_id = _run_victim(cluster, node, "requeue")
+        aggressor_id = _queue_aggressor(cluster, node, "requeue")
 
         try:
             # Victim must be requeued (PD), not cancelled.
@@ -187,27 +235,15 @@ class TestSuspendMode:
 
     @pytest.fixture
     def cluster_config_overrides(self):
-        return {**_AUTH_ROOT, "partitions": [{**_PARTITION, "preempt_mode": "suspend"}]}
+        return _config("suspend")
 
-    def test_preempt_mode_suspend_freezes_job_and_retains_node(self, cluster):
+    def test_preempt_mode_suspend_freezes_job_and_retains_node(self, accounting_cluster):
+        cluster = accounting_cluster
         node = cluster.node_names[0]
+        _create_qos_pair(cluster)
 
-        victim = cluster.write_file("victim.sh", _SLEEP_SCRIPT)
-        aggressor = cluster.write_file("aggressor.sh", _QUICK_SCRIPT)
-
-        victim_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", victim])
-        )
-        wait_job_state(cluster, victim_id, "R", timeout=30)
-        _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim initial")
-
-        aggressor_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", aggressor])
-        )
-        wait_job_state(cluster, aggressor_id, "PD", timeout=30)
-        _assert_scontrol_state(cluster, aggressor_id, "PENDING", "aggressor before preemption")
-
-        cluster.scontrol("update", f"JobId={aggressor_id}", "Priority=1000000")
+        victim_id = _run_victim(cluster, node, "suspend")
+        aggressor_id = _queue_aggressor(cluster, node, "suspend")
 
         try:
             # Victim must be suspended (S) — frozen but NOT terminated.
@@ -233,33 +269,33 @@ class TestSuspendMode:
 
 
 class TestPreemptOff:
-    """preempt_mode=off: no running job may be evicted, regardless of how high the
-    pending job's priority is set."""
+    """preempt_mode=off: no running job may be evicted.
+
+    Everything else that gates preemption is deliberately satisfied here — the
+    cluster runs preempt_type=qos_priority, the hunter QOS allow-lists the victim
+    QOS and outranks it 100x, and the pending job is boosted far past the victim's
+    raw priority. preempt_mode=off is the single remaining reason nothing happens,
+    so this test cannot pass by accident of an unconfigured gate.
+    """
 
     @pytest.fixture
     def cluster_config_overrides(self):
-        return {**_AUTH_ROOT, "partitions": [{**_PARTITION, "preempt_mode": "off"}]}
+        return _config("off")
 
-    def test_preempt_mode_off_blocks_preemption(self, cluster):
+    def test_preempt_mode_off_blocks_preemption(self, accounting_cluster):
+        cluster = accounting_cluster
         node = cluster.node_names[0]
+        _create_qos_pair(cluster)
 
-        victim = cluster.write_file("victim.sh", _SLEEP_SCRIPT)
-        aggressor = cluster.write_file("aggressor.sh", _QUICK_SCRIPT)
+        victim_id = _run_victim(cluster, node, "off")
+        aggressor_id = _queue_aggressor(cluster, node, "off", _SLEEP_SCRIPT)
 
-        victim_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", victim])
-        )
-        wait_job_state(cluster, victim_id, "R", timeout=30)
-        _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim initial")
-
-        aggressor_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", aggressor])
-        )
         # Confirm contention is real before we test that nothing changes.
         wait_job_state(cluster, aggressor_id, "PD", timeout=30)
         _assert_scontrol_state(cluster, aggressor_id, "PENDING", "aggressor before guard")
 
-        cluster.scontrol("update", f"JobId={aggressor_id}", "Priority=1000000")
+        preempted_before = cluster.sdiag_jobs_preempted()
+        cluster.scontrol("update", f"JobId={aggressor_id}", f"Priority={_AGGRESSOR_PRIORITY}")
 
         try:
             # Let the scheduler run many cycles; nothing should change.
@@ -267,165 +303,90 @@ class TestPreemptOff:
 
             sq = cluster.squeue_all()
             assert job_state(sq, victim_id) == "R", (
-                "victim must not be evicted when preemption is disabled on the partition"
+                "victim must not be evicted when preemption is disabled on the partition, "
+                "even though the QOS allow-list and QOS rank both permit it"
             )
             _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim after guard")
 
             assert job_state(sq, aggressor_id) == "PD", (
-                "aggressor must stay pending — it cannot preempt"
+                "aggressor must stay pending — preempt_mode=off blocks eviction"
             )
             _assert_scontrol_state(cluster, aggressor_id, "PENDING", "aggressor after guard")
+            assert cluster.sdiag_jobs_preempted() == preempted_before, (
+                "no preemption decision may be recorded when preempt_mode=off"
+            )
         finally:
             cluster.cli_allow_fail(["scancel", str(victim_id)])
             cluster.cli_allow_fail(["scancel", str(aggressor_id)])
 
 
-class TestPriorityThreshold:
-    """Preemption is gated on a meaningful priority gap between the running and pending job.
-    A pending job at the same priority as a running job must not displace it."""
+class TestQosRankGate:
+    """An allow-listed victim is evicted only when the pending job's QOS priority is
+    strictly higher. Equal QOS priority must not displace a running job, and a raw
+    job-priority boost cannot make up the difference.
+
+    Both tests here hold the allow-list, the partition mode, and the node contention
+    constant and vary only the hunter QOS priority, so the outcome can be attributed
+    to the rank comparison and nothing else.
+    """
 
     @pytest.fixture
     def cluster_config_overrides(self):
-        return {**_AUTH_ROOT, "partitions": [{**_PARTITION, "preempt_mode": "cancel"}]}
+        return _config("cancel")
 
-    def test_equal_priority_does_not_trigger_preemption(self, cluster):
+    def test_equal_qos_priority_does_not_preempt(self, accounting_cluster):
+        cluster = accounting_cluster
         node = cluster.node_names[0]
+        # Same rank on both sides; the allow-list still names the victim, so the
+        # strict-greater-than comparison is the only thing left to block eviction.
+        _create_qos_pair(cluster, hunter_priority=100, victim_priority=100)
 
-        victim = cluster.write_file("victim.sh", _SLEEP_SCRIPT)
-        competitor = cluster.write_file("competitor.sh", _SLEEP_SCRIPT)
+        victim_id = _run_victim(cluster, node, "rank-equal")
+        aggressor_id = _queue_aggressor(cluster, node, "rank-equal", _SLEEP_SCRIPT)
 
-        victim_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", victim])
-        )
-        wait_job_state(cluster, victim_id, "R", timeout=30)
-        _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim initial")
+        wait_job_state(cluster, aggressor_id, "PD", timeout=30)
+        _assert_scontrol_state(cluster, aggressor_id, "PENDING", "aggressor before guard")
 
-        competitor_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", competitor])
-        )
-        # No priority manipulation: both jobs are submitted under identical conditions
-        # and must receive the same effective priority from the scheduler.
-        wait_job_state(cluster, competitor_id, "PD", timeout=30)
-        _assert_scontrol_state(cluster, competitor_id, "PENDING", "competitor before guard")
+        preempted_before = cluster.sdiag_jobs_preempted()
+        # Job priority is not part of the eligibility rule any more; boosting it
+        # here fails the test loudly if that ever regresses.
+        cluster.scontrol("update", f"JobId={aggressor_id}", f"Priority={_AGGRESSOR_PRIORITY}")
 
         try:
             time.sleep(_GUARD_SECS)
 
             sq = cluster.squeue_all()
             assert job_state(sq, victim_id) == "R", (
-                "running job must not be displaced by a pending job at equal priority"
+                "an allow-listed victim at equal QOS priority must not be displaced, "
+                "not even by a pending job with a far higher raw job priority"
             )
             _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim after guard")
 
-            assert job_state(sq, competitor_id) == "PD", (
-                "equal-priority pending job must wait its turn"
+            assert job_state(sq, aggressor_id) == "PD", (
+                "the equal-rank aggressor must wait its turn"
             )
-            _assert_scontrol_state(cluster, competitor_id, "PENDING", "competitor after guard")
-        finally:
-            cluster.cli_allow_fail(["scancel", str(victim_id)])
-            cluster.cli_allow_fail(["scancel", str(competitor_id)])
-
-    def test_sufficiently_higher_priority_triggers_preemption(self, cluster):
-        node = cluster.node_names[0]
-
-        victim = cluster.write_file("victim.sh", _SLEEP_SCRIPT)
-        aggressor = cluster.write_file("aggressor.sh", _QUICK_SCRIPT)
-
-        victim_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", victim])
-        )
-        wait_job_state(cluster, victim_id, "R", timeout=30)
-        _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim initial")
-
-        aggressor_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", aggressor])
-        )
-        wait_job_state(cluster, aggressor_id, "PD", timeout=30)
-        _assert_scontrol_state(cluster, aggressor_id, "PENDING", "aggressor before preemption")
-
-        # Only boost the aggressor. The gap between the victim's default priority
-        # and 1000000 is large enough to cross the preemption threshold.
-        cluster.scontrol("update", f"JobId={aggressor_id}", "Priority=1000000")
-
-        try:
-            terminal = wait_job(cluster, victim_id, timeout=_WAIT_PREEMPT)
-            assert terminal in ("CA", "GONE"), (
-                f"victim should be preempted by the much-higher-priority aggressor; got {terminal!r}"
+            _assert_scontrol_state(cluster, aggressor_id, "PENDING", "aggressor after guard")
+            assert cluster.sdiag_jobs_preempted() == preempted_before, (
+                "no preemption decision may be recorded between QOS of equal priority"
             )
-            if terminal != "GONE":
-                _assert_scontrol_state(cluster, victim_id, "CANCELLED", "victim after preemption")
-
-            wait_job_state(cluster, aggressor_id, "R", timeout=30)
-            _assert_scontrol_state(cluster, aggressor_id, "RUNNING", "aggressor after preemption")
-
-            # Cancelled victim must not reappear while aggressor holds the node.
-            recheck = job_state(cluster.squeue_all(), victim_id)
-            assert recheck not in ("PD", "R"), (
-                f"cancelled victim must not re-enter the queue; got {recheck!r}"
-            )
-
-            final = wait_job(cluster, aggressor_id, timeout=30)
-            assert final == "CD", f"aggressor must complete successfully; got {final!r}"
         finally:
             cluster.cli_allow_fail(["scancel", str(victim_id)])
             cluster.cli_allow_fail(["scancel", str(aggressor_id)])
 
-
-class TestPriorityTier:
-    """A job on a higher priority_tier partition must gain enough effective priority
-    to preempt a running job on a lower-tier partition, with no raw priority
-    manipulation required — the tier alone must be the deciding factor."""
-
-    @pytest.fixture
-    def cluster_config_overrides(self):
-        return {
-            **_AUTH_ROOT,
-            "partitions": [
-                {
-                    "name": "standard",
-                    "state": "UP",
-                    "nodes": "ALL",
-                    "max_time": "24:00:00",
-                    "default_time": "10:00",
-                    "priority_tier": 1,
-                    "preempt_mode": "cancel",
-                },
-                {
-                    "name": "premium",
-                    "state": "UP",
-                    "nodes": "ALL",
-                    "max_time": "24:00:00",
-                    "default_time": "10:00",
-                    "priority_tier": 3,
-                    "preempt_mode": "cancel",
-                },
-            ]
-        }
-
-    def test_priority_tier_drives_preemption_across_partitions(self, cluster):
+    def test_strictly_higher_qos_priority_preempts(self, accounting_cluster):
+        cluster = accounting_cluster
         node = cluster.node_names[0]
+        # Identical to the test above apart from the hunter's QOS rank. No raw
+        # priority boost, so QOS rank is demonstrably what carries the decision.
+        _create_qos_pair(cluster, hunter_priority=10000, victim_priority=100)
 
-        victim = cluster.write_file("victim.sh", _SLEEP_SCRIPT)
-        aggressor = cluster.write_file("aggressor.sh", _QUICK_SCRIPT)
-
-        victim_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", "-p", "standard", victim])
-        )
-        wait_job_state(cluster, victim_id, "R", timeout=30)
-        _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim initial")
-
-        # Same node, same raw priority — only the partition tier differs.
-        aggressor_id = parse_job_id(
-            cluster.sbatch(["-N1", "--exclusive", f"--nodelist={node}", "-p", "premium", aggressor])
-        )
-        wait_job_state(cluster, aggressor_id, "PD", timeout=30)
-        _assert_scontrol_state(cluster, aggressor_id, "PENDING", "aggressor before preemption")
+        victim_id = _run_victim(cluster, node, "rank-higher")
+        aggressor_id = _queue_aggressor(cluster, node, "rank-higher")
 
         try:
             terminal = wait_job(cluster, victim_id, timeout=_WAIT_PREEMPT)
             assert terminal in ("CA", "GONE"), (
-                f"standard-tier job must be preempted by a premium-tier job of equal raw priority; "
-                f"got {terminal!r}"
+                f"victim should be preempted by the higher-ranked QOS; got {terminal!r}"
             )
             if terminal != "GONE":
                 _assert_scontrol_state(cluster, victim_id, "CANCELLED", "victim after preemption")

--- a/tests/native_host/e2e/test_preemption_multinode.py
+++ b/tests/native_host/e2e/test_preemption_multinode.py
@@ -7,16 +7,24 @@ Black-box end-to-end tests for preemption of multi-node jobs.
 When a job spans multiple compute nodes, preemption must reach every node agent —
 if even one agent misses the signal, that node stays occupied and the incoming
 job cannot start. These tests verify the outcome from the outside: once the
-multi-node victim is evicted, the higher-priority job must be able to acquire
-all nodes and run to completion.
+multi-node victim is evicted, the higher-QOS job must be able to acquire all
+nodes and run to completion.
 
 Every state transition is verified through both squeue (the primary user-facing
 queue view) and scontrol show job (the detailed record view) so that a divergence
 between the two surfaces is caught as a test failure rather than silently masked.
 
+Requires:
+  - at least 2 nodes in SPUR_TEST_NODES
+  - preempt_type=qos_priority (scheduler config); preemption is off otherwise
+  - a QOS pair where the aggressor allow-lists the victim and outranks it
+  - Postgres on node 0 (accounting_cluster fixture, skips when Docker is absent)
+
 NOTE: REST API cross-verification is not yet covered here — the e2e infrastructure
 does not have a REST client helper. That is tracked as a separate gap.
 """
+
+import time
 
 import pytest
 
@@ -27,6 +35,10 @@ _QUICK_SCRIPT = "#!/bin/bash\nsleep 5\n"
 
 _WAIT_PREEMPT = 30
 _WAIT_RUN = 60
+
+# QOS cache refreshes on the accounting interval; a freshly added QOS needs a
+# cycle before the scheduler acts on it.
+_CACHE_WARMUP_SECS = 15
 
 
 # Required when the test runner SSHes in as root: spurd refuses to execute jobs
@@ -45,7 +57,7 @@ def _assert_scontrol_state(cluster, job_id: int, expected: str, label: str = "")
 
 class TestMultiNodePreemption:
     """A running job that spans multiple nodes must be fully preempted — every
-    node freed — so that a higher-priority job can acquire them all."""
+    node freed — so that a higher-QOS job can acquire them all."""
 
     @pytest.fixture
     def cluster_config_overrides(self):
@@ -61,20 +73,36 @@ class TestMultiNodePreemption:
                     "preempt_mode": "cancel",
                 }
             ],
+            "scheduler": {
+                "preempt_type": "qos_priority",
+            },
             **_AUTH_ROOT,
         }
 
-    def test_preempted_multinode_job_frees_all_nodes(self, multi_node_cluster):
+    def test_preempted_multinode_job_frees_all_nodes(self, accounting_cluster):
         """When a multi-node victim is cancelled by preemption, every node it
         held must be released so that a second multi-node aggressor can start."""
-        c = multi_node_cluster
+        c = accounting_cluster
         n_nodes = len(c.node_names)
+        if n_nodes < 2:
+            pytest.skip(
+                f"multi-node preemption requires at least 2 nodes in "
+                f"SPUR_TEST_NODES (got {n_nodes})"
+            )
+
+        c.sacctmgr(["add", "qos", "name=mn-victim-qos", "priority=100",
+                    "preemptmode=cancel"])
+        c.sacctmgr(["add", "qos", "name=mn-hunter-qos", "priority=10000",
+                    "preempt=mn-victim-qos"])
+        time.sleep(_CACHE_WARMUP_SECS)
 
         victim = c.write_file("mn-victim.sh", _SLEEP_SCRIPT)
         aggressor = c.write_file("mn-aggressor.sh", _QUICK_SCRIPT)
 
         # Victim claims all available nodes.
-        victim_id = parse_job_id(c.sbatch([f"-N{n_nodes}", "--exclusive", victim]))
+        victim_id = parse_job_id(
+            c.sbatch([f"-N{n_nodes}", "--exclusive", "-q", "mn-victim-qos", victim])
+        )
         wait_job_state(c, victim_id, "R", timeout=60)
         _assert_scontrol_state(c, victim_id, "RUNNING", "victim initial")
 
@@ -86,13 +114,10 @@ class TestMultiNodePreemption:
 
         # Aggressor also wants all nodes — it can only start once every agent
         # receives and processes the preemption signal.
-        aggressor_id = parse_job_id(c.sbatch([f"-N{n_nodes}", "--exclusive", aggressor]))
-
-        # All nodes are occupied; aggressor must be pending before we trigger preemption.
-        wait_job_state(c, aggressor_id, "PD", timeout=30)
-        _assert_scontrol_state(c, aggressor_id, "PENDING", "aggressor before preemption")
-
-        c.scontrol("update", f"JobId={aggressor_id}", "Priority=1000000")
+        aggressor_id = parse_job_id(
+            c.sbatch([f"-N{n_nodes}", "--exclusive", "-q", "mn-hunter-qos", aggressor])
+        )
+        assert aggressor_id is not None, "aggressor submit failed"
 
         try:
             terminal = wait_job(c, victim_id, timeout=_WAIT_PREEMPT)

--- a/tests/native_host/e2e/test_preemption_qos_hierarchy.py
+++ b/tests/native_host/e2e/test_preemption_qos_hierarchy.py
@@ -19,8 +19,11 @@ Covers four scenarios:
    was set via scontrol update-partition, confirming the fix for the
    reconfigure-wipe bug.
 
-Tests 1 and 2 require Postgres (accounting_cluster fixture, skips when Docker
-is unavailable). Tests 3 and 4 only need the base cluster fixture.
+Preemption only runs under preempt_type=qos_priority, so tests 1-3 set it and
+build a QOS pair; whatever they are isolating (the allow-list, the exempt window)
+is then the only gate left unsatisfied. Tests 1-3 require Postgres
+(accounting_cluster fixture, skips when Docker is unavailable). Test 4 touches no
+jobs and only needs the base cluster fixture.
 """
 
 import time
@@ -35,9 +38,9 @@ _AUTH_ALLOW_ROOT = {"auth": {"plugin": "none", "allow_root_jobs": True}}
 
 
 class TestQosPreemptHierarchyBlocked:
-    """With preempt_type=qos_priority, a high-priority job whose QOS has an
-    empty preempt allow-list must NOT preempt a running job, even with a
-    priority gap well above 2×."""
+    """With preempt_type=qos_priority, a high-rank job whose QOS has an empty
+    preempt allow-list must NOT preempt a running job, even with a 1000x QOS
+    priority advantage."""
 
     @pytest.fixture
     def cluster_config_overrides(self):
@@ -213,13 +216,22 @@ class TestPreemptExemptTime:
             ],
             "scheduler": {
                 "preempt_exempt_time": self.EXEMPT_SECS,
+                "preempt_type": "qos_priority",
             },
             **_AUTH_ALLOW_ROOT,
         }
 
-    def test_exempt_window_protects_then_expires(self, cluster):
-        c = cluster
+    def test_exempt_window_protects_then_expires(self, accounting_cluster):
+        c = accounting_cluster
         node0 = c.node_names[0]
+
+        # Everything except the exempt window permits preemption here: the
+        # hunter QOS allow-lists the victim QOS and outranks it 100x.
+        c.sacctmgr(["add", "qos", "name=exempt-low", "priority=100",
+                    "preemptmode=cancel"])
+        c.sacctmgr(["add", "qos", "name=exempt-high", "priority=10000",
+                    "preempt=exempt-low"])
+        time.sleep(15)  # wait past QoS cache refresh floor
 
         low_id = None
         try:
@@ -228,24 +240,23 @@ class TestPreemptExemptTime:
             )
             low_out = c.sbatch(
                 ["-J", "exempt-low", "-N", "1", f"--nodelist={node0}",
-                 "--exclusive", low_script]
+                 "--exclusive", "-q", "exempt-low", low_script]
             )
             low_id = parse_job_id(low_out)
             assert low_id is not None, f"submit failed:\n{low_out}"
             wait_job_state(c, low_id, "R", timeout=60)
 
-            # Submit the high-priority job immediately after low starts.
+            # Submit the high-QOS job immediately after low starts, so the whole
+            # exempt window is measured from a point where a preemptor is queued.
             high_script = c.write_file(
                 "exempt-high.sh", "#!/bin/bash\nsleep 2\n"
             )
             high_out = c.sbatch(
                 ["-J", "exempt-high", "-N", "1", f"--nodelist={node0}",
-                 "--exclusive", high_script]
+                 "--exclusive", "-q", "exempt-high", high_script]
             )
             high_id = parse_job_id(high_out)
             assert high_id is not None, f"submit failed:\n{high_out}"
-            # Force high's priority above the 2× threshold.
-            c.scontrol("update", f"JobId={high_id}", "Priority=1000000")
 
             # Within the exempt window: low must still be running.
             time.sleep(self.SAFE_WAIT_SECS)
@@ -260,11 +271,12 @@ class TestPreemptExemptTime:
             wait_job_state(c, low_id, "CA", timeout=30)
             high_state = wait_job(c, high_id, timeout=30)
             assert high_state == "CD", (
-                f"high-priority job did not complete after exempt window: {high_state}"
+                f"high-QOS job did not complete after exempt window: {high_state}"
             )
         finally:
             if low_id is not None:
                 c.cli_allow_fail(["scancel", str(low_id)])
+            c.cli_allow_fail(["scancel", "--name=exempt-high"])
 
 
 class TestReconfigurePreservesExemptTime:

--- a/tests/native_host/e2e/test_preemption_same_qos.py
+++ b/tests/native_host/e2e/test_preemption_same_qos.py
@@ -5,18 +5,20 @@
 Black-box end-to-end tests for preemption between two jobs in the *same* QOS.
 
 Under preempt_type=qos_priority a pending job may only evict a running job when
-the pending job's QOS lists the running job's QOS in its `preempt` allow-list.
-Spur applies that check uniformly, with no special case for the two QOS being
-identical — so a QOS naming *itself* is what enables same-QOS preemption.
+the pending job's QOS lists the running job's QOS in its `preempt` allow-list and
+outranks it. Spur carves out the identical-QOS case from the rank comparison —
+where a strict rank test could never hold — so a QOS naming *itself* is what
+enables same-QOS preemption.
 
 This differs from Slurm, where the allow-list is consulted only on the
 different-QOS branch and same-QOS preemption is gated by a dedicated
 PreemptMode=WITHIN flag; there, self-listing is a no-op.
 
-Every test here holds the priority gap constant and varies only the allow-list,
-so a passing result cannot be explained by the priority threshold instead. That
-matters: an existing test in test_burst_qos.py exercises two *different* burst
-QOS with equal priority, where either gate alone would produce the same outcome.
+Every test here holds the QOS rank constant and varies only the allow-list, so a
+passing result can only be explained by the allow-list. Both jobs are additionally
+submitted with a large raw priority boost on the pending side, which the current
+policy ignores entirely — if raw job priority ever regains influence over
+preemption eligibility, these tests fail loudly rather than drift.
 
 Requires:
   - preempt_type=qos_priority (scheduler config) so allow-list gating applies
@@ -39,8 +41,8 @@ _GUARD_SECS = 12
 # a freshly added or modified QOS needs a cycle before the scheduler sees it.
 _CACHE_WARMUP_SECS = 15
 
-# Large enough to clear the 2x effective-priority threshold against a job left
-# at the default base priority, matching how test_preemption_modes.py boosts.
+# Raw job priority is not part of the eligibility rule. It is boosted anyway so
+# that a regression re-introducing a job-priority gate is caught here.
 _AGGRESSOR_PRIORITY = 1_000_000
 
 _BASE_CONFIG = {
@@ -74,12 +76,15 @@ def _assert_scontrol_state(cluster, job_id: int, expected: str, label: str = "")
 
 def _start_pair(cluster, qos: str, node: str, prefix: str):
     """Run a victim under *qos*, then queue an aggressor in the same QOS behind
-    it and boost the aggressor past the 2x preemption threshold.
+    it and boost the aggressor's raw job priority far past the victim's.
 
-    Returns (victim_id, aggressor_id, preempted_before) with the victim RUNNING
-    and the aggressor PENDING, both asserted. preempted_before is the `Jobs
-    preempted` counter sampled just before the boost, so callers can assert
-    whether the scheduler actually acted on the allow-list gate.
+    Returns (victim_id, aggressor_id, preempted_before) with the victim RUNNING.
+    preempted_before is sampled while only the victim exists: once the aggressor
+    is queued the scheduler may act on it immediately, so a later sample can
+    already include this pair's own preemption.
+
+    The caller asserts the aggressor's state — under a self-listing QOS it may
+    never be observably PENDING.
     """
     victim_script = cluster.write_file(f"{prefix}-victim.sh", _SLEEP_SCRIPT)
     victim_id = parse_job_id(
@@ -91,6 +96,8 @@ def _start_pair(cluster, qos: str, node: str, prefix: str):
     wait_job_state(cluster, victim_id, "R", timeout=30)
     _assert_scontrol_state(cluster, victim_id, "RUNNING", "victim initial")
 
+    preempted_before = cluster.sdiag_jobs_preempted()
+
     aggressor_script = cluster.write_file(f"{prefix}-aggressor.sh", _QUICK_SCRIPT)
     aggressor_id = parse_job_id(
         cluster.sbatch([
@@ -98,21 +105,17 @@ def _start_pair(cluster, qos: str, node: str, prefix: str):
         ])
     )
     assert aggressor_id is not None, "aggressor submit failed"
-    wait_job_state(cluster, aggressor_id, "PD", timeout=30)
-    _assert_scontrol_state(cluster, aggressor_id, "PENDING", "aggressor before boost")
 
-    preempted_before = cluster.sdiag_jobs_preempted()
-
-    # Both jobs share a QOS, so their base priorities are identical and no gap
-    # exists until the aggressor is boosted. Boosting isolates the allow-list as
-    # the only remaining variable between this test and its counterpart.
+    # Both jobs share a QOS, so nothing but the allow-list differs between this
+    # test and its counterpart. The boost makes the raw job priorities differ too,
+    # which must not change the outcome either way.
     cluster.scontrol("update", f"JobId={aggressor_id}", f"Priority={_AGGRESSOR_PRIORITY}")
     return victim_id, aggressor_id, preempted_before
 
 
 class TestSameQosBlockedWithoutSelfListing:
     """A QOS that does not list itself must not preempt its own jobs, even when
-    the pending job's priority is far above the 2x threshold."""
+    the pending job carries a far higher raw job priority."""
 
     @pytest.fixture
     def cluster_config_overrides(self):
@@ -133,13 +136,16 @@ class TestSameQosBlockedWithoutSelfListing:
                 c, "solo-burst", node, "same-qos-block"
             )
 
-            # The priority gap is satisfied; only the allow-list stands in the
-            # way. Nothing must change over several scheduler cycles.
+            wait_job_state(c, aggressor_id, "PD", timeout=30)
+
+            # The same-QOS carve-out would permit this pairing; only the empty
+            # allow-list stands in the way. Nothing must change over several
+            # scheduler cycles.
             time.sleep(_GUARD_SECS)
             sq = c.squeue_all()
             assert job_state(sq, victim_id) == "R", (
                 "a QOS with an empty preempt allow-list must not evict its own job, "
-                "even with a priority gap well past the 2x threshold"
+                "even when the pending job's raw priority is far higher"
             )
             _assert_scontrol_state(c, victim_id, "RUNNING", "victim after guard")
             assert job_state(sq, aggressor_id) == "PD", (
@@ -157,7 +163,7 @@ class TestSameQosBlockedWithoutSelfListing:
 
 class TestSameQosAllowedWhenSelfListed:
     """A QOS that names itself in its own preempt allow-list may evict its own
-    jobs, given the usual priority gap.
+    jobs, even though the two QOS priorities are necessarily equal.
 
     Same cluster config, same priority boost, same QOS priority as the blocked
     case above — the single difference is `preempt=solo-burst-open`.
@@ -221,9 +227,10 @@ class TestEmptyAllowListsDisablePreemptionClusterWide:
     """With preempt_type=qos_priority and every allow-list left empty, no job may
     preempt any other regardless of priority or QOS.
 
-    This is the recommended stop-the-bleeding configuration for a cluster whose
-    preemption is misbehaving, so it is worth an explicit test: flipping one
-    config field turns already-blank allow-lists into an effective kill switch.
+    A cluster whose preemption is misbehaving can be quieted either by clearing
+    preempt_type outright or, if the gate must stay on for other QOS, by emptying
+    the allow-lists. This test pins the second route: with the gate on, blank
+    allow-lists are still a complete kill switch.
     """
 
     @pytest.fixture
@@ -234,8 +241,8 @@ class TestEmptyAllowListsDisablePreemptionClusterWide:
         c = accounting_cluster
         node = c.node_names[0]
 
-        # A 100x QOS priority gap across two distinct QOS, neither listing the
-        # other. Under preempt_type=none this pairing preempts readily.
+        # A 100x QOS rank gap across two distinct QOS, neither listing the other.
+        # Add `preempt=killswitch-low` to the high QOS and this pairing evicts.
         c.sacctmgr(["add", "qos", "name=killswitch-low", "priority=100", "preemptmode=cancel"])
         c.sacctmgr(["add", "qos", "name=killswitch-high", "priority=10000", "preemptmode=cancel"])
         time.sleep(_CACHE_WARMUP_SECS)

--- a/tests/native_host/e2e/test_qos_preemption.py
+++ b/tests/native_host/e2e/test_qos_preemption.py
@@ -8,8 +8,11 @@ Every state transition is verified through both squeue (the primary user-facing
 queue view) and scontrol show job (the detailed record view) so that a divergence
 between the two surfaces is caught as a test failure rather than silently masked.
 
-Requires Postgres on node 0 (the accounting_cluster fixture, which skips
-when Docker is unavailable).
+Requires:
+  - preempt_type=qos_priority (scheduler config); preemption is off otherwise,
+    and eligibility is then decided by the QOS allow-list plus QOS rank
+  - Postgres on node 0 (the accounting_cluster fixture, which skips when Docker
+    is unavailable)
 
 NOTE: REST API cross-verification is not yet covered here — the e2e infrastructure
 does not have a REST client helper. That is tracked as a separate gap.
@@ -26,6 +29,12 @@ from cluster import job_state, parse_job_id, wait_job, wait_job_state
 # as uid 0 unless this is explicitly enabled.
 _AUTH_ROOT = {"auth": {"allow_root_jobs": True}}
 
+# QOS cache refreshes on the accounting interval; a freshly added QOS needs a
+# cycle before the scheduler acts on it.
+_CACHE_WARMUP_SECS = 15
+
+_GUARD_SECS = 12
+
 
 def _assert_scontrol_state(cluster, job_id: int, expected: str, label: str = "") -> None:
     """Assert JobState=<expected> appears in scontrol show job output."""
@@ -38,9 +47,9 @@ def _assert_scontrol_state(cluster, job_id: int, expected: str, label: str = "")
 
 class TestQosPriorityPreemption:
     """A low-QOS running job must be preempted by a high-QOS pending job
-    contending for the same exclusive node, driven purely by the QOS
-    priority delta and the low QOS's preempt_mode override, once the
-    partition has opted into preemption at all."""
+    contending for the same exclusive node, driven by the high QOS's
+    allow-list entry for the low QOS plus its higher QOS rank, and evicted
+    according to the low QOS's preempt_mode override."""
 
     @pytest.fixture
     def cluster_config_overrides(self):
@@ -60,6 +69,9 @@ class TestQosPriorityPreemption:
                     "preempt_mode": "cancel",
                 }
             ],
+            "scheduler": {
+                "preempt_type": "qos_priority",
+            },
             **_AUTH_ROOT,
         }
 
@@ -68,9 +80,9 @@ class TestQosPriorityPreemption:
         node0 = c.node_names[0]
 
         c.sacctmgr(["add", "qos", "name=low", "priority=-1000", "preemptmode=requeue"])
-        c.sacctmgr(["add", "qos", "name=high", "priority=100000"])
+        c.sacctmgr(["add", "qos", "name=high", "priority=100000", "preempt=low"])
         # Wait past the QoS cache refresh floor (10s) before submitting.
-        time.sleep(15)
+        time.sleep(_CACHE_WARMUP_SECS)
 
         low_id = None
         high_id = None
@@ -129,8 +141,6 @@ class TestQosPreemptModeOverride:
     disagree: a victim whose QOS says cancel must be cancelled even when the partition
     would otherwise requeue it."""
 
-    _CACHE_WARMUP_SECS = 15
-
     @pytest.fixture
     def cluster_config_overrides(self):
         return {
@@ -145,6 +155,9 @@ class TestQosPreemptModeOverride:
                     "preempt_mode": "requeue",
                 }
             ],
+            "scheduler": {
+                "preempt_type": "qos_priority",
+            },
             **_AUTH_ROOT,
         }
 
@@ -155,8 +168,8 @@ class TestQosPreemptModeOverride:
         node = c.node_names[0]
 
         c.sacctmgr(["add", "qos", "name=fragile", "priority=-1000", "preemptmode=cancel"])
-        c.sacctmgr(["add", "qos", "name=strong",  "priority=100000"])
-        time.sleep(self._CACHE_WARMUP_SECS)
+        c.sacctmgr(["add", "qos", "name=strong",  "priority=100000", "preempt=fragile"])
+        time.sleep(_CACHE_WARMUP_SECS)
 
         victim_id = None
         aggressor_id = None
@@ -215,8 +228,6 @@ class TestQosPreemptModeOff:
     takes effect. To prevent a QOS's jobs from being preempted, the QOS must
     simply not appear in any preemptor QOS's allow-list."""
 
-    _CACHE_WARMUP_SECS = 15
-
     @pytest.fixture
     def cluster_config_overrides(self):
         return {
@@ -231,6 +242,9 @@ class TestQosPreemptModeOff:
                     "preempt_mode": "cancel",
                 }
             ],
+            "scheduler": {
+                "preempt_type": "qos_priority",
+            },
             **_AUTH_ROOT,
         }
 
@@ -241,8 +255,8 @@ class TestQosPreemptModeOff:
         node = c.node_names[0]
 
         c.sacctmgr(["add", "qos", "name=defer-off", "priority=-500", "preemptmode=off"])
-        c.sacctmgr(["add", "qos", "name=hunter",    "priority=100000"])
-        time.sleep(self._CACHE_WARMUP_SECS)
+        c.sacctmgr(["add", "qos", "name=hunter", "priority=100000", "preempt=defer-off"])
+        time.sleep(_CACHE_WARMUP_SECS)
 
         victim_id = None
         aggressor_id = None
@@ -279,9 +293,99 @@ class TestQosPreemptModeOff:
             final = wait_job(c, aggressor_id, timeout=30)
             assert final == "CD", f"aggressor must complete; got {final!r}"
         finally:
-            if victim_id is not None:
-                c.cli_allow_fail(["scancel", str(victim_id)])
-            if aggressor_id is not None:
-                c.cli_allow_fail(["scancel", str(aggressor_id)])
-            if aggressor_id is not None:
-                c.cli_allow_fail(["scancel", str(aggressor_id)])
+            for jid in (victim_id, aggressor_id):
+                if jid is not None:
+                    c.cli_allow_fail(["scancel", str(jid)])
+
+
+class TestPreemptTypeUnsetDisablesPreemption:
+    """Preemption is off unless `scheduler.preempt_type = qos_priority`.
+
+    This is the global gate, and it is the one thing left unset here: the
+    partition allows cancellation, the hunter QOS allow-lists the victim QOS
+    and outranks it 100x, and the pending job is boosted far past the victim's
+    raw priority. That is exactly the configuration that evicts in
+    TestQosPreemptModeOverride, so nothing may happen here for any reason other
+    than the absent preempt_type.
+    """
+
+    # Deliberately not part of the eligibility rule any more; boosting it here
+    # fails the test loudly if raw job priority ever regains the ability to
+    # drive preemption on its own.
+    _AGGRESSOR_PRIORITY = 1_000_000
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {
+            "partitions": [
+                {
+                    "name": "default",
+                    "state": "UP",
+                    "default": True,
+                    "nodes": "ALL",
+                    "max_time": "24:00:00",
+                    "default_time": "10:00",
+                    "preempt_mode": "cancel",
+                }
+            ],
+            # No "scheduler" section at all: preempt_type falls back to its
+            # default, which disables preemption entirely.
+            **_AUTH_ROOT,
+        }
+
+    def test_absent_preempt_type_blocks_an_otherwise_valid_preemption(
+        self, accounting_cluster
+    ):
+        c = accounting_cluster
+        node = c.node_names[0]
+
+        c.sacctmgr(["add", "qos", "name=gate-victim", "priority=100",
+                    "preemptmode=cancel"])
+        c.sacctmgr(["add", "qos", "name=gate-hunter", "priority=10000",
+                    "preempt=gate-victim"])
+        time.sleep(_CACHE_WARMUP_SECS)
+
+        victim_id = None
+        aggressor_id = None
+        try:
+            victim_script = c.write_file("gate-victim.sh", "#!/bin/bash\nsleep 600\n")
+            victim_id = parse_job_id(
+                c.sbatch(["-N1", "--exclusive", f"--nodelist={node}",
+                          "-q", "gate-victim", victim_script])
+            )
+            assert victim_id is not None, "victim submit failed"
+            wait_job_state(c, victim_id, "R", timeout=30)
+            _assert_scontrol_state(c, victim_id, "RUNNING", "victim initial")
+
+            aggressor_script = c.write_file("gate-hunter.sh", "#!/bin/bash\nsleep 600\n")
+            aggressor_id = parse_job_id(
+                c.sbatch(["-N1", "--exclusive", f"--nodelist={node}",
+                          "-q", "gate-hunter", aggressor_script])
+            )
+            assert aggressor_id is not None, "aggressor submit failed"
+            wait_job_state(c, aggressor_id, "PD", timeout=30)
+            _assert_scontrol_state(c, aggressor_id, "PENDING", "aggressor before guard")
+
+            preempted_before = c.sdiag_jobs_preempted()
+            c.scontrol("update", f"JobId={aggressor_id}",
+                       f"Priority={self._AGGRESSOR_PRIORITY}")
+
+            time.sleep(_GUARD_SECS)
+            sq = c.squeue_all()
+            assert job_state(sq, victim_id) == "R", (
+                "preemption must stay off while scheduler.preempt_type is unset, "
+                "even with a valid allow-list and a 100x QOS rank gap"
+            )
+            _assert_scontrol_state(c, victim_id, "RUNNING", "victim after guard")
+            assert job_state(sq, aggressor_id) == "PD", (
+                "the allow-listed, higher-ranked aggressor must wait while the "
+                "global preemption gate is off"
+            )
+            _assert_scontrol_state(c, aggressor_id, "PENDING", "aggressor after guard")
+            assert c.sdiag_jobs_preempted() == preempted_before, (
+                "no preemption decision may be recorded with preempt_type unset"
+            )
+        finally:
+            for jid in (victim_id, aggressor_id):
+                if jid is not None:
+                    c.cli_allow_fail(["scancel", str(jid)])


### PR DESCRIPTION
## Summary

Makes QoS-priority preemption an explicit, deterministic policy and removes the priority-gap heuristic that let fair-share and job age drive eviction.

Preemption is disabled unless `scheduler.preempt_type = "qos_priority"` (`"none"` is the default; `"off"` is accepted as a synonym). When enabled, a pending job may evict a running job only when the pending job's QoS allow-lists the victim's QoS **and** outranks it on the stable QoS `priority`.

A QoS that lists itself may preempt its own jobs, where a strict rank test can never hold. There, **submit order decides** — a pending job may only displace one submitted before it. Submit order never changes across a requeue, so a victim requeued by preemption can never turn around and preempt the job that displaced it; without that rule a self-listing QoS using `preemptmode=requeue` would ping-pong indefinitely.

```text
can_preempt =
  scheduler.preempt_type == qos_priority
  AND pending job needs a node the victim currently occupies
  AND (victim is not in an active reservation
       OR pending partition priority_tier > victim partition priority_tier)
  AND pending_qos.preempt contains victim_qos.name
  AND (pending_qos.name == victim_qos.name
       OR pending_qos.priority > victim_qos.priority)
  AND victim has been running at least its preempt_exempt_time
  AND resolved_action != off

resolved_action =
  victim_qos.preemptmode                    if it is not off
  else most aggressive preempt_mode among the victim's matched partitions
       (cancel > requeue > suspend > off)
```

Partition `preempt_mode` and QoS `preemptmode` both default to **unset** rather than `off`. Unset and `off` resolve identically — neither is a protection, and a QoS action overrides a partition `off` — so the distinction is purely diagnostic: you can now tell whether anyone configured the field. `scontrol show partition` reports `PreemptMode=NONE` when unset and `PreemptMode=OFF` when explicitly set; `sacctmgr show qos` leaves the column blank when unset. Setting `PreemptMode=NONE` (or an empty value) via `scontrol update` clears a partition back to unset.

An action must still be configured at one scope or the other for anything to be preempted. Both scopes now **reject** an unrecognized mode rather than silently reading it back as "no preemption" — previously a typo such as `preemptmode=cancle` was accepted and disabled preemption for that QoS.

| Global engine | Victim partition mode | Victim QoS mode | Allow-list + rank | Result |
| --- | --- | --- | --- | --- |
| `none` / `off` | any | any | any | No preemption |
| `qos_priority` | any | any | empty or excludes victim | No preemption |
| `qos_priority` | any | any | contains victim, but QoS rank not higher | No preemption |
| `qos_priority` | unset or `off` | unset or `off` | contains victim + higher rank | No preemption |
| `qos_priority` | `cancel` / `requeue` | unset or `off` | contains victim + higher rank | Partition action |
| `qos_priority` | unset or `off` | `cancel` / `requeue` | contains victim + higher rank | QoS action |
| `qos_priority` | action | different action | contains victim + higher rank | QoS action |
| `qos_priority` | any | any | victim QoS is the pending QoS and lists itself | QoS action if set, else partition action |

Fair-share, age, and effective job priority continue to order pending jobs but no longer affect preemption eligibility. Victims are now considered least-important-first (QoS priority, then job ID) — `get_jobs` iterates a `HashMap`, so the previous ordering was nondeterministic.

## Deliberately not changed

- **`off` is not given a stronger meaning.** An earlier revision made explicit `off` a hard protection that a QoS action could not override. That was dropped: old and new payloads serialize `Off` identically, so `#[serde(default)]` cannot distinguish "legacy default" from "explicit protection", and every pre-upgrade partition (reachable from both `WalOperation::PartitionCreate` and `ClusterSnapshot`) plus every legacy `qos.preempt_mode = 'off'` row would have become silently preemption-proof. Keeping unset and `off` behaviourally identical is what makes the default change safe and migration-free.
- **`suspend` behaviour is untouched** and works exactly as on `main`. Its separate defect — the victim keeps its allocation and nothing ever resumes it — is tracked in SPUR-271 rather than changed here.

## Behavior change on upgrade

Clusters that relied on the implicit priority-gap behaviour will stop preempting until they set `preempt_type = "qos_priority"` and populate QoS `preempt` allow-lists. Documented under "Behavior Changes Between Releases" in `docs/deployment/upgrading.rst`.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — no warnings
- `cargo test --locked`

Unit and controller tests cover the global gate, the allow-list, strict QoS ranking, the same-QoS carve-out, QoS-over-partition action precedence, and the node-overlap / reservation-tier / exempt-time guards.

Frozen-payload tests pin the upgrade contract: a legacy `PartitionCreate` entry carrying `"preempt_mode":"Off"` still deserializes and resolves to no action, a legacy `"Cancel"` keeps its action, and a legacy `qos.preempt_mode='off'` row resolves the same as unset. Each was verified to fail if explicit `off` stops resolving like unset.

Mutation-tested: reverting the same-QoS submit-order rule, the strict rank test, the global gate, or any of the three victim guards turns exactly one test red.

Three pre-existing guard tests (`preempt_skips_jobs_in_active_reservation_at_same_tier`, `preempt_skips_jobs_on_unrelated_nodes`, `preempt_exempt_time_protects_recently_started_job`) were passing only because the new gate returns early before reaching them. They now configure a valid allow-list and rank gap so the guard under test is the only thing blocking eviction, and each was verified to fail when its guard is removed.

## Live verification

Two-node cluster with accounting, on isolated ports and an isolated database. The cluster was first populated by the **pre-change** binary — writing `"preempt_mode":"Off"` and `"Cancel"` into the Raft log and `preempt_mode='off'` into Postgres — then upgraded in place to the new binary on the same state directory and database. Replay was clean across four restarts, `legacyp` came back as `PreemptMode=OFF`, `legacycancel` kept `CANCEL`, and a newly created partition showed `PreemptMode=NONE`. The matrix below then ran against that upgraded, mixed legacy/new cluster.

| # | Scenario | Result |
| --- | --- | --- |
| 1 | `preempt_type` absent, and `= "off"` | No preemption |
| 2 | Allow-listed + higher QoS rank | Victim CANCELLED |
| 3 | Not allow-listed (pending QoS priority 10000) | No preemption |
| 4 | Equal QoS rank, allow-listed | No preemption |
| 5 | QoS lists itself | Victim CANCELLED |
| 6 | Victim QoS `requeue` vs partition `cancel` | Victim REQUEUED |
| 7 | Partition `off` + victim QoS `cancel` | Victim CANCELLED |
| 8 | Partition `off`, victim QoS `off` | No preemption |
| 9 | Pending QoS priority 10000, empty allow-list | No preemption |
| 10 | Equal QoS rank, pending job priority raised to 900000 against victim 1100 | No preemption |
| 11 | Victim on a node the pending job does not need | No preemption |

Row 10 is the regression that motivated this change: an 818x job-priority advantage no longer substitutes for QoS rank.

Preemption provenance was checked on each eviction — `PreemptedBy`, `PreemptMode` (`Cancel` / `Requeue`), and `PreemptQOS` are recorded, including for the same-QoS case.
