### PR TITLE
ci: pull e2e and CI images from mirror.gcr.io to dodge Docker Hub rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       contents: read
     services:
       postgres:
-        image: postgres:16@sha256:33f923b05f64ca54ac4401c01126a6b92afe839a0aa0a52bc5aeb5cc958e5f20
+        image: mirror.gcr.io/library/postgres:16@sha256:33f923b05f64ca54ac4401c01126a6b92afe839a0aa0a52bc5aeb5cc958e5f20
         env:
           POSTGRES_USER: spur_ci
           POSTGRES_PASSWORD: spur_ci

--- a/tests/k8s/e2e/k8s_cluster.py
+++ b/tests/k8s/e2e/k8s_cluster.py
@@ -546,7 +546,7 @@ class ClusterFixture:
 def base_spec(name: str, command: list[str], num_nodes: int = 1) -> dict:
     return {
         "name": name,
-        "image": "busybox:latest",
+        "image": "mirror.gcr.io/library/busybox:latest",
         "gpus": {},
         "numNodes": num_nodes,
         "tasksPerNode": 1,

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -226,8 +226,8 @@ class SpurCluster:
     # Real public image pulled by pull_container_image(). Its config.Env holds
     # PATH (first entry below), LANG and PYTHON_VERSION, none of which the job
     # environment supplies. Pinned so those expectations stay true.
-    TEST_IMAGE = "docker.io/library/python:3.11-slim"
-    TEST_IMAGE_REGISTRY = "registry-1.docker.io"
+    TEST_IMAGE = "mirror.gcr.io/library/python:3.11-slim"
+    TEST_IMAGE_REGISTRY = "mirror.gcr.io"
     TEST_IMAGE_PATH_HEAD = "/usr/local/bin"
 
     def __init__(self, nodes: list[SshNode], remote_dir: str, bin_dir: str):

--- a/tests/native_host/e2e/test_wg_k0s.py
+++ b/tests/native_host/e2e/test_wg_k0s.py
@@ -27,7 +27,7 @@ from wg_cluster import WG_IFACE, wait_until
 # InternalIPs) so a kubectl error string is never mistaken for an address.
 _IPV4_RE = re.compile(r"^\d{1,3}(?:\.\d{1,3}){3}$")
 
-BUSYBOX_IMAGE = "docker.io/library/busybox:1.36"
+BUSYBOX_IMAGE = "mirror.gcr.io/library/busybox:1.36"
 
 
 # --- kubectl helpers (run `k0s kubectl` on the control-plane node) -----------


### PR DESCRIPTION
## What

Switch the container images used by CI and the e2e suites from Docker Hub to Google's public mirror (`mirror.gcr.io`), a read-through cache of Docker Hub. This avoids the anonymous Docker Hub pull rate limits that intermittently fail CI.

Images changed:
- `.github/workflows/ci.yml`: `postgres:16` accounting service container (digest pin preserved).
- `tests/native_host/e2e/cluster.py`: `python:3.11-slim` (`TEST_IMAGE`) and its DNS reachability probe (`TEST_IMAGE_REGISTRY`).
- `tests/native_host/e2e/test_wg_k0s.py`: `busybox:1.36`.
- `tests/k8s/e2e/k8s_cluster.py`: `busybox:latest`.

`postgres:16-alpine` in `cluster.py` already pointed at `mirror.gcr.io`; this brings the rest in line.

## Why mirror.gcr.io and not quay.io

`mirror.gcr.io` serves the exact same images by digest (verified: identical content, `linux/amd64` present for every tag), so it is a drop-in prefix change. quay.io does not mirror Docker Hub's `library` namespace. The closest equivalents (`prometheus/busybox`, `enterprisedb/postgresql`) are different images with different entrypoints, and there is no match for `busybox:1.36` or `postgres:16-alpine`.

## Verification

- Each `mirror.gcr.io/library/...` tag resolves anonymously via the Registry v2 API (HTTP 200) with a `linux/amd64` manifest.
- The CI-pinned `postgres:16` digest resolves on the mirror, so the digest pin is unchanged.
- spur's OCI client (`spur-net/src/oci.rs`) pulls non-Docker-Hub registries anonymously, matching how `mirror.gcr.io` serves public content.

## Follow-up (infra, separate repo)

The self-hosted CI VMs enforce a default-deny egress allowlist (`spur-ci-infra`, `egress_allowed_hosts`) that lists `registry-1.docker.io` but not `mirror.gcr.io`. The native-host and k8s e2e nodes need `mirror.gcr.io` added there for these pulls to succeed. This gap predates this PR (`postgres:16-alpine` already targets the mirror without an allowlist entry). Infra PR to follow.

## Testing

Not yet run against a live cluster. Changes are registry-prefix swaps to identical images. Will trigger the e2e suite once the egress allowlist is updated.
