### PR TITLE
fix(spurctld): enforce qos preemption policy

### DIFF
--- a/crates/spur-core/src/accounting.rs
+++ b/crates/spur-core/src/accounting.rs
@@ -294,7 +294,8 @@ pub struct Qos {
     pub name: String,
     pub description: String,
     pub priority: i32,
-    pub preempt_mode: QosPreemptMode,
+    #[serde(default)]
+    pub preempt_mode: Option<QosPreemptMode>,
     pub limits: QosLimits,
     /// Usage factor — multiplier for fair-share usage accounting.
     /// 0.0 = don't charge, 1.0 = normal, 2.0 = double charge.
@@ -377,7 +378,7 @@ impl Default for Qos {
             name: String::new(),
             description: String::new(),
             priority: 0,
-            preempt_mode: QosPreemptMode::Off,
+            preempt_mode: None,
             limits: QosLimits::default(),
             usage_factor: 1.0,
             preempt: Vec::new(),
@@ -588,6 +589,14 @@ mod tests {
             "unknown".parse::<QosPreemptMode>().unwrap(),
             QosPreemptMode::Off
         );
+    }
+
+    #[test]
+    fn qos_without_preempt_mode_deserializes_as_unset() {
+        let mut value = serde_json::to_value(Qos::default()).unwrap();
+        value.as_object_mut().unwrap().remove("preempt_mode");
+        let decoded: Qos = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded.preempt_mode, None);
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -653,11 +653,9 @@ pub struct SchedulerConfig {
     /// operator-only. Raise it to grant users a band above the baseline.
     #[serde(default = "default_max_user_priority")]
     pub max_user_priority: u32,
-    /// Controls which jobs are eligible to preempt which. `None` (default)
-    /// enforces no cross-QOS restrictions — any job with sufficient priority gap
-    /// may preempt any other. `QosPriority` requires the pending job's QOS to
-    /// list the running job's QOS in its `preempt` allow-list. Mirrors Slurm's
-    /// `PreemptType`.
+    /// Controls whether the scheduler may preempt jobs. `None` (default) and
+    /// `Off` disable preemption. `QosPriority` requires the pending QOS to list
+    /// the running QOS in its `preempt` allow-list and have a higher QOS priority.
     #[serde(default)]
     pub preempt_type: PreemptType,
     /// Cluster-wide minimum number of seconds a job must have been running before
@@ -1947,12 +1945,14 @@ impl SlurmConfig {
                 deny_qos: pc.deny_qos.clone(),
                 allow_qos: pc.allow_qos.clone(),
                 priority_tier: pc.priority_tier,
-                preempt_mode: match pc.preempt_mode.to_lowercase().as_str() {
-                    "cancel" => PreemptMode::Cancel,
-                    "requeue" => PreemptMode::Requeue,
-                    "suspend" => PreemptMode::Suspend,
-                    _ => PreemptMode::Off,
-                },
+                preempt_mode: (!pc.preempt_mode.is_empty()).then(|| {
+                    match pc.preempt_mode.to_lowercase().as_str() {
+                        "cancel" => PreemptMode::Cancel,
+                        "requeue" => PreemptMode::Requeue,
+                        "suspend" => PreemptMode::Suspend,
+                        _ => PreemptMode::Off,
+                    }
+                }),
                 preempt_exempt_time: pc.preempt_exempt_time,
                 ..Default::default()
             })
@@ -3166,6 +3166,40 @@ deny_accounts = ["student"]
             vec!["research".to_string(), "faculty".to_string()]
         );
         assert_eq!(parts[0].deny_accounts, vec!["student".to_string()]);
+    }
+
+    #[test]
+    fn preemption_config_preserves_unset_and_explicit_off() {
+        let unset = SlurmConfig::load_from_str(
+            r#"
+cluster_name = "test"
+
+[[partitions]]
+name = "gpu"
+"#,
+        )
+        .unwrap();
+        assert_eq!(unset.scheduler.preempt_type, PreemptType::None);
+        assert_eq!(unset.build_partitions()[0].preempt_mode, None);
+
+        let configured = SlurmConfig::load_from_str(
+            r#"
+cluster_name = "test"
+
+[scheduler]
+preempt_type = "off"
+
+[[partitions]]
+name = "gpu"
+preempt_mode = "off"
+"#,
+        )
+        .unwrap();
+        assert_eq!(configured.scheduler.preempt_type, PreemptType::Off);
+        assert_eq!(
+            configured.build_partitions()[0].preempt_mode,
+            Some(PreemptMode::Off)
+        );
     }
 
     #[test]

--- a/crates/spur-core/src/partition.rs
+++ b/crates/spur-core/src/partition.rs
@@ -35,7 +35,8 @@ pub struct Partition {
     pub deny_qos: Vec<String>,
 
     /// Scheduling
-    pub preempt_mode: PreemptMode,
+    #[serde(default)]
+    pub preempt_mode: Option<PreemptMode>,
     pub priority_tier: u32,
     /// Partition-level override for the minimum seconds a job must have been
     /// running before it is eligible for preemption. `None` defers to the
@@ -73,10 +74,11 @@ impl std::fmt::Display for PartitionState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum PreemptType {
-    /// No QOS-level restrictions — eligibility is determined solely by priority
-    /// gap, partition mode, and reservation tier (existing behaviour).
+    /// Preemption is not selected. This is the safe default.
     #[default]
     None,
+    /// Explicit hard disable, retained separately from an unset selection.
+    Off,
     /// A pending job may only preempt a running job when the pending job's QOS
     /// lists the running job's QOS in its `preempt` allow-list.
     QosPriority,
@@ -154,7 +156,7 @@ impl Default for Partition {
             allow_qos: Vec::new(),
             deny_accounts: Vec::new(),
             deny_qos: Vec::new(),
-            preempt_mode: PreemptMode::Off,
+            preempt_mode: None,
             priority_tier: 1,
             preempt_exempt_time: None,
         }
@@ -170,6 +172,18 @@ mod tests {
         assert!(PreemptMode::Cancel.aggressiveness() > PreemptMode::Requeue.aggressiveness());
         assert!(PreemptMode::Requeue.aggressiveness() > PreemptMode::Suspend.aggressiveness());
         assert!(PreemptMode::Suspend.aggressiveness() > PreemptMode::Off.aggressiveness());
+    }
+
+    #[test]
+    fn partition_without_preempt_mode_deserializes_as_unset() {
+        let partition = Partition {
+            name: "gpu".into(),
+            ..Default::default()
+        };
+        let mut value = serde_json::to_value(partition).unwrap();
+        value.as_object_mut().unwrap().remove("preempt_mode");
+        let decoded: Partition = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded.preempt_mode, None);
     }
 
     fn partition_with_tier(name: &str, priority_tier: u32) -> Partition {

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -20,13 +20,9 @@ impl From<QosPreemptMode> for PreemptMode {
     }
 }
 
-/// A QOS-level preempt mode override, or `None` if unset. `Off` can't be
-/// told apart from "unset" on the wire, so it's treated as no override.
+/// A QOS-level preempt mode override, or `None` if unset.
 pub fn qos_preempt_override(qos: &Qos) -> Option<PreemptMode> {
-    match qos.preempt_mode {
-        QosPreemptMode::Off => None,
-        other => Some(other.into()),
-    }
+    qos.preempt_mode.map(Into::into)
 }
 
 /// Result of QOS limit check.
@@ -1111,30 +1107,30 @@ mod tests {
     }
 
     #[test]
-    fn test_qos_preempt_override_off_is_none() {
+    fn test_qos_preempt_override_preserves_explicit_off() {
         let qos = Qos {
-            preempt_mode: QosPreemptMode::Off,
+            preempt_mode: Some(QosPreemptMode::Off),
             ..Default::default()
         };
-        assert_eq!(qos_preempt_override(&qos), None);
+        assert_eq!(qos_preempt_override(&qos), Some(PreemptMode::Off));
     }
 
     #[test]
     fn test_qos_preempt_override_maps_variants() {
         let requeue = Qos {
-            preempt_mode: QosPreemptMode::Requeue,
+            preempt_mode: Some(QosPreemptMode::Requeue),
             ..Default::default()
         };
         assert_eq!(qos_preempt_override(&requeue), Some(PreemptMode::Requeue));
 
         let cancel = Qos {
-            preempt_mode: QosPreemptMode::Cancel,
+            preempt_mode: Some(QosPreemptMode::Cancel),
             ..Default::default()
         };
         assert_eq!(qos_preempt_override(&cancel), Some(PreemptMode::Cancel));
 
         let suspend = Qos {
-            preempt_mode: QosPreemptMode::Suspend,
+            preempt_mode: Some(QosPreemptMode::Suspend),
             ..Default::default()
         };
         assert_eq!(qos_preempt_override(&suspend), Some(PreemptMode::Suspend));

--- a/crates/spur-tests/src/t17_submit.rs
+++ b/crates/spur-tests/src/t17_submit.rs
@@ -195,17 +195,17 @@ mod tests {
 
         let part_off = Partition {
             name: "nopreempt".into(),
-            preempt_mode: PreemptMode::Off,
+            preempt_mode: Some(PreemptMode::Off),
             ..Default::default()
         };
-        assert_eq!(part_off.preempt_mode, PreemptMode::Off);
+        assert_eq!(part_off.preempt_mode, Some(PreemptMode::Off));
 
         let part_requeue = Partition {
             name: "requeue".into(),
-            preempt_mode: PreemptMode::Requeue,
+            preempt_mode: Some(PreemptMode::Requeue),
             ..Default::default()
         };
-        assert_eq!(part_requeue.preempt_mode, PreemptMode::Requeue);
+        assert_eq!(part_requeue.preempt_mode, Some(PreemptMode::Requeue));
     }
 
     #[test]

--- a/crates/spur-tests/src/t21_acctmgr.rs
+++ b/crates/spur-tests/src/t21_acctmgr.rs
@@ -92,7 +92,7 @@ mod tests {
     fn t21_8_qos_defaults() {
         let qos = Qos::default();
         assert_eq!(qos.priority, 0);
-        assert_eq!(qos.preempt_mode, QosPreemptMode::Off);
+        assert_eq!(qos.preempt_mode, None);
         assert_eq!(qos.usage_factor, 1.0);
     }
 

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -92,7 +92,7 @@ CREATE TABLE IF NOT EXISTS qos (
     name            TEXT PRIMARY KEY,
     description     TEXT NOT NULL DEFAULT '',
     priority        INTEGER NOT NULL DEFAULT 0,
-    preempt_mode    TEXT NOT NULL DEFAULT 'off',
+    preempt_mode    TEXT NOT NULL DEFAULT '',
     preempt         TEXT NOT NULL DEFAULT '',
     usage_factor    REAL NOT NULL DEFAULT 1.0,
     max_jobs_per_user INTEGER,
@@ -162,6 +162,7 @@ ALTER TABLE associations ADD COLUMN IF NOT EXISTS grp_submit_jobs INTEGER;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS grp_tres TEXT;
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS preempt TEXT NOT NULL DEFAULT '';
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS preempt_exempt_time INTEGER;
+ALTER TABLE qos ALTER COLUMN preempt_mode SET DEFAULT '';
 ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempted_by BIGINT;
 ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempt_mode TEXT NOT NULL DEFAULT '';
 ALTER TABLE jobs ADD COLUMN IF NOT EXISTS preempt_qos TEXT NOT NULL DEFAULT '';

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4009,10 +4009,11 @@ impl ClusterManager {
             .filter(|p| current_names.contains(&p.name))
         {
             let preempt_str = match part.preempt_mode {
-                spur_core::partition::PreemptMode::Cancel => "cancel",
-                spur_core::partition::PreemptMode::Requeue => "requeue",
-                spur_core::partition::PreemptMode::Suspend => "suspend",
-                spur_core::partition::PreemptMode::Off => "off",
+                Some(spur_core::partition::PreemptMode::Cancel) => "cancel",
+                Some(spur_core::partition::PreemptMode::Requeue) => "requeue",
+                Some(spur_core::partition::PreemptMode::Suspend) => "suspend",
+                Some(spur_core::partition::PreemptMode::Off) => "off",
+                None => "",
             };
             self.propose(WalOperation::PartitionUpdate {
                 name: part.name.clone(),
@@ -5088,8 +5089,7 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Recompute a job's live effective priority. A running job's stored
-    /// `priority` is stale; this recalculates from age, fair-share, and tier.
+    #[cfg(test)]
     pub(crate) fn current_effective_priority(&self, job: &Job, partitions: &[Partition]) -> u32 {
         let now = Utc::now();
         let age_minutes = (now - job.submit_time).num_minutes().max(0);
@@ -6293,10 +6293,11 @@ impl ClusterManager {
                         }
                         if let Some(pm) = preempt_mode {
                             part.preempt_mode = match pm.to_lowercase().as_str() {
-                                "cancel" => spur_core::partition::PreemptMode::Cancel,
-                                "requeue" => spur_core::partition::PreemptMode::Requeue,
-                                "suspend" => spur_core::partition::PreemptMode::Suspend,
-                                _ => spur_core::partition::PreemptMode::Off,
+                                "cancel" => Some(spur_core::partition::PreemptMode::Cancel),
+                                "requeue" => Some(spur_core::partition::PreemptMode::Requeue),
+                                "suspend" => Some(spur_core::partition::PreemptMode::Suspend),
+                                "" => None,
+                                _ => Some(spur_core::partition::PreemptMode::Off),
                             };
                         }
                         if let Some(def) = is_default {
@@ -15091,20 +15092,24 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
         config.partitions[0].preempt_mode = "cancel".into();
+        config.scheduler.preempt_type = spur_core::partition::PreemptType::QosPriority;
         let cm = test_cluster_with_config(&dir, config).await;
         register_node(&cm, "n1", 8, 16000);
 
         cm.qos_cache().insert(Qos {
+            name: "low".into(),
+            priority: 100,
+            ..Default::default()
+        });
+        cm.qos_cache().insert(Qos {
             name: "high".into(),
             priority: 5000,
+            preempt: vec!["low".into()],
             ..Default::default()
         });
 
-        // low job has no QOS (base=DEFAULT_PRIORITY=1000); high job's QOS
-        // priority (5000) becomes its base, making it >2x the low job's
-        // effective priority and crossing the preemption threshold.
         let mut low = basic_spec("low");
-        low.priority = Some(1000);
+        low.qos = Some("low".into());
         let low_id = submit_and_wait(&cm, low);
         let res = scalar_alloc(2, 4000);
         cm.start_job(
@@ -15137,6 +15142,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
         config.partitions[0].preempt_mode = "cancel".into();
+        config.scheduler.preempt_type = spur_core::partition::PreemptType::QosPriority;
         let cm = test_cluster_with_config(&dir, config).await;
         register_node(&cm, "n1", 8, 16000);
 
@@ -15148,6 +15154,7 @@ mod tests {
         cm.qos_cache().insert(Qos {
             name: "primus".into(),
             priority: 10000,
+            preempt: vec!["burst".into()],
             ..Default::default()
         });
 
@@ -15168,19 +15175,9 @@ mod tests {
         primus.qos = Some("primus".into());
         submit_and_wait(&cm, primus);
 
-        // Confirm that primus effective > 2x burst effective (preemption threshold).
         let pending = cm.pending_jobs();
         let pending_refs: Vec<&Job> = pending.iter().collect();
         let partitions = cm.get_partitions();
-
-        let burst_job = cm.get_job(burst_id).unwrap();
-        let burst_effective = cm.current_effective_priority(&burst_job, &partitions);
-        let primus_effective = pending_refs[0].priority;
-        assert!(
-            primus_effective >= burst_effective * 2,
-            "primus effective ({primus_effective}) must be ≥2x burst ({burst_effective}) \
-             for preemption to fire"
-        );
 
         crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler)
             .await;
@@ -15194,14 +15191,11 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn explicit_priority_disables_qos_based_preemption() {
-        // When --priority is set explicitly on both jobs, QOS priority is not
-        // applied as the base seed. Both jobs land at the same effective
-        // priority and preemption does not fire — this is intentional: explicit
-        // --priority opts the job out of QOS-based scheduling.
+    async fn qos_rank_allows_preemption_despite_equal_effective_job_priority() {
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
         config.partitions[0].preempt_mode = "cancel".into();
+        config.scheduler.preempt_type = spur_core::partition::PreemptType::QosPriority;
         let cm = test_cluster_with_config(&dir, config).await;
         register_node(&cm, "n1", 8, 16000);
 
@@ -15213,6 +15207,7 @@ mod tests {
         cm.qos_cache().insert(Qos {
             name: "primus".into(),
             priority: 10000,
+            preempt: vec!["burst".into()],
             ..Default::default()
         });
 
@@ -15241,13 +15236,7 @@ mod tests {
         crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs, &cm.config().scheduler)
             .await;
 
-        // burst job must still be running — equal explicit priorities, no preemption.
-        let burst_job = cm.get_job(burst_id).unwrap();
-        assert_eq!(
-            burst_job.state,
-            JobState::Running,
-            "burst job must keep running when both jobs have identical explicit --priority"
-        );
+        settle(&cm, burst_id, JobState::Cancelled);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -15446,17 +15435,24 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn preempt_uses_candidate_qos_preempt_mode_over_partition() {
+    async fn suspend_preempt_mode_does_not_make_capacity_for_a_pending_job() {
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
-        // Partition says Cancel; the candidate's QoS overrides it to Suspend.
         config.partitions[0].preempt_mode = "cancel".into();
+        config.scheduler.preempt_type = spur_core::partition::PreemptType::QosPriority;
         let cm = test_cluster_with_config(&dir, config).await;
         register_node(&cm, "n1", 8, 16000);
 
         cm.qos_cache().insert(Qos {
             name: "suspend-me".into(),
-            preempt_mode: spur_core::accounting::QosPreemptMode::Suspend,
+            priority: 100,
+            preempt_mode: Some(spur_core::accounting::QosPreemptMode::Suspend),
+            ..Default::default()
+        });
+        cm.qos_cache().insert(Qos {
+            name: "high".into(),
+            priority: 200,
+            preempt: vec!["suspend-me".into()],
             ..Default::default()
         });
 
@@ -15475,7 +15471,7 @@ mod tests {
         settle(&cm, low_id, JobState::Running);
 
         let mut high = basic_spec("high");
-        high.priority = Some(10_000);
+        high.qos = Some("high".into());
         let high_id = submit_and_wait(&cm, high);
         let high_job = cm.get_job(high_id).unwrap();
         let partitions = cm.get_partitions();
@@ -15483,9 +15479,7 @@ mod tests {
         crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job], &cm.config().scheduler)
             .await;
 
-        // Suspended, not Cancelled: proves the QoS override reached the real
-        // preemption action, not just the pure job_preempt_mode() decision.
-        settle(&cm, low_id, JobState::Suspended);
+        assert_eq!(cm.get_job(low_id).unwrap().state, JobState::Running);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -24074,6 +24068,7 @@ mod tests {
             max_time_minutes: Some(1440),
             allow_accounts: vec!["ml-team".into()],
             priority_tier: 2,
+            preempt_mode: Some(spur_core::partition::PreemptMode::Cancel),
             ..Default::default()
         }
     }
@@ -24125,6 +24120,34 @@ mod tests {
         assert_eq!(gpu.state, spur_core::partition::PartitionState::Drain);
         assert_eq!(gpu.max_time_minutes, Some(2880));
         assert!(gpu.allow_accounts.contains(&"infra".into()));
+
+        cm.apply_operation(&WalOperation::PartitionUpdate {
+            name: "gpu".into(),
+            nodes: None,
+            selector: None,
+            state: None,
+            max_time_minutes: None,
+            default_time_minutes: None,
+            max_nodes: None,
+            min_nodes: None,
+            allow_accounts: None,
+            allow_groups: None,
+            deny_accounts: None,
+            deny_qos: None,
+            allow_qos: None,
+            priority_tier: None,
+            preempt_mode: Some(String::new()),
+            is_default: None,
+            preempt_exempt_time: None,
+        });
+        assert_eq!(
+            cm.get_partitions()
+                .into_iter()
+                .find(|p| p.name == "gpu")
+                .unwrap()
+                .preempt_mode,
+            None
+        );
 
         cm.apply_operation(&WalOperation::PartitionDelete { name: "gpu".into() });
         assert!(

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -238,7 +238,8 @@ fn qos_from_record(r: crate::accounting::db::QosRecord) -> Qos {
         name: r.name,
         description: r.description,
         priority: r.priority,
-        preempt_mode: r.preempt_mode.parse::<QosPreemptMode>().unwrap_or_default(),
+        preempt_mode: (!r.preempt_mode.is_empty())
+            .then(|| r.preempt_mode.parse::<QosPreemptMode>().unwrap_or_default()),
         preempt: r
             .preempt
             .split(',')
@@ -390,7 +391,7 @@ mod tests {
         assert_eq!(qos.limits.max_submit_jobs_per_account, Some(40));
         assert_eq!(qos.limits.grp_submit_jobs, Some(30));
         assert_eq!(qos.priority, 100);
-        assert_eq!(qos.preempt_mode, QosPreemptMode::Cancel);
+        assert_eq!(qos.preempt_mode, Some(QosPreemptMode::Cancel));
         assert_eq!(qos.usage_factor, 2.0);
         assert_eq!(qos.limits.max_jobs_per_user, Some(10));
         assert_eq!(qos.limits.max_wall_minutes, Some(60));

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -590,8 +590,6 @@ fn busy_until_from_running_jobs(running: &[spur_core::job::Job]) -> HashMap<Stri
     busy_until
 }
 
-/// Resolve the effective PreemptMode for a job: QoS override wins if set
-/// (see `qos_preempt_override`), else the most aggressive matched partition.
 fn job_preempt_mode(
     job: &spur_core::job::Job,
     partitions: &[spur_core::partition::Partition],
@@ -599,15 +597,31 @@ fn job_preempt_mode(
 ) -> spur_core::partition::PreemptMode {
     use spur_core::partition::PreemptMode;
 
-    if let Some(mode) = spur_core::qos::qos_preempt_override(qos) {
-        return mode;
+    let modes: Vec<_> =
+        spur_core::partition::matched_partitions(job.spec.partition.as_deref(), partitions)
+            .into_iter()
+            .filter_map(|partition| partition.preempt_mode)
+            .collect();
+    if qos.preempt_mode == Some(spur_core::accounting::QosPreemptMode::Off)
+        || modes.contains(&PreemptMode::Off)
+    {
+        return PreemptMode::Off;
     }
-
-    spur_core::partition::matched_partitions(job.spec.partition.as_deref(), partitions)
-        .into_iter()
-        .map(|p| p.preempt_mode)
-        .max_by_key(|m| m.aggressiveness())
+    qos.preempt_mode
+        .map(Into::into)
+        .or_else(|| modes.into_iter().max_by_key(|mode| mode.aggressiveness()))
         .unwrap_or(PreemptMode::Off)
+}
+
+fn qos_preempt_allowed(
+    pending: &spur_core::accounting::Qos,
+    victim: &spur_core::accounting::Qos,
+) -> bool {
+    pending.preempt.contains(&victim.name) && pending.priority > victim.priority
+}
+
+fn qos_priority_preemption_enabled(sched: &spur_core::config::SchedulerConfig) -> bool {
+    sched.preempt_type == spur_core::partition::PreemptType::QosPriority
 }
 
 /// Effective preempt-exempt seconds for a running job: QOS > partition > global.
@@ -640,8 +654,12 @@ pub(crate) async fn try_preempt(
 ) {
     use crate::cluster::PreemptOutcome;
     use spur_core::job::JobState;
-    use spur_core::partition::{Partition, PreemptMode, PreemptType};
+    use spur_core::partition::{Partition, PreemptMode};
     use spur_core::reservation::job_runs_in_active_reservation;
+
+    if !qos_priority_preemption_enabled(sched) {
+        return;
+    }
 
     let now = chrono::Utc::now();
     let reservations = cluster.get_reservations();
@@ -650,31 +668,27 @@ pub(crate) async fn try_preempt(
     let partition_for = |job: &spur_core::job::Job| -> Option<&Partition> {
         spur_core::partition::matched_partitions(job.spec.partition.as_deref(), partitions)
             .into_iter()
-            .max_by_key(|p| p.preempt_mode.aggressiveness())
+            .max_by_key(|partition| {
+                partition
+                    .preempt_mode
+                    .unwrap_or(PreemptMode::Off)
+                    .aggressiveness()
+            })
     };
 
-    let mut running: Vec<spur_core::job::Job> = cluster
+    let running: Vec<spur_core::job::Job> = cluster
         .get_jobs(&JobFilter {
             states: &[JobState::Running],
             ..Default::default()
         })
         .into_iter()
         .collect();
-    // Resolve once, reuse for both the priority recompute and the
-    // preempt-mode decision below.
+    // Resolve once for the policy checks and action decision below.
     let running_qos: std::collections::HashMap<spur_core::job::JobId, spur_core::accounting::Qos> =
         running
             .iter()
             .map(|j| (j.job_id, cluster.resolve_qos(j)))
             .collect();
-    // Running jobs' stored `priority` is the raw base value, unlike
-    // `pending`'s fully adjusted one; recompute a comparable value.
-    let running_priority: std::collections::HashMap<spur_core::job::JobId, u32> = running
-        .iter()
-        .map(|j| (j.job_id, cluster.current_effective_priority(j, partitions)))
-        .collect();
-    running.sort_by_key(|j| running_priority[&j.job_id]);
-
     // Pending job's QOS is resolved once per pending job; used for the
     // QosPriority hierarchy check.
     let pending_qos_map: std::collections::HashMap<
@@ -689,18 +703,10 @@ pub(crate) async fn try_preempt(
         let Some(pending_part) = partition_for(pending) else {
             continue;
         };
-        if pending_part.preempt_mode == PreemptMode::Off {
-            continue;
-        }
         let pending_tier = pending_part.priority_tier;
         let pending_qos = &pending_qos_map[&pending.job_id];
 
         for candidate in &running {
-            let candidate_priority = running_priority[&candidate.job_id];
-            if candidate_priority >= pending.priority / 2 {
-                continue;
-            }
-
             if !preempt_overlaps_pending_nodes(pending, candidate, &cluster_nodes) {
                 continue;
             }
@@ -717,9 +723,7 @@ pub(crate) async fn try_preempt(
             // QOS hierarchy: pending job may only preempt candidate when the
             // pending QOS explicitly lists the candidate's QOS in its allow-list.
             let candidate_qos = &running_qos[&candidate.job_id];
-            if sched.preempt_type == PreemptType::QosPriority
-                && !pending_qos.preempt.contains(&candidate_qos.name)
-            {
+            if !qos_preempt_allowed(pending_qos, candidate_qos) {
                 continue;
             }
 
@@ -737,22 +741,17 @@ pub(crate) async fn try_preempt(
             }
 
             let mode = job_preempt_mode(candidate, partitions, candidate_qos);
-            if mode == PreemptMode::Off {
+            if !matches!(mode, PreemptMode::Cancel | PreemptMode::Requeue) {
                 continue;
             }
             info!(
                 preempted_job = candidate.job_id,
-                preempted_priority = candidate_priority,
                 pending_job = pending.job_id,
                 pending_priority = pending.priority,
                 mode = ?mode,
                 "preempting lower-priority job"
             );
-            let preempt_qos = if sched.preempt_type == PreemptType::QosPriority {
-                Some(pending_qos.name.clone())
-            } else {
-                None
-            };
+            let preempt_qos = Some(pending_qos.name.clone());
             match cluster.preempt_job(candidate.job_id, mode, pending.job_id, preempt_qos) {
                 Ok(PreemptOutcome::Killed) => {
                     // Signal 0 = graceful cancel (SIGTERM then SIGKILL).
@@ -2833,7 +2832,7 @@ mod tests {
     ) -> spur_core::partition::Partition {
         spur_core::partition::Partition {
             name: name.into(),
-            preempt_mode: mode,
+            preempt_mode: Some(mode),
             ..Default::default()
         }
     }
@@ -2847,17 +2846,33 @@ mod tests {
 
     fn qos_with_mode(mode: spur_core::accounting::QosPreemptMode) -> spur_core::accounting::Qos {
         spur_core::accounting::Qos {
-            preempt_mode: mode,
+            preempt_mode: Some(mode),
             ..Default::default()
         }
     }
 
-    fn no_qos_override() -> spur_core::accounting::Qos {
-        qos_with_mode(spur_core::accounting::QosPreemptMode::Off)
+    fn qos_without_preempt_mode() -> spur_core::accounting::Qos {
+        spur_core::accounting::Qos::default()
     }
 
     fn sched_config_default() -> spur_core::config::SchedulerConfig {
         spur_core::config::SchedulerConfig::default()
+    }
+
+    #[test]
+    fn only_qos_priority_enables_preemption() {
+        use spur_core::partition::PreemptType;
+        assert!(!qos_priority_preemption_enabled(&sched_config_default()));
+        let off = spur_core::config::SchedulerConfig {
+            preempt_type: PreemptType::Off,
+            ..Default::default()
+        };
+        assert!(!qos_priority_preemption_enabled(&off));
+        let qos_priority = spur_core::config::SchedulerConfig {
+            preempt_type: PreemptType::QosPriority,
+            ..Default::default()
+        };
+        assert!(qos_priority_preemption_enabled(&qos_priority));
     }
 
     fn sched_config_with_exempt(secs: u32) -> spur_core::config::SchedulerConfig {
@@ -2899,7 +2914,7 @@ mod tests {
             "gpu",
             spur_core::partition::PreemptMode::Cancel,
         )];
-        let qos = no_qos_override();
+        let qos = qos_without_preempt_mode();
         let sched = sched_config_with_exempt(120);
         assert_eq!(effective_exempt_secs(&job, &parts, &qos, &sched), 120);
     }
@@ -2908,7 +2923,7 @@ mod tests {
     fn effective_exempt_secs_partition_overrides_global() {
         let job = job_in_partitions("gpu");
         let parts = vec![partition_with_exempt("gpu", 60)];
-        let qos = no_qos_override();
+        let qos = qos_without_preempt_mode();
         let sched = sched_config_with_exempt(300);
         assert_eq!(effective_exempt_secs(&job, &parts, &qos, &sched), 60);
     }
@@ -2929,7 +2944,7 @@ mod tests {
             "gpu",
             spur_core::partition::PreemptMode::Cancel,
         )];
-        let qos = no_qos_override();
+        let qos = qos_without_preempt_mode();
         let sched = sched_config_default();
         assert_eq!(effective_exempt_secs(&job, &parts, &qos, &sched), 0);
     }
@@ -2969,11 +2984,44 @@ mod tests {
     }
 
     #[test]
+    fn qos_preempt_requires_a_strictly_higher_stable_qos_priority() {
+        let victim = spur_core::accounting::Qos {
+            name: "victim".into(),
+            priority: 100,
+            ..Default::default()
+        };
+        let pending = spur_core::accounting::Qos {
+            priority: 101,
+            preempt: vec!["victim".into()],
+            ..Default::default()
+        };
+        assert!(qos_preempt_allowed(&pending, &victim));
+
+        let equal_rank = spur_core::accounting::Qos {
+            priority: 100,
+            preempt: vec!["victim".into()],
+            ..Default::default()
+        };
+        assert!(!qos_preempt_allowed(&equal_rank, &victim));
+
+        let lower_rank = spur_core::accounting::Qos {
+            priority: 99,
+            preempt: vec!["victim".into()],
+            ..Default::default()
+        };
+        assert!(!qos_preempt_allowed(&lower_rank, &victim));
+    }
+
+    #[test]
     fn job_preempt_mode_single_partition() {
         use spur_core::partition::PreemptMode;
         let parts = vec![partition_with_mode("gpu", PreemptMode::Requeue)];
         assert_eq!(
-            job_preempt_mode(&job_in_partitions("gpu"), &parts, &no_qos_override()),
+            job_preempt_mode(
+                &job_in_partitions("gpu"),
+                &parts,
+                &qos_without_preempt_mode()
+            ),
             PreemptMode::Requeue
         );
     }
@@ -2986,12 +3034,16 @@ mod tests {
             job_preempt_mode(
                 &job_with_spec(JobSpec::default()),
                 &parts,
-                &no_qos_override()
+                &qos_without_preempt_mode()
             ),
             PreemptMode::Off
         );
         assert_eq!(
-            job_preempt_mode(&job_in_partitions("nope"), &parts, &no_qos_override()),
+            job_preempt_mode(
+                &job_in_partitions("nope"),
+                &parts,
+                &qos_without_preempt_mode()
+            ),
             PreemptMode::Off
         );
     }
@@ -3006,7 +3058,11 @@ mod tests {
             partition_with_mode("cpu", PreemptMode::Cancel),
         ];
         assert_eq!(
-            job_preempt_mode(&job_in_partitions("gpu, cpu"), &parts, &no_qos_override()),
+            job_preempt_mode(
+                &job_in_partitions("gpu, cpu"),
+                &parts,
+                &qos_without_preempt_mode()
+            ),
             PreemptMode::Cancel
         );
     }
@@ -3019,7 +3075,62 @@ mod tests {
             partition_with_mode("cpu", PreemptMode::Off),
         ];
         assert_eq!(
-            job_preempt_mode(&job_in_partitions("gpu,cpu"), &parts, &no_qos_override()),
+            job_preempt_mode(
+                &job_in_partitions("gpu,cpu"),
+                &parts,
+                &qos_without_preempt_mode()
+            ),
+            PreemptMode::Off
+        );
+    }
+
+    #[test]
+    fn job_preempt_mode_partition_off_protects_despite_qos_action() {
+        use spur_core::accounting::QosPreemptMode;
+        use spur_core::partition::PreemptMode;
+        let parts = vec![partition_with_mode("gpu", PreemptMode::Off)];
+        assert_eq!(
+            job_preempt_mode(
+                &job_in_partitions("gpu"),
+                &parts,
+                &qos_with_mode(QosPreemptMode::Cancel),
+            ),
+            PreemptMode::Off
+        );
+    }
+
+    #[test]
+    fn job_preempt_mode_qos_action_works_without_partition_action() {
+        use spur_core::accounting::QosPreemptMode;
+        use spur_core::partition::PreemptMode;
+        let parts = vec![spur_core::partition::Partition {
+            name: "gpu".into(),
+            ..Default::default()
+        }];
+        assert_eq!(
+            job_preempt_mode(
+                &job_in_partitions("gpu"),
+                &parts,
+                &qos_with_mode(QosPreemptMode::Requeue),
+            ),
+            PreemptMode::Requeue
+        );
+    }
+
+    #[test]
+    fn job_preempt_mode_any_multi_partition_off_protects() {
+        use spur_core::accounting::QosPreemptMode;
+        use spur_core::partition::PreemptMode;
+        let parts = vec![
+            partition_with_mode("gpu", PreemptMode::Cancel),
+            partition_with_mode("cpu", PreemptMode::Off),
+        ];
+        assert_eq!(
+            job_preempt_mode(
+                &job_in_partitions("gpu,cpu"),
+                &parts,
+                &qos_with_mode(QosPreemptMode::Requeue),
+            ),
             PreemptMode::Off
         );
     }
@@ -5214,12 +5325,17 @@ mod tests {
     }
 
     #[test]
-    fn job_preempt_mode_qos_off_falls_back_to_partition() {
+    fn job_preempt_mode_qos_off_protects_despite_partition_action() {
+        use spur_core::accounting::QosPreemptMode;
         use spur_core::partition::PreemptMode;
         let parts = vec![partition_with_mode("gpu", PreemptMode::Cancel)];
         assert_eq!(
-            job_preempt_mode(&job_in_partitions("gpu"), &parts, &no_qos_override()),
-            PreemptMode::Cancel
+            job_preempt_mode(
+                &job_in_partitions("gpu"),
+                &parts,
+                &qos_with_mode(QosPreemptMode::Off),
+            ),
+            PreemptMode::Off
         );
     }
 }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2329,7 +2329,7 @@ impl SlurmController for ControllerService {
             deny_qos: req.deny_qos,
             allow_qos: req.allow_qos,
             priority_tier: req.priority_tier,
-            preempt_mode,
+            preempt_mode: Some(preempt_mode),
             preempt_exempt_time: req.preempt_exempt_time,
             ..Default::default()
         };
@@ -4432,7 +4432,14 @@ fn partition_to_proto(part: &spur_core::partition::Partition) -> PartitionInfo {
         allow_qos: part.allow_qos.join(","),
         deny_accounts: part.deny_accounts.join(","),
         deny_qos: part.deny_qos.join(","),
-        preempt_mode: format!("{:?}", part.preempt_mode),
+        preempt_mode: match part.preempt_mode {
+            Some(spur_core::partition::PreemptMode::Off) => "OFF",
+            Some(spur_core::partition::PreemptMode::Cancel) => "CANCEL",
+            Some(spur_core::partition::PreemptMode::Requeue) => "REQUEUE",
+            Some(spur_core::partition::PreemptMode::Suspend) => "SUSPEND",
+            None => "",
+        }
+        .into(),
         priority_tier: part.priority_tier,
         preempt_exempt_time: part.preempt_exempt_time,
     }

--- a/docs/admin-guide/accounting.rst
+++ b/docs/admin-guide/accounting.rst
@@ -437,16 +437,16 @@ QOS keys
      - Base priority seed for jobs submitted under this QOS. When a job is
        submitted without an explicit ``--priority``, this value becomes the
        job's base priority and is amplified by the multiplicative scheduling
-       formula (fair-share × age × partition tier). Higher values run sooner
-       and are more likely to preempt lower-priority running jobs. ``0``
+       formula (fair-share × age × partition tier). Higher values run sooner.
+       For preemption eligibility, Spur compares the stable QOS priority rather
+       than this moving effective priority. ``0``
        leaves the job at the scheduler default (1000).
    * - ``preemptmode``
-     - ``off``
+     - unset
      - What happens to a job in this QOS when it gets kicked out by a
-       higher-priority job. This setting overrides whatever the partition says,
-       but only for *how* the job is removed — it does not control *whether*
-       preemption happens (that depends on the partition's ``preempt_mode``
-       and the priority gap).
+       eligible pending job. This setting overrides a non-``off`` partition
+       action. Explicit ``off`` at either QOS or partition level protects the
+       victim job from preemption.
 
        ``cancel`` — the job is stopped and removed from the queue. Its final
        state is ``CANCELLED`` (``PREEMPTED`` in accounting records).
@@ -454,21 +454,17 @@ QOS keys
        start again automatically once a slot is free.
        ``suspend`` — the job is paused, keeping its node allocation. It
        resumes automatically once the higher-priority job finishes.
-       ``off`` (default) — no change from what the partition says. Setting
-       ``preemptmode=off`` on a QOS is the same as leaving it unset. It does
-       **not** protect the job from being preempted.
+       unset (default) — no QOS action is configured; the partition action may
+       apply. ``off`` — explicit hard protection; the job is not preempted.
 
        **Example of the override:** a partition is set to ``cancel`` but a
        specific QOS is set to ``preemptmode=requeue``. When a job in that QOS
        is kicked out, it goes back to the queue instead of being cancelled.
 
-       **How to actually protect a QOS from preemption:** simply do not add it
-       to any other QOS's ``preempt`` allow-list. When
-       ``preempt_type = "qos_priority"`` is enabled (see :doc:`configuration`),
-       a QOS that nobody has permission to preempt will never lose its running
-       jobs, no matter how large the priority gap is.
+       Not listing a QOS in any allow-list also prevents it from being selected,
+       but ``preemptmode=off`` is the direct hard-protection setting.
    * - ``preempt``
-     - ``""`` (no restriction)
+     - ``""`` (preempt nothing)
      - Comma-separated list of QOS names that jobs in this QOS are allowed to
        preempt. Only enforced when ``scheduler.preempt_type = "qos_priority"``
        (see :doc:`configuration`). An empty value means this QOS may not preempt
@@ -741,143 +737,6 @@ database available.
    upgrading starts from zero and fills over the following
    ``grp_wall_window_days``.
 
-How the priority gap is computed
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-By default, Spur's preemption eligibility is based purely on the numeric
-priority gap: a pending job may preempt a running job when
-
-.. code-block:: text
-
-   candidate_effective_priority < pending_effective_priority / 2
-
-Effective priority is:
-
-.. code-block:: text
-
-   effective_priority = base_priority × min(fair_share, 10.0) × age_factor × max(partition_tier, 1)
-   age_factor = 1.0 + min(waiting_minutes / 10080, 1.0)   # 1.0 -> 2.0 over 7 days
-
-``base_priority`` is the explicit ``--priority`` if given; otherwise it is
-``1000 + qos.priority`` (see the QOS ``priority`` field, above) — so a QOS's
-priority contributes to the base *before* the multiplicative factors, and is
-scaled by fair-share/age/tier along with everything else, not added on top of
-them. Both sides of the comparison go through the same formula: a pending
-job's stored priority is kept refreshed with it every scheduling pass, and a
-running job's is recomputed the same way at preemption-check time (a running
-job's own priority field is frozen at whatever it was when dispatched).
-
-The gap must exceed 2× — not merely be larger — for preemption to fire.
-
-**Scenarios where preemption fires**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 40 30
-
-   * - Cause
-     - Example
-     - Result
-   * - Higher base priority
-     - Pending base 1000 vs. running base 100 (both otherwise equal)
-     - ``100 × 1.0 = 100 < 1000 / 2 = 500`` → fires
-   * - Higher QOS priority
-     - Pending on a QOS with ``priority=2000`` (base ``1000+2000=3000``) vs.
-       running with no QOS (base 1000), otherwise equal
-     - ``1000 < 3000 / 2 = 1500`` → fires
-   * - Fair-share divergence alone
-     - Same base/QOS/tier; pending's user has low usage
-       (``fair_share=2.0``, fully aged), running's user is heavy
-       (``fair_share=0.1``, no age boost)
-     - ``1000×0.1×1.0=100 < (1000×2.0×2.0)/2=2000`` → fires
-   * - Higher partition tier (≥ 3×)
-     - Pending on a ``priority_tier=3`` partition vs. running on
-       ``priority_tier=1``, otherwise equal
-     - ``1000 < 3000 / 2 = 1500`` → fires
-   * - Combination of smaller gaps
-     - No single factor differs by 2×, but several compound: base 500 both
-       sides; pending has ``fair_share=2.0``, full age boost, ``tier=2``;
-       running has ``fair_share=0.5``, no age boost, ``tier=1``
-     - ``250 < 4000 / 2 = 2000`` → fires
-
-A 2×+ gap in fair-share, age, or partition tier alone is exactly as effective
-as a 2×+ base-priority gap — this is the main **silent** path: two jobs
-submitted with identical priority and QOS by different users can still
-trigger preemption purely from fair-share divergence, with no priority or
-QOS change involved.
-
-**Scenarios where the priority gap alone cannot fire preemption**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 45 55
-
-   * - Scenario
-     - Why it cannot fire
-   * - Same base, QOS, fair-share, and partition tier
-     - The age factor tops out at 2.0×, exactly cancelling the 2× threshold:
-       worst case is pending at ``2P`` and running at ``P``, and ``P < P`` is
-       false (strict ``<`` is required).
-   * - Pending on ``priority_tier=2`` vs. running on ``priority_tier=1``,
-       otherwise equal
-     - Same cancellation: ``2000 / 2 = 1000``, not strictly less than the
-       running job's 1000.
-
-**Configuration guards checked after the priority gap** (any one blocks
-preemption regardless of how large the gap is):
-
-.. list-table::
-   :header-rows: 1
-   :widths: 45 55
-
-   * - Guard
-     - Condition
-   * - Pending partition preempt mode
-     - The pending job's own partition ``preempt_mode`` (no QOS override
-       here) is ``off`` — checked once per pending job, before any
-       candidate is considered.
-   * - QOS allow-list
-     - ``preempt_type = "qos_priority"`` and the pending job's QOS does not
-       list the running job's QOS in its ``preempt`` field.
-   * - Preempt mode
-     - The running job's effective ``preempt_mode`` (QOS override, else
-       partition) is ``off``.
-   * - Exempt time
-     - The running job has not yet been running for ``preempt_exempt_time``
-       (QOS > partition > global).
-   * - Reservation protection
-     - The running job is in an active reservation and the pending job's
-       partition tier is not strictly higher than the running job's.
-   * - No node overlap
-     - The pending job does not need any node the running job occupies.
-
-**Comparison with Slurm**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 35 35
-
-   * -
-     - Spur
-     - Slurm (``PreemptType=preempt/qos``)
-   * - Preemption gate
-     - Effective priority gap > 2×
-     - QOS ``Preempt=`` allow-list only
-   * - Does fair-share affect preemption?
-     - Yes, via the effective-priority formula
-     - No — fair-share affects scheduling order only
-   * - Does age affect preemption?
-     - Yes, via the effective-priority formula
-     - No
-   * - Can priority alone trigger preemption with no QOS config?
-     - Yes (``preempt_type = "none"``, the default)
-     - No — QOS preemption always requires an explicit allow-list
-
-The practical difference: in Spur, preemption eligibility can shift day to
-day as fair-share and age change, even with no configuration change. In
-Slurm's QOS-priority model, eligibility is fixed by the allow-list and does
-not drift on its own.
-
 QOS preemption hierarchy
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -892,6 +751,70 @@ hierarchy in ``spur.conf``:
 With ``preempt_type = "qos_priority"``, a job may only preempt a running job
 when the pending job's QOS lists the running job's QOS name in its ``preempt``
 allow-list. An empty allow-list means the QOS may not preempt anything.
+
+.. code-block:: text
+
+   can_preempt =
+     global_engine == qos_priority
+     AND partition_mode != off
+     AND qos_mode != off
+     AND pending_qos.allow_list contains victim_qos
+     AND pending_qos.priority > victim_qos.priority
+     AND resolved_action is cancel or requeue
+
+.. list-table:: QOS-priority preemption decision table
+   :header-rows: 1
+
+   * - Global engine
+     - Victim partition mode
+     - Victim QOS mode
+     - Allow-list
+     - Result
+   * - unset / ``off``
+     - any
+     - any
+     - any
+     - No preemption
+   * - ``qos_priority``
+     - ``off``
+     - any
+     - any
+     - No preemption
+   * - ``qos_priority``
+     - any
+     - ``off``
+     - any
+     - No preemption
+   * - ``qos_priority``
+     - any
+     - any
+     - Empty or excludes victim
+     - No preemption
+   * - ``qos_priority``
+     - unset
+     - ``cancel`` / ``requeue``
+     - Contains victim
+     - QOS action if QOS priority is higher
+   * - ``qos_priority``
+     - ``cancel`` / ``requeue``
+     - unset
+     - Contains victim
+     - Partition action if QOS priority is higher
+   * - ``qos_priority``
+     - ``cancel`` / ``requeue``
+     - different ``cancel`` / ``requeue``
+     - Contains victim
+     - QOS action if QOS priority is higher
+   * - ``qos_priority``
+     - unset
+     - unset
+     - Contains victim
+     - No preemption
+
+An explicit ``off`` at either victim scope is a hard protection. Otherwise a
+victim QOS action overrides a victim partition action. ``suspend`` preserves
+the victim's allocation, so the scheduler does not select it to free capacity
+for a pending job.
 
 **Example: two-tier system**
 
@@ -909,13 +832,14 @@ allow-list. An empty allow-list means the QOS may not preempt anything.
 
 With this setup:
 
-- A ``priority`` job preempts ``burst`` jobs when the priority gap is large enough.
+- A ``priority`` job preempts ``burst`` jobs because its QOS priority is higher
+  and its allow-list contains ``burst``.
 - A ``priority`` job cannot preempt ``reserved`` jobs (``reserved`` is not in
   ``priority``'s allow-list).
 - A ``burst`` job never preempts anyone (empty allow-list).
 - ``reserved`` jobs are never kicked out because no other QOS lists
-  ``reserved`` in its ``preempt`` field. That is what provides the protection
-  — not ``preemptmode=off``, which simply means "use the partition default".
+  ``reserved`` in its ``preempt`` field. Set ``preemptmode=off`` as an explicit
+  hard protection when that guarantee must not depend on other QOS allow-lists.
 
 **Minimum exempt time**
 
@@ -974,8 +898,8 @@ With this setup:
 - ``burst`` jobs can never kick out ``normal`` jobs — ``burst`` has no
   entries in its ``preempt`` allow-list.
 - A QOS that no other QOS lists in its ``preempt`` field (for example, a
-  ``reserved`` tier) will never have its jobs kicked out, regardless of how
-  large a priority gap exists.
+  ``reserved`` tier) will never have its jobs kicked out. The same is guaranteed
+  directly by setting its ``preemptmode=off``.
 
 How a job's QOS is resolved
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -486,16 +486,11 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
        cancelled.
    * - ``preempt_type``
      - string
-     - ``"none"``
+     - unset
      - Live
-     - Controls cross-QOS preemption eligibility. ``"none"`` (default) applies no
-       QOS-level restrictions — any job with a sufficient priority gap may preempt
-       any other. ``"qos_priority"`` enforces the per-QOS ``preempt`` allow-list:
-       a pending job may only preempt a running job when the pending job's QOS
-       explicitly lists the running job's QOS name in its ``preempt`` field. An
-       empty allow-list means the QOS may not preempt anything. Mirrors Slurm's
-       ``PreemptType=preempt/qos``. See :doc:`accounting` for the QOS
-       ``preempt`` field.
+     - Preemption is disabled when unset or ``"off"``. ``"qos_priority"`` enables
+       QOS-priority preemption, which requires both the pending QOS allow-list and
+       a higher stable QOS priority. See :doc:`accounting` for the decision table.
    * - ``preempt_exempt_time``
      - integer
      - ``0``
@@ -526,17 +521,13 @@ Scheduling loop cadence, per-cycle limits, and fairshare decay.
    available capacity — it does not reclaim capacity already given to a
    running job. Configure:
 
-   - A priority gap of more than 2× between the jobs that must run and the
-     jobs they need to be able to displace (via base ``--priority``, QOS
-     ``priority``, or a combination — see :doc:`accounting` for how the
-     effective priority gap is computed).
-   - ``preempt_type`` (and, if a running job should not simply be killed,
-     ``preemptmode=requeue`` or ``suspend`` on its QOS) so that gap actually
-     triggers preemption instead of only affecting scheduling order.
+   - ``preempt_type = "qos_priority"``.
+   - A pending QOS with a higher stable QOS priority and an allow-list entry
+     for the victim QOS.
+   - A victim action of ``cancel`` or ``requeue`` at its QOS or partition.
 
-   With both in place, a high-priority job that cannot find free capacity
-   will preempt a lower-priority running job holding the capacity it needs,
-   rather than waiting for it to finish on its own.
+   With those policy settings in place, a pending job that cannot find free
+   capacity can preempt an eligible lower-QOS job holding the capacity it needs.
 
 .. note::
 
@@ -747,7 +738,7 @@ jobs is skipped rather than deleted (see :ref:`reload-scope`).
        tier among them.
    * - ``preempt_mode``
      - string
-     - ``"off"``
+     - unset
      - What the scheduler does to a running job when a higher-priority job needs
        its node.
 
@@ -759,13 +750,12 @@ jobs is skipped rather than deleted (see :ref:`reload-scope`).
        finishes. Because the node stays occupied, any other job that also needs
        that node exclusively will have to wait until the paused job either
        finishes or is cancelled.
-       ``"off"`` (default) — running jobs in this partition are never kicked
-       out. The scheduler will wait for a free slot instead of preempting.
+       unset (default) — no partition action is configured.
+       ``"off"`` — running jobs in this partition are never kicked out.
 
-       A job's QOS can change what happens to *that specific job* when it is
-       kicked out (see ``preemptmode`` in :doc:`accounting`). The partition
-       field is the on/off switch: preemption is only attempted at all when
-       this is set to something other than ``"off"``.
+       A victim QOS action overrides a partition action. An explicit ``"off"``
+       at either scope protects the victim; when both are unset, there is no
+       action. See :doc:`accounting` for the complete decision table.
    * - ``preempt_exempt_time``
      - integer or null
      - ``null`` (inherit global)


### PR DESCRIPTION
## Summary

Makes QoS-priority preemption an explicit, deterministic policy. Global preemption is disabled when unset or `off`; only `qos_priority` enables it.

The victim action resolves as QoS over partition, except explicit `off` at either scope is a hard protection. Unset remains distinct from `off` through config, accounting, runtime updates, and API output.

```text
can_preempt =
  global_engine == qos_priority
  AND partition_mode != off
  AND qos_mode != off
  AND pending_qos.allow_list contains victim_qos
  AND pending_qos.priority > victim_qos.priority
  AND resolved_action is cancel or requeue
```

| Global engine | Victim partition mode | Victim QoS mode | Allow-list | Result |
| --- | --- | --- | --- | --- |
| unset / `off` | any | any | any | No preemption |
| `qos_priority` | `off` | any | any | No preemption |
| `qos_priority` | any | `off` | any | No preemption |
| `qos_priority` | any | any | empty or excludes victim | No preemption |
| `qos_priority` | unset | `cancel` / `requeue` | contains victim | QoS action if QoS priority is higher |
| `qos_priority` | `cancel` / `requeue` | unset | contains victim | Partition action if QoS priority is higher |
| `qos_priority` | action | different action | contains victim | QoS action, if neither is `off` and QoS priority is higher |
| `qos_priority` | unset | unset | contains victim | No preemption |

Fair-share, age, and effective job priority continue to order pending jobs but no longer affect preemption eligibility. `suspend` retains the allocation, so it is not selected to make capacity for a pending job.

## Validation

- `cargo fmt --all --check`
- `cargo test --locked`
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked -- -D warnings`
- `cargo build --release --locked --bin spurctld --bin spurd --bin spur`

Focused unit and controller tests cover the global gate, allow-list direction, strict stable-QoS ranking, QoS/partition precedence, hard protection, multi-partition behavior, persisted compatibility, API rendering, and capacity-releasing actions.

## Follow-up

The available lab environment cannot currently provide the accounting dependency required for a QoS E2E scenario, so live QoS E2E is not claimed here.