### PR TITLE
feat(scheduler): lend idle nodes to over-quota jobs and reclaim them on demand

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -671,6 +671,16 @@ pub struct SchedulerConfig {
     /// `PreemptExemptTime`.
     #[serde(default)]
     pub preempt_exempt_time: u32,
+    /// Let a job that is over its QOS group node cap run on nodes that are
+    /// otherwise idle, on the understanding that a job with a quota claim can
+    /// reclaim them by preemption. A group node cap protects a share of a
+    /// contested cluster; while nodes sit empty there is no contest, so enforcing
+    /// it strands capacity. `false` (default) keeps the strict behaviour.
+    ///
+    /// Cluster-wide only: an over-quota job is by definition escaping a per-QOS
+    /// limit, so a per-QOS opt-in would let a QOS grant itself the exemption.
+    #[serde(default)]
+    pub idle_fill_enabled: bool,
 }
 
 /// How often an interactive client (`salloc`/`srun`) pings the controller to
@@ -712,6 +722,7 @@ impl Default for SchedulerConfig {
             max_user_priority: default_max_user_priority(),
             preempt_type: PreemptType::None,
             preempt_exempt_time: 0,
+            idle_fill_enabled: false,
         }
     }
 }

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -250,6 +250,58 @@ pub fn check_qos_limits_with_grp_node_charge(
     }
 }
 
+/// Whether the QOS group *node* cap is the only limit holding this job back, so
+/// idle-fill may loan it idle nodes.
+///
+/// The blocked reason alone cannot answer this. `qos_resource_breach` reports
+/// only the first breach it finds and checks `grp_tres` in the order cpu, node,
+/// mem, gpu — so a job over both its node and GPU caps reports the node one, and
+/// treating that reason as eligibility would loan nodes to a job whose real
+/// constraint is a contended resource. Instead this re-runs the full check with
+/// the node dimension lifted: idle nodes are spare, every other cap is not.
+///
+/// Lifting means setting the dimension to `0`, which `tres_cap_breach` skips —
+/// a TRES dimension of 0 is ignored rather than blocking.
+#[allow(clippy::too_many_arguments)]
+pub fn grp_node_is_sole_blocker(
+    job: &Job,
+    qos: &Qos,
+    user_running_count: u32,
+    user_submitted_count: u32,
+    user_running_tres: &TresRecord,
+    qos_running_tres: &TresRecord,
+    consumed_wall_minutes: Option<u64>,
+    grp_node_charge: u64,
+) -> bool {
+    let check = |qos: &Qos| {
+        check_qos_limits_with_grp_node_charge(
+            job,
+            qos,
+            user_running_count,
+            user_submitted_count,
+            user_running_tres,
+            qos_running_tres,
+            consumed_wall_minutes,
+            grp_node_charge,
+        )
+    };
+
+    if check(qos) == QosCheckResult::Allowed {
+        return false;
+    }
+
+    let mut lifted = qos.clone();
+    let Some(grp) = lifted.limits.grp_tres.as_mut() else {
+        return false;
+    };
+    if grp.get(TresType::Node) == 0 {
+        return false;
+    }
+    grp.set(TresType::Node, 0);
+
+    check(&lifted) == QosCheckResult::Allowed
+}
+
 /// QOS submit-count limits (`MaxSubmitJobsPerUser`, `MaxSubmitJobsPerAccount`,
 /// `GrpSubmitJobs`). These always deny at submission (Slurm's
 /// `acct_policy_validate`), independent of `DenyOnLimit`, because admitting the
@@ -892,6 +944,118 @@ mod tests {
             result,
             QosCheckResult::Blocked(PendingReason::QosGrpNodeLimit)
         );
+    }
+
+    /// A QOS whose group cap is `grp`, over which `running` is already charged.
+    fn grp_qos(grp: TresRecord) -> Qos {
+        Qos {
+            name: "grp".into(),
+            limits: QosLimits {
+                grp_tres: Some(grp),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn sole_blocker(
+        job: &Job,
+        qos: &Qos,
+        qos_running: &TresRecord,
+        user_running_count: u32,
+    ) -> bool {
+        grp_node_is_sole_blocker(
+            job,
+            qos,
+            user_running_count,
+            0,
+            &TresRecord::new(),
+            qos_running,
+            None,
+            job.spec.num_nodes as u64,
+        )
+    }
+
+    #[test]
+    fn grp_node_is_sole_blocker_when_only_the_node_cap_is_breached() {
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Node, 4);
+        let qos = grp_qos(grp);
+        let mut job = make_test_job();
+        job.spec.num_nodes = 3;
+        let mut qos_running = TresRecord::new();
+        qos_running.set(TresType::Node, 2); // 2 + 3 > 4
+
+        assert!(sole_blocker(&job, &qos, &qos_running, 0));
+    }
+
+    #[test]
+    fn grp_node_not_sole_blocker_when_the_job_already_fits() {
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Node, 10);
+        let qos = grp_qos(grp);
+        let mut job = make_test_job();
+        job.spec.num_nodes = 3;
+
+        assert!(!sole_blocker(&job, &qos, &TresRecord::new(), 0));
+    }
+
+    /// The reason code alone is not enough to decide eligibility: `grp_tres` is
+    /// checked cpu -> node -> mem -> gpu and only the first breach is reported,
+    /// so this job reports the node limit while a memory breach also stands.
+    /// Loaning it idle nodes would let it escape a cap on a contended resource.
+    #[test]
+    fn grp_node_not_sole_blocker_when_the_memory_cap_is_also_breached() {
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Node, 4);
+        grp.set(TresType::Memory, 2000);
+        let qos = grp_qos(grp);
+        let mut job = make_test_job();
+        job.spec.num_nodes = 3;
+        job.spec.memory_per_node_mb = Some(1000); // 3 * 1000 > 2000
+        let mut qos_running = TresRecord::new();
+        qos_running.set(TresType::Node, 2); // 2 + 3 > 4
+
+        assert_eq!(
+            check_qos_limits(&job, &qos, 0, 0, &TresRecord::new(), &qos_running, None),
+            QosCheckResult::Blocked(PendingReason::QosGrpNodeLimit),
+            "precondition: the node breach is the one reported"
+        );
+        assert!(!sole_blocker(&job, &qos, &qos_running, 0));
+    }
+
+    #[test]
+    fn grp_node_not_sole_blocker_when_a_non_tres_limit_also_blocks() {
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Node, 4);
+        let mut qos = grp_qos(grp);
+        qos.limits.max_jobs_per_user = Some(1);
+        let mut job = make_test_job();
+        job.spec.num_nodes = 3;
+        let mut qos_running = TresRecord::new();
+        qos_running.set(TresType::Node, 2);
+
+        assert!(!sole_blocker(&job, &qos, &qos_running, 1));
+    }
+
+    #[test]
+    fn grp_node_not_sole_blocker_without_a_group_cap() {
+        let qos = make_qos(None, None);
+        let mut job = make_test_job();
+        job.spec.num_nodes = 3;
+
+        assert!(!sole_blocker(&job, &qos, &TresRecord::new(), 0));
+    }
+
+    #[test]
+    fn grp_node_not_sole_blocker_when_the_node_dimension_is_unset() {
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Cpu, 2); // job asks for 4 cpus
+        let qos = grp_qos(grp);
+        let mut job = make_test_job();
+        job.spec.num_nodes = 3;
+
+        assert!(!sole_blocker(&job, &qos, &TresRecord::new(), 0));
     }
 
     #[test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -484,6 +484,9 @@ struct PendingJobClassification {
     jobs: Vec<Job>,
     reason_updates: Vec<(JobId, PendingReason)>,
     bb_stage_candidates: Vec<JobId>,
+    /// Over-quota jobs that idle-fill may place on nodes Phase 1 leaves empty,
+    /// highest priority first. Empty unless `scheduler.idle_fill_enabled`.
+    idle_fill_candidates: Vec<Job>,
 }
 
 struct PendingJobCandidate {
@@ -3708,7 +3711,15 @@ impl ClusterManager {
             .map(|candidate| (candidate.job.job_id, self.resolve_qos(&candidate.job)))
             .collect();
 
+        // Jobs the QOS gate rejects on the group node cap alone. They stay
+        // rejected here and keep reporting that reason: idle-fill decides
+        // separately, against the nodes Phase 1 leaves empty. Only the QOS gate
+        // feeds this, so a job the account gate already rejected never appears —
+        // the account gate runs first and returns before this one.
+        let mut idle_fill_candidates = Vec::new();
+
         {
+            let idle_fill = self.config().scheduler.idle_fill_enabled;
             let mut reserved = PassReservations::default();
             let grp_wall_usage = self.grp_wall_cache.usage();
             let nodes = self.nodes.read();
@@ -3735,9 +3746,23 @@ impl ClusterManager {
                     &nodes,
                     &reserved,
                     consumed_wall,
+                    idle_fill,
                 ) {
                     Ok(charge) => charge,
-                    Err(reason) => return GateOutcome::Block(reason),
+                    Err(block) => {
+                        if block.idle_fill_eligible {
+                            let mut candidate = job.clone();
+                            // The account gate credits nodes it already occupies,
+                            // which have running jobs and so are never idle. Left
+                            // in place the credit reads as a nodelist and, once it
+                            // covers `num_nodes`, restricts placement to exactly
+                            // those non-idle nodes — see
+                            // `NodePlacement::nodelist_is_additive`.
+                            candidate.preferred_nodes.clear();
+                            idle_fill_candidates.push(candidate);
+                        }
+                        return GateOutcome::Block(block.reason);
+                    }
                 };
                 reserved.reserve(job, qos_charge, account_charge);
                 GateOutcome::Keep
@@ -3822,6 +3847,7 @@ impl ClusterManager {
                 .collect(),
             reason_updates,
             bb_stage_candidates,
+            idle_fill_candidates,
         }
     }
 
@@ -7168,12 +7194,22 @@ fn license_block(job: &Job, pool: &HashMap<String, u64>) -> Option<spur_core::jo
     None
 }
 
-/// `Err(reason)` if the job would exceed a QOS group/per-user cap. `reserved`
+/// Why the QOS gate rejected a job.
+struct QosBlock {
+    reason: PendingReason,
+    /// The group node cap is the only limit in the way, so idle-fill may loan
+    /// this job idle nodes. Always `false` when idle-fill is switched off, so
+    /// the extra limit evaluation is not paid for on the default path.
+    idle_fill_eligible: bool,
+}
+
+/// `Err(..)` if the job would exceed a QOS group/per-user cap. `reserved`
 /// folds in headroom claimed earlier this pass so it can't over-subscribe. On
 /// success, extends `job.preferred_nodes` with any nodes credited toward the
 /// grp-node cap so placement actually lands on one of them, and returns the
 /// node count actually charged against `grp_tres` so the caller can record it
 /// (rather than the job's raw `num_nodes`) in `reserved`.
+#[allow(clippy::too_many_arguments)]
 fn qos_block_with(
     job: &mut Job,
     qos: &Qos,
@@ -7181,7 +7217,8 @@ fn qos_block_with(
     nodes: &HashMap<String, Node>,
     reserved: &PassReservations,
     consumed_wall_minutes: Option<u64>,
-) -> Result<u64, spur_core::job::PendingReason> {
+    idle_fill: bool,
+) -> Result<u64, QosBlock> {
     let Some(qos_name) = job.spec.qos.as_ref() else {
         return Ok(0);
     };
@@ -7242,7 +7279,20 @@ fn qos_block_with(
             job.preferred_nodes.extend(reusable_nodes);
             Ok(grp_node_charge)
         }
-        QosCheckResult::Blocked(reason) => Err(reason),
+        QosCheckResult::Blocked(reason) => Err(QosBlock {
+            reason,
+            idle_fill_eligible: idle_fill
+                && spur_core::qos::grp_node_is_sole_blocker(
+                    job,
+                    qos,
+                    running_count,
+                    submitted_count,
+                    &user_running_tres,
+                    &qos_running_tres,
+                    consumed_wall_minutes,
+                    grp_node_charge,
+                ),
+        }),
     }
 }
 


### PR DESCRIPTION
**Draft, for design review.** The code here is deliberately inert; what I am asking for is agreement on the approach and answers to the open questions at the bottom before I write the half that changes behaviour.

## The problem

A job whose QOS has exhausted its group *node* quota stays pending even when nodes are idle. The quota exists to stop one team monopolising a contested cluster — but while machines sit empty there is no contest, so the cluster strands capacity enforcing a fairness rule nobody is competing over. On a cluster with `grptres=node=4` per team, a team with four nodes busy and a fifth job queued leaves every other idle node untouched.

Idle-fill lets an over-quota job run on otherwise-idle nodes as a **loan**, and reclaims those nodes by preemption when a job with a genuine quota claim needs them.

## Approach

Two tiers. A *legitimate* job is within quota and is never preempted by this mechanism. An *opportunistic* job runs only because nodes were spare, and any legitimate job can displace it. The contract is "you may use spare capacity, and you will lose it on demand".

Two scheduling passes inside one cycle: pass 1 is today's scheduling, unchanged; pass 2 places over-quota jobs on whatever pass 1 left empty.

The key implementation choice is that **pass 2 is a second `schedule()` call over a filtered node slice**. `ClusterState.nodes` is a plain `&[Node]`, so this reuses the whole placement engine — GPU matching, topology, `cons_tres`, per-node capacity — without touching `backfill.rs`, and inherits atomicity and priority ordering for free.

Everything is behind `scheduler.idle_fill_enabled`, default `false`, so an existing cluster sees no change.

### Eligibility is not a reason-code check

The obvious rule — "the job was blocked with `QOSGrpNodeLimit`" — is wrong, and this is the subtle part of the change. `qos_resource_breach` returns only the *first* breach and evaluates `grp_tres` in the order cpu, node, mem, gpu. A job over both its node cap and its GPU cap therefore reports the node one, and that rule would lend idle nodes to a job whose real constraint is a contended resource.

`grp_node_is_sole_blocker` instead re-runs the whole limit check with the node dimension lifted, and treats the job as eligible only if it then passes. Lifting means setting the dimension to `0`, which is ignored rather than blocking. A regression test asserts the misleading reason code as an explicit precondition so the trap cannot silently return.

Eligibility is decided inside `qos_block_with`, where the running aggregates already exist; computing it in the gate would re-derive every aggregate that #797 removed. It is also gated on the config flag, so the extra evaluation is not paid for by default.

## What is in this draft

- `grp_node_is_sole_blocker` and its six unit tests.
- `scheduler.idle_fill_enabled`, cluster-only. Deliberately not per-QOS: an over-quota job is by definition escaping a per-QOS limit, so a per-QOS opt-in would let a QOS grant itself the exemption.
- The QOS gate collects eligible jobs onto a side list. Rejection is unchanged, reason included.

Nothing reads that list yet, so there is no behavioural change. **`clippy` will flag the field as never read until the pass-2 commit lands in this same PR** — that one failure is expected, not worth investigating.

The collected job has `preferred_nodes` cleared. The account gate runs first and, on success, credits nodes it already occupies; those nodes have running jobs and so are never idle, and left in place the credit reads as a nodelist that restricts placement to exactly them (`NodePlacement::nodelist_is_additive`).

## Still to come in this PR

The idle budget and the pass-2 call, a persisted `idle_fill` flag on `Job`, and the reclaim path. `planned_starts()` already reports nodes that are idle now but hold a future reservation for a legitimate job, which is exactly the set the budget must exclude — otherwise idle-fill would delay the large job that backfill was protecting.

## Three corrections to the design this came from

Worth recording because two of them removed knobs:

| Assumed | Actual |
|---|---|
| A new `idle_fill_exempt_secs` knob is needed | `preempt_exempt_time` already exists with the same cluster → partition → QOS chain, plus a partition level the design omitted |
| `idle_fill_atomic` needs a cluster/partition/QOS override chain, defaulting to true | Whole-job-or-nothing is already invariant — placement refuses to assign when fewer nodes are placeable than requested. `true` is a no-op and `false` would mean building partial dispatch |
| Eviction fates are `REQUEUE`, `CANCEL`, `CHECKPOINT` | There is no `Checkpoint` variant; the fourth mode is `Suspend`. Unrecognised mode strings parse to `Off`, so a config typo yields no preemption rather than an error |

So the configuration surface is two knobs, not four.

Separately, `plans/implementation-roadmap.md` claims under "Gang Scheduling" that the scheduler partially starts multi-node jobs. That is stale and I will correct it separately.

## Why the loan and the recall must ship together

I originally planned to land pass-2 scheduling first and preemption second. That is wrong. Without reclaim, idle-fill is not a smaller version of this feature — it converts "idle node plus a pending job" into "node held by a job with no claim that cannot be evicted". The fallback of letting idle-fill jobs run to completion only holds for *bounded* jobs, and `scheduler.default_time_limit_minutes` defaults to `0`, so a job submitted without `-t` is unbounded and can hold borrowed nodes indefinitely.

Being default-off is what makes shipping both halves as one PR safe.

Reclaim is also not free reuse of existing preemption, which is the finding I would most like a second opinion on. `try_preempt` skips any victim whose priority is not *less than half* the pending job's, so a legitimate job of comparable priority cannot reclaim its own quota — under default configuration. When `preempt_type = qos_priority`, the QOS allow list blocks it too, and that is exactly the setting a cluster with QOS node quotas is likely to use. So reclaim needs a deliberate opportunistic-victim path.

## Verification

**Not yet verified on a live cluster.** This branch is inert and there is no behaviour to exercise; `idle_fill_enabled` has no reader. Stating that plainly rather than implying the unit tests cover it.

Before this leaves draft it will be built from this branch, installed on a real cluster, and exercised: confirm an over-quota job still pends with `QOSGrpNodeLimit` while disabled; enable it and watch a second job take an idle node; submit an in-quota job and watch the loan get called in; confirm the exempt window delays eviction; and restart the controller with an idle-fill job running to confirm the flag survives. Commands and real output will go in this description.

Local: `cargo test` passes — 676 in `spur-core` (670 before, plus 6 new) and 1059 in `spurctld`, so the `qos_block_with` signature change broke nothing.

## Open questions

1. **Unbounded jobs.** Should idle-fill refuse a job with no effective time limit, and refuse entirely when the victim's `PreemptMode` is `Off`? My preference is both: we should only lend what we can take back.
2. **How far should reclaim override the existing gates?** Relax both the priority gap and the QOS allow list for idle-fill victims, or only the allow list? Relaxing both means a low-priority legitimate job can evict a high-priority idle-fill job — correct under the loan model, surprising under a pure-priority one.
3. **Scope.** This covers the QOS group node cap only. A job over its *association* group node cap does not benefit, because the account gate runs first and returns early. Is QOS-only the right first cut?
4. **Evicted job fate.** Fate follows the existing `PreemptMode`, so a cluster set to `Cancel` destroys work that only ran opportunistically. Is a per-tier override worth the complexity, or is `Requeue` guidance enough?
5. **Observability.** Is a `squeue` indicator enough, or do operators want counters for nodes currently on loan and idle-fill evictions?
