### PR TITLE
fix(spur-cli): accept --noconvert on accounting commands

### DIFF
--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -54,6 +54,10 @@ pub struct SacctArgs {
     #[arg(short = 'n', long)]
     pub noheader: bool,
 
+    /// Accepted for Slurm compatibility; has no effect
+    #[arg(long)]
+    pub noconvert: bool,
+
     /// Max records
     #[arg(long, default_value = "100")]
     pub limit: u32,
@@ -301,6 +305,13 @@ mod tests {
             derived_exit_code,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn noconvert_is_accepted() {
+        // Slurm scripts pass --noconvert to keep output machine-parseable.
+        let args = SacctArgs::try_parse_from(["sacct", "--noconvert"]).unwrap();
+        assert!(args.noconvert);
     }
 
     #[test]

--- a/crates/spur-cli/src/sreport.rs
+++ b/crates/spur-cli/src/sreport.rs
@@ -27,6 +27,10 @@ pub struct SreportArgs {
     #[arg(long, global = true)]
     pub noheader: bool,
 
+    /// Accepted for Slurm compatibility; has no effect
+    #[arg(long, global = true)]
+    pub noconvert: bool,
+
     /// Parsable output
     #[arg(short = 'p', long, global = true)]
     pub parsable: bool,
@@ -430,4 +434,31 @@ async fn report_job_sizes_by_user(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noconvert_is_accepted() {
+        // Slurm scripts pass --noconvert to keep output machine-parseable.
+        let before = SreportArgs::try_parse_from([
+            "sreport",
+            "--noconvert",
+            "cluster",
+            "AccountUtilizationByUser",
+        ])
+        .unwrap();
+        assert!(before.noconvert);
+
+        let after = SreportArgs::try_parse_from([
+            "sreport",
+            "cluster",
+            "AccountUtilizationByUser",
+            "--noconvert",
+        ])
+        .unwrap();
+        assert!(after.noconvert);
+    }
 }

--- a/crates/spur-cli/src/sshare.rs
+++ b/crates/spur-cli/src/sshare.rs
@@ -31,6 +31,10 @@ pub struct SshareArgs {
     #[arg(short = 'h', long)]
     pub noheader: bool,
 
+    /// Accepted for Slurm compatibility; has no effect
+    #[arg(long)]
+    pub noconvert: bool,
+
     /// Print help
     #[arg(long, action = clap::ArgAction::Help)]
     pub help: Option<bool>,
@@ -234,6 +238,13 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn noconvert_is_accepted() {
+        // Slurm scripts pass --noconvert to keep output machine-parseable.
+        let args = SshareArgs::try_parse_from(["sshare", "--noconvert"]).unwrap();
+        assert!(args.noconvert);
+    }
 
     #[test]
     fn short_h_means_noheader() {

--- a/crates/spur-cli/src/sstat.rs
+++ b/crates/spur-cli/src/sstat.rs
@@ -22,6 +22,10 @@ pub struct SstatArgs {
     #[arg(long)]
     pub noheader: bool,
 
+    /// Accepted for Slurm compatibility; has no effect
+    #[arg(long)]
+    pub noconvert: bool,
+
     /// Parsable output (delimiter-separated)
     #[arg(short = 'p', long)]
     pub parsable: bool,
@@ -249,6 +253,14 @@ fn state_name(state: i32) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn noconvert_is_accepted() {
+        // Slurm scripts pass --noconvert to keep output machine-parseable.
+        let args = SstatArgs::try_parse_from(["sstat", "--noconvert", "--jobs", "1"]).unwrap();
+        assert!(args.noconvert);
+        assert_eq!(args.job_id, "1");
+    }
 
     #[test]
     fn parse_field_list_accepts_aliases_case_and_padding() {

--- a/docs/migration-from-slurm.rst
+++ b/docs/migration-from-slurm.rst
@@ -55,8 +55,8 @@ noted as "accepted for compatibility" parse without error but have no effect yet
      - Difference
    * - Partitions
      - Defined in ``spur.conf``; there is no runtime ``scontrol create/update/delete partition``. Edit the config and reload the controller to change a partition.
-   * - ``squeue``/``sinfo`` ``--noconvert``
-     - Accepted for compatibility; Spur already reports raw values where applicable (``sinfo``'s memory columns are MB integers; ``squeue`` has no memory column yet), so there is nothing to suppress. Slurm also defines the flag on ``sacct``, ``sstat``, ``sshare`` and ``sreport``, where it is not accepted yet.
+   * - ``--noconvert``
+     - Accepted for compatibility on ``squeue``, ``sinfo``, ``sacct``, ``sstat``, ``sshare``, and ``sreport``. Spur already reports raw values where applicable (``sinfo``'s memory columns are MB integers; ``squeue`` has no memory column yet), so there is nothing to suppress. ``sstat`` still prints ``MemAlloc`` with an ``M`` suffix whether or not the flag is passed.
    * - ``sacct --jobs``
      - Accepted for compatibility; the job-id filter is not yet applied server-side.
    * - ``sacct`` ``ReqMem``


### PR DESCRIPTION
## Summary
- `sacct`, `sstat`, `sshare`, and `sreport` rejected Slurm's `--noconvert` at clap parse time, so migrated scripts exited with no output.
- Accept the flag the same way `squeue`/`sinfo` already do, and ignore it. Those commands already print raw values; this does not strip `sstat`'s `MemAlloc` `M` suffix.
- `sreport` takes the flag as a global option so it works before or after the subcommand.

Fixes #695

## Test plan
- [ ] `cargo test -p spur-cli --locked noconvert_is_accepted`
- [ ] `sacct --noconvert` (and `sstat`/`sshare`/`sreport`) no longer print `unexpected argument '--noconvert'`
- [ ] Output without the flag is unchanged


Made with [Cursor](https://cursor.com)