### PR TITLE
feat(spur-cli): add sinfo -R with node reason provenance (user/time)

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -185,6 +185,7 @@ MaxWall
 msg
 NNodes
 NODELIST
+nodelist
 OpenMetrics
 overridable
 PMIx

--- a/crates/spur-cli/src/format_engine.rs
+++ b/crates/spur-cli/src/format_engine.rs
@@ -371,6 +371,12 @@ pub const SQUEUE_DEFAULT_FORMAT: &str = "%.18i %.9P %.8j %.8u %.2t %10M %6D %R";
 /// Default sinfo format string.
 pub const SINFO_DEFAULT_FORMAT: &str = "%#P %5a %.10l %.6D %.6t %N";
 
+/// sinfo `-R` / `--list-reasons` format string (matches Slurm).
+pub const SINFO_LIST_REASONS_FORMAT: &str = "%20E %9u %19H %N";
+
+/// sinfo `-R -l` / `--long --list-reasons` format string (matches Slurm).
+pub const SINFO_LIST_REASONS_LONG_FORMAT: &str = "%20E %12U %19H %6t %N";
+
 /// Header names for squeue format specifiers.
 pub fn squeue_header(spec: char) -> &'static str {
     match spec {
@@ -425,6 +431,9 @@ pub fn sinfo_header(spec: char) -> &'static str {
         'n' => "HOSTNAMES",
         'O' => "CPU_LOAD",
         'e' => "FREE_MEM",
+        'E' => "REASON",
+        'H' => "TIMESTAMP",
+        'u' | 'U' => "USER",
         _ => "?",
     }
 }

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -16,6 +16,7 @@ mod net;
 mod node;
 mod nodelist;
 mod privilege;
+mod reason;
 mod sacct;
 mod sacctmgr;
 mod salloc;

--- a/crates/spur-cli/src/reason.rs
+++ b/crates/spur-cli/src/reason.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Display helpers for node drain/down reason provenance.
+
+/// Render the user who set a node reason. `with_uid` appends the numeric uid in
+/// parens (sinfo `%U`); otherwise just the name (sinfo `%u`, scontrol). An unset
+/// or unresolvable uid falls back to `Unknown`.
+pub fn reason_user(uid: Option<u32>, with_uid: bool) -> String {
+    match uid {
+        Some(uid) => {
+            let name = spur_core::auth::username_for_uid(uid).unwrap_or_else(|| "Unknown".into());
+            if with_uid {
+                format!("{name}({uid})")
+            } else {
+                name
+            }
+        }
+        None => "Unknown".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unset_uid_is_unknown() {
+        assert_eq!(reason_user(None, false), "Unknown");
+        assert_eq!(reason_user(None, true), "Unknown");
+    }
+
+    #[test]
+    fn unresolvable_uid_without_id_is_unknown() {
+        // u32::MAX has no passwd entry (see auth::username_for_uid tests).
+        assert_eq!(reason_user(Some(u32::MAX), false), "Unknown");
+    }
+
+    #[test]
+    fn unresolvable_uid_with_id_keeps_the_number() {
+        assert_eq!(reason_user(Some(u32::MAX), true), "Unknown(4294967295)");
+    }
+}

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -603,11 +603,20 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                 let total = node.total_resources.as_ref();
                 let alloc = node.alloc_resources.as_ref();
                 println!("NodeName={}", node.name);
-                println!(
-                    "   State={} Reason={}",
-                    node_state_display(&node),
-                    node.state_reason
-                );
+                // Append `[user@time]` to the reason when a set-time is recorded,
+                // matching Slurm's `scontrol show node` format.
+                let reason = match (node.reason_time.as_ref(), node.state_reason.is_empty()) {
+                    (Some(t), false) => {
+                        let user = crate::reason::reason_user(node.reason_uid, false);
+                        format!(
+                            "{} [{user}@{}]",
+                            node.state_reason,
+                            crate::timefmt::format_timestamp(Some(t))
+                        )
+                    }
+                    _ => node.state_reason.clone(),
+                };
+                println!("   State={} Reason={}", node_state_display(&node), reason);
                 if !node.partitions.is_empty() {
                     println!("   Partitions={}", node.partitions.join(","));
                 }

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -41,6 +41,10 @@ pub struct SinfoArgs {
     #[arg(short = 'N', long)]
     pub node_oriented: bool,
 
+    /// List reasons nodes are down, drained, draining, or in error state
+    #[arg(short = 'R', long = "list-reasons")]
+    pub list_reasons: bool,
+
     /// Don't print header
     #[arg(short = 'h', long)]
     pub noheader: bool,
@@ -71,6 +75,12 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     let fmt = if let Some(ref f) = args.format {
         f.clone()
+    } else if args.list_reasons {
+        if args.long {
+            format_engine::SINFO_LIST_REASONS_LONG_FORMAT.to_string()
+        } else {
+            format_engine::SINFO_LIST_REASONS_FORMAT.to_string()
+        }
     } else if args.long {
         "%#P %5a %.10l %.4D %.6t %.8c %.8m %N".to_string()
     } else if args.node_oriented {
@@ -111,7 +121,13 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     if !args.noheader {
         println!("{}", format_engine::format_header(&fields));
     }
-    for line in render_sinfo_output(&fields, &partitions, &nodes, args.node_oriented) {
+
+    let lines = if args.list_reasons {
+        render_list_reasons(&fields, &nodes)
+    } else {
+        render_sinfo_output(&fields, &partitions, &nodes, args.node_oriented)
+    };
+    for line in lines {
         println!("{}", line);
     }
 
@@ -160,11 +176,14 @@ fn parse_states_arg(s: &str) -> Result<Vec<spur_proto::proto::NodeState>> {
     Ok(states)
 }
 
-fn group_nodes_by_display_state<'a>(nodes: &[&'a NodeInfo]) -> Vec<(String, Vec<&'a NodeInfo>)> {
+/// Group nodes by an arbitrary string key, returning groups sorted by key.
+fn group_nodes_by<'a>(
+    nodes: &[&'a NodeInfo],
+    key_fn: impl Fn(&NodeInfo) -> String,
+) -> Vec<(String, Vec<&'a NodeInfo>)> {
     let mut groups: BTreeMap<String, Vec<&'a NodeInfo>> = BTreeMap::new();
     for node in nodes {
-        let key = effective_state_str(node);
-        groups.entry(key).or_default().push(node);
+        groups.entry(key_fn(node)).or_default().push(node);
     }
     groups.into_iter().collect()
 }
@@ -198,7 +217,7 @@ fn render_sinfo_output(
                 .iter()
                 .filter(|n| n.partitions.contains(&part.name))
                 .collect();
-            let state_groups = group_nodes_by_display_state(&part_nodes);
+            let state_groups = group_nodes_by(&part_nodes, effective_state_str);
 
             if state_groups.is_empty() {
                 let row = format_engine::format_row(fields, &|spec| {
@@ -217,6 +236,39 @@ fn render_sinfo_output(
     }
 
     lines
+}
+
+/// Render the `-R` / `--list-reasons` view: nodes in an unavailable state,
+/// grouped by their admin reason, one row per reason with a compressed nodelist.
+fn render_list_reasons(fields: &[format_engine::FormatToken], nodes: &[NodeInfo]) -> Vec<String> {
+    let unavailable: Vec<&NodeInfo> = nodes
+        .iter()
+        .filter(|n| {
+            spur_core::node::NodeState::from_proto_i32(n.state)
+                .map(|s| s.is_unavailable())
+                .unwrap_or(false)
+        })
+        .collect();
+
+    // Slurm splits list-reason rows when reason, setter uid, or set-time differ.
+    // Effective state joins the key too: admin-hold precedence keeps a node's
+    // reason/uid/time when it later goes Down, so a still-drained peer with
+    // identical attribution must not share a row (which would misreport the
+    // `-R -l` STATE column). State is last so reason stays the primary sort key.
+    group_nodes_by(&unavailable, |n| {
+        let ts = n.reason_time.as_ref().map(|t| t.seconds).unwrap_or(0);
+        format!(
+            "{}\u{1}{:?}\u{1}{ts}\u{1}{}",
+            n.state_reason,
+            n.reason_uid,
+            effective_state_str(n)
+        )
+    })
+    .iter()
+    .map(|(_, group_nodes)| {
+        format_engine::format_row(fields, &|spec| resolve_list_reason_field(group_nodes, spec))
+    })
+    .collect()
 }
 
 fn resolve_node_field(
@@ -280,11 +332,48 @@ fn resolve_node_field(
     }
 }
 
+/// Fields resolvable from a group of nodes alone (no partition context):
+/// the group's shared display state and its nodelist rendering. Returns `None`
+/// for specs that need more than the node group.
+fn resolve_node_group_field(nodes: &[&spur_proto::proto::NodeInfo], spec: char) -> Option<String> {
+    match spec {
+        't' | 'T' => Some(if nodes.is_empty() {
+            "n/a".into()
+        } else {
+            effective_state_str(nodes[0])
+        }),
+        'N' => {
+            let names: Vec<String> = nodes.iter().map(|n| n.name.clone()).collect();
+            Some(spur_core::hostlist::compress(&names))
+        }
+        'n' => {
+            // Expanded form of the same sorted hostlist as `%N`, so `%n` and
+            // `%N` stay consistent (Slurm derives both from one sorted list).
+            let names: Vec<String> = nodes.iter().map(|n| n.name.clone()).collect();
+            let compressed = spur_core::hostlist::compress(&names);
+            Some(
+                spur_core::hostlist::expand(&compressed)
+                    .unwrap_or_else(|_| {
+                        let mut fallback = names;
+                        fallback.sort();
+                        fallback.dedup();
+                        fallback
+                    })
+                    .join(","),
+            )
+        }
+        _ => None,
+    }
+}
+
 fn resolve_partition_field(
     part: &spur_proto::proto::PartitionInfo,
     nodes: &[&spur_proto::proto::NodeInfo],
     spec: char,
 ) -> String {
+    if let Some(v) = resolve_node_group_field(nodes, spec) {
+        return v;
+    }
     match spec {
         'P' | 'R' => {
             if part.is_default {
@@ -302,32 +391,31 @@ fn resolve_partition_field(
             }
         }
         'D' => nodes.len().to_string(),
-        't' | 'T' => {
-            if nodes.is_empty() {
-                "n/a".into()
-            } else {
-                effective_state_str(nodes[0])
-            }
-        }
-        'N' => {
-            let names: Vec<String> = nodes.iter().map(|n| n.name.clone()).collect();
-            spur_core::hostlist::compress(&names)
-        }
-        'n' => {
-            // Expanded form of the same sorted hostlist as `%N`, so `%n` and
-            // `%N` stay consistent (Slurm derives both from one sorted list).
-            let names: Vec<String> = nodes.iter().map(|n| n.name.clone()).collect();
-            let compressed = spur_core::hostlist::compress(&names);
-            spur_core::hostlist::expand(&compressed)
-                .unwrap_or_else(|_| {
-                    let mut fallback = names;
-                    fallback.sort();
-                    fallback.dedup();
-                    fallback
-                })
-                .join(",")
-        }
         'c' => part.total_cpus.to_string(),
+        _ => "?".into(),
+    }
+}
+
+/// Resolver for the `-R` / `--list-reasons` view. Delegates nodelist and state
+/// specs to [`resolve_node_group_field`] and resolves the reason (`%E`), setter
+/// user (`%u`/`%U`), and set-time (`%H`) from the group's first node.
+fn resolve_list_reason_field(nodes: &[&spur_proto::proto::NodeInfo], spec: char) -> String {
+    if let Some(v) = resolve_node_group_field(nodes, spec) {
+        return v;
+    }
+    let first = nodes.first();
+    match spec {
+        'E' => first.map(|n| n.state_reason.clone()).unwrap_or_default(),
+        // %u: user name of who set the reason.
+        'u' => crate::reason::reason_user(first.and_then(|n| n.reason_uid), false),
+        // %U: user name and uid, e.g. `root(0)`; `Unknown(<uid>)` when the uid
+        // has no passwd entry, `Unknown` when no uid was recorded.
+        'U' => crate::reason::reason_user(first.and_then(|n| n.reason_uid), true),
+        // %H: timestamp of the reason.
+        'H' => match first.and_then(|n| n.reason_time.as_ref()) {
+            Some(ts) => crate::timefmt::format_timestamp(Some(ts)),
+            None => "Unknown".into(),
+        },
         _ => "?".into(),
     }
 }
@@ -631,7 +719,7 @@ mod tests {
             make_node("n4", NodeState::NodeDrain, "p"),
         ];
         let refs: Vec<&NodeInfo> = nodes.iter().collect();
-        let groups = group_nodes_by_display_state(&refs);
+        let groups = group_nodes_by(&refs, effective_state_str);
 
         assert_eq!(groups.len(), 3);
         // BTreeMap ordering: alphabetical — "down", "drain", "idle"
@@ -651,7 +739,7 @@ mod tests {
             make_node("n3", NodeState::NodeIdle, "p"),
         ];
         let refs: Vec<&NodeInfo> = nodes.iter().collect();
-        let groups = group_nodes_by_display_state(&refs);
+        let groups = group_nodes_by(&refs, effective_state_str);
 
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].0, "idle");
@@ -660,7 +748,7 @@ mod tests {
 
     #[test]
     fn test_group_nodes_by_display_state_empty() {
-        let groups = group_nodes_by_display_state(&[]);
+        let groups = group_nodes_by(&[], effective_state_str);
         assert!(groups.is_empty());
     }
 
@@ -881,7 +969,7 @@ mod tests {
             make_reserved_node("n3", NodeState::NodeIdle, "p", "maint"),
         ];
         let refs: Vec<&NodeInfo> = nodes.iter().collect();
-        let groups = group_nodes_by_display_state(&refs);
+        let groups = group_nodes_by(&refs, effective_state_str);
 
         assert_eq!(groups.len(), 2, "expected idle + resv groups: {groups:?}");
         assert_eq!(groups[0].0, "idle");
@@ -897,7 +985,7 @@ mod tests {
             make_reserved_node("n2", NodeState::NodeAllocated, "p", "maint"),
         ];
         let refs: Vec<&NodeInfo> = nodes.iter().collect();
-        let groups = group_nodes_by_display_state(&refs);
+        let groups = group_nodes_by(&refs, effective_state_str);
 
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].0, "alloc");
@@ -1022,5 +1110,201 @@ mod tests {
         let lines = render_sinfo_output(&fields, &partitions, &nodes, true);
         assert_eq!(lines.len(), 1, "orphan node still gets one row");
         assert!(lines[0].contains("orphan"));
+    }
+
+    // --- list-reasons (-R) tests ---
+
+    fn make_reason_node(name: &str, state: NodeState, reason: &str) -> NodeInfo {
+        let mut n = make_node(name, state, "p");
+        n.state_reason = reason.into();
+        n
+    }
+
+    fn make_reason_node_attr(
+        name: &str,
+        state: NodeState,
+        reason: &str,
+        uid: Option<u32>,
+        time_secs: Option<i64>,
+    ) -> NodeInfo {
+        let mut n = make_reason_node(name, state, reason);
+        n.reason_uid = uid;
+        n.reason_time = time_secs.map(|seconds| prost_types::Timestamp { seconds, nanos: 0 });
+        n
+    }
+
+    fn list_reasons_fields() -> Vec<format_engine::FormatToken> {
+        format_engine::parse_format(
+            format_engine::SINFO_LIST_REASONS_FORMAT,
+            &format_engine::sinfo_header,
+        )
+    }
+
+    #[test]
+    fn list_reasons_flag_parses() {
+        assert!(parse_sinfo_args(&["sinfo", "-R"]).list_reasons);
+        assert!(parse_sinfo_args(&["sinfo", "--list-reasons"]).list_reasons);
+    }
+
+    #[test]
+    fn list_reasons_excludes_available_nodes() {
+        let nodes = vec![
+            make_reason_node("n1", NodeState::NodeIdle, ""),
+            make_reason_node("n2", NodeState::NodeAllocated, ""),
+            make_reason_node("n3", NodeState::NodeDown, "hw fault"),
+        ];
+        let lines = render_list_reasons(&list_reasons_fields(), &nodes);
+        assert_eq!(lines.len(), 1, "only the down node is listed: {lines:?}");
+        assert!(lines[0].contains("hw fault"));
+        assert!(lines[0].contains("n3"));
+        assert!(!lines[0].contains("n1"));
+    }
+
+    #[test]
+    fn list_reasons_groups_shared_reason_into_one_row() {
+        let nodes = vec![
+            make_reason_node("n1", NodeState::NodeDown, "Memory errors"),
+            make_reason_node("n5", NodeState::NodeDown, "Memory errors"),
+        ];
+        let lines = render_list_reasons(&list_reasons_fields(), &nodes);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("Memory errors"));
+        assert!(
+            lines[0].contains("n[1,5]"),
+            "shared reason compresses the nodelist: {}",
+            lines[0]
+        );
+    }
+
+    #[test]
+    fn list_reasons_distinct_reasons_are_separate_rows_sorted_by_reason() {
+        let nodes = vec![
+            make_reason_node("n1", NodeState::NodeDrain, "maintenance"),
+            make_reason_node("n2", NodeState::NodeDown, "Memory errors"),
+        ];
+        let lines = render_list_reasons(&list_reasons_fields(), &nodes);
+        assert_eq!(lines.len(), 2);
+        // BTreeMap ordering is by byte value: 'M' (77) sorts before 'm' (109).
+        assert!(lines[0].contains("Memory errors"), "{lines:?}");
+        assert!(lines[1].contains("maintenance"), "{lines:?}");
+    }
+
+    #[test]
+    fn list_reasons_header_and_unknown_when_uid_time_unset() {
+        let fields = list_reasons_fields();
+        let header = format_engine::format_header(&fields);
+        assert!(header.contains("REASON"), "{header}");
+        assert!(header.contains("USER"), "{header}");
+        assert!(header.contains("TIMESTAMP"), "{header}");
+        assert!(header.contains("NODELIST"), "{header}");
+
+        // No reason_uid / reason_time recorded (e.g. a pre-upgrade node): USER
+        // and TIMESTAMP fall back to "Unknown".
+        let nodes = vec![make_reason_node("n1", NodeState::NodeDown, "hw fault")];
+        let lines = render_list_reasons(&fields, &nodes);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("hw fault"));
+        assert_eq!(
+            lines[0].matches("Unknown").count(),
+            2,
+            "USER and TIMESTAMP both Unknown: {}",
+            lines[0]
+        );
+    }
+
+    #[test]
+    fn list_reasons_renders_uid_and_time_when_set() {
+        // %U carries the uid in parens and %H the Slurm-form timestamp. The
+        // username half of %U depends on NSS, so assert only the uid/time parts.
+        let fields = format_engine::parse_format("%E|%U|%H", &format_engine::sinfo_header);
+        let nodes = vec![make_reason_node_attr(
+            "n1",
+            NodeState::NodeDown,
+            "hw fault",
+            Some(0),
+            Some(1_756_281_787),
+        )];
+        let lines = render_list_reasons(&fields, &nodes);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("(0)"), "%U shows uid: {}", lines[0]);
+        assert!(
+            lines[0].contains("2025-08-27T08:03:07"),
+            "%H shows the set-time: {}",
+            lines[0]
+        );
+    }
+
+    #[test]
+    fn list_reasons_splits_rows_on_differing_uid() {
+        // Same reason text but different setters: Slurm emits separate rows.
+        let nodes = vec![
+            make_reason_node_attr("n1", NodeState::NodeDown, "hw fault", Some(1), Some(100)),
+            make_reason_node_attr("n2", NodeState::NodeDown, "hw fault", Some(2), Some(100)),
+        ];
+        let lines = render_list_reasons(&list_reasons_fields(), &nodes);
+        assert_eq!(lines.len(), 2, "differing uid splits the group: {lines:?}");
+    }
+
+    #[test]
+    fn list_reasons_splits_rows_on_differing_state_same_attribution() {
+        // Admin-hold precedence keeps a node's reason/uid/time when it later
+        // goes Down. A still-drained peer with identical attribution must land
+        // in its own row, or `-R -l` would misreport one node's STATE.
+        let fields = format_engine::parse_format(
+            format_engine::SINFO_LIST_REASONS_LONG_FORMAT,
+            &format_engine::sinfo_header,
+        );
+        let nodes = vec![
+            make_reason_node_attr("n1", NodeState::NodeDrain, "hw swap", Some(1000), Some(100)),
+            make_reason_node_attr("n2", NodeState::NodeDown, "hw swap", Some(1000), Some(100)),
+        ];
+        let lines = render_list_reasons(&fields, &nodes);
+        assert_eq!(
+            lines.len(),
+            2,
+            "differing state splits the group: {lines:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("drain") && l.contains("n1")),
+            "drained node keeps its state: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("down") && l.contains("n2")),
+            "downed node keeps its state: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn list_reasons_long_adds_state_column() {
+        let fields = format_engine::parse_format(
+            format_engine::SINFO_LIST_REASONS_LONG_FORMAT,
+            &format_engine::sinfo_header,
+        );
+        let nodes = vec![make_reason_node("n1", NodeState::NodeDrain, "maintenance")];
+        let lines = render_list_reasons(&fields, &nodes);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("maintenance"));
+        assert!(
+            lines[0].contains("drain"),
+            "long -R includes the STATE column: {}",
+            lines[0]
+        );
+    }
+
+    #[test]
+    fn list_reasons_no_unavailable_nodes_yields_no_rows() {
+        // Mirrors `sinfo -R -t idle`: the state filter leaves only available
+        // nodes, so list-reasons produces nothing.
+        let nodes = vec![
+            make_reason_node("n1", NodeState::NodeIdle, ""),
+            make_reason_node("n2", NodeState::NodeMixed, ""),
+        ];
+        let lines = render_list_reasons(&list_reasons_fields(), &nodes);
+        assert!(
+            lines.is_empty(),
+            "no unavailable nodes -> no rows: {lines:?}"
+        );
     }
 }

--- a/crates/spur-core/src/auth.rs
+++ b/crates/spur-core/src/auth.rs
@@ -53,6 +53,15 @@ pub fn resolve_unix_credentials(user: &str) -> Result<(u32, u32), AuthError> {
     }
 }
 
+/// Reverse-resolve a UID to its username via NSS. `None` when the UID has no
+/// passwd entry, mirroring how Slurm's `uid_to_string` falls back for display.
+pub fn username_for_uid(uid: u32) -> Option<String> {
+    nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+        .ok()
+        .flatten()
+        .map(|u| u.name)
+}
+
 /// Authenticated identity extracted from a token or peer credentials.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Identity {
@@ -346,6 +355,13 @@ mod tests {
         assert_eq!(id.user, "alice");
         assert_eq!(id.uid, 1000);
         assert!(!id.is_admin);
+    }
+
+    #[test]
+    fn username_for_uid_is_none_for_unknown_uid() {
+        // A uid with no passwd entry resolves to None, mirroring how Slurm's
+        // display falls back when reason_uid can't be named.
+        assert_eq!(username_for_uid(u32::MAX), None);
     }
 
     #[test]

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -82,6 +82,17 @@ impl NodeState {
         )
     }
 
+    /// The unavailable states `sinfo -R` reports: Down, Drain, Draining, Error.
+    /// Unlike [`is_admin_hold`](Self::is_admin_hold), this is purely about state,
+    /// not who set it or whether a reason exists, and excludes `Suspended`
+    /// (power management, not a fault).
+    pub fn is_unavailable(&self) -> bool {
+        matches!(
+            self,
+            Self::Down | Self::Drain | Self::Draining | Self::Error
+        )
+    }
+
     pub fn display(&self) -> &'static str {
         match self {
             Self::Idle => "idle",
@@ -299,6 +310,14 @@ pub struct Node {
     pub hostname: String,
     pub state: NodeState,
     pub state_reason: Option<String>,
+    /// UID that set the current `state_reason` (Slurm's `reason_uid`). `None`
+    /// when no reason is set or the setter was unauthenticated.
+    #[serde(default)]
+    pub reason_uid: Option<u32>,
+    /// When the current `state_reason` was set (Slurm's `reason_time`).
+    /// Captured at emit time so Raft replay is deterministic.
+    #[serde(default)]
+    pub reason_time: Option<DateTime<Utc>>,
     /// When true, the current state was set by an operator (admin API, drain,
     /// etc.) and auto-recovery is suppressed. Only an explicit admin action
     /// can clear it. Automatically-set states (heartbeat timeout) leave this
@@ -373,6 +392,8 @@ impl Node {
             hostname: String::new(),
             state: NodeState::Unknown,
             state_reason: None,
+            reason_uid: None,
+            reason_time: None,
             admin_locked: false,
             partitions: Vec::new(),
             source: NodeSource::default(),
@@ -475,6 +496,20 @@ mod tests {
         value.as_object_mut().unwrap().remove("k0s_last_error");
         let back: Node = serde_json::from_value(value).expect("deserialize node");
         assert_eq!(back.k0s_last_error, None);
+    }
+
+    #[test]
+    fn a_node_snapshot_without_reason_attribution_still_deserializes() {
+        // Pre-upgrade snapshots predate reason_uid/reason_time; replay must load
+        // them as absent rather than failing the restore.
+        let node = Node::new("n1".into(), ResourceSet::default());
+        let mut value = serde_json::to_value(&node).expect("serialize node");
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("reason_uid");
+        obj.remove("reason_time");
+        let back: Node = serde_json::from_value(value).expect("deserialize node");
+        assert_eq!(back.reason_uid, None);
+        assert_eq!(back.reason_time, None);
     }
 
     #[test]
@@ -639,6 +674,29 @@ mod tests {
         }
         for &s in &non_holds {
             assert!(!s.is_admin_hold(), "{s:?} should not be admin hold");
+        }
+    }
+
+    #[test]
+    fn unavailable_states() {
+        let unavailable = [
+            NodeState::Down,
+            NodeState::Drain,
+            NodeState::Draining,
+            NodeState::Error,
+        ];
+        let available = [
+            NodeState::Idle,
+            NodeState::Allocated,
+            NodeState::Mixed,
+            NodeState::Suspended,
+            NodeState::Unknown,
+        ];
+        for &s in &unavailable {
+            assert!(s.is_unavailable(), "{s:?} should be unavailable");
+        }
+        for &s in &available {
+            assert!(!s.is_unavailable(), "{s:?} should not be unavailable");
         }
     }
 

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -232,6 +232,10 @@ pub enum WalOperation {
         reason: Option<String>,
         #[serde(default)]
         admin_locked: bool,
+        #[serde(default)]
+        reason_uid: Option<u32>,
+        #[serde(default)]
+        reason_time: Option<chrono::DateTime<chrono::Utc>>,
     },
     NodeLabelsUpdate {
         name: String,

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2795,6 +2795,7 @@ impl ClusterManager {
         name: &str,
         state: NodeState,
         reason: Option<String>,
+        reason_uid: Option<u32>,
     ) -> anyhow::Result<()> {
         let (old_state, effective_state) = {
             let nodes = self.nodes.read();
@@ -2821,12 +2822,16 @@ impl ClusterManager {
         // Resuming to Idle clears the lock.
         let admin_locked = effective_state.is_admin_hold();
 
+        let (reason_uid, reason_time) = reason_attribution(&reason, reason_uid);
+
         self.propose(WalOperation::NodeStateChange {
             name: name.to_string(),
             old_state,
             new_state: effective_state,
             reason,
             admin_locked,
+            reason_uid,
+            reason_time,
         })?;
         info!(node = %name, old = ?old_state, new = ?effective_state, "node state updated");
         Ok(())
@@ -3031,17 +3036,25 @@ impl ClusterManager {
                 } => {
                     warn!(node = %name, "node marked DOWN (heartbeat timeout)");
                     // An admin hold's reason takes precedence over the liveness
-                    // reason it would otherwise be marked with.
-                    let reason = admin_locked
-                        .then(|| self.get_node(&name).and_then(|n| n.state_reason))
+                    // reason it would otherwise be marked with; keep that hold's
+                    // original attribution too. Otherwise this is a system
+                    // (heartbeat) action attributed to uid 0 at this instant.
+                    let held = admin_locked
+                        .then(|| self.get_node(&name))
                         .flatten()
-                        .or_else(|| Some("Not responding".into()));
+                        .filter(|n| n.state_reason.is_some());
+                    let (reason, reason_uid, reason_time) = match held {
+                        Some(n) => (n.state_reason, n.reason_uid, n.reason_time),
+                        None => (Some("Not responding".into()), Some(0), Some(Utc::now())),
+                    };
                     match self.propose(WalOperation::NodeStateChange {
                         name: name.clone(),
                         old_state,
                         new_state: NodeState::Down,
                         reason,
                         admin_locked,
+                        reason_uid,
+                        reason_time,
                     }) {
                         Ok(resp) => {
                             // A node that stopped heartbeating won't refresh its k0s unit gauge, so
@@ -3061,9 +3074,13 @@ impl ClusterManager {
                     let node = self.get_node(&name);
                     let admin_locked = node.as_ref().is_some_and(|n| n.admin_locked);
                     let recovered_state = recovered_node_state(node.as_ref());
-                    // An admin hold applied since the action was computed keeps its reason;
-                    // otherwise recovery clears the liveness reason it is replacing.
-                    let reason = node.and_then(|n| n.state_reason).filter(|_| admin_locked);
+                    // An admin hold applied since the action was computed keeps its reason
+                    // and attribution; otherwise recovery clears the liveness reason it is
+                    // replacing.
+                    let (reason, reason_uid, reason_time) = match node {
+                        Some(n) if admin_locked => (n.state_reason, n.reason_uid, n.reason_time),
+                        _ => (None, None, None),
+                    };
                     info!(node = %name, state = ?recovered_state, "node recovered (heartbeat resumed)");
                     if let Err(e) = self.propose(WalOperation::NodeStateChange {
                         name,
@@ -3071,6 +3088,8 @@ impl ClusterManager {
                         new_state: recovered_state,
                         reason,
                         admin_locked,
+                        reason_uid,
+                        reason_time,
                     }) {
                         warn!(error = %e, "failed to propose node recovery");
                     }
@@ -3086,6 +3105,7 @@ impl ClusterManager {
         &self,
         name: &str,
         reason: Option<String>,
+        reason_uid: Option<u32>,
     ) -> anyhow::Result<(NodeState, u32)> {
         let (old_state, running_count) = {
             // Lock order is jobs before nodes, matching apply_operation. Taking
@@ -3115,12 +3135,15 @@ impl ClusterManager {
         } else {
             NodeState::Drain
         };
+        let (reason_uid, reason_time) = reason_attribution(&reason, reason_uid);
         self.propose(WalOperation::NodeStateChange {
             name: name.to_string(),
             old_state,
             new_state: target_state,
             reason,
             admin_locked: true,
+            reason_uid,
+            reason_time,
         })?;
         info!(node = %name, state = %target_state, "node drain requested");
         Ok((target_state, running_count))
@@ -6106,11 +6129,15 @@ impl ClusterManager {
                 new_state,
                 reason,
                 admin_locked,
+                reason_uid,
+                reason_time,
                 ..
             } => {
                 if let Some(node) = nodes.get_mut(name) {
                     node.state = *new_state;
                     node.state_reason = reason.clone();
+                    node.reason_uid = *reason_uid;
+                    node.reason_time = *reason_time;
                     node.admin_locked = *admin_locked;
                 }
                 if *new_state == NodeState::Down {
@@ -7612,6 +7639,20 @@ pub(crate) enum HealthAction {
         name: String,
         old_state: NodeState,
     },
+}
+
+/// Attribution captured when an admin sets a node's state. A set-time is
+/// recorded only when a reason is present; clearing a reason (e.g. resume to
+/// Idle) leaves both unset. Captured at the call site, not in apply, so Raft
+/// replay stays deterministic.
+fn reason_attribution(
+    reason: &Option<String>,
+    reason_uid: Option<u32>,
+) -> (Option<u32>, Option<DateTime<Utc>>) {
+    match reason {
+        Some(_) => (reason_uid, Some(Utc::now())),
+        None => (None, None),
+    }
 }
 
 pub(crate) fn recovered_node_state(node: Option<&Node>) -> NodeState {
@@ -9883,6 +9924,8 @@ mod tests {
             new_state: NodeState::Drain,
             reason: Some("maintenance".into()),
             admin_locked: true,
+            reason_uid: None,
+            reason_time: None,
         });
 
         let node = cm.get_node("n1").unwrap();
@@ -12465,7 +12508,7 @@ mod tests {
         let job_id = run_job_on(&cm, "spool-fault", "worker1");
 
         let (state, _) = cm
-            .drain_node("worker1", Some("launch failed: ENOSPC".into()))
+            .drain_node("worker1", Some("launch failed: ENOSPC".into()), None)
             .unwrap();
         assert_eq!(state, NodeState::Draining, "the job still holds the node");
 
@@ -20474,7 +20517,7 @@ mod tests {
         let cm = test_cluster(&dir).await;
         register_node(&cm, "n1", 4, 8000);
 
-        cm.update_node_state("n1", NodeState::Drain, Some("maint".into()))
+        cm.update_node_state("n1", NodeState::Drain, Some("maint".into()), Some(1000))
             .unwrap();
         wait_for("node drain applied", || {
             cm.get_node("n1")
@@ -20483,6 +20526,85 @@ mod tests {
         let node = cm.get_node("n1").unwrap();
         assert_eq!(node.state, NodeState::Drain);
         assert_eq!(node.state_reason, Some("maint".into()));
+        assert_eq!(node.reason_uid, Some(1000));
+        assert!(
+            node.reason_time.is_some(),
+            "set-time recorded with the reason"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_node_state_resume_clears_reason_attribution() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+
+        cm.update_node_state("n1", NodeState::Drain, Some("maint".into()), Some(1000))
+            .unwrap();
+        wait_for("drain applied", || {
+            cm.get_node("n1")
+                .is_some_and(|n| n.reason_uid == Some(1000))
+        });
+
+        cm.update_node_state("n1", NodeState::Idle, None, None)
+            .unwrap();
+        wait_for("resume applied", || {
+            cm.get_node("n1")
+                .is_some_and(|n| n.state == NodeState::Idle)
+        });
+        let node = cm.get_node("n1").unwrap();
+        assert_eq!(node.state_reason, None);
+        assert_eq!(node.reason_uid, None, "resume clears the setter uid");
+        assert_eq!(node.reason_time, None, "resume clears the set-time");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn heartbeat_down_attributes_reason_to_system_uid() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "stale", 4, 8000);
+        if let Some(node) = cm.nodes.write().get_mut("stale") {
+            node.last_heartbeat = Some(Utc::now() - chrono::Duration::seconds(200));
+        }
+
+        cm.check_node_health(90, super::MarkDownPolicy::Allowed);
+        wait_for("health down applied", || {
+            cm.get_node("stale")
+                .is_some_and(|n| n.state == NodeState::Down)
+        });
+        let node = cm.get_node("stale").unwrap();
+        assert_eq!(node.state_reason.as_deref(), Some("Not responding"));
+        assert_eq!(node.reason_uid, Some(0), "system reason is uid 0");
+        assert!(node.reason_time.is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn heartbeat_down_preserves_admin_hold_attribution() {
+        // A drained node (admin hold) that then stops heartbeating keeps the
+        // operator's reason and its original uid/time, not the system uid.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+
+        cm.update_node_state("n1", NodeState::Drain, Some("hw swap".into()), Some(1000))
+            .unwrap();
+        wait_for("drain applied", || {
+            cm.get_node("n1")
+                .is_some_and(|n| n.reason_uid == Some(1000))
+        });
+
+        cm.apply_health_actions(vec![super::HealthAction::MarkDown {
+            name: "n1".into(),
+            old_state: NodeState::Drain,
+            admin_locked: true,
+        }]);
+        wait_for("down applied", || {
+            cm.get_node("n1")
+                .is_some_and(|n| n.state == NodeState::Down)
+        });
+        let node = cm.get_node("n1").unwrap();
+        assert_eq!(node.state_reason.as_deref(), Some("hw swap"));
+        assert_eq!(node.reason_uid, Some(1000), "admin-hold uid preserved");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -20631,7 +20753,7 @@ mod tests {
                 .is_some_and(|n| n.state == NodeState::Down)
         });
 
-        cm.update_node_state("n1", NodeState::Drain, Some("hw swap".into()))
+        cm.update_node_state("n1", NodeState::Drain, Some("hw swap".into()), None)
             .unwrap();
         wait_for("drain applied", || {
             cm.get_node("n1")
@@ -20698,7 +20820,7 @@ mod tests {
         .unwrap();
         settle(&cm, id, JobState::Running);
 
-        cm.update_node_state("n1", NodeState::Drain, Some("hw swap".into()))
+        cm.update_node_state("n1", NodeState::Drain, Some("hw swap".into()), None)
             .unwrap();
         wait_for("draining applied", || {
             cm.get_node("n1")
@@ -20785,7 +20907,7 @@ mod tests {
         settle(&cm, id, JobState::Running);
 
         // Admin drains while job is running — becomes Draining (admin_locked)
-        cm.update_node_state("locked", NodeState::Drain, Some("hw swap".into()))
+        cm.update_node_state("locked", NodeState::Drain, Some("hw swap".into()), None)
             .unwrap();
         wait_for("draining applied", || {
             cm.get_node("locked")
@@ -23597,6 +23719,8 @@ mod tests {
             new_state: NodeState::Down,
             reason: Some("heartbeat timeout".into()),
             admin_locked: false,
+            reason_uid: None,
+            reason_time: None,
         });
         assert_eq!(resp.jobs_finalized.len(), 1);
         assert_eq!(resp.jobs_finalized[0].job_id, id);
@@ -23624,6 +23748,8 @@ mod tests {
             new_state: NodeState::Down,
             reason: None,
             admin_locked: false,
+            reason_uid: None,
+            reason_time: None,
         });
         assert!(resp.jobs_finalized.is_empty());
         assert_eq!(cm.get_node("n1").unwrap().state, NodeState::Down);
@@ -23672,7 +23798,8 @@ mod tests {
         let id = submit_and_wait(&cm, basic_spec("drain-job"));
         start_job_on(&cm, id, "n1");
 
-        cm.drain_node("n1", Some("maintenance".into())).unwrap();
+        cm.drain_node("n1", Some("maintenance".into()), None)
+            .unwrap();
         wait_for("n1 draining", || {
             cm.get_node("n1")
                 .is_some_and(|n| n.state == NodeState::Draining)
@@ -23690,7 +23817,7 @@ mod tests {
 
         register_node(&cm, "n1", 4, 8000);
 
-        cm.drain_node("n1", None).unwrap();
+        cm.drain_node("n1", None, None).unwrap();
         wait_for("n1 drain", || {
             cm.get_node("n1")
                 .is_some_and(|n| n.state == NodeState::Drain)
@@ -23771,7 +23898,7 @@ mod tests {
         let id = submit_and_wait(&cm, basic_spec("drain-job"));
         start_job_on(&cm, id, "n1");
 
-        cm.drain_node("n1", None).unwrap();
+        cm.drain_node("n1", None, None).unwrap();
         wait_for("n1 draining", || {
             cm.get_node("n1")
                 .is_some_and(|n| n.state == NodeState::Draining)

--- a/crates/spurctld/src/rest/convert.rs
+++ b/crates/spurctld/src/rest/convert.rs
@@ -48,6 +48,8 @@ pub fn node_to_json(
         "name": node.name,
         "state": node.state.display(),
         "reason": node.state_reason,
+        "reason_uid": node.reason_uid,
+        "reason_time": node.reason_time.map(|t| t.to_rfc3339()),
         "partitions": node.partitions,
         "cpus": node.total_resources.cpus,
         "alloc_cpus": node.alloc_resources.cpus,

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1839,7 +1839,7 @@ async fn confirm_dispatch_on_nodes(
     // with the hold that stops the job walking the cluster.
     for (node_name, reason) in &prolog_failed {
         warn!(job_id, node = %node_name, reason = %reason, "draining node after prolog failure");
-        if let Err(e) = cluster.drain_node(node_name, Some(reason.clone())) {
+        if let Err(e) = cluster.drain_node(node_name, Some(reason.clone()), Some(0)) {
             error!(job_id, node = %node_name, error = %e, "failed to drain node after prolog failure");
         }
     }
@@ -2215,6 +2215,7 @@ async fn manage_power(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 &node.name,
                 spur_core::node::NodeState::Suspended,
                 Some("Power saving".into()),
+                Some(0),
             );
             if let Some(ref cmd) = cluster.config().power.suspend_command {
                 spawn_power_command(&cmd.replace("{node}", &node.name), &node.name, "suspend");
@@ -2229,8 +2230,12 @@ async fn manage_power(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                     continue;
                 }
                 info!(node = %node.name, "resuming suspended node for pending jobs");
-                let _ =
-                    cluster.update_node_state(&node.name, spur_core::node::NodeState::Idle, None);
+                let _ = cluster.update_node_state(
+                    &node.name,
+                    spur_core::node::NodeState::Idle,
+                    None,
+                    None,
+                );
                 if let Some(ref cmd) = cluster.config().power.resume_command {
                     spawn_power_command(&cmd.replace("{node}", &node.name), &node.name, "resume");
                 }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1364,12 +1364,13 @@ impl SlurmController for ControllerService {
 
         self.require_admin(&request, "update node")?;
 
+        let reason_uid = Self::verified_identity(&request).map(|id| id.uid);
         let req = request.into_inner();
         if let Some(state) = req.state {
             let node_state = spur_core::node::NodeState::from_proto_i32(state)
                 .ok_or_else(|| Status::invalid_argument("invalid node state"))?;
             self.cluster
-                .update_node_state(&req.name, node_state, req.reason)
+                .update_node_state(&req.name, node_state, req.reason, reason_uid)
                 .map_err(|e| Status::internal(e.to_string()))?;
         }
         if !req.labels.is_empty() || !req.remove_labels.is_empty() {
@@ -1397,6 +1398,7 @@ impl SlurmController for ControllerService {
                 }
             }
         }
+        let reason_uid = Self::verified_identity(&request).map(|id| id.uid);
         let req = request.into_inner();
         let reason = if req.reason.is_empty() {
             None
@@ -1408,7 +1410,7 @@ impl SlurmController for ControllerService {
         }
         let (actual_state, running_jobs) = self
             .cluster
-            .drain_node(&req.name, reason)
+            .drain_node(&req.name, reason, reason_uid)
             .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(spur_proto::proto::DrainNodeResponse {
             actual_state: actual_state.to_string(),
@@ -1800,6 +1802,9 @@ impl SlurmController for ControllerService {
                 &req.reporting_node,
                 spur_core::node::NodeState::Drain,
                 Some(req.drain_reason),
+                // Unauthenticated RPC with client-supplied node/reason; render
+                // Unknown rather than attributing to root (uid 0).
+                None,
             ) {
                 warn!(
                     node = %req.reporting_node,
@@ -4404,6 +4409,8 @@ fn node_to_proto(node: &spur_core::node::Node) -> NodeInfo {
         features: node.features.clone(),
         planned_job_id: 0,
         planned_start: None,
+        reason_uid: node.reason_uid,
+        reason_time: node.reason_time.map(datetime_to_proto),
     }
 }
 

--- a/docs/user-guide/monitoring-jobs.rst
+++ b/docs/user-guide/monitoring-jobs.rst
@@ -243,6 +243,9 @@ Flags:
    * - ``--node-oriented``
      - ``-N``
      - One line per node instead of per partition.
+   * - ``--list-reasons``
+     - ``-R``
+     - List unavailable nodes (down/drain/draining/error) grouped by reason.
    * - ``--format``
      - ``-o``
      - Custom column format.
@@ -261,6 +264,27 @@ PARTITION STATE CPUS MEMORY GRES``.
 
    sinfo -N -o "%N %.6D %.11T %c %m %G"
    sinfo -p gpu -l
+
+``-R`` / ``--list-reasons`` lists only nodes that are unavailable (``down``,
+``drain``, ``drng``, ``err``), grouped by the admin reason set when the node was
+drained or downed, one row per reason with a compressed nodelist:
+
+.. code-block:: text
+
+   REASON               USER      TIMESTAMP           NODELIST
+   Memory errors        alice     2026-08-27T08:03:07 node[05,08]
+   Not responding       root      2026-08-27T09:15:44 node[01-03]
+
+All four columns are populated from live state. ``USER`` (``%u``, or ``%U`` for
+``user(uid)``) is the user who set the reason, resolved from the recorded UID;
+automatic reasons (for example a heartbeat timeout) are attributed to ``root``.
+``TIMESTAMP`` (``%H``) is when the reason was set. A UID that cannot be resolved
+to a name, or a node whose reason predates provenance tracking, renders as
+``Unknown``. ``-R -l`` adds a ``STATE`` column (``%t``).
+
+``scontrol show node`` appends the same provenance to the reason line as
+``Reason=<text> [<user>@<timestamp>]`` when a set-time is recorded, and the REST
+node object carries ``reason_uid`` and ``reason_time`` fields.
 
 Node states are shown as short abbreviations: ``idle`` (free), ``alloc`` (fully
 allocated), ``mix`` (partly allocated), ``down``, ``drain`` (offline, not

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -326,6 +326,12 @@ message NodeInfo {
   // reservation for a specific pending job (0 = no planned reservation).
   uint32 planned_job_id = 54;
   google.protobuf.Timestamp planned_start = 55;
+
+  // Who set state_reason (Slurm reason_uid) and when (reason_time). `reason_uid`
+  // is absent when no reason is set or the setter was unauthenticated; uid 0
+  // marks a system/automatic reason.
+  optional uint32 reason_uid = 56;
+  google.protobuf.Timestamp reason_time = 57;
 }
 
 message PartitionInfo {

--- a/tests/native_host/e2e/test_deregistration.py
+++ b/tests/native_host/e2e/test_deregistration.py
@@ -95,6 +95,9 @@ class TestDrainAndRemove:
         out = cluster.sinfo()
         assert "drain" in out.lower()
 
+        reasons = cluster.cli(["sinfo", "-R"])
+        assert "maintenance" in reasons and node0 in reasons, reasons
+
         script = cluster.write_file(
             "drain_test.sh", "#!/bin/bash\nsleep 1\necho done\n"
         )


### PR DESCRIPTION
## What

Add `sinfo -R` / `--list-reasons` and populate the node reason provenance it depends on: who set a node's drain/down reason (`reason_uid`) and when (`reason_time`), matching Slurm's `reason_uid` / `reason_time`. This replaces the phase-1 placeholder `?` values in the USER/TIMESTAMP columns with real data.

## Compatibility

New `Node` and `WalOperation::NodeStateChange` fields use `#[serde(default)]`, so a new controller cleanly replays old WAL entries and snapshots (they load with no attribution and render as `Unknown`). Proto tags are append-only, so old clients ignore them.

## Testing

- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`: clean.
- Unit tests: serde-default snapshot replay, uid reverse-resolve fallback, attribution recorded on drain/update, system uid 0 on heartbeat-down, admin-hold precedence preserved under timeout, resume clears attribution, and `sinfo -R` grouping/splitting/long-format/empty cases.
- e2e: `sinfo -R` assertion added to `test_deregistration.py`.
- Bare-metal cluster: validated the v0.11.0 to current upgrade (old drains survive as `Unknown`), both uid paths end to end (system uid 0 via heartbeat shows `root`; authenticated non-root uid 1000 via JWT shows `vm`), and a snapshot round-trip that persists uid/time across a controller restart.